### PR TITLE
Keep MLA prefix-cache hits when DFlash2 EAGLE-drops a scheduler page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -444,13 +444,17 @@ COPY overlay/patch_suppress_stops_in_reasoning.py /opt/glm53/patch_suppress_stop
 COPY tests/test_suppress_stops.py /opt/glm53/test_suppress_stops.py
 COPY overlay/patch_scheduler_decode_floor.py /opt/glm53/patch_scheduler_decode_floor.py
 COPY tests/test_scheduler_decode_floor.py /opt/glm53/test_scheduler_decode_floor.py
+COPY overlay/patch_hybrid_prefix_hit.py /opt/glm53/patch_hybrid_prefix_hit.py
+COPY tests/test_hybrid_prefix_hit.py /opt/glm53/test_hybrid_prefix_hit.py
 RUN python3 /opt/glm53/patch_model_overrides.py
 RUN python3 /opt/glm53/patch_dflash2.py
 RUN python3 /opt/glm53/patch_glm_eagle3.py
 RUN python3 /opt/glm53/patch_glm5_drafter_group.py
 RUN python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
 RUN python3 /opt/glm53/patch_scheduler_decode_floor.py
+RUN python3 /opt/glm53/patch_hybrid_prefix_hit.py
 
 RUN EXL3_SELFCHECK_GPU=0 python3 /opt/glm53/test_exl3_overlay.py \
     && python3 /opt/glm53/test_suppress_stops.py \
-    && python3 /opt/glm53/test_scheduler_decode_floor.py
+    && python3 /opt/glm53/test_scheduler_decode_floor.py \
+    && python3 /opt/glm53/test_hybrid_prefix_hit.py

--- a/README.md
+++ b/README.md
@@ -190,33 +190,47 @@ Keep **`SKIP_MM_PROFILING=1`** — a max-size image+video dummy profile OOMs thi
 **NVFP4 KV is not available here.** FlashInfer’s SM12x NVFP4 kernels are dense MHA,
 not sparse MLA. Do not confuse that with NVFP4 **weights** (`--moe-backend marlin`).
 
-## Prefix caching (this kit, 2026-08-28)
+## Prefix caching (this kit, 2026-08-29)
 
 `--enable-prefix-caching` is on. The OpenAI API is **stateless**: the client
 resends the full history each turn; vLLM hashes that prefix. Concurrent chats
 do **not** mix activations. `--max-num-seqs 4` is four **in-flight** generations,
-not four parked sessions. This boot’s pool is **1,754,237** tokens (1.75× at
-1M; CUDA-graph memory profiling). MLA `KpoolTailManager`
-disables **fine-grained** hits — only **block-aligned** tokens count.
+not four parked sessions. MLA `KpoolTailManager` disables **fine-grained**
+hits — only **block-aligned** tokens count (3584-token hybrid align).
+`KpoolTail` already opts out of the hybrid min (1-block circular scratch).
 
-Live A/B, temp **0**, thinking **off**, two distinct ~7.7k-token chats:
+`dflash` is `use_eagle()`. GLM never sets `is_eagle_group` (that annotator is
+DeepseekV4-only), so stock HybridKVCacheCoordinator flagged **every** group.
+MLA dropped its last 3584-token page, and the DFlash2 SlidingWindow group
+re-aligned the min by another scheduler page. Overlay
+`patch_hybrid_prefix_hit.py` flags only the drafter SWA group as EAGLE and
+does **not** let that group shrink the MLA+mamba hit. Mamba stays in the min
+(skipping a mamba miss is a correctness hole). Do not raise
+`--max-num-batched-tokens` to “fix” APC.
 
-| Turn | Prefix hits | Compute | Prompt tok | TTFT |
+Live multi-turn, temp **0**, thinking **off**, real chat history
+(`user` + `assistant` + follow-up `user`), 1M serve:
+
+| Turn | Hits | Compute | Prompt tok | TTFT |
 |---|---:|---:|---:|---:|
