### PR TITLE
preflight: validate NCCL_IB_GID_INDEX on both nodes; document other-kit setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,10 +12,20 @@ WORKER_IP=10.0.0.2
 
 # Direct CX7 QSFP (spark1 f1 ↔ spark2 f0 on this kit). NCCL cannot use the
 # 10.0.0.x loopback aliases — without these pins ncclCommInitRank hangs.
+# Other kits: names differ (e.g. enP2p1s0f1np1/roceP2p1s0f1 on both nodes of
+# some Spark pairs) — list yours with `ls /sys/class/infiniband` + `ip -br a`.
+# These per-node values are what the containers get; exporting generic
+# NCCL_SOCKET_IFNAME / NCCL_IB_HCA does NOT override them.
 HEAD_CX7_IF=enp1s0f1np1
 WORKER_CX7_IF=enp1s0f0np0
 HEAD_CX7_IB=rocep1s0f1
 WORKER_CX7_IB=rocep1s0f0
+# NCCL_IB_GID_INDEX (default 3) must be a POPULATED entry on BOTH devices —
+# some pairs have gid 3 all-zero on one node, which kills the worker rank
+# ~60 s in (ibv_modify_qp errno 61). preflight now verifies this. Inspect:
+#   cat /sys/class/infiniband/<dev>/ports/1/gids/{0,1,2,3}
+# and pick the index carrying the ::ffff:<ip> RoCEv2 entry on both nodes.
+# NCCL_IB_GID_INDEX=2
 
 # --- weights -----------------------------------------------------------
 # Durable public mirror (same bytes as brandonmusic snapshot 5ab363a8).

--- a/README.md
+++ b/README.md
@@ -301,6 +301,27 @@ Mixed OS accounts: set `WORKER_USER` (this kit uses `zurih` on spark2).
 NCCL cannot use the `10.0.0.x` loopback aliases — leave the CX7 pins unless
 your cabling differs. `ncclCommInitRank` hangs without them.
 
+## Running on a different 2×Spark kit
+
+Independently reproduced on a second GB10 pair (2026-08-28) — decode within the
+same bands (structured 38–62, prose 27.1) after three kit-specific adjustments
+that are now documented/enforced:
+
+- **NIC names differ per kit.** Set all four of `HEAD_CX7_IF/IB`,
+  `WORKER_CX7_IF/IB` in `.env` (some pairs use the same names on both nodes,
+  e.g. `enP2p1s0f1np1`/`roceP2p1s0f1`). Exporting generic
+  `NCCL_SOCKET_IFNAME`/`NCCL_IB_HCA` does **not** override the per-node values.
+- **`NCCL_IB_GID_INDEX` (default 3) may be an all-zero entry on one node** —
+  the launch then dies ~60 s in with `ibv_modify_qp` errno 61 on the worker
+  rank. `preflight` now validates the index on both devices and prints both
+  GID tables when it refuses; pick the index carrying the `::ffff:<ip>`
+  RoCEv2 entry on both nodes.
+- **`GPU_MEM_UTIL=0.87` needs ≥105.9 GiB free *after* vLLM's own ~9 GiB
+  init.** Nodes running resident services (dashboards, TTS, desktop) can miss
+  it by well under 1 GiB and fail the startup memory check; `GPU_MEM_UTIL=0.86`
+  with `MAX_MODEL_LEN=800000` (the previously published pair) fits with margin.
+  If :8888 is taken on your head node, `PORT` moves the API cleanly.
+
 ## .env
 
 | Knob | Default | What |

