### PR TITLE
Backport XGrammar termination fix for speculative batches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -446,6 +446,8 @@ COPY overlay/patch_scheduler_decode_floor.py /opt/glm53/patch_scheduler_decode_f
 COPY tests/test_scheduler_decode_floor.py /opt/glm53/test_scheduler_decode_floor.py
 COPY overlay/patch_hybrid_prefix_hit.py /opt/glm53/patch_hybrid_prefix_hit.py
 COPY tests/test_hybrid_prefix_hit.py /opt/glm53/test_hybrid_prefix_hit.py
+COPY overlay/patch_xgrammar_termination.py /opt/glm53/patch_xgrammar_termination.py
+COPY tests/test_xgrammar_termination.py /opt/glm53/test_xgrammar_termination.py
 RUN python3 /opt/glm53/patch_model_overrides.py
 RUN python3 /opt/glm53/patch_dflash2.py
 RUN python3 /opt/glm53/patch_glm_eagle3.py
@@ -453,8 +455,10 @@ RUN python3 /opt/glm53/patch_glm5_drafter_group.py
 RUN python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
 RUN python3 /opt/glm53/patch_scheduler_decode_floor.py
 RUN python3 /opt/glm53/patch_hybrid_prefix_hit.py
+RUN python3 /opt/glm53/patch_xgrammar_termination.py
 
 RUN EXL3_SELFCHECK_GPU=0 python3 /opt/glm53/test_exl3_overlay.py \
     && python3 /opt/glm53/test_suppress_stops.py \
     && python3 /opt/glm53/test_scheduler_decode_floor.py \
-    && python3 /opt/glm53/test_hybrid_prefix_hit.py
+    && python3 /opt/glm53/test_hybrid_prefix_hit.py \
+    && python3 /opt/glm53/test_xgrammar_termination.py

--- a/README.md
+++ b/README.md
@@ -124,16 +124,21 @@ checkpoint `is_causal: false` so draft attention is bidirectional inside the
 block. Draft KV is forced `auto` because dense DFlash2 cannot use the target's
 `fp8_ds_mla` layout and SM121 has no FA3/FA4 for plain FP8.
 