-| A cold | 0 | 7734 | 7734 | 10.5 s |
-| A follow-up | **3584** | 4176 | 7760 | 11.4 s |
-| B cold (different text) | 0 | 7734 | 7734 | 10.5 s |
-| B follow-up | **3584** | 4176 | 7760 | 5.9 s |
-| A again after B | **0** | 7786 | 7786 | 10.8 s |
-| A+B concurrent | 3584 total | rest recomputed | 7748 each | A 9.5 s / B 16.1 s |
+| ~7.7k cold | 0 | 7696 | 7696 | 9.7 s |
+| ~7.7k follow-up | **7168** | 549 | 7717 | **1.17 s** |
+| ~12k cold | 0 | 11994 | 11994 | 13.4 s |
+| ~12k follow-up | **10752** | 1263 | 12015 | **1.94 s** |
+| ~16k cold | 0 | 15994 | 15994 | 17.7 s |
+| ~16k follow-up | **14336** | 1679 | 16015 | **2.18 s** |
+| 4× ~7.5k concurrent follow-ups | **7168 each** (28672 total) | rest | 7515 each | **1.86–2.50 s** |
 
-Isolation held: A answered `STILL_A` / `CONCUR_A`, B answered `CONCUR_B`.
+A ~7.7k follow-up reuses **93%** of the prompt (7168 / 7717), not 46%.
+Hits work **below** UserHIJ’s 14,336-token floor (that floor is 896-chunk ×
+2048-align LCM on a different geometry; this kit’s 3584 is 4×896). Isolation
+held (`STILL_READY_S` / `STILL_C0`…`C3`). Idle chats are not reserved; after
+the pool drains, a later turn of an old window prefills again. Concurrent
+colds still serialize under `GLM53_MIXED_PREFILL_CHUNK=skip` (`Deferred`).
 
-A follow-up reused **46%** of the prompt (3584 / 7760), not the whole history.
-After talking in B, A’s prefix was gone. Concurrent A+B: only one session hit.
-Idle chats are not reserved in the pool. Expect prefill on later turns of an
-old window; only the next turn of a still-hashed, block-aligned prefix skips
-part of it.
+This 1M boot: **1,670,157** tokens / **1.67×** / 638 GPU blocks (padded
+slot-share still applied). The 900k process measured 1,754,237 / 690 blocks
+on the same recipe; the delta is leftover UMA, not a slot-share collapse.
 
 ## Quick start (2× Spark)
 