--- a/start.sh
+++ b/start.sh
@@ -297,6 +297,26 @@ preflight() {
     worker_ssh "nvidia-smi -L 2>/dev/null | grep -q GB10" \
         || warn "no GB10 GPU visible on worker"
 
+    # NCCL_IB_GID_INDEX must name a populated GID on BOTH nodes' CX7 devices.
+    # An empty (all-zero) entry passes every earlier check and then kills the
+    # worker rank ~60 s in with ibv_modify_qp errno 61 "No data available" —
+    # kits differ: on some GB10 pairs gid 3 is populated on one node and
+    # all-zero on the other. Fail here, in seconds, with the fix in hand.
+    local gid_head gid_worker gid_path
+    gid_path="/sys/class/infiniband/${HEAD_CX7_IB}/ports/1/gids/${NCCL_IB_GID_INDEX}"
+    gid_head=$(cat "$gid_path" 2>/dev/null | tr -d ':0' || true)
+    gid_path="/sys/class/infiniband/${WORKER_CX7_IB}/ports/1/gids/${NCCL_IB_GID_INDEX}"
+    gid_worker=$(worker_ssh "cat '$gid_path' 2>/dev/null" | tr -d ':0' || true)
+    if [ -z "$gid_head" ] || [ -z "$gid_worker" ]; then
+        warn "NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} is EMPTY on $( [ -z "$gid_head" ] && echo "head(${HEAD_CX7_IB})" ) $( [ -z "$gid_worker" ] && echo "worker(${WORKER_CX7_IB})" )"
+        warn "GID tables (pick an index whose entry is non-zero on BOTH nodes — the ::ffff:<ip> RoCEv2 one):"
+        for i in 0 1 2 3; do
+            printf '    head   gid%s: %s\n' "$i" "$(cat "/sys/class/infiniband/${HEAD_CX7_IB}/ports/1/gids/$i" 2>/dev/null)" >&2
+        done
+        worker_ssh "for i in 0 1 2 3; do printf '    worker gid%s: %s\n' \"\$i\" \"\$(cat /sys/class/infiniband/${WORKER_CX7_IB}/ports/1/gids/\$i 2>/dev/null)\"; done" >&2 || true
+        die "set NCCL_IB_GID_INDEX in .env to a populated index (this kills the worker rank with ibv_modify_qp errno 61 otherwise)"
+    fi
+
     [ "$TP" = "2" ] || warn "TP=${TP} on a 2×1-GPU cluster — expected TP=2"
     [ "$NNODES" = "2" ] || warn "NNODES=${NNODES} — expected 2"
 


### PR DESCRIPTION
Independent reproduction on a second 2×GB10 kit (2026-08-28): decode landed in your published bands (structured 38–62 tok/s, prose 27.1) — but getting to first boot hit three kit-specific walls this PR turns into fast failures / documentation:

1. **Empty GID index kills the worker rank ~60 s in.** On our pair, gid 3 is populated on one node and all-zero on the other; the launch passed every preflight check, then died with `ibv_modify_qp` errno 61 ("No data available") deep in NCCL init. `preflight` now reads the entry on **both** devices and refuses with both GID tables printed, so the fix (pick the `::ffff:<ip>` RoCEv2 index valid on both nodes) is in hand in seconds instead of after a container autopsy.

2. **Per-node NIC vars silently win over generic NCCL env pins.** We first set `NCCL_SOCKET_IFNAME`/`NCCL_IB_HCA` (our devices are `enP2p1s0f1np1`/`roceP2p1s0f1` on *both* nodes) and watched the launcher use your kit's defaults anyway — the per-node `-e` flags come later in the docker args. `.env.example` now says so and shows how to list a kit's devices.

3. **`GPU_MEM_UTIL=0.87` needs ≥105.9 GiB free *after* vLLM's ~9 GiB init.** Nodes carrying resident services miss it by <1 GiB and fail the startup memory check; README notes 0.86/800k as the fitting fallback pair (that's what our kit runs).

No behavior change for your kit — the GID check passes trivially where the index is valid, everything else is comments/docs.

Thanks for the recipe — it took us from your tweet to a serving 800k-context brain in one evening, and these were the only three walls on the way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJapN9zZpWqv2dBDNsJW9A