### PR TITLE
perf: decouple DFlash proposal and verification widths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,12 +54,15 @@ ENFORCE_EAGER=0
 EXL3_FUSED_MOE=1
 SERVED_MODEL_NAME=GLM-5.3-Flash-EXL3
 
-# Winner on this 2× GB10 kit with DFlash2: fused MoE + DFlash2 k=7.
+# DFlash2 proposes its trained k=7 block. Low-acceptance workloads can opt in
+# to graph-aligned verify k=3 without changing the proposal distribution.
 # Draft KV is auto/bf16; the target still uses KV_CACHE_DTYPE=fp8 (fp8_ds_mla).
 # Rollback: SPEC_METHOD=mtp
 SPEC_METHOD=dflash
 DFLASH_MODEL=incoai/GLM-5.3-Flash-DFlash2
 DFLASH_TOKENS=7
+# 0 = verify all proposals. Use 1/3/7; 3 won the small English-prose A/B below.
+DFLASH_VERIFY_TOKENS=0
 # Drafter TP. 1 = rank 0 only (default; skip CX7 on a 2.3 GiB draft). Empty = inherit TP.
 # DFLASH_DRAFT_TP=1
 MTP_TOKENS=2

--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ your cabling differs. `ncclCommInitRank` hangs without them.
 | `SPEC_METHOD` | `dflash` | `dflash` / `mtp` / `none`. Rollback: `SPEC_METHOD=mtp ./start.sh restart` |
 | `DFLASH_MODEL` | `incoai/GLM-5.3-Flash-DFlash2` | DFlash2 draft Hub repo (~2.3 GiB BF16) |
 | `DFLASH_TOKENS` | `7` | DFlash2 speculative tokens (trained block 8) |
+| `DFLASH_VERIFY_TOKENS` | `0` (full width) | publish a graph-aligned prefix (`1`, `3`, or `7`) to the target verifier while retaining the trained `DFLASH_TOKENS` proposal block; structured output stays full-width |
 | `DFLASH_DRAFT_TP` | `1` | keep the 2.3 GiB drafter on rank 0 (no CX7 per draft step). Empty = inherit TP |
 | DFlash2 draft KV | `auto` (bf16) | target stays `fp8`/`fp8_ds_mla`; dense draft has no MLA FP8 backend on SM121 |
 | DFlash2 attention | *(unset)* | SM121 picks FLASH_ATTN for non-causal SWA. Do not pin `TRITON_ATTN` |
@@ -355,6 +356,52 @@ your cabling differs. `ncclCommInitRank` hangs without them.
 | `HEAD_CX7_IF` / `WORKER_CX7_IF` | `enp1s0f1np1` / `enp1s0f0np0` | NCCL sockets |
 | `HEAD_CX7_IB` / `WORKER_CX7_IB` | `rocep1s0f1` / `rocep1s0f0` | NCCL HCAs |
 | `USE_HOST_NCCL` | `0` | image nvidia-nccl; host preload duplicates DeepEP |
