### PR TITLE
ci: dispatch Ablit overlay sync on main pushes

### DIFF
--- a/.github/workflows/ping-ablit.yml
+++ b/.github/workflows/ping-ablit.yml
@@ -1,0 +1,37 @@
+# After each merge to public main, wake the Ablit overlay sync.
+# Guarded so a later merge of this file into AblitBrench is a no-op there.
+#
+# One-time: add repo secret ABLIT_SYNC_TOKEN on THIS repo. Fine-grained PAT
+# (only MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks-AblitBrench, Contents:
+# Read and Write) or a classic token with `repo`. Without the secret this
+# job succeeds and Ablit still syncs hourly / via workflow_dispatch.
+name: Ping Ablit overlay
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  dispatch:
+    if: github.repository == 'MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks'
+    runs-on: ubuntu-latest
+    steps:
+      - name: repository_dispatch AblitBrench
+        env:
+          ABLIT_SYNC_TOKEN: ${{ secrets.ABLIT_SYNC_TOKEN }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ABLIT_SYNC_TOKEN}" ]; then
+            echo "ABLIT_SYNC_TOKEN unset — Ablit hourly/manual sync still runs"
+            exit 0
+          fi
+          code=$(curl -sS -o /tmp/dispatch.json -w "%{http_code}" -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${ABLIT_SYNC_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks-AblitBrench/dispatches \
+            -d "{\"event_type\":\"public-main-pushed\",\"client_payload\":{\"sha\":\"${SHA}\"}}")
+          cat /tmp/dispatch.json
+          echo
+          test "$code" = "204"


### PR DESCRIPTION
## Summary

- On push to \`main\`, \`repository_dispatch\` AblitBrench so the overlay picks up the merge immediately
- No-op if \`ABLIT_SYNC_TOKEN\` is unset (Ablit still syncs hourly / manually)
- Guarded to this repo so a later sync into Ablit does not ping itself

Add repo secret \`ABLIT_SYNC_TOKEN\` (fine-grained PAT on AblitBrench, Contents: Read and Write) for instant sync.

## Test plan

- [ ] Merge this PR; Actions → Ping Ablit overlay should succeed (204 or skip if secret missing)

Made with [Cursor](https://cursor.com)