### PR TITLE
Land Triton persist + post-ready warmup on main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,8 +90,19 @@ ABLIT_ALPHA=3.0
 # Also edit the MTP block's o_proj when it is loaded (SPEC_METHOD=mtp).
 ABLIT_INCLUDE_MTP=1
 
+# --- JIT caches / boot warmup ----------------------------------------------
+# Overlay ~/.triton and ~/.tilelang die on container recreate. These host
+# dirs are bind-mounted to /root/.triton/cache and /root/.tilelang/cache.
+# TRITON_HOST_CACHE=
+# TILELANG_HOST_CACHE=
+# After /health, burn DFlash2 BLOCK / sampler / kpool shapes so TP=2 does
+# not JIT mid-collective. 0 = skip (nonfatal either way).
+GLM53_BOOT_SHAPE_WARMUP=1
+# GLM53_WARMUP_REQ_TIMEOUT=240
 # Suppress client stop strings until </think> (thinking-on default). 0 = off.
 GLM53_SUPPRESS_STOPS_IN_REASONING=1
+# EngineCore execute timeout (seconds). Stock 300 is short for a cold JIT.
+# VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 
 # Host NCCL preload. Default off: the glm53-flash image already has nvidia-nccl,
 # and LD_PRELOAD of a second SO makes DeepEP assert duplicate NCCL.

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ SPEC_METHOD=mtp ./start.sh restart      # MTP k=2
 3. Download the TR3 EXL3 repo into `$HF_HOME` / `~/.cache/huggingface` (~164 GiB, 120 shards) if missing. Same job as `./download.sh`, which stops here (head only).
 4. `rsync` that cache to `${WORKER_HOME}/.cache/huggingface`
 5. Start rank 1 `--headless` on the worker, rank 0 + API on the head
-6. Poll `/health` (weight load + warmup is slow; `READY_TIMEOUT` default 3600s)
+6. Poll `/health` (weight load + warmup is slow; `READY_TIMEOUT` default 3600s), then a **nonfatal** DFlash2/sampler shape sweep so the first client is not the first JIT on TP=2. `GLM53_BOOT_SHAPE_WARMUP=0` skips it.
 
 The worker does not need GHCR access — only the head pulls, then ships the image over SSH.
 
@@ -337,6 +337,8 @@ your cabling differs. `ncclCommInitRank` hangs without them.
 | `MAX_NUM_SEQS` | `4` | decode batch; MTP adds k+1 tokens/seq |
 | `MAX_NUM_BATCHED_TOKENS` | `1024` | prefill chunk; 8192 oversubscribes GB10 indexer topk on long context |
 | `GLM53_SUPPRESS_STOPS_IN_REASONING` | `1` | ignore client `stop` strings until `</think>` (thinking-on default) |
+| `GLM53_BOOT_SHAPE_WARMUP` | `1` | after `/health`, burn DFlash2 BLOCK / sampler / kpool shapes (nonfatal) |
+| `TRITON_HOST_CACHE` / `TILELANG_HOST_CACHE` | `$CACHE_ROOT/triton` / `tilelang` | persist JIT caches across container recreate |
 | `LANGUAGE_MODEL_ONLY` | `0` | load vision tower (image + video) |
 | `SKIP_MM_PROFILING` | `1` | skip max-size MM dummy at init (OOM otherwise) |
 | `LIMIT_MM` | `{"image":4,"video":1}` | `--limit-mm-per-prompt` |
@@ -376,6 +378,7 @@ this Dockerfile instead. After CUDA compile, Python overlay edits
 | `overlay/ablit_runtime.py` | ABLIT: o_proj refusal-direction orthogonalization at load (`ABLIT=1`) |
 | `overlay/patch_ablit.py` | install the ABLIT hook into `Glm5NextModel` / `Glm5NextMTP` load (idempotent) |
 | `overlay/patch_suppress_stops_in_reasoning.py` | fail-closed detokenizer guard: client `stop` dormant until `</think>` |