--- a/overlay/patch_hybrid_prefix_hit.py
+++ b/overlay/patch_hybrid_prefix_hit.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Keep hybrid prefix-cache hits when the DFlash2 group would zero them.
+
+Issue #7: OpenClaw follow-ups looked like 0% APC. On this kit the MLA +
+mamba groups already hit at the 3584-token hybrid align (README 3584/7760).
+Two coordinator bugs then throw the extra block away:
+
+1. ``dflash`` is ``use_eagle()``. GLM never sets ``is_eagle_group`` (that
+   annotator is DeepseekV4-only), so HybridKVCacheCoordinator flags EVERY
+   group. MLA drops its last scheduler-aligned block (~3584 tokens).
+2. The DFlash2 SlidingWindow group still participates in the hybrid min.
+   After an EAGLE one-block pop it re-aligns down by a full 3584-token
+   scheduler page (block=64, align=3584), which can wipe a longer MLA hit.
+
+KpoolTail already opts out of prefix caching (1-block circular scratch).
+Mamba align-mode state *does* materialize at 896-token chunk ends, and
+3584 is a multiple of 896, so mamba must stay in the min — skipping a
+mamba miss is a correctness hole (vLLM #47491 / #43090).
+
+This patch: flag only exact SlidingWindowSpec groups as EAGLE, and do not
+let that drafter group shrink ``curr_hit_length``. If the drafter window
+does not cover the MLA/mamba hit, leave its blocks empty so a fresh
+window is allocated (zeros / new pages). Wrong indexer tail state is
+fatal — we do not touch KpoolTailManager.
+
+Fail closed if the vLLM coordinator anchors drift.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+P = Path(
+    os.environ.get(
+        "GLM53_KV_COORDINATOR_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/kv_cache_coordinator.py",
+    )
+)
+MARK = "# [glm53-hybrid-apc]"
+
+HELPER = '''
+def _glm53_inner_kv_spec(spec):
+    specs = getattr(spec, "kv_cache_specs", None)
+    if isinstance(specs, dict) and specs:
+        return next(iter(specs.values()))
+    return spec
+
+
+def _glm53_is_draft_swa_spec(spec) -> bool:
+    """DFlash2 drafter: exact SlidingWindowSpec, not KpoolTailSpec."""
+    return type(_glm53_inner_kv_spec(spec)).__name__ == "SlidingWindowSpec"
+
+
+'''
+
+EAGLE_OLD = """        # Conservatively fall back to flag all groups when no group is flagged.
+        if use_eagle and not self.eagle_group_ids:
+            self.eagle_group_ids = set(range(len(kv_cache_config.kv_cache_groups)))
+"""
+
+EAGLE_NEW = """        # Conservatively fall back to flag all groups when no group is flagged.
+        if use_eagle and not self.eagle_group_ids:
+            # [glm53-hybrid-apc] dflash is use_eagle(); GLM has no is_eagle_group
+            # annotator. Flag only the drafter SlidingWindowSpec group so MLA /
+            # mamba do not drop a whole scheduler page (~3584). MTP with no SWA
+            # group keeps the upstream all-groups fallback.
+            swa_ids = {
+                i
+                for i, g in enumerate(kv_cache_config.kv_cache_groups)
+                if _glm53_is_draft_swa_spec(g.kv_cache_spec)
+            }
+            self.eagle_group_ids = swa_ids or set(
+                range(len(kv_cache_config.kv_cache_groups))
+            )
+"""
+
+MIN_OLD = """                if drop_eagle_block:
+                    eagle_verified.add(idx)
+                elif _new_hit_length < curr_hit_length:
+                    # length shrunk; invalidate previous eagle verifications
+                    eagle_verified.clear()
+                curr_hit_length = _new_hit_length
+                for group_id, blocks in zip(group_ids, hit_blocks):
+                    hit_blocks_by_group[group_id] = blocks
+                    hit_length_by_group[group_id] = _new_hit_length
+
+                longest_hit_length = max(longest_hit_length, curr_hit_length)
+"""
+
+MIN_NEW = """                if drop_eagle_block:
+                    eagle_verified.add(idx)
+                elif _new_hit_length < curr_hit_length:
+                    # length shrunk; invalidate previous eagle verifications
+                    eagle_verified.clear()
+                if _glm53_is_draft_swa_spec(spec):  # [glm53-hybrid-apc]
+                    # Drafter SWA must not min() the hybrid hit. Its EAGLE pop
+                    # re-aligns by LCM(window block, MLA page) = 3584. If the
+                    # cached window does not cover the MLA/mamba hit, leave
+                    # blocks empty so a fresh window is allocated; do not
+                    # reseed the indexer tail here (KpoolTail already opted out).
+                    if _new_hit_length >= curr_hit_length:
+                        for group_id, blocks in zip(group_ids, hit_blocks):
+                            hit_blocks_by_group[group_id] = blocks
+                            hit_length_by_group[group_id] = _new_hit_length
+                    continue
+                curr_hit_length = _new_hit_length
+                for group_id, blocks in zip(group_ids, hit_blocks):
+                    hit_blocks_by_group[group_id] = blocks
+                    hit_length_by_group[group_id] = _new_hit_length
+
+                longest_hit_length = max(longest_hit_length, curr_hit_length)
+"""
+
+LOG_OLD = """        # Propagate the eagle bit to each manager (default to ``use_eagle=False``).
+        for group in self.attention_groups:
+            if group.use_eagle:
+                for gid in group.group_ids:
+                    self.single_type_managers[gid].use_eagle = True
+"""
+
+LOG_NEW = """        # Propagate the eagle bit to each manager (default to ``use_eagle=False``).
+        for group in self.attention_groups:
+            if group.use_eagle:
+                for gid in group.group_ids:
+                    self.single_type_managers[gid].use_eagle = True
+        logger.info(  # [glm53-hybrid-apc]
+            "hybrid APC groups: %s; eagle_group_ids=%s",
+            [
+                (
+                    type(_glm53_inner_kv_spec(g.spec)).__name__,
+                    g.group_ids,
+                    getattr(g.manager_cls, "__name__", type(g.manager_cls).__name__),
+                    g.use_eagle,
+                )
+                for g in self.attention_groups
+            ],
+            sorted(self.eagle_group_ids),
+        )
+"""
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f"{P}: expected one {label} target, found {n}")
+    return text.replace(old, new, 1)
+
+
+def main() -> int:
+    if not P.is_file():
+        raise SystemExit(f"missing {P}")
+    text = P.read_text()
+    if MARK in text:
+        print(f"{P.name}: {MARK} already present — skipping")
+        return 0
+    needle = "def _validate_prefix_cache_retention_interval(\n"
+    if text.count(needle) != 1:
+        raise SystemExit(f"{P}: helper insert point not unique")
+    if "def _glm53_inner_kv_spec(" not in text:
+        text = text.replace(needle, HELPER + needle, 1)
+    text = replace_once(text, EAGLE_OLD, EAGLE_NEW, "eagle-fallback")
+    text = replace_once(text, MIN_OLD, MIN_NEW, "hybrid-min")
+    text = replace_once(text, LOG_OLD, LOG_NEW, "group-log")
+    P.write_text(text)
+    print(f"patched {P.name} (hybrid APC: drafter SWA skipped in min, eagle on SWA only)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/start.sh
+++ b/start.sh
@@ -140,6 +140,7 @@ VIDEO_PATCH_HOST="${VIDEO_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm_video_placeh
 STOP_PATCH_HOST="${STOP_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_suppress_stops_in_reasoning.py}"
 SCHED_PATCH_HOST="${SCHED_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_scheduler_decode_floor.py}"
 DRAFTER_PATCH_HOST="${DRAFTER_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm5_drafter_group.py}"
+APC_PATCH_HOST="${APC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_hybrid_prefix_hit.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
 QUANTIZATION="${QUANTIZATION:-exl3}"
 LANGUAGE_MODEL_ONLY="${LANGUAGE_MODEL_ONLY:-0}"
@@ -314,6 +315,7 @@ preflight() {
     [ -f "$STOP_PATCH_HOST" ] || die "$STOP_PATCH_HOST missing"
     [ -f "$SCHED_PATCH_HOST" ] || die "$SCHED_PATCH_HOST missing"
     [ -f "$DRAFTER_PATCH_HOST" ] || die "$DRAFTER_PATCH_HOST missing"
+    [ -f "$APC_PATCH_HOST" ] || die "$APC_PATCH_HOST missing"
 
     local need_kb=$((180 * 1024 * 1024)) avail
     mkdir -p "$HF_CACHE_DIR"
@@ -712,6 +714,9 @@ fi
 if [ -f /opt/glm53/patch_glm5_drafter_group.py ]; then
     python3 /opt/glm53/patch_glm5_drafter_group.py
 fi
+if [ -f /opt/glm53/patch_hybrid_prefix_hit.py ]; then
+    python3 /opt/glm53/patch_hybrid_prefix_hit.py
+fi
 say "launching: vllm serve ${MODEL_DIR} ${ARGS[*]}"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -785,6 +790,9 @@ fi
 if [ -f /opt/glm53/patch_glm5_drafter_group.py ]; then
     python3 /opt/glm53/patch_glm5_drafter_group.py
 fi
+if [ -f /opt/glm53/patch_hybrid_prefix_hit.py ]; then
+    python3 /opt/glm53/patch_hybrid_prefix_hit.py
+fi
 say "joining TP2 at ${HEAD_IP}:${MASTER_PORT} as rank 1"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -809,6 +817,8 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$SCHED_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_scheduler_decode_floor.py"
     [ -f "$DRAFTER_PATCH_HOST" ] || die "missing $DRAFTER_PATCH_HOST"
     scp -q -o BatchMode=yes "$DRAFTER_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_glm5_drafter_group.py"
+    [ -f "$APC_PATCH_HOST" ] || die "missing $APC_PATCH_HOST"
+    scp -q -o BatchMode=yes "$APC_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_hybrid_prefix_hit.py"
 
     local -a nccl_common=(
         -e NCCL_IB_DISABLE=0
@@ -889,6 +899,7 @@ launch_cluster() {
         -v '/tmp/patch_suppress_stops_in_reasoning.py:/opt/glm53/patch_suppress_stops_in_reasoning.py:ro' \
         -v '/tmp/patch_scheduler_decode_floor.py:/opt/glm53/patch_scheduler_decode_floor.py:ro' \
         -v '/tmp/patch_glm5_drafter_group.py:/opt/glm53/patch_glm5_drafter_group.py:ro' \
+        -v '/tmp/patch_hybrid_prefix_hit.py:/opt/glm53/patch_hybrid_prefix_hit.py:ro' \
         ${worker_preload} \
         ${worker_nccl} \
         -e NCCL_SOCKET_IFNAME='$WORKER_CX7_IF' \
@@ -913,6 +924,7 @@ launch_cluster() {
         -v "$STOP_PATCH_HOST:/opt/glm53/patch_suppress_stops_in_reasoning.py:ro" \
         -v "$SCHED_PATCH_HOST:/opt/glm53/patch_scheduler_decode_floor.py:ro" \
         -v "$DRAFTER_PATCH_HOST:/opt/glm53/patch_glm5_drafter_group.py:ro" \
+        -v "$APC_PATCH_HOST:/opt/glm53/patch_hybrid_prefix_hit.py:ro" \
         "${head_preload[@]}" \
         "${nccl_common[@]}" \
         -e NCCL_SOCKET_IFNAME="$HEAD_CX7_IF" \

--- a/tests/test_hybrid_prefix_hit.py
+++ b/tests/test_hybrid_prefix_hit.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Apply overlay/patch_hybrid_prefix_hit.py to a copy of kv_cache_coordinator.py."""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+PATCH = next(
+    p
+    for p in (
+        HERE / "patch_hybrid_prefix_hit.py",
+        HERE.parent / "overlay" / "patch_hybrid_prefix_hit.py",
+    )
+    if p.is_file()
+)
+SRC = Path(
+    "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/kv_cache_coordinator.py"
+)
+
+
+def main() -> int:
+    if not PATCH.is_file():
+        raise SystemExit(f"missing {PATCH}")
+    src = Path(os.environ.get("GLM53_KV_COORDINATOR_PY_SRC", SRC))
+    if not src.is_file():
+        raise SystemExit(f"missing kv_cache_coordinator.py at {src}")
+    with tempfile.TemporaryDirectory() as tmp:
+        dst = Path(tmp) / "kv_cache_coordinator.py"
+        shutil.copyfile(src, dst)
+        env = os.environ.copy()
+        env["GLM53_KV_COORDINATOR_PY"] = str(dst)
+        subprocess.check_call([sys.executable, str(PATCH)], env=env)
+        text = dst.read_text()
+        assert "[glm53-hybrid-apc]" in text
+        assert text.count("[glm53-hybrid-apc]") >= 3
+        assert "def _glm53_is_draft_swa_spec(" in text
+        assert "swa_ids or set(" in text
+        subprocess.check_call([sys.executable, str(PATCH)], env=env)
+        assert dst.read_text().count("[glm53-hybrid-apc]") == text.count(
+            "[glm53-hybrid-apc]"
+        )
+    print("hybrid prefix-hit patch OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- `#7` was not a missing `--enable-prefix-caching` flag and not the 3×256k KV tax (`#13`). Real OpenClaw follow-ups already hit the 3584-token MLA/mamba align; `dflash` is `use_eagle()` and GLM never sets `is_eagle_group`, so the hybrid coordinator dropped the last 3584-token MLA page and the DFlash2 SWA group re-aligned the min by another scheduler page.
- Overlay `patch_hybrid_prefix_hit.py` flags only the drafter SlidingWindow group as EAGLE and keeps it out of the hybrid min. KpoolTail already opted out. Mamba stays in the min (skipping a miss is a correctness hole). No CLI knob, no `MAX_NUM_BATCHED_TOKENS` change, 1M + padded slot-share kept.
- Live retest (thinking off, temp 0, real `user`+`assistant`+follow-up): 7.7k follow-up **7168 / 7717** hits, TTFT **9.7 s → 1.17 s** (was 3584 / 11.4 s). Same below and above 14,336. 4 concurrent follow-ups 7168 each. Decode 59 tok/s. 100k prefill 934 tok/s. `#6` skip still on.

## Test plan
- [x] Correct multi-turn harness (not a mutated single user string)
- [x] Follow-up hits below 14,336 and above
- [x] 4 concurrent sessions then follow-ups
- [x] Decode ~50–70 tok/s thinking-off
- [x] Solo ~100k prefill HTTP 200
- [x] Boot: padded slot-share, mixed prefill policy=skip, eagle_group_ids=[drafter only]


Made with [Cursor](https://cursor.com)