-The pinned vLLM `487ecf187` also predates the merged XGrammar speculative-batch
-termination fix. `overlay/patch_xgrammar_termination.py` is a source-exact
-behavioral backport of [vLLM PR #52805](https://github.com/vllm-project/vllm/pull/52805)
-([commit `12f64b39`](https://github.com/vllm-project/vllm/commit/12f64b39d29282437e35be9aa5db432fb2a1a6e6)).
-It stops `accept_tokens()` and `validate_tokens()` at the first terminating
-token, ignores later advances after termination, and clears the cached flag on
-reset. The fail-closed, idempotent script is mounted and run on both ranks. This
-fixes the matcher-after-stop defect in issue #19; it does not reinterpret an
-invalid client request that combines GLM XML tool output with a JSON response
-schema, nor does it remove cold-prefill queue time.
+The pinned vLLM `487ecf187` also predates two merged XGrammar speculative-decode
+fixes. `overlay/patch_xgrammar_termination.py` source-exactly backports
+[vLLM PR #52805](https://github.com/vllm-project/vllm/pull/52805)
+([commit `12f64b39`](https://github.com/vllm-project/vllm/commit/12f64b39d29282437e35be9aa5db432fb2a1a6e6))
+and [vLLM PR #53046](https://github.com/vllm-project/vllm/pull/53046)
+([commit `c6e19b3`](https://github.com/vllm-project/vllm/commit/c6e19b3be24338759a443e03c8325d76da9ee202)).
+The first stops `accept_tokens()` and `validate_tokens()` at the first
+terminating token, ignores later advances after termination, and clears the
+cached flag on reset. The second validates drafts produced before a mid-window
+reasoning-end marker before advancing the newly active grammar, avoiding a
+spurious `Failed to advance FSM` error for invalid drafts. The fail-closed,
+idempotent script preflights both source files before writing and is already
+mounted and run on both ranks. These address issue #19's matcher-error paths;
+they do not reinterpret a client request that combines GLM XML tool output
+with a JSON response schema, nor do they remove cold-prefill queue time.
 
 `overlay/patch_glm_video_placeholders.py` routes Glm5Next video timestamps through
 the glm46v path and aligns placeholder blocks to encoder `grid_t`. The overlay
@@ -418,8 +423,8 @@ this Dockerfile instead. After CUDA compile, Python overlay edits
 | `overlay/patch_glm_video_placeholders.py` | align video timestamp blocks to encoder `grid_t` |
 | `overlay/patch_suppress_stops_in_reasoning.py` | fail-closed detokenizer guard: client `stop` dormant until `</think>` |
 | `overlay/patch_scheduler_decode_floor.py` | skip (or cap) peer prefill while another seq is decoding |
-| `overlay/patch_xgrammar_termination.py` | source-exact vLLM #52805 backport; stop speculative XGrammar batches at termination |
-| `tests/test_xgrammar_termination.py` | exact patch, idempotence, fail-closed drift, termination/rollback/reset behavior, launcher wiring |
+| `overlay/patch_xgrammar_termination.py` | source-exact vLLM #52805/#53046 backports; stop at termination and validate post-reasoning speculative drafts before FSM advance |
+| `tests/test_xgrammar_termination.py` | exact two-file patch, idempotence, cross-file fail-closed drift, termination/rollback/reset and post-reasoning draft behavior, launcher wiring |
 | `scripts/boot-shape-warmup.sh` | post-`/health` DFlash2 k=7 BLOCK ladder + sampler/kpool arms |
 
 Image-build runs `EXL3_SELFCHECK_GPU=0`. `./start.sh` runs the GPU self-check
@@ -456,4 +461,3 @@ DFlash2 stays [CC BY-NC-ND 4.0](https://huggingface.co/incoai/GLM-5.3-Flash-DFla
   (CC BY-NC-ND 4.0, research/eval)
 - **KLD panel:** [malaiwah](https://huggingface.co/malaiwah) —
   [discussion #1](https://huggingface.co/brandonmusic/GLM-5.3-Flash-tr3-4bpw/discussions/1#6a9144846b0bdba943bfe86f)
-

--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ checkpoint `is_causal: false` so draft attention is bidirectional inside the
 block. Draft KV is forced `auto` because dense DFlash2 cannot use the target's
 `fp8_ds_mla` layout and SM121 has no FA3/FA4 for plain FP8.
 
+The pinned vLLM `487ecf187` also predates the merged XGrammar speculative-batch
+termination fix. `overlay/patch_xgrammar_termination.py` is a source-exact
+behavioral backport of [vLLM PR #52805](https://github.com/vllm-project/vllm/pull/52805)
+([commit `12f64b39`](https://github.com/vllm-project/vllm/commit/12f64b39d29282437e35be9aa5db432fb2a1a6e6)).
+It stops `accept_tokens()` and `validate_tokens()` at the first terminating
+token, ignores later advances after termination, and clears the cached flag on
+reset. The fail-closed, idempotent script is mounted and run on both ranks. This
+fixes the matcher-after-stop defect in issue #19; it does not reinterpret an
+invalid client request that combines GLM XML tool output with a JSON response
+schema, nor does it remove cold-prefill queue time.
+
 `overlay/patch_glm_video_placeholders.py` routes Glm5Next video timestamps through
 the glm46v path and aligns placeholder blocks to encoder `grid_t`. The overlay
 also disables GB10 `persistent_topk` so long-history decode uses
@@ -407,6 +418,8 @@ this Dockerfile instead. After CUDA compile, Python overlay edits
 | `overlay/patch_glm_video_placeholders.py` | align video timestamp blocks to encoder `grid_t` |
 | `overlay/patch_suppress_stops_in_reasoning.py` | fail-closed detokenizer guard: client `stop` dormant until `</think>` |
 | `overlay/patch_scheduler_decode_floor.py` | skip (or cap) peer prefill while another seq is decoding |
+| `overlay/patch_xgrammar_termination.py` | source-exact vLLM #52805 backport; stop speculative XGrammar batches at termination |
+| `tests/test_xgrammar_termination.py` | exact patch, idempotence, fail-closed drift, termination/rollback/reset behavior, launcher wiring |
 | `scripts/boot-shape-warmup.sh` | post-`/health` DFlash2 k=7 BLOCK ladder + sampler/kpool arms |
 
 Image-build runs `EXL3_SELFCHECK_GPU=0`. `./start.sh` runs the GPU self-check

--- a/overlay/patch_xgrammar_termination.py
+++ b/overlay/patch_xgrammar_termination.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Backport vLLM's XGrammar speculative-batch termination fix.
+
+The base image pins vLLM ``487ecf187``, whose XGrammar backend can continue
+feeding tokens to a matcher after an EOS/stop token terminates it.  That is
+especially visible with a multi-token speculative batch: the first trailing
+token is rejected, subsequent advances can warn, and the cached termination
+flag can become inconsistent with the matcher.
+
+This is a source-exact behavioral backport of upstream vLLM PR #52805, merged
+as commit 12f64b39d29282437e35be9aa5db432fb2a1a6e6:
+
+https://github.com/vllm-project/vllm/pull/52805
+https://github.com/vllm-project/vllm/commit/12f64b39d29282437e35be9aa5db432fb2a1a6e6
+
+Only the three upstream method edits are made.  The patch is idempotent and
+fails closed before writing if the pinned anchors drift or a partial patch is
+found.
+"""
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+
+TARGET = Path(
+    os.environ.get(
+        "GLM53_XGRAMMAR_BACKEND_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/v1/structured_output/"
+        "backend_xgrammar.py",
+    )
+)
+MARK = (
+    "    # [glm53-xgrammar-termination] Source-exact vLLM 12f64b39 backport.\n"
+)
+
+ACCEPT_OLD = '''    def accept_tokens(self, request_id: str, tokens: list[int]) -> bool:
+        """Accepts a list of tokens and advances the FSM.
+
+        Returns True if the FSM was advanced successfully.
+        Returns False if the FSM failed to advance.
+        """
+        if self._is_terminated:
+            return False
+        for token in tokens:
+            if not self.matcher.accept_token(token):
+                logger.error(
+                    "Failed to advance FSM for request %s "
+                    "for tokens %s. Please file an issue.",
+                    request_id,
+                    token,
+                )
+                return False
+            self.num_processed_tokens += 1
+        self._is_terminated = self.matcher.is_terminated()
+        return True
+'''
+
+ACCEPT_UPSTREAM = '''    def accept_tokens(self, request_id: str, tokens: list[int]) -> bool:
+        """Accepts a list of tokens and advances the FSM.
+
+        Returns True if all grammar-constrained tokens were accepted.
+        Tokens after termination are ignored. Returns False if the FSM
+        failed to advance.
+        """
+        if self._is_terminated:
+            return True
+        for token in tokens:
+            if not self.matcher.accept_token(token):
+                logger.error(
+                    "Failed to advance FSM for request %s "
+                    "for tokens %s. Please file an issue.",
+                    request_id,
+                    token,
+                )
+                return False
+            self.num_processed_tokens += 1
+            self._is_terminated = self.matcher.is_terminated()
+            if self._is_terminated:
+                break
+        return True
+'''
+
+VALIDATE_OLD = '''    def validate_tokens(self, tokens: list[int]) -> list[int]:
+        """Checks if the list of tokens are accepted by the FSM in sequence.
+        Will not advance the FSM.
+
+        Returns the prefix list of tokens that are accepted by the FSM.
+        """
+        accepted_tokens = []
+        for token in tokens:
+            if self.matcher.accept_token(token):
+                accepted_tokens.append(token)
+            else:
+                break
+        if len(accepted_tokens) > 0:
+            # Rollback the FSM to the initial state
+            self.matcher.rollback(len(accepted_tokens))
+        return accepted_tokens
+'''
+
+VALIDATE_UPSTREAM = '''    def validate_tokens(self, tokens: list[int]) -> list[int]:
+        """Checks if the list of tokens are accepted by the FSM in sequence.
+        Will not advance the FSM.
+
+        Returns the prefix list of tokens that are accepted by the FSM.
+        """
+        if self._is_terminated:
+            return []
+
+        accepted_tokens = []
+        for token in tokens:
+            if self.matcher.accept_token(token):
+                accepted_tokens.append(token)
+                if self.matcher.is_terminated():
+                    break
+            else:
+                break
+        if len(accepted_tokens) > 0:
+            # Rollback the FSM to the initial state
+            self.matcher.rollback(len(accepted_tokens))
+        return accepted_tokens
+'''
+
+RESET_OLD = '''    def reset(self):
+        self.num_processed_tokens = 0
+        self.matcher.reset()
+'''
+
+RESET_UPSTREAM = '''    def reset(self):
+        self.matcher.reset()
+        self.num_processed_tokens = 0
+        self._is_terminated = False
+'''
+
+
+def counts(text: str) -> tuple[list[int], list[int]]:
+    old = [text.count(x) for x in (ACCEPT_OLD, VALIDATE_OLD, RESET_OLD)]
+    new = [
+        text.count(ACCEPT_UPSTREAM),
+        text.count(VALIDATE_UPSTREAM),
+        text.count(RESET_UPSTREAM),
+    ]
+    return old, new
+
+
+def verified_upstream_state(text: str) -> bool:
+    old, new = counts(text)
+    return old == [0, 0, 0] and new == [1, 1, 1]
+
+
+def main() -> int:
+    if not TARGET.is_file():
+        raise SystemExit(f"missing {TARGET}")
+
+    source = TARGET.read_text()
+    old, new = counts(source)
+    marker_count = source.count(MARK)
+
+    if marker_count:
+        if marker_count != 1 or not verified_upstream_state(source):
+            raise SystemExit(
+                f"{TARGET}: partial/inconsistent xgrammar termination patch "
+                f"(marker={marker_count}, old={old}, new={new})"
+            )
+        compile(source, str(TARGET), "exec")
+        print(f"{TARGET.name}: xgrammar termination patch already present")
+        return 0
+
+    # A newer image may already contain the exact merged upstream behavior.
+    # Accept that exact state without adding a recipe marker; any other drift
+    # remains fatal.
+    if verified_upstream_state(source):
+        compile(source, str(TARGET), "exec")
+        print(f"{TARGET.name}: upstream xgrammar termination fix already present")
+        return 0
+
+    if old != [1, 1, 1] or new != [0, 0, 0]:
+        raise SystemExit(
+            f"{TARGET}: pinned xgrammar anchors drifted; refusing partial write "
+            f"(old={old}, new={new})"
+        )
+
+    patched = source.replace(ACCEPT_OLD, MARK + ACCEPT_UPSTREAM, 1)
+    patched = patched.replace(VALIDATE_OLD, VALIDATE_UPSTREAM, 1)
+    patched = patched.replace(RESET_OLD, RESET_UPSTREAM, 1)
+    if not verified_upstream_state(patched) or patched.count(MARK) != 1:
+        raise SystemExit(f"{TARGET}: post-patch verification failed")
+    compile(patched, str(TARGET), "exec")
+
+    tmp = TARGET.with_name(f".{TARGET.name}.glm53-xgrammar.tmp")
+    try:
+        tmp.write_text(patched)
+        os.chmod(tmp, stat.S_IMODE(TARGET.stat().st_mode))
+        os.replace(tmp, TARGET)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+    print(
+        f"patched {TARGET.name} "
+        "(vLLM #52805: stop XGrammar token batches at termination)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/overlay/patch_xgrammar_termination.py
+++ b/overlay/patch_xgrammar_termination.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Backport vLLM's XGrammar speculative-batch termination fix.
+"""Backport vLLM's XGrammar speculative-decoding fixes.
 
 The base image pins vLLM ``487ecf187``, whose XGrammar backend can continue
 feeding tokens to a matcher after an EOS/stop token terminates it.  That is
@@ -7,15 +7,25 @@ especially visible with a multi-token speculative batch: the first trailing
 token is rejected, subsequent advances can warn, and the cached termination
 flag can become inconsistent with the matcher.
 
-This is a source-exact behavioral backport of upstream vLLM PR #52805, merged
-as commit 12f64b39d29282437e35be9aa5db432fb2a1a6e6:
+This applies two source-exact behavioral backports:
+
+* vLLM PR #52805, merged as commit
+  ``12f64b39d29282437e35be9aa5db432fb2a1a6e6``, stops token batches at
+  grammar termination.
+* vLLM PR #53046, merged as commit
+  ``c6e19b3be24338759a443e03c8325d76da9ee202``, validates speculative
+  drafts produced before a mid-window reasoning-end marker before advancing
+  the grammar.  This avoids a spurious ``Failed to advance FSM`` error when
+  such a draft is invalid under the newly active grammar.
 
 https://github.com/vllm-project/vllm/pull/52805
 https://github.com/vllm-project/vllm/commit/12f64b39d29282437e35be9aa5db432fb2a1a6e6
+https://github.com/vllm-project/vllm/pull/53046
+https://github.com/vllm-project/vllm/commit/c6e19b3be24338759a443e03c8325d76da9ee202
 
-Only the three upstream method edits are made.  The patch is idempotent and
-fails closed before writing if the pinned anchors drift or a partial patch is
-found.
+Only the exact upstream behavior is changed.  The patch is idempotent and
+preflights both files before writing, failing closed if a pinned anchor drifts
+or a partial patch is found.
 """
 from __future__ import annotations
 
@@ -25,15 +35,26 @@ import sys
 from pathlib import Path
 
 
-TARGET = Path(
+BACKEND_TARGET = Path(
     os.environ.get(
         "GLM53_XGRAMMAR_BACKEND_PY",
         "/usr/local/lib/python3.12/dist-packages/vllm/v1/structured_output/"
         "backend_xgrammar.py",
     )
 )
-MARK = (
+MANAGER_TARGET = Path(
+    os.environ.get(
+        "GLM53_XGRAMMAR_MANAGER_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/v1/structured_output/"
+        "__init__.py",
+    )
+)
+BACKEND_MARK = (
     "    # [glm53-xgrammar-termination] Source-exact vLLM 12f64b39 backport.\n"
+)
+MANAGER_MARK = (
+    "                    # [glm53-xgrammar-reasoning] Source-exact vLLM "
+    "c6e19b3 backport.\n"
 )
 
 ACCEPT_OLD = '''    def accept_tokens(self, request_id: str, tokens: list[int]) -> bool:
@@ -135,8 +156,33 @@ RESET_UPSTREAM = '''    def reset(self):
         self._is_terminated = False
 '''
 
+MANAGER_OLD = '''                    if advance_grammar and not grammar.is_terminated():
+                        accepted = grammar.accept_tokens(req_id, [token])
+                        if accepted:
+                            state_advancements += 1
+                        elif not post_reasoning_end_in_window:
+                            raise AssertionError(
+                                (token, req_id, scheduled_spec_decode_tokens)
+                            )
+'''
 
-def counts(text: str) -> tuple[list[int], list[int]]:
+MANAGER_UPSTREAM = '''                    if advance_grammar and not grammar.is_terminated():
+                        if post_reasoning_end_in_window:
+                            accepted = bool(grammar.validate_tokens([token]))
+                            if accepted:
+                                accepted = grammar.accept_tokens(req_id, [token])
+                        else:
+                            accepted = grammar.accept_tokens(req_id, [token])
+                        if accepted:
+                            state_advancements += 1
+                        elif not post_reasoning_end_in_window:
+                            raise AssertionError(
+                                (token, req_id, scheduled_spec_decode_tokens)
+                            )
+'''
+
+
+def backend_counts(text: str) -> tuple[list[int], list[int]]:
     old = [text.count(x) for x in (ACCEPT_OLD, VALIDATE_OLD, RESET_OLD)]
     new = [
         text.count(ACCEPT_UPSTREAM),
@@ -146,63 +192,98 @@ def counts(text: str) -> tuple[list[int], list[int]]:
     return old, new
 
 
-def verified_upstream_state(text: str) -> bool:
-    old, new = counts(text)
+def verified_backend_state(text: str) -> bool:
+    old, new = backend_counts(text)
     return old == [0, 0, 0] and new == [1, 1, 1]
 
 
-def main() -> int:
-    if not TARGET.is_file():
-        raise SystemExit(f"missing {TARGET}")
+def verified_manager_state(text: str) -> bool:
+    return text.count(MANAGER_OLD) == 0 and text.count(MANAGER_UPSTREAM) == 1
 
-    source = TARGET.read_text()
-    old, new = counts(source)
-    marker_count = source.count(MARK)
 
+def prepare_backend(source: str) -> tuple[str, str]:
+    old, new = backend_counts(source)
+    marker_count = source.count(BACKEND_MARK)
     if marker_count:
-        if marker_count != 1 or not verified_upstream_state(source):
-            raise SystemExit(
-                f"{TARGET}: partial/inconsistent xgrammar termination patch "
+        if marker_count != 1 or not verified_backend_state(source):
+            raise ValueError(
+                "partial/inconsistent xgrammar termination patch "
                 f"(marker={marker_count}, old={old}, new={new})"
             )
-        compile(source, str(TARGET), "exec")
-        print(f"{TARGET.name}: xgrammar termination patch already present")
-        return 0
-
-    # A newer image may already contain the exact merged upstream behavior.
-    # Accept that exact state without adding a recipe marker; any other drift
-    # remains fatal.
-    if verified_upstream_state(source):
-        compile(source, str(TARGET), "exec")
-        print(f"{TARGET.name}: upstream xgrammar termination fix already present")
-        return 0
-
+        return source, "already present"
+    if verified_backend_state(source):
+        return source, "already upstream"
     if old != [1, 1, 1] or new != [0, 0, 0]:
-        raise SystemExit(
-            f"{TARGET}: pinned xgrammar anchors drifted; refusing partial write "
+        raise ValueError(
+            "pinned xgrammar termination anchors drifted "
             f"(old={old}, new={new})"
         )
-
-    patched = source.replace(ACCEPT_OLD, MARK + ACCEPT_UPSTREAM, 1)
+    patched = source.replace(ACCEPT_OLD, BACKEND_MARK + ACCEPT_UPSTREAM, 1)
     patched = patched.replace(VALIDATE_OLD, VALIDATE_UPSTREAM, 1)
     patched = patched.replace(RESET_OLD, RESET_UPSTREAM, 1)
-    if not verified_upstream_state(patched) or patched.count(MARK) != 1:
-        raise SystemExit(f"{TARGET}: post-patch verification failed")
-    compile(patched, str(TARGET), "exec")
+    if not verified_backend_state(patched) or patched.count(BACKEND_MARK) != 1:
+        raise ValueError("xgrammar termination post-patch verification failed")
+    return patched, "patched"
 
-    tmp = TARGET.with_name(f".{TARGET.name}.glm53-xgrammar.tmp")
+
+def prepare_manager(source: str) -> tuple[str, str]:
+    old = source.count(MANAGER_OLD)
+    new = source.count(MANAGER_UPSTREAM)
+    marker_count = source.count(MANAGER_MARK)
+    if marker_count:
+        if marker_count != 1 or not verified_manager_state(source):
+            raise ValueError(
+                "partial/inconsistent xgrammar reasoning patch "
+                f"(marker={marker_count}, old={old}, new={new})"
+            )
+        return source, "already present"
+    if verified_manager_state(source):
+        return source, "already upstream"
+    if old != 1 or new != 0:
+        raise ValueError(
+            "pinned xgrammar reasoning anchor drifted "
+            f"(old={old}, new={new})"
+        )
+    patched = source.replace(MANAGER_OLD, MANAGER_MARK + MANAGER_UPSTREAM, 1)
+    if not verified_manager_state(patched) or patched.count(MANAGER_MARK) != 1:
+        raise ValueError("xgrammar reasoning post-patch verification failed")
+    return patched, "patched"
+
+
+def replace_file(target: Path, source: str) -> None:
+    tmp = target.with_name(f".{target.name}.glm53-xgrammar.tmp")
     try:
-        tmp.write_text(patched)
-        os.chmod(tmp, stat.S_IMODE(TARGET.stat().st_mode))
-        os.replace(tmp, TARGET)
+        tmp.write_text(source)
+        os.chmod(tmp, stat.S_IMODE(target.stat().st_mode))
+        os.replace(tmp, target)
     finally:
         if tmp.exists():
             tmp.unlink()
 
-    print(
-        f"patched {TARGET.name} "
-        "(vLLM #52805: stop XGrammar token batches at termination)"
-    )
+
+def main() -> int:
+    for target in (BACKEND_TARGET, MANAGER_TARGET):
+        if not target.is_file():
+            raise SystemExit(f"missing {target}")
+
+    backend_source = BACKEND_TARGET.read_text()
+    manager_source = MANAGER_TARGET.read_text()
+    try:
+        backend_patched, backend_action = prepare_backend(backend_source)
+        manager_patched, manager_action = prepare_manager(manager_source)
+    except ValueError as exc:
+        raise SystemExit(f"xgrammar patch preflight failed: {exc}") from exc
+
+    compile(backend_patched, str(BACKEND_TARGET), "exec")
+    compile(manager_patched, str(MANAGER_TARGET), "exec")
+
+    if backend_patched != backend_source:
+        replace_file(BACKEND_TARGET, backend_patched)
+    if manager_patched != manager_source:
+        replace_file(MANAGER_TARGET, manager_patched)
+
+    print(f"{BACKEND_TARGET.name}: termination fix {backend_action} (#52805)")
+    print(f"{MANAGER_TARGET.name}: reasoning fix {manager_action} (#53046)")
     return 0
 
 

--- a/start.sh
+++ b/start.sh
@@ -141,6 +141,7 @@ STOP_PATCH_HOST="${STOP_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_suppress_stops_in_
 SCHED_PATCH_HOST="${SCHED_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_scheduler_decode_floor.py}"
 DRAFTER_PATCH_HOST="${DRAFTER_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm5_drafter_group.py}"
 APC_PATCH_HOST="${APC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_hybrid_prefix_hit.py}"
+XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_xgrammar_termination.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
 QUANTIZATION="${QUANTIZATION:-exl3}"
 LANGUAGE_MODEL_ONLY="${LANGUAGE_MODEL_ONLY:-0}"
@@ -336,6 +337,7 @@ preflight() {
     [ -f "$SCHED_PATCH_HOST" ] || die "$SCHED_PATCH_HOST missing"
     [ -f "$DRAFTER_PATCH_HOST" ] || die "$DRAFTER_PATCH_HOST missing"
     [ -f "$APC_PATCH_HOST" ] || die "$APC_PATCH_HOST missing"
+    [ -f "$XGRAMMAR_PATCH_HOST" ] || die "$XGRAMMAR_PATCH_HOST missing"
 
     local need_kb=$((180 * 1024 * 1024)) avail
     mkdir -p "$HF_CACHE_DIR"
@@ -737,6 +739,9 @@ fi
 if [ -f /opt/glm53/patch_hybrid_prefix_hit.py ]; then
     python3 /opt/glm53/patch_hybrid_prefix_hit.py
 fi
+if [ -f /opt/glm53/patch_xgrammar_termination.py ]; then
+    python3 /opt/glm53/patch_xgrammar_termination.py
+fi
 say "launching: vllm serve ${MODEL_DIR} ${ARGS[*]}"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -813,6 +818,9 @@ fi
 if [ -f /opt/glm53/patch_hybrid_prefix_hit.py ]; then
     python3 /opt/glm53/patch_hybrid_prefix_hit.py
 fi
+if [ -f /opt/glm53/patch_xgrammar_termination.py ]; then
+    python3 /opt/glm53/patch_xgrammar_termination.py
+fi
 say "joining TP2 at ${HEAD_IP}:${MASTER_PORT} as rank 1"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -839,6 +847,8 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$DRAFTER_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_glm5_drafter_group.py"
     [ -f "$APC_PATCH_HOST" ] || die "missing $APC_PATCH_HOST"
     scp -q -o BatchMode=yes "$APC_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_hybrid_prefix_hit.py"
+    [ -f "$XGRAMMAR_PATCH_HOST" ] || die "missing $XGRAMMAR_PATCH_HOST"
+    scp -q -o BatchMode=yes "$XGRAMMAR_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_xgrammar_termination.py"
 
     local -a nccl_common=(
         -e NCCL_IB_DISABLE=0
@@ -920,6 +930,7 @@ launch_cluster() {
         -v '/tmp/patch_scheduler_decode_floor.py:/opt/glm53/patch_scheduler_decode_floor.py:ro' \
         -v '/tmp/patch_glm5_drafter_group.py:/opt/glm53/patch_glm5_drafter_group.py:ro' \
         -v '/tmp/patch_hybrid_prefix_hit.py:/opt/glm53/patch_hybrid_prefix_hit.py:ro' \
+        -v '/tmp/patch_xgrammar_termination.py:/opt/glm53/patch_xgrammar_termination.py:ro' \
         ${worker_preload} \
         ${worker_nccl} \
         -e NCCL_SOCKET_IFNAME='$WORKER_CX7_IF' \
@@ -945,6 +956,7 @@ launch_cluster() {
         -v "$SCHED_PATCH_HOST:/opt/glm53/patch_scheduler_decode_floor.py:ro" \
         -v "$DRAFTER_PATCH_HOST:/opt/glm53/patch_glm5_drafter_group.py:ro" \
         -v "$APC_PATCH_HOST:/opt/glm53/patch_hybrid_prefix_hit.py:ro" \
+        -v "$XGRAMMAR_PATCH_HOST:/opt/glm53/patch_xgrammar_termination.py:ro" \
         "${head_preload[@]}" \
         "${nccl_common[@]}" \
         -e NCCL_SOCKET_IFNAME="$HEAD_CX7_IF" \

--- a/tests/test_xgrammar_termination.py
+++ b/tests/test_xgrammar_termination.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Regression tests for the vLLM #52805 XGrammar runtime backport."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+PATCH = next(
+    p
+    for p in (
+        HERE / "patch_xgrammar_termination.py",
+        ROOT / "overlay" / "patch_xgrammar_termination.py",
+    )
+    if p.is_file()
+)
+INSTALLED = Path(
+    "/usr/local/lib/python3.12/dist-packages/vllm/v1/structured_output/"
+    "backend_xgrammar.py"
+)
+MARK = "# [glm53-xgrammar-termination] Source-exact vLLM 12f64b39 backport."
+
+# Exact vLLM 487ecf187 method bodies, embedded in a dependency-free harness.
+PINNED_FIXTURE = '''class _Logger:
+    def error(self, *args):
+        pass
+
+
+logger = _Logger()
+
+
+class XgrammarGrammar:
+    def __init__(self, matcher):
+        self.matcher = matcher
+        self.num_processed_tokens = 0
+        self._is_terminated = False
+
+    def accept_tokens(self, request_id: str, tokens: list[int]) -> bool:
+        """Accepts a list of tokens and advances the FSM.
+
+        Returns True if the FSM was advanced successfully.
+        Returns False if the FSM failed to advance.
+        """
+        if self._is_terminated:
+            return False
+        for token in tokens:
+            if not self.matcher.accept_token(token):
+                logger.error(
+                    "Failed to advance FSM for request %s "
+                    "for tokens %s. Please file an issue.",
+                    request_id,
+                    token,
+                )
+                return False
+            self.num_processed_tokens += 1
+        self._is_terminated = self.matcher.is_terminated()
+        return True
+
+    def validate_tokens(self, tokens: list[int]) -> list[int]:
+        """Checks if the list of tokens are accepted by the FSM in sequence.
+        Will not advance the FSM.
+
+        Returns the prefix list of tokens that are accepted by the FSM.
+        """
+        accepted_tokens = []
+        for token in tokens:
+            if self.matcher.accept_token(token):
+                accepted_tokens.append(token)
+            else:
+                break
+        if len(accepted_tokens) > 0:
+            # Rollback the FSM to the initial state
+            self.matcher.rollback(len(accepted_tokens))
+        return accepted_tokens
+
+    def rollback(self, num_tokens: int) -> None:
+        self.matcher.rollback(num_tokens)
+        self.num_processed_tokens -= num_tokens
+        self._is_terminated = self.matcher.is_terminated()
+
+    def fill_bitmask(self, bitmask, idx: int) -> None:
+        self.matcher.fill_next_token_bitmask(bitmask, idx)
+
+    def is_terminated(self) -> bool:
+        return self._is_terminated
+
+    def reset(self):
+        self.num_processed_tokens = 0
+        self.matcher.reset()
+'''
+
+
+class FakeMatcher:
+    """Small matcher that terminates on token 99 and detects over-advance."""
+
+    def __init__(self):
+        self.accepted: list[int] = []
+        self.calls_after_termination = 0
+
+    def accept_token(self, token: int) -> bool:
+        if self.is_terminated():
+            self.calls_after_termination += 1
+            return False
+        if token == -1:
+            return False
+        self.accepted.append(token)
+        return True
+
+    def is_terminated(self) -> bool:
+        return bool(self.accepted and self.accepted[-1] == 99)
+
+    def rollback(self, count: int) -> None:
+        if count:
+            del self.accepted[-count:]
+
+    def reset(self) -> None:
+        self.accepted.clear()
+
+    def fill_next_token_bitmask(self, bitmask, idx: int) -> None:
+        pass
+
+
+def run_patch(path: Path, *, ok: bool = True) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["GLM53_XGRAMMAR_BACKEND_PY"] = str(path)
+    proc = subprocess.run(
+        [sys.executable, str(PATCH)],
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if ok and proc.returncode != 0:
+        raise AssertionError(proc.stdout + proc.stderr)
+    if not ok and proc.returncode == 0:
+        raise AssertionError("patch unexpectedly accepted a drifted/partial target")
+    return proc
+
+
+def assert_behavior(source: str) -> None:
+    namespace: dict[str, object] = {}
+    exec(compile(source, "patched_backend_fixture.py", "exec"), namespace)
+    grammar_cls = namespace["XgrammarGrammar"]
+
+    matcher = FakeMatcher()
+    grammar = grammar_cls(matcher)
+    assert grammar.accept_tokens("req", [7, 99, 8])
+    assert matcher.accepted == [7, 99]
+    assert matcher.calls_after_termination == 0
+    assert grammar.num_processed_tokens == 2
+    assert grammar.is_terminated()
+    assert grammar.accept_tokens("req", [8])
+    assert matcher.accepted == [7, 99]
+    assert matcher.calls_after_termination == 0
+
+    grammar.reset()
+    assert matcher.accepted == []
+    assert grammar.num_processed_tokens == 0
+    assert not grammar.is_terminated()
+
+    assert grammar.validate_tokens([7, 99, 8]) == [7, 99]
+    assert matcher.accepted == []
+    assert matcher.calls_after_termination == 0
+    assert not grammar.is_terminated()
+
+    assert grammar.accept_tokens("req", [99])
+    assert grammar.validate_tokens([8]) == []
+    assert matcher.calls_after_termination == 0
+
+
+def test_fixture() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "backend_xgrammar.py"
+        target.write_text(PINNED_FIXTURE)
+        run_patch(target)
+        patched = target.read_text()
+        assert patched.count(MARK) == 1
+        assert "Tokens after termination are ignored." in patched
+        assert "if self.matcher.is_terminated():\n                    break" in patched
+        assert "self.matcher.reset()\n        self.num_processed_tokens = 0" in patched
+        assert_behavior(patched)
+
+        run_patch(target)
+        assert target.read_text() == patched
+
+        # Exact merged behavior is accepted when a newer image already has it.
+        target.write_text(patched.replace(f"    {MARK}\n", "", 1))
+        upstream = target.read_text()
+        run_patch(target)
+        assert target.read_text() == upstream
+
+
+def test_fail_closed() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "backend_xgrammar.py"
+        drifted = PINNED_FIXTURE.replace(
+            "Returns False if the FSM failed to advance.",
+            "Returns False on failure.",
+            1,
+        )
+        target.write_text(drifted)
+        run_patch(target, ok=False)
+        assert target.read_text() == drifted
+
+        partial = PINNED_FIXTURE.replace(
+            "    def accept_tokens",
+            f"    {MARK}\n    def accept_tokens",
+            1,
+        )
+        target.write_text(partial)
+        run_patch(target, ok=False)
+        assert target.read_text() == partial
+
+
+def test_installed_copy_if_present() -> None:
+    source = Path(os.environ.get("GLM53_XGRAMMAR_BACKEND_PY_SRC", INSTALLED))
+    if not source.is_file():
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "backend_xgrammar.py"
+        target.write_bytes(source.read_bytes())
+        run_patch(target)
+        patched = target.read_text()
+        compile(patched, str(target), "exec")
+        assert "Tokens after termination are ignored." in patched
+        assert "self._is_terminated = False" in patched
+        run_patch(target)
+
+
+def test_recipe_wiring_if_present() -> None:
+    start = ROOT / "start.sh"
+    dockerfile = ROOT / "Dockerfile"
+    if not start.is_file() or not dockerfile.is_file():
+        return
+    launcher = start.read_text()
+    image = dockerfile.read_text()
+    assert 'XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-' in launcher
+    assert launcher.count("python3 /opt/glm53/patch_xgrammar_termination.py") == 2
+    assert (
+        "-v '/tmp/patch_xgrammar_termination.py:"
+        "/opt/glm53/patch_xgrammar_termination.py:ro'" in launcher
+    )
+    assert (
+        '-v "$XGRAMMAR_PATCH_HOST:'
+        '/opt/glm53/patch_xgrammar_termination.py:ro"' in launcher
+    )
+    assert "scp -q -o BatchMode=yes \"$XGRAMMAR_PATCH_HOST\"" in launcher
+    assert "COPY overlay/patch_xgrammar_termination.py" in image
+    assert "RUN python3 /opt/glm53/patch_xgrammar_termination.py" in image
+    assert "python3 /opt/glm53/test_xgrammar_termination.py" in image
+
+
+def main() -> int:
+    test_fixture()
+    test_fail_closed()
+    test_installed_copy_if_present()
+    test_recipe_wiring_if_present()
+    print("xgrammar termination patch OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_xgrammar_termination.py
+++ b/tests/test_xgrammar_termination.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Regression tests for the vLLM #52805 XGrammar runtime backport."""
+"""Regression tests for the vLLM #52805/#53046 XGrammar backports."""
 from __future__ import annotations
 
 import os
@@ -19,14 +19,23 @@ PATCH = next(
     )
     if p.is_file()
 )
-INSTALLED = Path(
+INSTALLED_BACKEND = Path(
     "/usr/local/lib/python3.12/dist-packages/vllm/v1/structured_output/"
     "backend_xgrammar.py"
 )
-MARK = "# [glm53-xgrammar-termination] Source-exact vLLM 12f64b39 backport."
+INSTALLED_MANAGER = Path(
+    "/usr/local/lib/python3.12/dist-packages/vllm/v1/structured_output/"
+    "__init__.py"
+)
+BACKEND_MARK = (
+    "# [glm53-xgrammar-termination] Source-exact vLLM 12f64b39 backport."
+)
+MANAGER_MARK = (
+    "# [glm53-xgrammar-reasoning] Source-exact vLLM c6e19b3 backport."
+)
 
-# Exact vLLM 487ecf187 method bodies, embedded in a dependency-free harness.
-PINNED_FIXTURE = '''class _Logger:
+# Exact vLLM 487ecf187 patch anchors, embedded in a dependency-free harness.
+PINNED_BACKEND_FIXTURE = '''class _Logger:
     def error(self, *args):
         pass
 
@@ -94,6 +103,31 @@ class XgrammarGrammar:
         self.matcher.reset()
 '''
 
+PINNED_MANAGER_FIXTURE = '''class StructuredOutputManager:
+    def advance_speculative_draft(
+        self,
+        grammar,
+        token: int,
+        post_reasoning_end_in_window: bool,
+    ) -> int:
+        advance_grammar = True
+        req_id = "req"
+        scheduled_spec_decode_tokens = {req_id: [token]}
+        state_advancements = 0
+        if grammar is not None:
+            for req_id in scheduled_spec_decode_tokens:
+                for token in [token]:
+                    if advance_grammar and not grammar.is_terminated():
+                        accepted = grammar.accept_tokens(req_id, [token])
+                        if accepted:
+                            state_advancements += 1
+                        elif not post_reasoning_end_in_window:
+                            raise AssertionError(
+                                (token, req_id, scheduled_spec_decode_tokens)
+                            )
+        return state_advancements
+'''
+
 
 class FakeMatcher:
     """Small matcher that terminates on token 99 and detects over-advance."""
@@ -125,9 +159,37 @@ class FakeMatcher:
         pass
 
 
-def run_patch(path: Path, *, ok: bool = True) -> subprocess.CompletedProcess[str]:
+class FakeGrammar:
+    """Grammar whose invalid tokens must be validated, never advanced."""
+
+    def __init__(self, valid_token: int):
+        self.valid_token = valid_token
+        self.validated: list[list[int]] = []
+        self.accepted: list[list[int]] = []
+
+    def is_terminated(self) -> bool:
+        return False
+
+    def validate_tokens(self, tokens: list[int]) -> list[int]:
+        self.validated.append(tokens)
+        return tokens if tokens == [self.valid_token] else []
+
+    def accept_tokens(self, request_id: str, tokens: list[int]) -> bool:
+        if tokens != [self.valid_token]:
+            raise AssertionError("invalid speculative draft reached accept_tokens")
+        self.accepted.append(tokens)
+        return True
+
+
+def run_patch(
+    backend: Path,
+    manager: Path,
+    *,
+    ok: bool = True,
+) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
-    env["GLM53_XGRAMMAR_BACKEND_PY"] = str(path)
+    env["GLM53_XGRAMMAR_BACKEND_PY"] = str(backend)
+    env["GLM53_XGRAMMAR_MANAGER_PY"] = str(manager)
     proc = subprocess.run(
         [sys.executable, str(PATCH)],
         env=env,
@@ -143,7 +205,7 @@ def run_patch(path: Path, *, ok: bool = True) -> subprocess.CompletedProcess[str
     return proc
 
 
-def assert_behavior(source: str) -> None:
+def assert_backend_behavior(source: str) -> None:
     namespace: dict[str, object] = {}
     exec(compile(source, "patched_backend_fixture.py", "exec"), namespace)
     grammar_cls = namespace["XgrammarGrammar"]
@@ -174,63 +236,145 @@ def assert_behavior(source: str) -> None:
     assert matcher.calls_after_termination == 0
 
 
+def assert_manager_behavior(source: str) -> None:
+    namespace: dict[str, object] = {}
+    exec(compile(source, "patched_manager_fixture.py", "exec"), namespace)
+    manager = namespace["StructuredOutputManager"]()
+
+    grammar = FakeGrammar(valid_token=7)
+    assert manager.advance_speculative_draft(grammar, 8, True) == 0
+    assert grammar.validated == [[8]]
+    assert grammar.accepted == []
+
+    assert manager.advance_speculative_draft(grammar, 7, True) == 1
+    assert grammar.validated == [[8], [7]]
+    assert grammar.accepted == [[7]]
+
+    # Drafts outside the mid-window reasoning boundary retain the original
+    # direct-advance path.
+    direct = FakeGrammar(valid_token=9)
+    assert manager.advance_speculative_draft(direct, 9, False) == 1
+    assert direct.validated == []
+    assert direct.accepted == [[9]]
+
+
 def test_fixture() -> None:
     with tempfile.TemporaryDirectory() as tmp:
-        target = Path(tmp) / "backend_xgrammar.py"
-        target.write_text(PINNED_FIXTURE)
-        run_patch(target)
-        patched = target.read_text()
-        assert patched.count(MARK) == 1
-        assert "Tokens after termination are ignored." in patched
-        assert "if self.matcher.is_terminated():\n                    break" in patched
-        assert "self.matcher.reset()\n        self.num_processed_tokens = 0" in patched
-        assert_behavior(patched)
+        backend = Path(tmp) / "backend_xgrammar.py"
+        manager = Path(tmp) / "__init__.py"
+        backend.write_text(PINNED_BACKEND_FIXTURE)
+        manager.write_text(PINNED_MANAGER_FIXTURE)
+        run_patch(backend, manager)
+        patched_backend = backend.read_text()
+        patched_manager = manager.read_text()
+        assert patched_backend.count(BACKEND_MARK) == 1
+        assert patched_manager.count(MANAGER_MARK) == 1
+        assert "Tokens after termination are ignored." in patched_backend
+        assert (
+            "if self.matcher.is_terminated():\n                    break"
+            in patched_backend
+        )
+        assert (
+            "self.matcher.reset()\n        self.num_processed_tokens = 0"
+            in patched_backend
+        )
+        assert "accepted = bool(grammar.validate_tokens([token]))" in patched_manager
+        assert_backend_behavior(patched_backend)
+        assert_manager_behavior(patched_manager)
 
-        run_patch(target)
-        assert target.read_text() == patched
+        run_patch(backend, manager)
+        assert backend.read_text() == patched_backend
+        assert manager.read_text() == patched_manager
 
         # Exact merged behavior is accepted when a newer image already has it.
-        target.write_text(patched.replace(f"    {MARK}\n", "", 1))
-        upstream = target.read_text()
-        run_patch(target)
-        assert target.read_text() == upstream
+        backend.write_text(
+            patched_backend.replace(f"    {BACKEND_MARK}\n", "", 1)
+        )
+        manager.write_text(
+            patched_manager.replace(f"                    {MANAGER_MARK}\n", "", 1)
+        )
+        upstream_backend = backend.read_text()
+        upstream_manager = manager.read_text()
+        run_patch(backend, manager)
+        assert backend.read_text() == upstream_backend
+        assert manager.read_text() == upstream_manager
 
 
 def test_fail_closed() -> None:
     with tempfile.TemporaryDirectory() as tmp:
-        target = Path(tmp) / "backend_xgrammar.py"
-        drifted = PINNED_FIXTURE.replace(
+        backend = Path(tmp) / "backend_xgrammar.py"
+        manager = Path(tmp) / "__init__.py"
+
+        drifted_backend = PINNED_BACKEND_FIXTURE.replace(
             "Returns False if the FSM failed to advance.",
             "Returns False on failure.",
             1,
         )
-        target.write_text(drifted)
-        run_patch(target, ok=False)
-        assert target.read_text() == drifted
+        backend.write_text(drifted_backend)
+        manager.write_text(PINNED_MANAGER_FIXTURE)
+        run_patch(backend, manager, ok=False)
+        assert backend.read_text() == drifted_backend
+        assert manager.read_text() == PINNED_MANAGER_FIXTURE
 
-        partial = PINNED_FIXTURE.replace(
-            "    def accept_tokens",
-            f"    {MARK}\n    def accept_tokens",
+        # The backend is not written when the second-file preflight fails.
+        drifted_manager = PINNED_MANAGER_FIXTURE.replace(
+            "accepted = grammar.accept_tokens(req_id, [token])",
+            "accepted = grammar.accept_tokens(req_id, tuple([token]))",
             1,
         )
-        target.write_text(partial)
-        run_patch(target, ok=False)
-        assert target.read_text() == partial
+        backend.write_text(PINNED_BACKEND_FIXTURE)
+        manager.write_text(drifted_manager)
+        run_patch(backend, manager, ok=False)
+        assert backend.read_text() == PINNED_BACKEND_FIXTURE
+        assert manager.read_text() == drifted_manager
+
+        partial_backend = PINNED_BACKEND_FIXTURE.replace(
+            "    def accept_tokens",
+            f"    {BACKEND_MARK}\n    def accept_tokens",
+            1,
+        )
+        backend.write_text(partial_backend)
+        manager.write_text(PINNED_MANAGER_FIXTURE)
+        run_patch(backend, manager, ok=False)
+        assert backend.read_text() == partial_backend
+        assert manager.read_text() == PINNED_MANAGER_FIXTURE
+
+        partial_manager = PINNED_MANAGER_FIXTURE.replace(
+            "                    if advance_grammar",
+            f"                    {MANAGER_MARK}\n"
+            "                    if advance_grammar",
+            1,
+        )
+        backend.write_text(PINNED_BACKEND_FIXTURE)
+        manager.write_text(partial_manager)
+        run_patch(backend, manager, ok=False)
+        assert backend.read_text() == PINNED_BACKEND_FIXTURE
+        assert manager.read_text() == partial_manager
 
 
 def test_installed_copy_if_present() -> None:
-    source = Path(os.environ.get("GLM53_XGRAMMAR_BACKEND_PY_SRC", INSTALLED))
-    if not source.is_file():
+    backend_source = Path(
+        os.environ.get("GLM53_XGRAMMAR_BACKEND_PY_SRC", INSTALLED_BACKEND)
+    )
+    manager_source = Path(
+        os.environ.get("GLM53_XGRAMMAR_MANAGER_PY_SRC", INSTALLED_MANAGER)
+    )
+    if not backend_source.is_file() or not manager_source.is_file():
         return
     with tempfile.TemporaryDirectory() as tmp:
-        target = Path(tmp) / "backend_xgrammar.py"
-        target.write_bytes(source.read_bytes())
-        run_patch(target)
-        patched = target.read_text()
-        compile(patched, str(target), "exec")
-        assert "Tokens after termination are ignored." in patched
-        assert "self._is_terminated = False" in patched
-        run_patch(target)
+        backend = Path(tmp) / "backend_xgrammar.py"
+        manager = Path(tmp) / "__init__.py"
+        backend.write_bytes(backend_source.read_bytes())
+        manager.write_bytes(manager_source.read_bytes())
+        run_patch(backend, manager)
+        patched_backend = backend.read_text()
+        patched_manager = manager.read_text()
+        compile(patched_backend, str(backend), "exec")
+        compile(patched_manager, str(manager), "exec")
+        assert "Tokens after termination are ignored." in patched_backend
+        assert "self._is_terminated = False" in patched_backend
+        assert "accepted = bool(grammar.validate_tokens([token]))" in patched_manager
+        run_patch(backend, manager)
 
 
 def test_recipe_wiring_if_present() -> None:
@@ -261,7 +405,7 @@ def main() -> int:
     test_fail_closed()
     test_installed_copy_if_present()
     test_recipe_wiring_if_present()
-    print("xgrammar termination patch OK")
+    print("xgrammar speculative patches OK")
     return 0
 
 


### PR DESCRIPTION
Addresses the matcher-after-stop defect in #19.

This is a fail-closed, idempotent runtime backport of merged vLLM PR #52805 / commit `12f64b39`. It stops `accept_tokens()` and `validate_tokens()` at the first terminating token, treats later advances as harmless, and clears the cached termination flag on reset. The patch is wired to both ranks and the image build.

Tests cover exact pinned anchors, source drift, idempotence, rollback/reset behavior, both-rank launcher wiring, Python compilation, and shell syntax.

Live verification on the pinned image:
- both ranks applied the patch at startup;
- one schema request plus 16 concurrent schema requests all returned valid strict JSON with `finish_reason=stop`;
- head logs contained zero `Failed to advance FSM` / matcher-after-termination warnings;
- a second patch invocation reported the exact already-present state.

Scope is intentionally narrow: this does not reinterpret an invalid request combining GLM XML tool output with a JSON response schema, and it does not remove cold-prefill queue time.