### PR TITLE
Fix warm-restart JSON stdout contamination

### DIFF
--- a/overlay/patch_glm_video_placeholders.py
+++ b/overlay/patch_glm_video_placeholders.py
@@ -6,6 +6,7 @@
 # processor wrapper still routed 5.3 through _get_video_second_idx_glm4v.
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 
@@ -92,7 +93,10 @@ def apply() -> None:
 
     Glm4vProcessingInfo._construct_video_placeholder = _construct_video_placeholder
     Glm4vProcessingInfo._glm53_video_t_aligned = True
-    print("glm53: video placeholders aligned to encoder grid_t (Glm5Next→glm46v)")
+    print(
+        "glm53: video placeholders aligned to encoder grid_t (Glm5Next→glm46v)",
+        file=sys.stderr,
+    )
 
 
 def _install_import_hook() -> None:
@@ -113,7 +117,7 @@ def _install_import_hook() -> None:
         try:
             apply()
         except Exception as exc:
-            print(f"glm53: video apply() failed: {exc!r}")
+            print(f"glm53: video apply() failed: {exc!r}", file=sys.stderr)
         finally:
             applying = False
 
@@ -139,10 +143,13 @@ def _disable_gb10_persistent_topk() -> None:
         raise FileNotFoundError(f"glm53: missing {KPOOL}")
     text = KPOOL.read_text()
     if KPOOL_NEW in text:
-        print("glm53: persistent_topk already disabled in kpool")
+        print("glm53: persistent_topk already disabled in kpool", file=sys.stderr)
     elif KPOOL_OLD in text:
         KPOOL.write_text(text.replace(KPOOL_OLD, KPOOL_NEW, 1))
-        print("glm53: disabled GB10 persistent_topk (use top_k_per_row_decode)")
+        print(
+            "glm53: disabled GB10 persistent_topk (use top_k_per_row_decode)",
+            file=sys.stderr,
+        )
     else:
         raise RuntimeError(
             "glm53: kpool persistent_topk pattern not found — patch the file by hand"
@@ -170,4 +177,4 @@ if __name__ == "__main__":
         "import glm53_video_patch\n"
     )
     _disable_gb10_persistent_topk()
-    print("glm53: overlay install ok aligned=True")
+    print("glm53: overlay install ok aligned=True", file=sys.stderr)

--- a/start.sh
+++ b/start.sh
@@ -673,7 +673,7 @@ ARGS=(
 [ -n "${MAX_NUM_BATCHED_TOKENS:-}" ] && ARGS+=(--max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}")
 [ -n "${KV_CACHE_DTYPE:-}" ] && ARGS+=(--kv-cache-dtype "${KV_CACHE_DTYPE}")
 if [ "${SPEC_METHOD:-mtp}" = "dflash" ]; then
-    ARGS+=(--speculative-config "$(python3 -c 'import json,os
+    ARGS+=(--speculative-config "$(python3 -S -c 'import json,os
 spec={"method":"dflash","model":os.environ["DFLASH_MODEL_DIR"],"num_speculative_tokens":int(os.environ.get("DFLASH_TOKENS","7")),"kv_cache_dtype":"auto","draft_sample_method":"probabilistic","rejection_sample_method":"standard"}
 tp=os.environ.get("DFLASH_DRAFT_TP","").strip()
 if tp:
@@ -751,7 +751,7 @@ ARGS=(
 [ -n "${MAX_NUM_BATCHED_TOKENS:-}" ] && ARGS+=(--max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}")
 [ -n "${KV_CACHE_DTYPE:-}" ] && ARGS+=(--kv-cache-dtype "${KV_CACHE_DTYPE}")
 if [ "${SPEC_METHOD:-mtp}" = "dflash" ]; then
-    ARGS+=(--speculative-config "$(python3 -c 'import json,os
+    ARGS+=(--speculative-config "$(python3 -S -c 'import json,os
 spec={"method":"dflash","model":os.environ["DFLASH_MODEL_DIR"],"num_speculative_tokens":int(os.environ.get("DFLASH_TOKENS","7")),"kv_cache_dtype":"auto","draft_sample_method":"probabilistic","rejection_sample_method":"standard"}
 tp=os.environ.get("DFLASH_DRAFT_TP","").strip()
 if tp:

--- a/tests/test_warm_restart_stdout.py
+++ b/tests/test_warm_restart_stdout.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Keep launcher JSON clean when the image imports the video overlay at startup."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_json_command_substitutions_skip_sitecustomize() -> None:
+    source = (ROOT / "start.sh").read_text()
+    marker = '$(python3 -S -c \'import json,os'
+    assert source.count(marker) == 2
+
+
+def test_import_time_overlay_never_writes_stdout() -> None:
+    path = ROOT / "overlay" / "patch_glm_video_placeholders.py"
+    tree = ast.parse(path.read_text(), filename=str(path))
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "print"
+    ]
+    assert calls
+    for call in calls:
+        file_keywords = [keyword for keyword in call.keywords if keyword.arg == "file"]
+        assert len(file_keywords) == 1, f"stdout print at line {call.lineno}"
+        target = file_keywords[0].value
+        assert (
+            isinstance(target, ast.Attribute)
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "sys"
+            and target.attr == "stderr"
+        ), f"print at line {call.lineno} must target sys.stderr"
+
+
+if __name__ == "__main__":
+    test_json_command_substitutions_skip_sitecustomize()
+    test_import_time_overlay_never_writes_stdout()
+    print("warm-restart stdout regression OK")


### PR DESCRIPTION
Fixes #15.

The runtime video overlay is imported through `sitecustomize`, so its status message was prepended to every `python3 -c` stdout stream. That can corrupt the JSON generated by launcher command substitutions during a warm restart.

This change:
- routes all video-overlay diagnostics to stderr;
- runs the two stdlib-only JSON command substitutions with `python3 -S` as defense in depth;
- adds a regression test that checks both properties.

Verified locally with the new regression, Python compilation, `bash -n`, and `git diff --check`. Verified on the live pinned image after mounting the patch: stdout was exactly `{"clean":true}` while the overlay status line appeared only on stderr (72 bytes).