+
+### DFlash2 proposal width vs verification width
+
+`DFLASH_VERIFY_TOKENS=3` keeps DFlash2's trained seven-token proposal block,
+but sends only its first three positions to the target model. This is ordinary
+standard rejection sampling over a shorter prefix: no prompt, checkpoint, or
+sampling-distribution change is involved. The launcher advertises the runtime
+width to vLLM so it captures four target rows per request, while the DFlash2
+drafter keeps its eight-row graph.
+
+The pinned GLM image also retained max-K GDN/KDA metadata after selecting a
+shorter runtime K. The fail-closed `patch_gdn_runtime_width.py` backports the
+proposed active-width fix from the still-open
+[vLLM #53542](https://github.com/vllm-project/vllm/pull/53542).
+It leaves max-width storage allocated, but keeps the active four-column view
+through FULL-graph staging. On GLM this avoids eight-wide short-convolution
+metadata in 34 KDA layers during a K3 verification step.
+
+The wide-proposal/narrow-verification pattern also appears in the broader
+adaptive-verification work in [vLLM #52559](https://github.com/vllm-project/vllm/pull/52559).
+This launcher uses a smaller fixed, batch-uniform prefix because the pinned
+V2 runner and sparse-MLA backend do not support that draft PR's adaptive path.
+
+```bash
+DFLASH_TOKENS=7 DFLASH_VERIFY_TOKENS=3 ./start.sh restart
+```
+
+Only graph-aligned prefixes (`1`, `3`, `7`) are accepted. `0` is the stock
+full-width rollback. Structured-output batches deliberately retain stock
+full-width publication; the grammar-validated path is outside this optimization.
+
+On two DGX Sparks, K3 was the best of the graph-aligned prefixes tested for a
+small controlled English-prose sample:
+
+| Mode | Proposal / verify | Median decode tok/s | Observed delta vs stock 7/7 |
+| --- | ---: | ---: | ---: |
+| Speculative decoding off | — | 13.91 | -15.58% |
+| Stock DFlash2 | 7 / 7 | 16.48 | — |
+| Static narrow block | 3 / 3 | 19.25 | +16.83% |
+| Wide proposal, narrow verify | 7 / 1 | 19.29 | +17.10% |
+| Wide proposal, narrow verify | 7 / 3 | **20.04** | **+21.64%** |
+
+Each row is the median of two fixed prompts with one 512-token completion per
+prompt, temperature 1, top-p 0.95, thinking off, single-stream, and a warmed
+idle endpoint. This is a small workload-specific A/B sample, not a statistical
+claim for other prompts, languages, context lengths, or concurrency levels.
 
 ## Image / overlay
 
@@ -387,6 +434,8 @@ this Dockerfile instead. After CUDA compile, Python overlay edits
 | `overlay/patch_glm_video_placeholders.py` | align video timestamp blocks to encoder `grid_t` |
 | `overlay/patch_suppress_stops_in_reasoning.py` | fail-closed detokenizer guard: client `stop` dormant until `</think>` |
 | `overlay/patch_scheduler_decode_floor.py` | skip (or cap) peer prefill while another seq is decoding |
+| `overlay/patch_dflash2_verify_width.py` | decouple the trained DFlash2 proposal block from its batch-uniform target verification width |
+| `overlay/patch_gdn_runtime_width.py` | preserve active runtime verification width through GDN/KDA FULL-graph metadata ([vLLM #53542](https://github.com/vllm-project/vllm/pull/53542)) |
 | `scripts/boot-shape-warmup.sh` | post-`/health` DFlash2 k=7 BLOCK ladder + sampler/kpool arms |
 
 Image-build runs `EXL3_SELFCHECK_GPU=0`. `./start.sh` runs the GPU self-check
@@ -423,4 +472,3 @@ DFlash2 stays [CC BY-NC-ND 4.0](https://huggingface.co/incoai/GLM-5.3-Flash-DFla
   (CC BY-NC-ND 4.0, research/eval)
 - **KLD panel:** [malaiwah](https://huggingface.co/malaiwah) —
   [discussion #1](https://huggingface.co/brandonmusic/GLM-5.3-Flash-tr3-4bpw/discussions/1#6a9144846b0bdba943bfe86f)
-

--- a/overlay/patch_dflash2_verify_width.py
+++ b/overlay/patch_dflash2_verify_width.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Decouple DFlash2 proposal width from target verification width.
+
+DFlash2 is trained to propose a fixed parallel block.  Low-acceptance workloads
+can benefit from keeping that trained proposal intact while publishing only a
+batch-uniform prefix to the target verifier.  Standard rejection sampling is
+unchanged; this only limits how many proposal positions the scheduler sees.
+
+DFLASH_VERIFY_TOKENS:
+  0 / unset  — publish the full proposal (stock behavior)
+  N>0        — publish the first N proposal tokens
+
+The patch is deliberately fail-closed if the vLLM source anchors drift.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+P = Path(
+    os.environ.get(
+        "GLM53_DRAFT_UTILS_PY",
+        "/usr/local/lib/python3.12/dist-packages/"
+        "vllm/v1/worker/gpu/spec_decode/utils.py",
+    )
+)
+MARK = "# [glm53-dflash2-verify-width]"
+
+IMPORT_OLD = "import numpy as np\nimport torch\n"
+IMPORT_NEW = "import os\n\nimport numpy as np\nimport torch\n"
+
+SET_OLD = """    ) -> None:
+        self.req_ids = input_batch.req_ids
+        self.num_draft_tokens = draft_tokens.shape[1]
+"""
+
+SET_NEW = """    ) -> None:
+        raw_limit = os.environ.get("DFLASH_VERIFY_TOKENS", "0").strip()
+        try:
+            verify_tokens = int(raw_limit or "0")
+        except ValueError as exc:
+            raise RuntimeError(
+                f"DFLASH_VERIFY_TOKENS must be an integer, got {raw_limit!r}"
+            ) from exc
+        proposal_tokens = draft_tokens.shape[1]
+        if verify_tokens < 0 or verify_tokens > proposal_tokens:
+            raise RuntimeError(
+                "DFLASH_VERIFY_TOKENS must be 0 or between 1 and the DFlash2 "
+                f"proposal width ({proposal_tokens}), got {verify_tokens}"
+            )
+        # Grammar validation can shorten different requests by different
+        # amounts. Keep stock full width there so this overlay never introduces
+        # a new ragged batch on a UNIFORM_BATCH-only attention backend.
+        if verify_tokens and not input_batch.has_structured_output_reqs:
+            draft_tokens = draft_tokens[:, :verify_tokens]  # [glm53-dflash2-verify-width]
+        self.req_ids = input_batch.req_ids
+        self.num_draft_tokens = draft_tokens.shape[1]
+"""
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{P}: expected one {label} target, found {count}")
+    return text.replace(old, new, 1)
+
+
+def main() -> int:
+    if not P.is_file():
+        raise SystemExit(f"missing {P}")
+    text = P.read_text()
+    if MARK in text:
+        checks = {
+            "marker": text.count(MARK) == 1,
+            "patched import": text.count(IMPORT_NEW) == 1,
+            "patched DraftTokensHandler": text.count(SET_NEW) == 1,
+            "stock DraftTokensHandler removed": SET_OLD not in text,
+        }
+        failed = [label for label, ok in checks.items() if not ok]
+        if failed:
+            raise SystemExit(
+                f"{P}: incomplete or drifted existing patch: {', '.join(failed)}"
+            )
+        print(f"{P.name}: {MARK} already present — skipping")
+        return 0
+    text = replace_once(text, IMPORT_OLD, IMPORT_NEW, "import block")
+    text = replace_once(text, SET_OLD, SET_NEW, "DraftTokensHandler")
+    P.write_text(text)
+    limit = os.environ.get("DFLASH_VERIFY_TOKENS", "0") or "0"
+    print(f"patched {P.name} (DFlash2 verify tokens={limit})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/overlay/patch_gdn_runtime_width.py
+++ b/overlay/patch_gdn_runtime_width.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Preserve active runtime-K width in GDN speculative metadata.
+
+The pinned vLLM build allocates GDN state metadata for the server's maximum
+speculative width and accidentally exposes that full width after selecting a
+shorter runtime verification horizon.  GLM-5.3-Flash reads the exposed width
+as ``max_query_len`` in each KDA layer, so max K7 / runtime K3 retains K7
+kernel metadata.
+
+This is a fail-closed runtime backport of vllm-project/vllm#53542 commit
+e981ca592d9c91a7d28464c6fc7256495bcb8642 for the v0.1.dev20051+g487ecf187
+source shipped by the Mia image. The backing staging allocation remains
+max-width; only the selected/copied/returned view narrows.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+P = Path(
+    os.environ.get(
+        "GLM53_GDN_ATTN_PY",
+        "/usr/local/lib/python3.12/dist-packages/"
+        "vllm/v1/attention/backends/gdn_attn.py",
+    )
+)
+MARK = "# [glm53-gdn-runtime-width]"
+
+INIT_OLD = """        spec_sequence_masks_cpu: torch.Tensor | None = None
+        if (
+"""
+INIT_NEW = """        spec_sequence_masks_cpu: torch.Tensor | None = None
+        active_spec_width = 0  # [glm53-gdn-runtime-width]
+        if (
+"""
+
+QUERY_OLD = """            assert spec_sequence_masks_cpu is not None
+            query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+
+            # Use CPU tensors to avoid CPU-GPU sync
+"""
+QUERY_NEW = """            assert spec_sequence_masks_cpu is not None
+            query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+            # Keep max-K storage, but expose only the widest active query in
+            # this step. This is CPU metadata and introduces no GPU sync.
+            active_spec_width = int(
+                query_lens_cpu[spec_sequence_masks_cpu].max().item()
+            )
+            if not 1 < active_spec_width <= self.num_spec + 1:
+                raise RuntimeError(
+                    "invalid active GDN speculative width "
+                    f"{active_spec_width}; expected 2..{self.num_spec + 1}"
+                )
+
+            # Use CPU tensors to avoid CPU-GPU sync
+"""
+
+SELECT_OLD = """                    spec_sequence_masks_cpu, : self.num_spec + 1
+"""
+SELECT_NEW = """                    spec_sequence_masks_cpu, :active_spec_width
+"""
+
+STAGE_OLD = """            assert spec_sequence_masks is not None
+            self.spec_state_indices_tensor[:num_spec_decodes].copy_(
+                spec_state_indices_tensor, non_blocking=True
+            )
+            spec_state_indices_tensor = self.spec_state_indices_tensor[:batch_size]
+            spec_state_indices_tensor[num_spec_decodes:].fill_(NULL_BLOCK_ID)
+"""
+STAGE_NEW = """            assert spec_sequence_masks is not None
+            if active_spec_width <= 0:
+                raise RuntimeError("active GDN speculative width was not initialized")
+            self.spec_state_indices_tensor[
+                :num_spec_decodes, :active_spec_width
+            ].copy_(spec_state_indices_tensor, non_blocking=True)
+            spec_state_indices_tensor = self.spec_state_indices_tensor[
+                :batch_size, :active_spec_width
+            ]
+            spec_state_indices_tensor[num_spec_decodes:].fill_(NULL_BLOCK_ID)
+"""
+
+
+def replace_exact(text: str, old: str, new: str, count: int, label: str) -> str:
+    found = text.count(old)
+    if found != count:
+        raise SystemExit(f"{P}: expected {count} {label} target(s), found {found}")
+    return text.replace(old, new, count)
+
+
+def main() -> int:
+    if not P.is_file():
+        raise SystemExit(f"missing {P}")
+    text = P.read_text()
+    if MARK in text:
+        checks = {
+            "marker": text.count(MARK) == 1,
+            "initialization": text.count(INIT_NEW) == 1,
+            "query width": text.count(QUERY_NEW) == 1,
+            "state selections": text.count(SELECT_NEW) == 2,
+            "FULL-graph staging": text.count(STAGE_NEW) == 1,
+            "stock state selection removed": SELECT_OLD not in text,
+            "stock FULL-graph staging removed": STAGE_OLD not in text,
+        }
+        failed = [label for label, ok in checks.items() if not ok]
+        if failed:
+            raise SystemExit(
+                f"{P}: incomplete or drifted existing patch: {', '.join(failed)}"
+            )
+        print(f"{P.name}: {MARK} already present — skipping")
+        return 0
+
+    text = replace_exact(text, INIT_OLD, INIT_NEW, 1, "initialization")
+    text = replace_exact(text, QUERY_OLD, QUERY_NEW, 1, "query-width")
+    text = replace_exact(text, SELECT_OLD, SELECT_NEW, 2, "state selection")
+    text = replace_exact(text, STAGE_OLD, STAGE_NEW, 1, "FULL-graph staging")
+    P.write_text(text)
+    print(f"patched {P.name} (active runtime-K GDN metadata width)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/start.sh
+++ b/start.sh
@@ -45,6 +45,11 @@
 # ============================================================================
 set -euo pipefail
 
+log()  { printf '\033[1;36m[glm53-exl3]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[glm53-exl3]\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m[glm53-exl3]\033[0m ERROR: %s\n' "$*" >&2; exit 1; }
+
+REQUESTED_COMMAND="${1:-start}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 if [ ! -f "$SCRIPT_DIR/.env" ]; then
@@ -58,6 +63,8 @@ fi
 # Caller exports (MTP_TOKENS=2 ./start.sh restart) must win over .env.
 _cli_mtp="${MTP_TOKENS-}"
 _cli_spec="${SPEC_METHOD-}"
+_cli_dflash_tokens="${DFLASH_TOKENS-}"
+_cli_dflash_verify="${DFLASH_VERIFY_TOKENS-}"
 _cli_eager="${ENFORCE_EAGER-}"
 _cli_fused="${EXL3_FUSED_MOE-}"
 _cli_image="${IMAGE-}"
@@ -69,6 +76,8 @@ source "$SCRIPT_DIR/.env"
 set +a
 [ -n "${_cli_mtp}" ] && MTP_TOKENS="$_cli_mtp"
 [ -n "${_cli_spec}" ] && SPEC_METHOD="$_cli_spec"
+[ -n "${_cli_dflash_tokens}" ] && DFLASH_TOKENS="$_cli_dflash_tokens"
+[ -n "${_cli_dflash_verify}" ] && DFLASH_VERIFY_TOKENS="$_cli_dflash_verify"
 [ -n "${_cli_eager}" ] && ENFORCE_EAGER="$_cli_eager"
 [ -n "${_cli_fused}" ] && EXL3_FUSED_MOE="$_cli_fused"
 [ -n "${_cli_image}" ] && IMAGE="$_cli_image"
@@ -124,6 +133,9 @@ SPEC_METHOD="${SPEC_METHOD:-dflash}"
 DFLASH_MODEL="${DFLASH_MODEL:-incoai/GLM-5.3-Flash-DFlash2}"
 DFLASH_CACHE_NAME="${DFLASH_CACHE_NAME:-models--${DFLASH_MODEL//\//--}}"
 DFLASH_TOKENS="${DFLASH_TOKENS:-7}"
+# Keep the trained proposal block at DFLASH_TOKENS while publishing only this
+# many positions to the target verifier. 0 preserves stock full-width behavior.
+DFLASH_VERIFY_TOKENS="${DFLASH_VERIFY_TOKENS:-0}"
 # 1 = keep the ~2.3 GiB drafter on rank 0 (no CX7 on every draft step).
 # Empty = inherit target TP. Do not pin attention_backend: SM121 already
 # prefers FLASH_ATTN for non-causal dense SWA. TRITON_ATTN was an SM120
@@ -132,6 +144,26 @@ DFLASH_DRAFT_TP="${DFLASH_DRAFT_TP-1}"
 MAX_MODEL_LEN="${MAX_MODEL_LEN:-1000000}"
 GPU_MEM_UTIL="${GPU_MEM_UTIL:-0.87}"
 MAX_NUM_SEQS="${MAX_NUM_SEQS:-4}"
+if [ "$REQUESTED_COMMAND" = "start" ] || [ "$REQUESTED_COMMAND" = "restart" ]; then
+    [[ "$MAX_NUM_SEQS" =~ ^[1-9][0-9]*$ ]] \
+        || die "MAX_NUM_SEQS must be a positive integer"
+    [ "$MAX_NUM_SEQS" -le 64 ] \
+        || die "MAX_NUM_SEQS must be at most 64 for bounded graph capture"
+    if [ "$SPEC_METHOD" = "dflash" ]; then
+        [[ "$DFLASH_TOKENS" =~ ^[1-9][0-9]*$ ]] \
+            || die "DFLASH_TOKENS must be a positive integer"
+        [[ "$DFLASH_VERIFY_TOKENS" =~ ^(0|[1-9][0-9]*)$ ]] \
+            || die "DFLASH_VERIFY_TOKENS must be 0 or a positive integer"
+        [ "$DFLASH_VERIFY_TOKENS" -le "$DFLASH_TOKENS" ] \
+            || die "DFLASH_VERIFY_TOKENS cannot exceed DFLASH_TOKENS"
+        case "$DFLASH_VERIFY_TOKENS" in
+            0|1|3|7) ;;
+            *) die "DFLASH_VERIFY_TOKENS must be a graph-aligned prefix: 0, 1, 3, or 7" ;;
+        esac
+    elif [ "$DFLASH_VERIFY_TOKENS" != "0" ]; then
+        die "DFLASH_VERIFY_TOKENS is only valid with SPEC_METHOD=dflash"
+    fi
+fi
 # 8192 chunk × long history oversubscribes GB10 persistent_topk smem (300k crash).
 MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-1024}"
 CHAT_TEMPLATE_HOST="${CHAT_TEMPLATE_HOST:-$SCRIPT_DIR/files/chat_template.jinja}"
@@ -141,6 +173,8 @@ STOP_PATCH_HOST="${STOP_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_suppress_stops_in_
 SCHED_PATCH_HOST="${SCHED_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_scheduler_decode_floor.py}"
 DRAFTER_PATCH_HOST="${DRAFTER_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm5_drafter_group.py}"
 APC_PATCH_HOST="${APC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_hybrid_prefix_hit.py}"
+DFLASH_VERIFY_PATCH_HOST="${DFLASH_VERIFY_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_dflash2_verify_width.py}"
+GDN_RUNTIME_PATCH_HOST="${GDN_RUNTIME_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_gdn_runtime_width.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
 QUANTIZATION="${QUANTIZATION:-exl3}"
 LANGUAGE_MODEL_ONLY="${LANGUAGE_MODEL_ONLY:-0}"
@@ -155,12 +189,27 @@ FLASHINFER_CUDA_ARCH_LIST="${FLASHINFER_CUDA_ARCH_LIST:-12.1a}"
 # 1..4 seqs × 3 tokens (must include 3). DFlash2 k=7 is 1..4 seqs × 8 tokens
 # (must include 8, 16, 24, 32).
 ENFORCE_EAGER="${ENFORCE_EAGER:-0}"
-if [ "${ENFORCE_EAGER}" != "1" ]; then
+if { [ "$REQUESTED_COMMAND" = "start" ] || [ "$REQUESTED_COMMAND" = "restart" ]; } \
+    && [ "${ENFORCE_EAGER}" != "1" ]; then
     case " ${EXTRA_ARGS:-} " in
         *" --cudagraph-capture-sizes "*|*" cudagraph-capture-sizes "*) ;;
         *)
             if [ "$SPEC_METHOD" = "dflash" ]; then
-                EXTRA_ARGS="${EXTRA_ARGS:+$EXTRA_ARGS }--cudagraph-capture-sizes 1 2 4 8 16 24 32"
+                # DFlash proposes its full trained block, but an optional
+                # uniform verification prefix changes target rows/request.
+                # Capture those exact totals for every supported concurrency.
+                _dflash_capture_sizes=(1 2 4 8 16 24 32)
+                _dflash_target_k="$DFLASH_TOKENS"
+                [ "$DFLASH_VERIFY_TOKENS" -gt 0 ] \
+                    && _dflash_target_k="$DFLASH_VERIFY_TOKENS"
+                for ((_capture_c = 1; _capture_c <= MAX_NUM_SEQS; _capture_c++)); do
+                    _capture_seen_size=$((_capture_c * (_dflash_target_k + 1)))
+                    _dflash_capture_sizes+=("$_capture_seen_size")
+                done
+                _dflash_capture_list="$(
+                    printf '%s\n' "${_dflash_capture_sizes[@]}" | sort -nu | paste -sd' ' -
+                )"
+                EXTRA_ARGS="${EXTRA_ARGS:+$EXTRA_ARGS }--cudagraph-capture-sizes ${_dflash_capture_list}"
             else
                 EXTRA_ARGS="${EXTRA_ARGS:+$EXTRA_ARGS }--cudagraph-capture-sizes 1 2 3 4 6 8 12"
             fi
@@ -208,9 +257,6 @@ WORKER_SCRIPT="$SCRIPT_DIR/.glm53-exl3-worker.inner.sh"
 EXPECTED_SHARDS="${EXPECTED_SHARDS:-120}"
 
 # ------------------------------- helpers -----------------------------------
-log()  { printf '\033[1;36m[glm53-exl3]\033[0m %s\n' "$*"; }
-warn() { printf '\033[1;33m[glm53-exl3]\033[0m %s\n' "$*" >&2; }
-die()  { printf '\033[1;31m[glm53-exl3]\033[0m ERROR: %s\n' "$*" >&2; exit 1; }
 
 banner() {
     local label="${1:-start.sh}"
@@ -300,7 +346,6 @@ preflight() {
 
     [ "$TP" = "2" ] || warn "TP=${TP} on a 2×1-GPU cluster — expected TP=2"
     [ "$NNODES" = "2" ] || warn "NNODES=${NNODES} — expected 2"
-
     local others
     others=$(worker_ssh "docker ps --format '  {{.Names}}  ({{.Image}})'" 2>/dev/null | grep -v "^  ${CONTAINER_WORKER}" || true)
     if [ -n "$others" ]; then
@@ -316,6 +361,10 @@ preflight() {
     [ -f "$SCHED_PATCH_HOST" ] || die "$SCHED_PATCH_HOST missing"
     [ -f "$DRAFTER_PATCH_HOST" ] || die "$DRAFTER_PATCH_HOST missing"
     [ -f "$APC_PATCH_HOST" ] || die "$APC_PATCH_HOST missing"
+    if [ "$SPEC_METHOD" = "dflash" ] && [ "$DFLASH_VERIFY_TOKENS" -gt 0 ]; then
+        [ -f "$DFLASH_VERIFY_PATCH_HOST" ] || die "$DFLASH_VERIFY_PATCH_HOST missing"
+        [ -f "$GDN_RUNTIME_PATCH_HOST" ] || die "$GDN_RUNTIME_PATCH_HOST missing"
+    fi
 
     local need_kb=$((180 * 1024 * 1024)) avail
     mkdir -p "$HF_CACHE_DIR"
@@ -678,6 +727,9 @@ spec={"method":"dflash","model":os.environ["DFLASH_MODEL_DIR"],"num_speculative_
 tp=os.environ.get("DFLASH_DRAFT_TP","").strip()
 if tp:
     spec["draft_tensor_parallel_size"]=int(tp)
+verify=int(os.environ.get("DFLASH_VERIFY_TOKENS","0"))
+if verify:
+    spec["num_speculative_tokens_per_batch_size"]=[[1,int(os.environ["MAX_NUM_SEQS"]),verify]]
 print(json.dumps(spec,separators=(",",":")))')")
 elif [ "${SPEC_METHOD:-mtp}" = "none" ]; then
     :
@@ -716,6 +768,10 @@ if [ -f /opt/glm53/patch_glm5_drafter_group.py ]; then
 fi
 if [ -f /opt/glm53/patch_hybrid_prefix_hit.py ]; then
     python3 /opt/glm53/patch_hybrid_prefix_hit.py
+fi
+if [ "${SPEC_METHOD:-}" = "dflash" ] && [ "${DFLASH_VERIFY_TOKENS:-0}" -gt 0 ]; then
+    python3 /opt/glm53/patch_dflash2_verify_width.py
+    python3 /opt/glm53/patch_gdn_runtime_width.py
 fi
 say "launching: vllm serve ${MODEL_DIR} ${ARGS[*]}"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
@@ -756,6 +812,9 @@ spec={"method":"dflash","model":os.environ["DFLASH_MODEL_DIR"],"num_speculative_
 tp=os.environ.get("DFLASH_DRAFT_TP","").strip()
 if tp:
     spec["draft_tensor_parallel_size"]=int(tp)
+verify=int(os.environ.get("DFLASH_VERIFY_TOKENS","0"))
+if verify:
+    spec["num_speculative_tokens_per_batch_size"]=[[1,int(os.environ["MAX_NUM_SEQS"]),verify]]
 print(json.dumps(spec,separators=(",",":")))')")
 elif [ "${SPEC_METHOD:-mtp}" = "none" ]; then
     :
@@ -793,6 +852,10 @@ fi
 if [ -f /opt/glm53/patch_hybrid_prefix_hit.py ]; then
     python3 /opt/glm53/patch_hybrid_prefix_hit.py
 fi
+if [ "${SPEC_METHOD:-}" = "dflash" ] && [ "${DFLASH_VERIFY_TOKENS:-0}" -gt 0 ]; then
+    python3 /opt/glm53/patch_dflash2_verify_width.py
+    python3 /opt/glm53/patch_gdn_runtime_width.py
+fi
 say "joining TP2 at ${HEAD_IP}:${MASTER_PORT} as rank 1"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -819,6 +882,19 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$DRAFTER_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_glm5_drafter_group.py"
     [ -f "$APC_PATCH_HOST" ] || die "missing $APC_PATCH_HOST"
     scp -q -o BatchMode=yes "$APC_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_hybrid_prefix_hit.py"
+    local -a head_width_mounts=()
+    local worker_width_mounts=""
+    if [ "$SPEC_METHOD" = "dflash" ] && [ "$DFLASH_VERIFY_TOKENS" -gt 0 ]; then
+        [ -f "$DFLASH_VERIFY_PATCH_HOST" ] || die "missing $DFLASH_VERIFY_PATCH_HOST"
+        scp -q -o BatchMode=yes "$DFLASH_VERIFY_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_dflash2_verify_width.py"
+        [ -f "$GDN_RUNTIME_PATCH_HOST" ] || die "missing $GDN_RUNTIME_PATCH_HOST"
+        scp -q -o BatchMode=yes "$GDN_RUNTIME_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_gdn_runtime_width.py"
+        head_width_mounts=(
+            -v "$DFLASH_VERIFY_PATCH_HOST:/opt/glm53/patch_dflash2_verify_width.py:ro"
+            -v "$GDN_RUNTIME_PATCH_HOST:/opt/glm53/patch_gdn_runtime_width.py:ro"
+        )
+        worker_width_mounts="-v '/tmp/patch_dflash2_verify_width.py:/opt/glm53/patch_dflash2_verify_width.py:ro' -v '/tmp/patch_gdn_runtime_width.py:/opt/glm53/patch_gdn_runtime_width.py:ro'"
+    fi
 
     local -a nccl_common=(
         -e NCCL_IB_DISABLE=0
@@ -878,7 +954,7 @@ launch_cluster() {
     for v in SERVED_MODEL_NAME PORT TP NNODES HEAD_IP MASTER_PORT QUANTIZATION \
              MAX_MODEL_LEN GPU_MEM_UTIL MAX_NUM_SEQS MAX_NUM_BATCHED_TOKENS \
              KV_CACHE_DTYPE MTP_TOKENS SPEC_METHOD DFLASH_TOKENS DFLASH_MODEL_DIR \
-             DFLASH_DRAFT_TP \
+             DFLASH_DRAFT_TP DFLASH_VERIFY_TOKENS \
              LANGUAGE_MODEL_ONLY SKIP_MM_PROFILING \
              LIMIT_MM CHAT_TEMPLATE ENFORCE_EAGER EXL3_FUSED_MOE MODEL_DIR EXTRA_ARGS; do
         serve_env+=" -e $v='${!v:-}'"
@@ -900,6 +976,7 @@ launch_cluster() {
         -v '/tmp/patch_scheduler_decode_floor.py:/opt/glm53/patch_scheduler_decode_floor.py:ro' \
         -v '/tmp/patch_glm5_drafter_group.py:/opt/glm53/patch_glm5_drafter_group.py:ro' \
         -v '/tmp/patch_hybrid_prefix_hit.py:/opt/glm53/patch_hybrid_prefix_hit.py:ro' \
+        ${worker_width_mounts} \
         ${worker_preload} \
         ${worker_nccl} \
         -e NCCL_SOCKET_IFNAME='$WORKER_CX7_IF' \
@@ -925,6 +1002,7 @@ launch_cluster() {
         -v "$SCHED_PATCH_HOST:/opt/glm53/patch_scheduler_decode_floor.py:ro" \
         -v "$DRAFTER_PATCH_HOST:/opt/glm53/patch_glm5_drafter_group.py:ro" \
         -v "$APC_PATCH_HOST:/opt/glm53/patch_hybrid_prefix_hit.py:ro" \
+        "${head_width_mounts[@]}" \
         "${head_preload[@]}" \
         "${nccl_common[@]}" \
         -e NCCL_SOCKET_IFNAME="$HEAD_CX7_IF" \
@@ -943,6 +1021,7 @@ launch_cluster() {
         -e DFLASH_TOKENS="${DFLASH_TOKENS:-7}" \
         -e DFLASH_MODEL_DIR="${DFLASH_MODEL_DIR:-}" \
         -e DFLASH_DRAFT_TP="${DFLASH_DRAFT_TP:-}" \
+        -e DFLASH_VERIFY_TOKENS="${DFLASH_VERIFY_TOKENS:-0}" \
         -e LANGUAGE_MODEL_ONLY="$LANGUAGE_MODEL_ONLY" \
         -e SKIP_MM_PROFILING="$SKIP_MM_PROFILING" \
         -e LIMIT_MM="$LIMIT_MM" \
@@ -1028,7 +1107,12 @@ on_ready() {
     local vision=on
     [ "${LANGUAGE_MODEL_ONLY}" = "1" ] && vision=off
     local spec="MTP k=${MTP_TOKENS}"
-    [ "$SPEC_METHOD" = "dflash" ] && spec="DFlash2 k=${DFLASH_TOKENS} (${DFLASH_MODEL})"
+    if [ "$SPEC_METHOD" = "dflash" ]; then
+        spec="DFlash2 draft k=${DFLASH_TOKENS}"
+        [ "${DFLASH_VERIFY_TOKENS:-0}" -gt 0 ] \
+            && spec+=" / verify k=${DFLASH_VERIFY_TOKENS}"
+        spec+=" (${DFLASH_MODEL})"
+    fi
     [ "$SPEC_METHOD" = "none" ] && spec=off
     log "  features   : tools=glm47+auto, reasoning=glm45, spec=${spec}, vision=${vision}"
     log "  quick test :"
@@ -1061,7 +1145,7 @@ start() {
         log "DFlash2 load path (in-container): ${DFLASH_MODEL_DIR}"
     fi
     log "model load path (in-container): ${MODEL_DIR}"
-    log "config: image=${IMAGE} tp=${TP} nnodes=${NNODES} quant=${QUANTIZATION} spec=${SPEC_METHOD} mtp=${MTP_TOKENS} dflash_k=${DFLASH_TOKENS} max-len=${MAX_MODEL_LEN} gpu-util=${GPU_MEM_UTIL} kv=${KV_CACHE_DTYPE} lm-only=${LANGUAGE_MODEL_ONLY} port=${PORT}"
+    log "config: image=${IMAGE} tp=${TP} nnodes=${NNODES} quant=${QUANTIZATION} spec=${SPEC_METHOD} mtp=${MTP_TOKENS} dflash_k=${DFLASH_TOKENS} dflash_verify_k=${DFLASH_VERIFY_TOKENS} max-len=${MAX_MODEL_LEN} gpu-util=${GPU_MEM_UTIL} kv=${KV_CACHE_DTYPE} lm-only=${LANGUAGE_MODEL_ONLY} port=${PORT}"
 
     launch_cluster
     if wait_for_health; then

--- a/tests/test_dflash2_verify_width.py
+++ b/tests/test_dflash2_verify_width.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Unit-test the fail-closed DFlash2 verification-width runtime patch."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+PATCH = HERE.parent / "overlay" / "patch_dflash2_verify_width.py"
+
+FIXTURE = '''from __future__ import annotations
+
+import numpy as np
+import torch
+
+
+class DraftTokensHandler:
+    def set_draft_tokens(
+        self, input_batch: InputBatch, draft_tokens: torch.Tensor
+    ) -> None:
+        self.req_ids = input_batch.req_ids
+        self.num_draft_tokens = draft_tokens.shape[1]
+        if not input_batch.has_structured_output_reqs:
+            self.draft_tokens_np = None
+            return
+        self.draft_tokens_np = draft_tokens
+'''
+
+
+class FakeTensor:
+    def __init__(self, rows: list[list[int]]):
+        self.rows = rows
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        return len(self.rows), len(self.rows[0])
+
+    def __getitem__(self, key):
+        row_sel, col_sel = key
+        assert row_sel == slice(None)
+        return FakeTensor([row[col_sel] for row in self.rows])
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        dst = Path(tmp) / "utils.py"
+        dst.write_text(FIXTURE)
+        env = os.environ.copy()
+        env["GLM53_DRAFT_UTILS_PY"] = str(dst)
+        env["DFLASH_VERIFY_TOKENS"] = "3"
+        subprocess.check_call([sys.executable, str(PATCH)], env=env)
+        text = dst.read_text()
+        assert text.count("[glm53-dflash2-verify-width]") == 1
+        assert 'draft_tokens = draft_tokens[:, :verify_tokens]' in text
+        assert 'self.num_draft_tokens = draft_tokens.shape[1]' in text
+        compile(text, str(dst), "exec")
+
+        # Execute the patched method with dependency stubs. Ordinary batches
+        # publish a uniform prefix; structured batches retain full width.
+        fake_np = types.ModuleType("numpy")
+        fake_torch = types.ModuleType("torch")
+        fake_torch.Tensor = FakeTensor
+        old_np = sys.modules.get("numpy")
+        old_torch = sys.modules.get("torch")
+        sys.modules["numpy"] = fake_np
+        sys.modules["torch"] = fake_torch
+        try:
+            namespace: dict[str, object] = {}
+            exec(compile(text, str(dst), "exec"), namespace)
+        finally:
+            if old_np is None:
+                del sys.modules["numpy"]
+            else:
+                sys.modules["numpy"] = old_np
+            if old_torch is None:
+                del sys.modules["torch"]
+            else:
+                sys.modules["torch"] = old_torch
+
+        handler_cls = namespace["DraftTokensHandler"]
+        tensor = FakeTensor([list(range(7)), list(range(10, 17))])
+        ordinary = types.SimpleNamespace(
+            req_ids=["a", "b"], has_structured_output_reqs=False
+        )
+        old_verify = os.environ.get("DFLASH_VERIFY_TOKENS")
+        os.environ["DFLASH_VERIFY_TOKENS"] = "3"
+        try:
+            handler = handler_cls()
+            handler.set_draft_tokens(ordinary, tensor)
+            assert handler.num_draft_tokens == 3
+
+            os.environ["DFLASH_VERIFY_TOKENS"] = "0"
+            handler = handler_cls()
+            handler.set_draft_tokens(ordinary, tensor)
+            assert handler.num_draft_tokens == 7
+
+            os.environ["DFLASH_VERIFY_TOKENS"] = "8"
+            handler = handler_cls()
+            try:
+                handler.set_draft_tokens(ordinary, tensor)
+            except RuntimeError as exc:
+                assert "proposal width (7)" in str(exc)
+            else:
+                raise AssertionError("out-of-range verification width was accepted")
+
+            os.environ["DFLASH_VERIFY_TOKENS"] = "not-an-integer"
+            handler = handler_cls()
+            try:
+                handler.set_draft_tokens(ordinary, tensor)
+            except RuntimeError as exc:
+                assert "must be an integer" in str(exc)
+            else:
+                raise AssertionError("non-integer verification width was accepted")
+
+            os.environ["DFLASH_VERIFY_TOKENS"] = "3"
+            structured = types.SimpleNamespace(
+                req_ids=["a", "b"], has_structured_output_reqs=True
+            )
+            handler = handler_cls()
+            handler.set_draft_tokens(structured, tensor)
+            assert handler.num_draft_tokens == 7
+            assert handler.draft_tokens_np.shape == (2, 7)
+        finally:
+            if old_verify is None:
+                del os.environ["DFLASH_VERIFY_TOKENS"]
+            else:
+                os.environ["DFLASH_VERIFY_TOKENS"] = old_verify
+
+        # Applying the overlay twice must not duplicate it.
+        subprocess.check_call([sys.executable, str(PATCH)], env=env)
+        assert dst.read_text().count("[glm53-dflash2-verify-width]") == 1
+
+        # A stray marker must not bypass validation of the complete patch.
+        incomplete = Path(tmp) / "incomplete.py"
+        incomplete.write_text(text.replace("        self.req_ids = input_batch.req_ids\n", "", 1))
+        env["GLM53_DRAFT_UTILS_PY"] = str(incomplete)
+        result = subprocess.run(
+            [sys.executable, str(PATCH)], env=env, capture_output=True, text=True
+        )
+        assert result.returncode != 0
+        assert "incomplete or drifted existing patch" in result.stderr
+
+        # Anchor drift must fail rather than silently run without the limit.
+        drifted = Path(tmp) / "drifted.py"
+        drifted.write_text("import numpy as np\nimport torch\n")
+        env["GLM53_DRAFT_UTILS_PY"] = str(drifted)
+        result = subprocess.run(
+            [sys.executable, str(PATCH)], env=env, capture_output=True, text=True
+        )
+        assert result.returncode != 0
+        assert "expected one DraftTokensHandler target" in result.stderr
+
+    print("DFlash2 verification-width patch OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gdn_runtime_width.py
+++ b/tests/test_gdn_runtime_width.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Unit-test the fail-closed active runtime-K GDN metadata backport."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+PATCH = HERE.parent / "overlay" / "patch_gdn_runtime_width.py"
+
+FIXTURE = '''class Builder:
+    def build(self):
+        spec_sequence_masks_cpu: torch.Tensor | None = None
+        if (
+            enabled
+        ):
+            pass
+
+        if spec_sequence_masks is None:
+            pass
+        else:
+            query_lens = query_start_loc[1:] - query_start_loc[:-1]
+            assert spec_sequence_masks_cpu is not None
+            query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+
+            # Use CPU tensors to avoid CPU-GPU sync
+            non_spec_query_lens_cpu = query_lens_cpu[~spec_sequence_masks_cpu]
+
+            if pure_spec:
+                spec_state_indices_tensor = block_table_tensor[
+                    spec_sequence_masks_cpu, : self.num_spec + 1
+                ]
+            else:
+                spec_state_indices_tensor = block_table_tensor[
+                    spec_sequence_masks_cpu, : self.num_spec + 1
+                ]
+
+        if full_graph:
+            assert spec_sequence_masks is not None
+            self.spec_state_indices_tensor[:num_spec_decodes].copy_(
+                spec_state_indices_tensor, non_blocking=True
+            )
+            spec_state_indices_tensor = self.spec_state_indices_tensor[:batch_size]
+            spec_state_indices_tensor[num_spec_decodes:].fill_(NULL_BLOCK_ID)
+'''
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        dst = Path(tmp) / "gdn_attn.py"
+        dst.write_text(FIXTURE)
+        env = os.environ.copy()
+        env["GLM53_GDN_ATTN_PY"] = str(dst)
+
+        subprocess.check_call([sys.executable, str(PATCH)], env=env)
+        text = dst.read_text()
+        assert text.count("[glm53-gdn-runtime-width]") == 1
+        assert text.count(":active_spec_width") == 4
+        assert text.count(": self.num_spec + 1") == 0
+        assert "query_lens_cpu[spec_sequence_masks_cpu].max().item()" in text
+        assert ":num_spec_decodes, :active_spec_width" in text
+        assert ":batch_size, :active_spec_width" in text
+        compile(text, str(dst), "exec")
+
+        # Applying twice is safe and does not duplicate the backport.
+        subprocess.check_call([sys.executable, str(PATCH)], env=env)
+        assert dst.read_text().count("[glm53-gdn-runtime-width]") == 1
+
+        # A stray marker must not bypass validation of the complete backport.
+        incomplete = Path(tmp) / "incomplete.py"
+        incomplete.write_text(
+            text.replace("                :batch_size, :active_spec_width\n", "", 1)
+        )
+        env["GLM53_GDN_ATTN_PY"] = str(incomplete)
+        result = subprocess.run(
+            [sys.executable, str(PATCH)],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "incomplete or drifted existing patch" in result.stderr
+
+        # Any source drift fails rather than silently leaving max-K metadata.
+        drifted = Path(tmp) / "drifted.py"
+        drifted.write_text("spec_sequence_masks_cpu = None\n")
+        env["GLM53_GDN_ATTN_PY"] = str(drifted)
+        result = subprocess.run(
+            [sys.executable, str(PATCH)],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "expected 1 initialization target" in result.stderr
+
+    print("GDN active runtime-K width patch OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_start_overrides.py
+++ b/tests/test_start_overrides.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Regression test for caller overrides that must win over ``.env``."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _config_preamble() -> str:
+    source = (ROOT / "start.sh").read_text()
+    marker = "# ----------------------------- configuration -------------------------------"
+    preamble, separator, _rest = source.partition(marker)
+    assert separator, "start.sh configuration marker is missing"
+    return preamble
+
+
+def _configuration_fragment() -> str:
+    source = (ROOT / "start.sh").read_text()
+    marker = "# 1 = fused exl3_moe (decode)."
+    fragment, separator, _rest = source.partition(marker)
+    assert separator, "start.sh post-graph configuration marker is missing"
+    return fragment
+
+
+def _run_configuration(
+    env_overrides: dict[str, str], command: str = "start"
+) -> subprocess.CompletedProcess[str]:
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        tmp = Path(raw_tmp)
+        script = tmp / "start.sh"
+        script.write_text(
+            _configuration_fragment()
+            + '\nprintf "EXTRA_ARGS=%s\\n" "${EXTRA_ARGS:-}"\n'
+        )
+        script.chmod(0o755)
+        settings = {
+            "DFLASH_TOKENS": "7",
+            "DFLASH_VERIFY_TOKENS": "0",
+            "MAX_NUM_SEQS": "4",
+        }
+        settings.update(env_overrides)
+        (tmp / ".env").write_text(
+            "".join(f"{key}={value}\n" for key, value in settings.items())
+        )
+        env = os.environ.copy()
+        for key in settings:
+            env.pop(key, None)
+        return subprocess.run(
+            ["bash", str(script), command], capture_output=True, text=True, env=env
+        )
+
+
+def test_dflash_inline_overrides_win() -> None:
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        tmp = Path(raw_tmp)
+        script = tmp / "start.sh"
+        script.write_text(
+            _config_preamble()
+            + '\nprintf "DFLASH_TOKENS=%s DFLASH_VERIFY_TOKENS=%s\\n" '
+            '"${DFLASH_TOKENS:-unset}" "${DFLASH_VERIFY_TOKENS:-unset}"\n'
+        )
+        script.chmod(0o755)
+        (tmp / ".env").write_text(
+            "DFLASH_TOKENS=7\nDFLASH_VERIFY_TOKENS=0\n"
+        )
+
+        env = os.environ.copy()
+        env["DFLASH_TOKENS"] = "3"
+        env["DFLASH_VERIFY_TOKENS"] = "1"
+        result = subprocess.run(
+            ["bash", str(script)],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    assert result.stdout.strip() == "DFLASH_TOKENS=3 DFLASH_VERIFY_TOKENS=1"
+
+
+def test_verify_width_is_advertised_to_cuda_graph_manager() -> None:
+    source = (ROOT / "start.sh").read_text()
+    assignment = (
+        'spec["num_speculative_tokens_per_batch_size"]='
+        '[[1,int(os.environ["MAX_NUM_SEQS"]),verify]]'
+    )
+    # The head and worker must construct byte-equivalent speculative configs.
+    assert source.count(assignment) == 2
+
+
+def test_runtime_width_capture_sizes_and_early_validation() -> None:
+    result = _run_configuration(
+        {
+            "DFLASH_TOKENS": "7",
+            "DFLASH_VERIFY_TOKENS": "3",
+            "MAX_NUM_SEQS": "5",
+        }
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == (
+        "EXTRA_ARGS=--cudagraph-capture-sizes 1 2 4 8 12 16 20 24 32"
+    )
+
+    for variable, value, expected in (
+        ("DFLASH_VERIFY_TOKENS", "wat", "must be 0 or a positive integer"),
+        ("DFLASH_VERIFY_TOKENS", "2", "must be a graph-aligned prefix"),
+        ("MAX_NUM_SEQS", "0", "must be a positive integer"),
+        ("MAX_NUM_SEQS", "65", "must be at most 64"),
+    ):
+        result = _run_configuration({variable: value})
+        assert result.returncode != 0
+        assert expected in result.stderr
+
+    # Malformed launch tuning must never block recovery/status subcommands.
+    result = _run_configuration(
+        {"DFLASH_TOKENS": "wat", "DFLASH_VERIFY_TOKENS": "also-wat"},
+        command="stop",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "EXTRA_ARGS="
+
+    # An irrelevant DFlash proposal value must not block an MTP rollback.
+    result = _run_configuration(
+        {"SPEC_METHOD": "mtp", "DFLASH_TOKENS": "wat"}
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_runtime_width_patches_are_wired_to_both_ranks() -> None:
+    source = (ROOT / "start.sh").read_text()
+    for patch_name in (
+        "patch_dflash2_verify_width.py",
+        "patch_gdn_runtime_width.py",
+    ):
+        assert source.count(f"python3 /opt/glm53/{patch_name}") == 2
+        assert source.count(f"/opt/glm53/{patch_name}:ro") == 2
+
+
+if __name__ == "__main__":
+    test_dflash_inline_overrides_win()
+    test_verify_width_is_advertised_to_cuda_graph_manager()
+    test_runtime_width_capture_sizes_and_early_validation()
+    test_runtime_width_patches_are_wired_to_both_ranks()
+    print("start.sh caller override regression OK")


### PR DESCRIPTION
## Summary

- add opt-in `DFLASH_VERIFY_TOKENS={1,3,7}` while DFlash2 retains its trained `DFLASH_TOKENS=7` proposal block
- publish one batch-uniform proposal prefix to the target and advertise the same width through vLLM's native target-graph schedule
- backport the active runtime-width GDN/KDA metadata fix proposed in vLLM PR #53542 for the exact pinned image source
- preserve `DFLASH_VERIFY_TOKENS=0` as an exact stock/full-width rollback: the new overlays are neither mounted nor applied
- keep structured-output publication on the existing stock path
- preserve inline DFlash overrides over `.env`, validate before graph arithmetic, and generate all required capture sizes up to the configured concurrency

This is a small graph-aligned integration for the pinned GLM/V2/sparse-MLA stack, not a new speculative-decoding algorithm. The wide-proposal/narrow-verification pattern has upstream prior art in the still-open adaptive-verification PR #52559.

## Controlled A/B

Two DGX Sparks, TP=2, `max_num_seqs=2`, EXL3 target, FP8 target KV, DFlash2 draft TP=1. Each row is the median of two fixed English-prose prompts with one 512-token completion per prompt, temperature 1, top-p 0.95, thinking off, single stream, and a warmed idle endpoint.

| Mode | Proposal / verify | Median decode tok/s | Observed delta vs stock 7/7 |
| --- | ---: | ---: | ---: |
| Speculative decoding off | — | 13.91 | -15.58% |
| Stock DFlash2 | 7 / 7 | 16.48 | — |
| Static narrow block | 3 / 3 | 19.25 | +16.83% |
| Wide proposal, narrow verify | 7 / 1 | 19.29 | +17.10% |
| Wide proposal, narrow verify | 7 / 3 | **20.04** | **+21.64%** |

Both final 7/3 prompts improved over stock (+22.25%, +21.03%) and static 3/3 (+4.49%, +3.74%). This is deliberately reported as a small workload-specific observation, not a population estimate or a claim about other prompts, languages, concurrency, or hardware.

A two-prompt code smoke had a +4.44% median but mixed per-prompt movement (-4.19%, +14.27%), so this PR does **not** claim a code speedup. The GDN backport's independent timing contribution is also not isolated; it is included as the active-width correctness fix and validated as part of the final stack.

## Correctness and rollback

The target still performs ordinary standard rejection sampling over the published prefix, so the sampling distribution is unchanged by construction. This stack was not bitwise repeatable across identical temperature-0 runs, so output hashes are not presented as a proof of equivalence.

Live validation on the final 7/3 server:

- ordinary requests published exactly 3 draft tokens per verification step (687 / 229)
- strict JSON-schema output returned the exact requested 1..40 sequence
- required tool choice returned `get_weather({"city":"Warsaw"})`
- structured output retained stock grammar handling without an error
- head and worker were healthy with zero container restarts
- corrected proposal-k=7 boot warmup passed 13/13 requests, including concurrency 2
- observed GPU peaks were 67 C / 61 C; the run used a 90 C pause threshold and never approached it

## Tests

```text
python3 tests/test_dflash2_verify_width.py
python3 tests/test_gdn_runtime_width.py
python3 tests/test_start_overrides.py
bash -n start.sh
python3 -m compileall -q overlay tests
git diff --check
```

The tests cover fixture application, idempotence, incomplete-marker rejection, source-drift failure, ordinary/structured publication behavior, invalid widths, stock rollback, caller-over-`.env` precedence, dynamic graph sizes beyond 32, recovery subcommands with malformed tuning, and wiring on both TP ranks. The image's live GPU overlay self-check also passed on both nodes.

## Upstream references

- vLLM adaptive verification (open draft): https://github.com/vllm-project/vllm/pull/52559
- vLLM active runtime-K GDN metadata fix (open): https://github.com/vllm-project/vllm/pull/53542