+| `scripts/boot-shape-warmup.sh` | post-`/health` DFlash2 k=7 BLOCK ladder + sampler/kpool arms |
 | `ablit/` | direction vectors + `LAYER_MAP.json` from drowzeys' published ablit recipe |
 | `tests/test_ablit.py` | recipe integrity, orthogonalization math, TP-shard equivalence, hook gating |
 

--- a/scripts/boot-shape-warmup.sh
+++ b/scripts/boot-shape-warmup.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# boot-shape-warmup.sh — burn DFlash2 / sampler / kpool shapes after /health.
+#
+# glm53-flash DFlash2 k=7:
+#   BLOCK_SIZE = min(256, next_pow2(scheduled_tokens + num_query_per_req))
+#   num_query_per_req = 1 + k = 8
+# BLOCK 8 is unreachable (min scheduled 1 → 9 → 16). Do not copy DSpark's
+# next_pow2(s+6) ladder or 9500-token 8192-chunk arms.
+#
+# Non-fatal: the launcher WARNs on nonzero exit. Pair with a persistent
+# TRITON_CACHE_DIR + TILELANG_CACHE_DIR so each shape compiles once per image.
+#
+# Usage: boot-shape-warmup.sh [base_url] [model]
+# Env:
+#   GLM53_WARMUP_REQ_TIMEOUT       per-request curl --max-time (default 240)
+#   GLM53_WARMUP_MAX_CONCURRENCY   resolved --max-num-seqs (default 4)
+#   GLM53_WARMUP_DFLASH_K          speculative tokens (default 7)
+#   GLM53_WARMUP_TRITON_CACHE_DIR  host Triton cache (sampler postcondition)
+#   GLM53_WARMUP_BEARER / VLLM_API_KEY
+#   WARMUP_CURL                    test seam
+set -u
+
+BASE="${1:-http://127.0.0.1:8888}"
+MODEL="${2:-GLM-5.3-Flash-EXL3}"
+CURL_BIN="${WARMUP_CURL:-curl}"
+REQ_TIMEOUT="${GLM53_WARMUP_REQ_TIMEOUT:-240}"
+MAX_CONCURRENCY="${GLM53_WARMUP_MAX_CONCURRENCY:-4}"
+DFLASH_K="${GLM53_WARMUP_DFLASH_K:-7}"
+case "$MAX_CONCURRENCY" in
+  ''|*[!0-9]*|0)
+    echo "boot-shape-warmup: invalid GLM53_WARMUP_MAX_CONCURRENCY=${MAX_CONCURRENCY@Q}; using 4" >&2
+    MAX_CONCURRENCY=4
+    ;;
+esac
+case "$DFLASH_K" in
+  ''|*[!0-9]*) DFLASH_K=7 ;;
+esac
+NONCE="$$-$(date +%s)"
+
+AUTH_ARGS=()
+if [ -n "${GLM53_WARMUP_BEARER:-}" ]; then
+  AUTH_ARGS=(-H "Authorization: Bearer ${GLM53_WARMUP_BEARER}")
+elif [ -n "${VLLM_API_KEY:-}" ]; then
+  AUTH_ARGS=(-H "Authorization: Bearer ${VLLM_API_KEY}")
+fi
+
+next_pow2() {
+  local n=$1 p=1
+  while [ "$p" -lt "$n" ]; do p=$((p * 2)); done
+  printf '%s' "$p"
+}
+
+# k=7 → +8. Pick one s per live BLOCK in {16,32,64,128,256}.
+LADDER_S=(1 24 56 120 248)
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+mk_prompt() {
+  local n=$1 tag=$2 body
+  body=$(printf 'warm %.0s' $(seq 1 "$n"))
+  printf '[warmup %s %s] The following is filler context, ignore it: %s Reply with OK.' \
+    "$NONCE" "$tag" "$body"
+}
+
+fire() {
+  local tag=$1 words=$2 thinking=$3 out=$4 profile=${5:-bounded} prompt payload sample_fields thinking_json
+  prompt=$(mk_prompt "$words" "$tag")
+  if [ "$thinking" = "true" ]; then thinking_json=true; else thinking_json=false; fi
+  if [ "$profile" = "serve-default" ]; then
+    payload='{"model":"'"$MODEL"'","messages":[{"role":"user","content":"'"$prompt"'"}],"temperature":0}'
+  elif [ "${profile#sampling}" != "$profile" ]; then
+    case "$profile" in
+      # Hub generation_config.json stamps top_p=0.95. Omitting top_p on a
+      # k-only arm compiles TOPK+TOPP, never k-only. top_p=1.0 / top_k=0
+      # are how glm53-flash's sampler drops the p / k tensors (None).
+      sampling-k)  sample_fields='"top_k":40,"top_p":1.0' ;;
+      sampling-p)  sample_fields='"top_k":0,"top_p":0.9' ;;
+      *)           sample_fields='"top_k":40,"top_p":0.9' ;;
+    esac
+    payload='{"model":"'"$MODEL"'","messages":[{"role":"user","content":"'"$prompt"'"}],"max_tokens":24,"temperature":0.8,'"$sample_fields"',"chat_template_kwargs":{"enable_thinking":'"$thinking_json"'}}'
+  else
+    payload='{"model":"'"$MODEL"'","messages":[{"role":"user","content":"'"$prompt"'"}],"max_tokens":24,"temperature":0,"chat_template_kwargs":{"enable_thinking":'"$thinking_json"'}}'
+  fi
+  if "$CURL_BIN" -fsS --max-time "$REQ_TIMEOUT" "${AUTH_ARGS[@]}" \
+      "$BASE/v1/chat/completions" -H "Content-Type: application/json" \
+      -d "$payload" >/dev/null 2>>"$tmpdir/errors"; then
+    echo ok > "$out"
+  else
+    echo fail > "$out"
+  fi
+}
+
+burst() {
+  local arm=$1 c=$2 words=$3 profile=${4:-bounded} thinking=${5:-false} i t0 t1
+  for i in $(seq 1 "$c"); do : > "$tmpdir/${arm}-${i}"; done
+  t0=$(date +%s)
+  for i in $(seq 1 "$c"); do
+    fire "${arm}-${i}" "$words" "$thinking" "$tmpdir/${arm}-${i}" "$profile" &
+  done
+  wait
+  t1=$(date +%s)
+  echo "  arm ${arm}: C=${c} x ~${words} tok, profile=${profile}, think=${thinking}, $((t1 - t0))s"
+}
+
+SAMPLER_KERNEL=_topk_topp_kernel
+
+sampler_cache_combos() {
+  local root=$1 ttir kuse puse combo
+  for ttir in "$root"/*/"$SAMPLER_KERNEL.ttir"; do
+    [ -f "$ttir" ] || continue
+    kuse=$(grep -oE '%K[^A-Za-z0-9_]' "$ttir" | wc -l)
+    puse=$(grep -oE '%P[^A-Za-z0-9_]' "$ttir" | wc -l)
+    if [ "$kuse" -gt 1 ] && [ "$puse" -gt 1 ]; then combo=k+p
+    elif [ "$kuse" -gt 1 ]; then combo=k-only
+    elif [ "$puse" -gt 1 ]; then combo=p-only
+    else combo=neither; fi
+    printf '%s\n' "$combo"
+  done | sort -u
+}
+
+verify_sampler_cache() {
+  local root="${GLM53_WARMUP_TRITON_CACHE_DIR:-}" combos combo n missing=""
+  if [ -z "$root" ] || [ ! -d "$root" ]; then
+    echo "  sampler-cache postcondition: SKIPPED (GLM53_WARMUP_TRITON_CACHE_DIR unset or not a directory)"
+    return 0
+  fi
+  combos=$(sampler_cache_combos "$root")
+  for combo in k-only p-only k+p; do
+    n=$(printf '%s\n' "$combos" | grep -cx "$combo")
+    [ "$n" -ge 1 ] || missing="${missing} ${combo}:0/1"
+  done
+  if [ -z "$missing" ]; then
+    echo "  sampler-cache postcondition: MET — ${SAMPLER_KERNEL} constexpr combos on this rank:"
+    printf '%s\n' "$combos" | sed 's/^/    /'
+    return 0
+  fi
+  echo "  sampler-cache postcondition: unmet —${missing} (constexpr combos)"
+  return 1
+}
+
+mk_ladder_prompt() {
+  local n=$1 out="hello" i
+  for ((i = 1; i < n; i++)); do out="$out hello"; done
+  printf '%s' "$out"
+}
+
+verify_ladder_rung() {
+  local s=$1 prompt want_block got resp t0 t1 qpad
+  qpad=$((DFLASH_K + 1))
+  : > "$tmpdir/ladder-$s"
+  prompt=$(mk_ladder_prompt "$s")
+  want_block=$(next_pow2 $((s + qpad)))
+  if [ "$want_block" -gt 256 ]; then want_block=256; fi
+  if ! resp=$("$CURL_BIN" -fsS --max-time 30 "${AUTH_ARGS[@]}" \
+        "$BASE/tokenize" -H "Content-Type: application/json" \
+        -d '{"model":"'"$MODEL"'","prompt":"'"$prompt"'"}' \
+        2>>"$tmpdir/errors"); then
+    echo "boot-shape-warmup: tokenize verify FAILED for rung s=${s}: POST /tokenize errored — rung skipped, BLOCK ${want_block} NOT warmed" >&2
+    echo fail > "$tmpdir/ladder-$s"
+    return 0
+  fi
+  got=$(printf '%s\n' "$resp" | grep -o '"count"[[:space:]]*:[[:space:]]*[0-9]*' | head -n 1 | grep -o '[0-9]*$')
+  if [ -z "$got" ]; then
+    echo "boot-shape-warmup: tokenize verify FAILED for rung s=${s}: no usable \"count\" in /tokenize response — rung skipped, BLOCK ${want_block} NOT warmed" >&2
+    echo fail > "$tmpdir/ladder-$s"
+    return 0
+  fi
+  if [ "$got" -ne "$s" ]; then
+    echo "boot-shape-warmup: tokenize verify FAILED for rung s=${s}: /tokenize reported ${got} tokens, need exactly ${s} — rung skipped, BLOCK ${want_block} NOT warmed" >&2
+    echo fail > "$tmpdir/ladder-$s"
+    return 0
+  fi
+  t0=$(date +%s)
+  if "$CURL_BIN" -fsS --max-time "$REQ_TIMEOUT" "${AUTH_ARGS[@]}" \
+      "$BASE/v1/completions" -H "Content-Type: application/json" \
+      -d '{"model":"'"$MODEL"'","prompt":"'"$prompt"'","max_tokens":1,"temperature":0}' \
+      >/dev/null 2>>"$tmpdir/errors"; then
+    echo ok > "$tmpdir/ladder-$s"
+    t1=$(date +%s)
+    echo "  ladder s=${s}: tokenize ${got}/${s} -> BLOCK ${want_block} fired ($((t1 - t0))s)"
+  else
+    echo fail > "$tmpdir/ladder-$s"
+    echo "  ladder s=${s}: tokenize ${got}/${s} -> BLOCK ${want_block} request FAILED"
+  fi
+}
+
+ladder() {
+  local s
+  for s in "${LADDER_S[@]}"; do
+    verify_ladder_rung "$s"
+  done
+}
+
+if ! "$CURL_BIN" -fsS --max-time 10 "${AUTH_ARGS[@]}" "$BASE/v1/models" >/dev/null 2>&1; then
+  echo "boot-shape-warmup: API not reachable at $BASE — skipping sweep" >&2
+  exit 1
+fi
+
+echo "boot-shape-warmup: sweeping DFlash2 k=${DFLASH_K} / sampler / kpool shapes"
+total_t0=$(date +%s)
+
+ladder
+
+EXPECTED_CHAT_REQUESTS=6
+burst c1        1 32 bounded false
+burst think-c1  1 16 bounded true
+burst short-c1  1 8 serve-default
+burst samp-k    1 8 sampling-k false
+burst samp-p    1 8 sampling-p false
+burst samp-kp   1 8 sampling-kp false
+if [ "$MAX_CONCURRENCY" -ge 2 ]; then
+  burst short-c2 2 8 serve-default
+  EXPECTED_CHAT_REQUESTS=$((EXPECTED_CHAT_REQUESTS + 2))
+fi
+if [ "$MAX_CONCURRENCY" -ge 3 ]; then
+  burst samp-kp-c3 3 8 sampling-kp false
+  EXPECTED_CHAT_REQUESTS=$((EXPECTED_CHAT_REQUESTS + 3))
+fi
+if [ "$MAX_CONCURRENCY" -ge 4 ]; then
+  burst short-c4 4 8 serve-default
+  EXPECTED_CHAT_REQUESTS=$((EXPECTED_CHAT_REQUESTS + 4))
+fi
+if [ "$MAX_CONCURRENCY" -gt 4 ]; then
+  echo "boot-shape-warmup: WARN: MAX_NUM_SEQS=${MAX_CONCURRENCY}; batch shapes above C=4 are not pre-warmed" >&2
+fi
+
+SAMPLER_POSTCOND=ok
+verify_sampler_cache || SAMPLER_POSTCOND=fail
+
+total=0 ok_count=0
+for f in "$tmpdir"/*-*; do
+  [ -f "$f" ] || continue
+  total=$((total + 1))
+  [ "$(cat "$f")" = "ok" ] && ok_count=$((ok_count + 1))
+done
+EXPECTED_REQUESTS=$(( ${#LADDER_S[@]} + EXPECTED_CHAT_REQUESTS ))
+if [ "$total" -ne "$EXPECTED_REQUESTS" ]; then
+  echo "boot-shape-warmup: internal error: tallied $total outcomes for $EXPECTED_REQUESTS scheduled requests" >&2
+  exit 1
+fi
+total_t1=$(date +%s)
+echo "boot-shape-warmup: ${ok_count}/${total} requests ok in $((total_t1 - total_t0))s"
+
+if [ "$ok_count" -lt "$total" ]; then
+  echo "boot-shape-warmup: $((total - ok_count)) request(s) failed — uncovered shapes may JIT mid-serve" >&2
+  sed -n '1,5p' "$tmpdir/errors" >&2 2>/dev/null || true
+  exit 1
+fi
+if [ "$SAMPLER_POSTCOND" != ok ]; then
+  echo "boot-shape-warmup: sampler-cache postcondition UNMET — ${SAMPLER_KERNEL} variants may JIT mid-serve" >&2
+  exit 1
+fi
+exit 0

--- a/start.sh
+++ b/start.sh
@@ -25,7 +25,8 @@
 #   4. sync       — rsync that cache to the worker (each rank loads local disk)
 #   5. launch     — worker --headless, then head + `vllm serve` (both
 #                   --network host --ipc=host)
-#   6. wait       — poll /health up to READY_TIMEOUT
+#   6. wait       — poll /health up to READY_TIMEOUT, then a nonfatal
+#                   DFlash2/sampler shape warmup (GLM53_BOOT_SHAPE_WARMUP)
 #
 # Usage:
 #   ./start.sh                    start (download/sync/launch) — default
@@ -186,6 +187,12 @@ ABLIT_INCLUDE_MTP="${ABLIT_INCLUDE_MTP:-1}"
 READY_TIMEOUT="${READY_TIMEOUT:-3600}"
 # 1 = suppress client stop strings until </think> (DSpark #42 class).
 GLM53_SUPPRESS_STOPS_IN_REASONING="${GLM53_SUPPRESS_STOPS_IN_REASONING:-1}"
+# EngineCore stock timeout is 300s; mid-serve Triton/TileLang JIT on TP=2 can
+# exceed that without being a true hang. NCCL watchdog is still 600s.
+VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS="${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-1800}"
+# 1 = after /health, burn DFlash2 BLOCK / sampler / kpool shapes. Nonfatal.
+GLM53_BOOT_SHAPE_WARMUP="${GLM53_BOOT_SHAPE_WARMUP:-1}"
+GLM53_WARMUP_REQ_TIMEOUT="${GLM53_WARMUP_REQ_TIMEOUT:-240}"
 
 CONTAINER_HEAD="${CONTAINER_HEAD:-glm53-exl3-head}"
 CONTAINER_WORKER="${CONTAINER_WORKER:-glm53-exl3-worker}"
@@ -197,6 +204,14 @@ DFLASH_PATH="$HF_CACHE_DIR/hub/$DFLASH_CACHE_NAME"
 WORKER_CACHE_DIR="$WORKER_HOME/.cache/huggingface"
 CACHE_ROOT="${CACHE_ROOT:-$HOME/.cache/vllm-glm53-flash}"
 WORKER_VLLM_CACHE="${WORKER_VLLM_CACHE:-$WORKER_HOME/.cache/vllm-glm53-flash}"
+# Overlay FS ~/.triton and ~/.tilelang die on container recreate (TP=2 JIT
+# stall → 600s NCCL watchdog). Persist next to the vLLM cache.
+TRITON_HOST_CACHE="${TRITON_HOST_CACHE:-$CACHE_ROOT/triton}"
+TILELANG_HOST_CACHE="${TILELANG_HOST_CACHE:-$CACHE_ROOT/tilelang}"
+WORKER_TRITON_CACHE="${WORKER_TRITON_CACHE:-$WORKER_VLLM_CACHE/triton}"
+WORKER_TILELANG_CACHE="${WORKER_TILELANG_CACHE:-$WORKER_VLLM_CACHE/tilelang}"
+TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-/root/.triton/cache}"
+TILELANG_CACHE_DIR="${TILELANG_CACHE_DIR:-/root/.tilelang/cache}"
 
 LOGDIR="$SCRIPT_DIR/logs"
 HEAD_SCRIPT="$SCRIPT_DIR/.glm53-exl3-head.inner.sh"
@@ -727,8 +742,8 @@ launch_cluster() {
     docker rm -f "$CONTAINER_HEAD" >/dev/null 2>&1 || true
     worker_ssh "docker rm -f '$CONTAINER_WORKER'" >/dev/null 2>&1 || true
 
-    mkdir -p "$CACHE_ROOT"
-    worker_ssh "mkdir -p '$WORKER_VLLM_CACHE'"
+    mkdir -p "$CACHE_ROOT" "$TRITON_HOST_CACHE" "$TILELANG_HOST_CACHE"
+    worker_ssh "mkdir -p '$WORKER_VLLM_CACHE' '$WORKER_TRITON_CACHE' '$WORKER_TILELANG_CACHE'"
     scp -q -o BatchMode=yes "$WORKER_SCRIPT" "${WORKER_SSH}:/tmp/${CONTAINER_WORKER}.sh"
     [ -f "$CHAT_TEMPLATE_HOST" ] || die "missing chat template: $CHAT_TEMPLATE_HOST"
     scp -q -o BatchMode=yes "$CHAT_TEMPLATE_HOST" "${WORKER_SSH}:/tmp/glm53-chat_template.jinja"
@@ -760,6 +775,9 @@ launch_cluster() {
         -e HF_HOME=/root/.cache/huggingface
         -e VLLM_CACHE_ROOT=/root/.cache/vllm
         -e "GLM53_SUPPRESS_STOPS_IN_REASONING=$GLM53_SUPPRESS_STOPS_IN_REASONING"
+        -e "TRITON_CACHE_DIR=$TRITON_CACHE_DIR"
+        -e "TILELANG_CACHE_DIR=$TILELANG_CACHE_DIR"
+        -e "VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=$VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS"
         -e "TORCH_CUDA_ARCH_LIST=$TORCH_CUDA_ARCH_LIST"
         -e "FLASHINFER_CUDA_ARCH_LIST=$FLASHINFER_CUDA_ARCH_LIST"
         -e FLASHINFER_DISABLE_VERSION_CHECK=1
@@ -811,6 +829,8 @@ launch_cluster() {
         --ulimit memlock=-1 --ulimit stack=67108864 \
         -v '$WORKER_CACHE_DIR:/root/.cache/huggingface' \
         -v '$WORKER_VLLM_CACHE:/root/.cache/vllm' \
+        -v '$WORKER_TRITON_CACHE:/root/.triton/cache' \
+        -v '$WORKER_TILELANG_CACHE:/root/.tilelang/cache' \
         -v '/tmp/${CONTAINER_WORKER}.sh:/start.sh:ro' \
         -v '/tmp/glm53-chat_template.jinja:${CHAT_TEMPLATE}:ro' \
         -v '/tmp/patch_glm_video_placeholders.py:/opt/glm53/patch_glm_video_placeholders.py:ro' \
@@ -834,6 +854,8 @@ launch_cluster() {
         --ulimit memlock=-1 --ulimit stack=67108864 \
         -v "$HF_CACHE_DIR:/root/.cache/huggingface" \
         -v "$CACHE_ROOT:/root/.cache/vllm" \
+        -v "$TRITON_HOST_CACHE:/root/.triton/cache" \
+        -v "$TILELANG_HOST_CACHE:/root/.tilelang/cache" \
         -v "$HEAD_SCRIPT:/start.sh:ro" \
         -v "$CHAT_TEMPLATE_HOST:$CHAT_TEMPLATE:ro" \
         -v "$VIDEO_PATCH_HOST:/opt/glm53/patch_glm_video_placeholders.py:ro" \
@@ -916,6 +938,24 @@ wait_for_health() {
     [ "$healthy" = "1" ]
 }
 
+post_ready_warmup() {
+    if [ "${GLM53_BOOT_SHAPE_WARMUP:-1}" = "0" ]; then
+        log "boot shape warmup skipped (GLM53_BOOT_SHAPE_WARMUP=0)"
+        return 0
+    fi
+    [ -f "$SCRIPT_DIR/scripts/boot-shape-warmup.sh" ] \
+        || { warn "boot-shape-warmup.sh missing — skipping"; return 0; }
+    log "post-ready DFlash2/sampler warmup (nonfatal; timeout ${GLM53_WARMUP_REQ_TIMEOUT}s/req) ..."
+    GLM53_WARMUP_MAX_CONCURRENCY="$MAX_NUM_SEQS" \
+    GLM53_WARMUP_REQ_TIMEOUT="$GLM53_WARMUP_REQ_TIMEOUT" \
+    GLM53_WARMUP_DFLASH_K="${DFLASH_TOKENS:-7}" \
+    GLM53_WARMUP_TRITON_CACHE_DIR="$TRITON_HOST_CACHE" \
+    GLM53_WARMUP_BEARER="${VLLM_API_KEY:-}" \
+        bash "$SCRIPT_DIR/scripts/boot-shape-warmup.sh" \
+            "http://127.0.0.1:${PORT}" "$SERVED_MODEL_NAME" \
+        || warn "boot shape warmup incomplete — uncovered shapes may JIT mid-serve on TP=2"
+}
+
 collect_failure_logs() {
     mkdir -p "$LOGDIR"
     docker logs "$CONTAINER_HEAD" >"$LOGDIR/head.log" 2>&1 || true
@@ -971,6 +1011,7 @@ start() {
 
     launch_cluster
     if wait_for_health; then
+        post_ready_warmup
         on_ready
         return
     fi


### PR DESCRIPTION
## Summary
- Follow-up: [#3](https://github.com/MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks/pull/3) merged into the stop-in-think branch after [#2](https://github.com/MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks/pull/2) already went to `main`. This brings persist + warmup onto `main`.

## Test plan
- Same as #3: persistent Triton/TileLang mounts, nonfatal boot-shape warmup, k-only `top_p=1.0`.


Made with [Cursor](https://cursor.com)