### PR TITLE
Fix thinking-off chat template handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,12 @@ curl -s http://127.0.0.1:8888/v1/chat/completions \
   }'
 ```
 
-Thinking off is **top-level** JSON: `"chat_template_kwargs": {"enable_thinking": false}`
-(nested `extra_body` is ignored). The launcher sets
+Thinking defaults on. Disable it with the **top-level** JSON field
+`"chat_template_kwargs": {"enable_thinking": false}`. This closes the empty
+thinking block in the generation prompt and omits the reasoning-effort hint.
+Do not send a literal nested `extra_body` object over raw HTTP; `extra_body` is
+an OpenAI Python SDK option that merges its contents into the top-level request.
+The launcher sets
 `--chat-template /opt/glm53/chat_template.jinja` (checkpoint jinja is language-only).
 
 Needs: Docker (no sudo) on both nodes, passwordless SSH head → worker,

--- a/files/chat_template.jinja
+++ b/files/chat_template.jinja
@@ -1,6 +1,11 @@
 [gMASK]<sop>
+{%- if thinking is defined or enable_thinking is defined -%}
+{%- set thinking_enabled = (thinking if thinking is defined else false) or (enable_thinking if enable_thinking is defined else false) -%}
+{%- else -%}
+{%- set thinking_enabled = true -%}
+{%- endif -%}
 {%- set effective_reasoning_effort = reasoning_effort if reasoning_effort is defined and reasoning_effort in ['low', 'high'] else 'max' -%}
-{%- if effective_reasoning_effort is not none -%}<|system|>Reasoning Effort: {{ effective_reasoning_effort | capitalize }}{%- endif -%}
+{%- if thinking_enabled and effective_reasoning_effort is not none -%}<|system|>Reasoning Effort: {{ effective_reasoning_effort | capitalize }}{%- endif -%}
 {%- set clear_thinking = clear_thinking if clear_thinking is defined else false -%}
 {%- if tools -%}
 {%- macro tool_to_json(tool) -%}
@@ -253,5 +258,5 @@ For each function call, output the function name and arguments within the follow
 {%- endif -%}
 {%- endfor -%}
 {%- if add_generation_prompt -%}
-    <|assistant|>{{- '<think>' -}}
+    <|assistant|>{{- '<think>' if thinking_enabled else '<think></think>' -}}
 {%- endif -%}

--- a/tests/bench_decode.py
+++ b/tests/bench_decode.py
@@ -51,7 +51,7 @@ def chat_nonstream(prompt: str, max_tokens: int = 64) -> dict:
         "messages": [{"role": "user", "content": prompt}],
         "temperature": 0,
         "max_tokens": max_tokens,
-        "extra_body": {"chat_template_kwargs": {"enable_thinking": False}},
+        "chat_template_kwargs": {"enable_thinking": False},
     }
     with _post("/v1/chat/completions", body) as resp:
         raw = resp.read().decode("utf-8")
@@ -69,7 +69,7 @@ def stream_bench(max_tokens: int = 200) -> dict:
         "max_tokens": max_tokens,
         "stream": True,
         "stream_options": {"include_usage": True},
-        "extra_body": {"chat_template_kwargs": {"enable_thinking": False}},
+        "chat_template_kwargs": {"enable_thinking": False},
     }
     t0 = time.perf_counter()
     first = None

--- a/tests/test_chat_template.py
+++ b/tests/test_chat_template.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Regression checks for GLM-5.3 chat-template reasoning controls."""
+
+import unittest
+from pathlib import Path
+
+from jinja2 import Environment
+
+
+TEMPLATE = Path(__file__).parents[1] / "files" / "chat_template.jinja"
+
+
+def render_generation_prompt(**kwargs: object) -> str:
+    template = Environment(extensions=["jinja2.ext.loopcontrols"]).from_string(
+        TEMPLATE.read_text()
+    )
+    return template.render(
+        messages=[{"role": "user", "content": "hello"}],
+        tools=None,
+        add_generation_prompt=True,
+        **kwargs,
+    )
+
+
+class ChatTemplateTests(unittest.TestCase):
+    def test_thinking_defaults_on(self) -> None:
+        rendered = render_generation_prompt()
+        self.assertIn("<|system|>Reasoning Effort: Max", rendered)
+        self.assertTrue(rendered.endswith("<|assistant|><think>"), rendered)
+
+    def test_thinking_can_be_disabled(self) -> None:
+        rendered = render_generation_prompt(enable_thinking=False)
+        self.assertNotIn("Reasoning Effort:", rendered)
+        self.assertTrue(rendered.endswith("<|assistant|><think></think>"), rendered)
+
+    def test_thinking_alias_matches_parser_behavior(self) -> None:
+        rendered = render_generation_prompt(thinking=False)
+        self.assertNotIn("Reasoning Effort:", rendered)
+        self.assertTrue(rendered.endswith("<|assistant|><think></think>"), rendered)
+
+    def test_explicit_thinking_preserves_reasoning_effort(self) -> None:
+        rendered = render_generation_prompt(
+            enable_thinking=True,
+            reasoning_effort="low",
+        )
+        self.assertIn("<|system|>Reasoning Effort: Low", rendered)
+        self.assertTrue(rendered.endswith("<|assistant|><think>"), rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Honor `enable_thinking: false` in the custom chat template.
- Match vLLM’s compatible `thinking` alias.
- Pre-close the empty `<think></think>` block and omit the reasoning-effort hint.
- Send `chat_template_kwargs` at the top level in the raw HTTP benchmark.
- Document raw HTTP versus OpenAI SDK `extra_body` behavior.
- Add regression coverage.

## Validation

- `python3 -m unittest tests/test_chat_template.py`
- Python compilation and `git diff --check`
- Rendered successfully with the checkpoint’s actual Transformers tokenizer for default thinking, both disabled-thinking flags, and explicit low reasoning effort.

Commit: eaf90d06bc8a1acd1489176d122e02b68fa6ec22