### PR TITLE
Honor inline MAX_NUM_SEQS override

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -63,6 +63,7 @@ _cli_fused="${EXL3_FUSED_MOE-}"
 _cli_image="${IMAGE-}"
 _cli_util="${GPU_MEM_UTIL-}"
 _cli_lm="${LANGUAGE_MODEL_ONLY-}"
+_cli_max_num_seqs="${MAX_NUM_SEQS-}"
 set -a
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/.env"
@@ -74,6 +75,7 @@ set +a
 [ -n "${_cli_image}" ] && IMAGE="$_cli_image"
 [ -n "${_cli_util}" ] && GPU_MEM_UTIL="$_cli_util"
 [ -n "${_cli_lm}" ] && LANGUAGE_MODEL_ONLY="$_cli_lm"
+[ -n "${_cli_max_num_seqs}" ] && MAX_NUM_SEQS="$_cli_max_num_seqs"
 
 # ----------------------------- configuration -------------------------------
 MODEL="${MODEL:-Mia-AiLab/GLM-5.3-Flash-EXL3-TR3-4bpw}"

--- a/tests/test_start_overrides.py
+++ b/tests/test_start_overrides.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Regression test for caller overrides that must win over ``.env``."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_max_num_seqs_inline_override_wins() -> None:
+    source = (ROOT / "start.sh").read_text()
+    marker = "# ----------------------------- configuration -------------------------------"
+    preamble, separator, _rest = source.partition(marker)
+    assert separator, "start.sh configuration marker is missing"
+
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        tmp = Path(raw_tmp)
+        script = tmp / "start.sh"
+        script.write_text(
+            preamble
+            + '\nprintf "MAX_NUM_SEQS=%s\\n" "${MAX_NUM_SEQS:-unset}"\n'
+        )
+        script.chmod(0o755)
+        (tmp / ".env").write_text("MAX_NUM_SEQS=2\n")
+
+        env = os.environ.copy()
+        env["MAX_NUM_SEQS"] = "4"
+        result = subprocess.run(
+            ["bash", str(script)],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    assert result.stdout.strip() == "MAX_NUM_SEQS=4"
+
+
+if __name__ == "__main__":
+    test_max_num_seqs_inline_override_wins()
+    print("start.sh caller override regression OK")


### PR DESCRIPTION
## Summary

- Preserve caller-exported MAX_NUM_SEQS across .env loading, using the launcher's existing override pattern.
- Add a dependency-free regression proving caller value 4 wins over a synthetic .env value 2.

## Why

The launcher documents caller exports as higher priority than .env, but MAX_NUM_SEQS was omitted from the capture/restore list. On a live benchmark restart, MAX_NUM_SEQS=4 ./start.sh restart silently launched vLLM with max-num-seqs 2 because .env contained the older deployment value. That makes launch tuning and benchmark reproduction misleading.

## Validation

- bash -n start.sh
- python3 tests/test_start_overrides.py
- git diff --check
- Live two-DGX-Spark restart with the existing image: generated command, vLLM parsed config, and both container environments reported max-seqs 4; health passed after 510 seconds; all 20 post-ready warmups including concurrency 3 and 4 passed; both ranks had zero restarts and no fatal, FSM, or CUDA OOM log matches.

The real .env was not read or changed.