### PR TITLE
Keep client stop strings dormant until </think>

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,9 @@ ABLIT_ALPHA=3.0
 # Also edit the MTP block's o_proj when it is loaded (SPEC_METHOD=mtp).
 ABLIT_INCLUDE_MTP=1
 
+# Suppress client stop strings until </think> (thinking-on default). 0 = off.
+GLM53_SUPPRESS_STOPS_IN_REASONING=1
+
 # Host NCCL preload. Default off: the glm53-flash image already has nvidia-nccl,
 # and LD_PRELOAD of a second SO makes DeepEP assert duplicate NCCL.
 USE_HOST_NCCL=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -446,11 +446,15 @@ COPY ablit /opt/glm53/ablit
 COPY overlay/ablit_runtime.py /opt/glm53/ablit_runtime.py
 COPY overlay/patch_ablit.py /opt/glm53/patch_ablit.py
 COPY tests/test_ablit.py /opt/glm53/test_ablit.py
+COPY overlay/patch_suppress_stops_in_reasoning.py /opt/glm53/patch_suppress_stops_in_reasoning.py
+COPY tests/test_suppress_stops.py /opt/glm53/test_suppress_stops.py
 RUN python3 /opt/glm53/patch_model_overrides.py
 RUN python3 /opt/glm53/patch_dflash2.py
 RUN python3 /opt/glm53/patch_glm_eagle3.py
 RUN python3 /opt/glm53/patch_glm5_drafter_group.py
 RUN python3 /opt/glm53/patch_ablit.py
+RUN python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
 
 RUN EXL3_SELFCHECK_GPU=0 python3 /opt/glm53/test_exl3_overlay.py \
-    && python3 /opt/glm53/test_ablit.py
+    && python3 /opt/glm53/test_ablit.py \
+    && python3 /opt/glm53/test_suppress_stops.py

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ your cabling differs. `ncclCommInitRank` hangs without them.
 | `MAX_MODEL_LEN` | `900000` | default context. The 982,612-token pool is **1.09×** a full 900k request. Native 1M does not allocate |
 | `MAX_NUM_SEQS` | `4` | decode batch; MTP adds k+1 tokens/seq |
 | `MAX_NUM_BATCHED_TOKENS` | `1024` | prefill chunk; 8192 oversubscribes GB10 indexer topk on long context |
+| `GLM53_SUPPRESS_STOPS_IN_REASONING` | `1` | ignore client `stop` strings until `</think>` (thinking-on default) |
 | `LANGUAGE_MODEL_ONLY` | `0` | load vision tower (image + video) |
 | `SKIP_MM_PROFILING` | `1` | skip max-size MM dummy at init (OOM otherwise) |
 | `LIMIT_MM` | `{"image":4,"video":1}` | `--limit-mm-per-prompt` |
@@ -374,6 +375,7 @@ this Dockerfile instead. After CUDA compile, Python overlay edits
 | `overlay/patch_glm_video_placeholders.py` | align video timestamp blocks to encoder `grid_t` |
 | `overlay/ablit_runtime.py` | ABLIT: o_proj refusal-direction orthogonalization at load (`ABLIT=1`) |
 | `overlay/patch_ablit.py` | install the ABLIT hook into `Glm5NextModel` / `Glm5NextMTP` load (idempotent) |
+| `overlay/patch_suppress_stops_in_reasoning.py` | fail-closed detokenizer guard: client `stop` dormant until `</think>` |
 | `ablit/` | direction vectors + `LAYER_MAP.json` from drowzeys' published ablit recipe |
 | `tests/test_ablit.py` | recipe integrity, orthogonalization math, TP-shard equivalence, hook gating |
 

