### PR TITLE
perf: opt out of the CUDA-graph KV deduction (CG_ESTIMATE)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,4 +99,8 @@ USE_HOST_NCCL=0
 # WORKER_NCCL_HOST_DIR=/home/you/nccl-2.30.7
 NCCL_SO_NAME=libnccl.so.2.30.7
 NCCL_IB_GID_INDEX=3
+# vLLM deducts a CUDA-graph memory estimate from the KV pool. Where the estimate
+# exceeds what the graphs actually use, 0 returns that memory to KV with graphs
+# still enabled. 1 = upstream default.
+CG_ESTIMATE=1
 NCCL_DEBUG=WARN

--- a/start.sh
+++ b/start.sh
@@ -104,6 +104,11 @@ HEAD_CX7_IB="${HEAD_CX7_IB:-rocep1s0f1}"
 WORKER_CX7_IB="${WORKER_CX7_IB:-rocep1s0f0}"
 NCCL_DEBUG="${NCCL_DEBUG:-WARN}"
 NCCL_IB_GID_INDEX="${NCCL_IB_GID_INDEX:-3}"
+# vLLM subtracts a CUDA-graph memory ESTIMATE from the KV pool. On this kit the
+# estimate is 2.43 GiB while the captured graphs actually consume -0.19 GiB, so
+# ~2.6 GiB of KV is reserved and never used. 0 keeps CUDA graphs ON and drops only
+# the deduction. 1 = upstream default.
+CG_ESTIMATE="${CG_ESTIMATE:-1}"
 NCCL_CROSS_NIC="${NCCL_CROSS_NIC:-0}"
 NCCL_HOST_DIR="${NCCL_HOST_DIR:-$HOME/nccl-2.30.7}"
 WORKER_NCCL_HOST_DIR="${WORKER_NCCL_HOST_DIR:-$WORKER_HOME/nccl-2.30.7}"
@@ -850,6 +855,7 @@ launch_cluster() {
         # thread then dumps JSONDecodeError. Stats are off on this private kit.
         -e VLLM_NO_USAGE_STATS=1
         -e DO_NOT_TRACK=1
+        -e "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=$CG_ESTIMATE"
     )
     local worker_nccl="" e
     for e in "${nccl_common[@]}"; do


### PR DESCRIPTION
vLLM deducts a CUDA-graph memory **estimate** from the KV pool. On our 2× GB10 kit the engine reports:

```
CUDA graph pool memory: -0.19 GiB (actual), 2.43 GiB (estimated), difference: 2.62 GiB
```

So ~2.6 GiB of KV is reserved and never used. vLLM itself flags this and suggests raising util to compensate:

```
The current --gpu-memory-utilization=0.8600 is equivalent to 0.8400 without CUDA
graph memory profiling. To maintain the same effective KV cache size, increase
--gpu-memory-utilization
```

Raising util is exactly what the kits in #16 cannot do — they miss `0.87` by under 1 GiB and fall back to `0.86/800k`. This returns the memory without touching util.

**Mechanism** (`vllm/v1/worker/gpu_worker.py`):

```python
cudagraph_memory_estimate_applied = (
    cudagraph_memory_estimate if envs.VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS else 0)
available_kv_cache_memory_bytes = (
    requested_memory - non_kv_cache_memory - cudagraph_memory_estimate_applied)
```

Graphs are still captured; only the deduction is skipped.

**Measured here** — `util 0.86`, `MAX_MODEL_LEN=800000`, EXL3 4bpw, DFlash2 k=7, `LANGUAGE_MODEL_ONLY=1`:

| | KV pool |
|---|---:|
| `CG_ESTIMATE=1` (default) | 802,083 |
| `CG_ESTIMATE=0` | **855,598** |

For reference the README records 837,065 at `util 0.86 / 800k`.

**Caveat:** these two figures come from separate boots rather than a single controlled A/B, and this kit runs `LANGUAGE_MODEL_ONLY=1`. The mechanism and the 2.43 vs -0.19 GiB split are from the engine log; treat the pool delta as indicative.

Default `CG_ESTIMATE=1` preserves current behaviour exactly — opt-in only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wA3kowHQUVCEPXWhwpw5p