--- a/overlay/patch_suppress_stops_in_reasoning.py
+++ b/overlay/patch_suppress_stops_in_reasoning.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Keep client stop strings dormant until </think> (glm53-flash detokenizer).
+
+vLLM v1 matches ``stop`` against the whole stream. Think-in-prompt starts
+inside ``<think>``; CoT often restates harness stops like ``Question:``.
+The request then finishes mid-reason with empty ``content`` (DSpark #42).
+
+Anchors are this image's ``v1/engine/detokenizer.py`` (TokenizersBackend
+factory, not Anemll's PreTrainedTokenizerFast). Fail closed if they drift.
+
+Guard arms only when the last prompt token is the reasoning start marker.
+EOS / max_tokens are unchanged. Spec-decode: when ``</think>`` arrives in
+the same k+1 chunk as prior think tokens, ``stop_check_offset`` jumps past
+the marker so a stop in that tail cannot fire.
+
+Opt-out: ``GLM53_SUPPRESS_STOPS_IN_REASONING=0`` or
+``VLLM_SUPPRESS_STOPS_IN_REASONING=0``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+P = Path("/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/detokenizer.py")
+MARK = "# [suppress-stops-in-reasoning]"
+
+IMPORT_OLD = (
+    "import sys\n"
+    "from abc import ABC, abstractmethod\n"
+)
+IMPORT_NEW = (
+    "import os\n"
+    "import sys\n"
+    "from abc import ABC, abstractmethod\n"
+)
+
+FACTORY_OLD = """        if USE_FAST_DETOKENIZER and isinstance(tokenizer, TokenizersBackend):
+            # Fast tokenizer => use tokenizers library DecodeStream.
+            return FastIncrementalDetokenizer(tokenizer, request)
+
+        # Fall back to slow python-based incremental detokenization.
+        return SlowIncrementalDetokenizer(tokenizer, request)
+"""
+
+FACTORY_NEW = """        if USE_FAST_DETOKENIZER and isinstance(tokenizer, TokenizersBackend):
+            # Fast tokenizer => use tokenizers library DecodeStream.
+            detok = FastIncrementalDetokenizer(tokenizer, request)
+        else:
+            # Fall back to slow python-based incremental detokenization.
+            detok = SlowIncrementalDetokenizer(tokenizer, request)
+        IncrementalDetokenizer._maybe_enable_reasoning_stop_guard(
+            detok, tokenizer, request
+        )
+        return detok
+
+    @staticmethod
+    def _reasoning_stop_markers() -> tuple[str, str]:
+        # [suppress-stops-in-reasoning] prefer reasoning_config markers.
+        start, end = "<think>", "</think>"
+        try:
+            from vllm.config import get_current_vllm_config_or_none
+
+            cfg = get_current_vllm_config_or_none()
+            rc = getattr(cfg, "reasoning_config", None) if cfg else None
+            if rc is not None:
+                start = getattr(rc, "reasoning_start_str", "") or start
+                end = getattr(rc, "reasoning_end_str", "") or end
+        except Exception as e:
+            logger.debug(
+                "suppress-stops-in-reasoning: no reasoning config (%s); using %r / %r",
+                e,
+                start,
+                end,
+            )
+        return start, end
+
+    @staticmethod
+    def _suppress_stops_enabled() -> bool:
+        for key in (
+            "GLM53_SUPPRESS_STOPS_IN_REASONING",
+            "VLLM_SUPPRESS_STOPS_IN_REASONING",
+        ):
+            if key in os.environ:
+                return os.environ.get(key) != "0"
+        return True
+
+    @staticmethod
+    def _maybe_enable_reasoning_stop_guard(detok, tokenizer, request) -> None:
+        # [suppress-stops-in-reasoning] last prompt token == <think> →
+        # keep client stop strings dormant until </think>.
+        if not IncrementalDetokenizer._suppress_stops_enabled():
+            return
+        try:
+            stop = getattr(detok, "stop", None)
+            ptids = getattr(request, "prompt_token_ids", None)
+            if not stop or not ptids:
+                return
+            start_str, end_str = IncrementalDetokenizer._reasoning_stop_markers()
+            think_id = None
+            convert = getattr(tokenizer, "convert_tokens_to_ids", None)
+            if callable(convert):
+                think_id = convert(start_str)
+            if think_id is None or think_id < 0:
+                encode = getattr(tokenizer, "encode", None)
+                if callable(encode):
+                    try:
+                        ids = encode(start_str, add_special_tokens=False)
+                    except TypeError:
+                        ids = encode(start_str)
+                    if isinstance(ids, list) and len(ids) == 1:
+                        think_id = ids[0]
+            if think_id is not None and think_id >= 0 and ptids[-1] == think_id:
+                detok._reasoning_stop_guard = True
+                detok._reasoning_end_str = end_str
+        except Exception as e:
+            logger.debug("suppress-stops-in-reasoning: guard not armed (%s)", e)
+"""
+
+INIT_OLD = """        self._last_output_text_offset: int = 0
+
+        # Generation data
+        self.output_text = ""
+"""
+
+INIT_NEW = """        self._last_output_text_offset: int = 0
+
+        # [suppress-stops-in-reasoning] client stops stay dormant while
+        # generation is still inside <think> (think-in-prompt).
+        self._reasoning_stop_guard: bool = False
+        self._reasoning_closed: bool = False
+        self._reasoning_end_str: str = "</think>"
+
+        # Generation data
+        self.output_text = ""
+"""
+
+STOP_OLD = """        # 2) Evaluate stop strings.
+        stop_string = None
+        if self.stop and self.num_output_tokens() > self.min_tokens:
+            stop = check_stop_strings(
+"""
+
+STOP_NEW = """        # 2) Evaluate stop strings.
+        # [suppress-stops-in-reasoning] keep stops dormant while reasoning
+        # is open. Advance stop_check_offset past </think> so a speculative
+        # chunk that also carries the last think tokens cannot fire.
+        if self._reasoning_stop_guard and not self._reasoning_closed:
+            marker = self._reasoning_end_str
+            window = max(0, stop_check_offset - (len(marker) - 1))
+            idx = self.output_text.find(marker, window)
+            if idx != -1:
+                self._reasoning_closed = True
+                stop_check_offset = max(stop_check_offset, idx + len(marker))
+        stop_string = None
+        if (
+            self.stop
+            and self.num_output_tokens() > self.min_tokens
+            and (not self._reasoning_stop_guard or self._reasoning_closed)
+        ):
+            stop = check_stop_strings(
+"""
+
+
+def apply_text(src: str) -> tuple[str, str]:
+    """Return (new_source, status): applied|skipped|missing:..."""
+    if MARK in src and "_maybe_enable_reasoning_stop_guard" in src:
+        return src, "skipped"
+    missing = []
+    if IMPORT_OLD not in src:
+        missing.append("import")
+    if FACTORY_OLD not in src:
+        missing.append("factory")
+    if INIT_OLD not in src:
+        missing.append("init")
+    if STOP_OLD not in src:
+        missing.append("stop")
+    if missing:
+        return src, "missing:" + ",".join(missing)
+    out = src.replace(IMPORT_OLD, IMPORT_NEW, 1)
+    out = out.replace(FACTORY_OLD, FACTORY_NEW, 1)
+    out = out.replace(INIT_OLD, INIT_NEW, 1)
+    out = out.replace(STOP_OLD, STOP_NEW, 1)
+    return out, "applied"
+
+
+def apply_file(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    new, status = apply_text(text)
+    if status == "applied":
+        path.write_text(new, encoding="utf-8")
+    return status
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) > 1 and argv[1] == "--status":
+        target = Path(argv[2]) if len(argv) > 2 else P
+        applied = target.is_file() and MARK in target.read_text()
+        print("suppress-stops-in-reasoning    :", "APPLIED" if applied else "NOT APPLIED")
+        return 0
+    target = Path(argv[1]) if len(argv) > 1 else P
+    if not target.is_file():
+        print(f"[suppress-stops-in-reasoning] missing {target}", file=sys.stderr)
+        return 1
+    status = apply_file(target)
+    print(f"[suppress-stops-in-reasoning] {status}: {target}")
+    return 0 if status.startswith("applied") or status == "skipped" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/start.sh
+++ b/start.sh
@@ -142,6 +142,7 @@ MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-1024}"
 CHAT_TEMPLATE_HOST="${CHAT_TEMPLATE_HOST:-$SCRIPT_DIR/files/chat_template.jinja}"
 CHAT_TEMPLATE="${CHAT_TEMPLATE:-/opt/glm53/chat_template.jinja}"
 VIDEO_PATCH_HOST="${VIDEO_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm_video_placeholders.py}"
+STOP_PATCH_HOST="${STOP_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_suppress_stops_in_reasoning.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
 QUANTIZATION="${QUANTIZATION:-exl3}"
 LANGUAGE_MODEL_ONLY="${LANGUAGE_MODEL_ONLY:-0}"
@@ -183,6 +184,8 @@ ABLIT_ALPHA="${ABLIT_ALPHA:-3.0}"              # 1.0 = plain projection, >1 over
 ABLIT_INCLUDE_MTP="${ABLIT_INCLUDE_MTP:-1}"
 
 READY_TIMEOUT="${READY_TIMEOUT:-3600}"
+# 1 = suppress client stop strings until </think> (DSpark #42 class).
+GLM53_SUPPRESS_STOPS_IN_REASONING="${GLM53_SUPPRESS_STOPS_IN_REASONING:-1}"
 
 CONTAINER_HEAD="${CONTAINER_HEAD:-glm53-exl3-head}"
 CONTAINER_WORKER="${CONTAINER_WORKER:-glm53-exl3-worker}"
@@ -311,6 +314,7 @@ preflight() {
     [ -f "$SCRIPT_DIR/ablit/refusal_direction_glm53_bf_oproj.pt" ] || die "$SCRIPT_DIR/ablit/refusal_direction_glm53_bf_oproj.pt missing"
     [ -f "$SCRIPT_DIR/overlay/ablit_runtime.py" ] || die "$SCRIPT_DIR/overlay/ablit_runtime.py missing"
     [ -f "$SCRIPT_DIR/overlay/patch_ablit.py" ] || die "$SCRIPT_DIR/overlay/patch_ablit.py missing"
+    [ -f "$STOP_PATCH_HOST" ] || die "$STOP_PATCH_HOST missing"
     if [ "$ABLIT" = "1" ]; then
         log "ablit: ON (direction=${ABLIT_DIRECTION} layers=${ABLIT_LAYERS} alpha=${ABLIT_ALPHA} mtp=${ABLIT_INCLUDE_MTP})"
     fi
@@ -629,6 +633,9 @@ fi
 if [ -f /opt/glm53/patch_ablit.py ]; then
     python3 /opt/glm53/patch_ablit.py
 fi
+if [ -f /opt/glm53/patch_suppress_stops_in_reasoning.py ]; then
+    python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
+fi
 if [ "${ABLIT:-0}" = "1" ]; then
     say "ablit: o_proj orthogonalization ON (direction=${ABLIT_DIRECTION:-dealign} layers=${ABLIT_LAYERS:-15-45} alpha=${ABLIT_ALPHA:-3.0})"
 else
@@ -701,6 +708,9 @@ fi
 if [ -f /opt/glm53/patch_ablit.py ]; then
     python3 /opt/glm53/patch_ablit.py
 fi
+if [ -f /opt/glm53/patch_suppress_stops_in_reasoning.py ]; then
+    python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
+fi
 if [ "${ABLIT:-0}" = "1" ]; then
     say "ablit: o_proj orthogonalization ON (direction=${ABLIT_DIRECTION:-dealign} layers=${ABLIT_LAYERS:-15-45} alpha=${ABLIT_ALPHA:-3.0})"
 else
@@ -724,6 +734,8 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$CHAT_TEMPLATE_HOST" "${WORKER_SSH}:/tmp/glm53-chat_template.jinja"
     [ -f "$VIDEO_PATCH_HOST" ] || die "missing $VIDEO_PATCH_HOST"
     scp -q -o BatchMode=yes "$VIDEO_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_glm_video_placeholders.py"
+    [ -f "$STOP_PATCH_HOST" ] || die "missing $STOP_PATCH_HOST"
+    scp -q -o BatchMode=yes "$STOP_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_suppress_stops_in_reasoning.py"
 
     # ablit artifacts + hook (read-only mounts inside both containers)
     worker_ssh "rm -rf /tmp/glm53-ablit"
@@ -747,6 +759,7 @@ launch_cluster() {
         -e TRANSFORMERS_OFFLINE=1
         -e HF_HOME=/root/.cache/huggingface
         -e VLLM_CACHE_ROOT=/root/.cache/vllm
+        -e "GLM53_SUPPRESS_STOPS_IN_REASONING=$GLM53_SUPPRESS_STOPS_IN_REASONING"
         -e "TORCH_CUDA_ARCH_LIST=$TORCH_CUDA_ARCH_LIST"
         -e "FLASHINFER_CUDA_ARCH_LIST=$FLASHINFER_CUDA_ARCH_LIST"
         -e FLASHINFER_DISABLE_VERSION_CHECK=1
@@ -801,6 +814,7 @@ launch_cluster() {
         -v '/tmp/${CONTAINER_WORKER}.sh:/start.sh:ro' \
         -v '/tmp/glm53-chat_template.jinja:${CHAT_TEMPLATE}:ro' \
         -v '/tmp/patch_glm_video_placeholders.py:/opt/glm53/patch_glm_video_placeholders.py:ro' \
+        -v '/tmp/patch_suppress_stops_in_reasoning.py:/opt/glm53/patch_suppress_stops_in_reasoning.py:ro' \
         -v '/tmp/glm53-ablit:/opt/glm53/ablit:ro' \
         -v '/tmp/glm53-ablit_runtime.py:/opt/glm53/ablit_runtime.py:ro' \
         -v '/tmp/patch_ablit.py:/opt/glm53/patch_ablit.py:ro' \
@@ -823,6 +837,7 @@ launch_cluster() {
         -v "$HEAD_SCRIPT:/start.sh:ro" \
         -v "$CHAT_TEMPLATE_HOST:$CHAT_TEMPLATE:ro" \
         -v "$VIDEO_PATCH_HOST:/opt/glm53/patch_glm_video_placeholders.py:ro" \
+        -v "$STOP_PATCH_HOST:/opt/glm53/patch_suppress_stops_in_reasoning.py:ro" \
         -v "$SCRIPT_DIR/ablit:/opt/glm53/ablit:ro" \
         -v "$SCRIPT_DIR/overlay/ablit_runtime.py:/opt/glm53/ablit_runtime.py:ro" \
         -v "$SCRIPT_DIR/overlay/patch_ablit.py:/opt/glm53/patch_ablit.py:ro" \

--- a/tests/test_suppress_stops.py
+++ b/tests/test_suppress_stops.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""CPU test: fail-closed #42 patcher matches glm53-flash detokenizer anchors."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HERE = Path(__file__).resolve().parent
+for _d in (HERE, ROOT / "overlay"):
+    if (_d / "patch_suppress_stops_in_reasoning.py").is_file():
+        sys.path.insert(0, str(_d))
+        break
+from patch_suppress_stops_in_reasoning import (  # noqa: E402
+    FACTORY_OLD,
+    IMPORT_OLD,
+    INIT_OLD,
+    MARK,
+    STOP_OLD,
+    apply_text,
+)
+
+MINIMAL = (
+    "# SPDX-License-Identifier: Apache-2.0\n"
+    f"{IMPORT_OLD}"
+    "class IncrementalDetokenizer:\n"
+    "    def from_new_request(cls, tokenizer, request):\n"
+    f"{FACTORY_OLD}"
+    "class BaseIncrementalDetokenizer:\n"
+    "    def __init__(self, request):\n"
+    f"{INIT_OLD}"
+    "    def update(self, new_token_ids, stop_terminated):\n"
+    "        stop_check_offset = 0\n"
+    f"{STOP_OLD}"
+    "                output_text=self.output_text,\n"
+    "            )\n"
+)
+
+
+def test_apply_then_skip() -> None:
+    out, status = apply_text(MINIMAL)
+    assert status == "applied", status
+    assert MARK in out
+    assert "_maybe_enable_reasoning_stop_guard" in out
+    assert "not self._reasoning_stop_guard or self._reasoning_closed" in out
+    assert "TokenizersBackend" in FACTORY_OLD
+    out2, status2 = apply_text(out)
+    assert status2 == "skipped", status2
+    assert out2 == out
+
+
+def test_missing_anchor_fails_closed() -> None:
+    _, status = apply_text("class IncrementalDetokenizer:\n    pass\n")
+    assert status.startswith("missing:"), status
+    assert "factory" in status
+
+
+if __name__ == "__main__":
+    test_apply_then_skip()
+    test_missing_anchor_fails_closed()
+    print("test_suppress_stops: ok")


### PR DESCRIPTION
## Summary
- Fail-closed detokenizer overlay so client `stop` strings (e.g. `Question:`) do not fire while generation is still inside `<think>`.
- Live repro on this kit: thinking-on + `stop: ["Question:"]` used to finish mid-CoT with empty content; thinking-off stop behavior is unchanged.

## Test plan
- [x] `python3 tests/test_suppress_stops.py` (CPU, fail-closed anchors)
- [x] Live thinking-on `stop: ["Question:"]` → `finish=length`, CoT continues past `Question:`
- [x] Live thinking-off same stop → `42` then `stop_reason=Question:`


Made with [Cursor](https://cursor.com)