### PR TITLE
Update cold-prefill receipts with 2026-08-29 ladder remeasure

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Live occupancy, temp **0**, thinking **off**, unique pads, `max_tokens=8`:
 | ~36k ×1 (padded slot-share) | 200 | **~16%** | — | one shared ID set |
 | ~36k ×3 concurrent | **3× 200** | **21%** (two in flight) | 54 / 96 / 137 s | `GLM53_MIXED_PREFILL_CHUNK=skip` still serializes prefills (`Running: 1`, others wait on capacity, then deferred) |
 | ~256k ×3 concurrent | **3× 200** | **29.5%** (two in flight) | 305 / 608 / 916 s | live on the 900k boot; 256,013 prompt tokens each, gen `OK`; third waited (skip) |
-| ~300k ×1 streamed | **200** | **26.0%** | **356 s** TTFT (~840 tok/s) | 299,213 prompt tokens, gen `OK` |
+| ~300k ×1 streamed | **200** | **26.0%** | **356 s** TTFT (~840 tok/s) | 299,213 prompt tokens, gen `OK`; ladder remeasure 2026-08-29: **323 s** TTFT (~928 tok/s) |
 
 Live **3×256k** held (the original failure). Prefills still serialize under skip; two 256k contexts were in KV at once at 29.5%. One 256k sat ~25%. Hybrid occupancy is a large length-independent floor (mamba + DFlash window) plus MLA pages that scale: 36k → 16%, 256k → ~25%, 300k → 26%.
 Default is **1M**. Do **not** drop `MAX_MODEL_LEN` to 256k to “free” slots —
@@ -224,19 +224,23 @@ does **not** let that group shrink the MLA+mamba hit. Mamba stays in the min
 (skipping a mamba miss is a correctness hole). Do not raise
 `--max-num-batched-tokens` to “fix” APC.
 
-**Live retest** (thinking off, temp 0, real user + assistant + follow-up), 1M serve:
+**Live receipts** (thinking off, temp 0, real user + assistant + follow-up), 1M serve. Cold rungs and the ~8k follow-up are the 2026-08-29 cold-prefill ladder remeasure (`docs/cold-prefill.md`, KV pool 1,691,099 tok); the ~12k/~16k follow-ups and the 4× concurrent row are from the earlier same-day retest:
 
-| Turn | Hits | Compute | Prompt tok | TTFT |
-|---|---:|---:|---:|---:|
-| ~7.7k cold | 0 | 7696 | 7696 | 9.7 s |
-| ~7.7k follow-up | **7168** | 549 | 7717 | **1.17 s** |
-| ~12k cold | 0 | 11994 | 11994 | 13.4 s |
-| ~12k follow-up | **10752** | 1263 | 12015 | **1.94 s** |
-| ~16k cold | 0 | 15994 | 15994 | 17.7 s |
-| ~16k follow-up | **14336** | 1679 | 16015 | **2.18 s** |
-| 4× ~7.5k concurrent follow-ups | **7168 each** (28672 total) | rest | 7515 each | **1.86–2.50 s** |
+| Turn | Hits | Compute | Prompt tok | TTFT | Prefill tok/s |
+|---|---:|---:|---:|---:|---:|
+| ~8k cold | 0 | 7995 | 7995 | 10.36 s | 772 |
+| ~8k follow-up | **7168** | 836 | 8004 | **1.30 s** | 6167 |
+| ~12k cold | 0 | 11995 | 11995 | 13.38 s | 896 |
+| ~12k follow-up | **10752** | 1263 | 12015 | **1.94 s** | — |
+| ~16k cold | 0 | 15995 | 15995 | 17.91 s | 893 |
+| ~16k follow-up | **14336** | 1679 | 16015 | **2.18 s** | — |
+| ~100k cold | 0 | 99995 | 99995 | 105.6 s | 947 |
+| ~256k cold | 0 | 255995 | 255995 | 273.4 s | 936 |
+| ~300k cold | 0 | 299995 | 299995 | 323.2 s | 928 |
+| 4× ~7.5k concurrent follow-ups | **7168 each** (28672 total) | rest | 7515 each | **1.86–2.50 s** | — |
 
-A ~7.7k follow-up reuses **93%** of the prompt (7168 / 7717), not 46%.
+An ~8k follow-up reuses **7168 / 8004 ≈ 90%** of the prompt (earlier retest: 93% of 7717), not 46%.
+Long colds got faster vs the 2026-08-28 receipts: ~256k 305 s / ~839 → **273 s / 936**, ~300k 356 s / ~840 → **323 s / 928**.
 Hits work **below** UserHIJ’s 14,336-token floor (that floor is 896-chunk ×
 2048-align LCM on a different geometry; this kit’s 3584 is 4×896). Isolation
 held (`STILL_READY_S` / `STILL_C0`…`C3`). Idle chats are not reserved; after

--- a/docs/_cold_prefill_raw.json
+++ b/docs/_cold_prefill_raw.json
@@ -1,0 +1,151 @@
+{
+  "served_model": "GLM-5.3-Flash-EXL3",
+  "max_model_len": 1000000,
+  "kv_cache_size_tokens": 1691099,
+  "wall_clock_utc": "2026-08-29T14:01:29Z",
+  "health": 200,
+  "started_metrics": {
+    "num_requests_running": 0.0,
+    "prefix_cache_queries_total": 32668.0,
+    "prefix_cache_hits_total": 14336.0,
+    "prompt_tokens_total": 32668.0,
+    "local_compute": 18332.0,
+    "local_cache_hit": 14336.0
+  },
+  "ended_metrics": {
+    "num_requests_running": 0.0,
+    "prefix_cache_queries_total": 732642.0,
+    "prefix_cache_hits_total": 21504.0,
+    "prompt_tokens_total": 732642.0,
+    "local_compute": 711138.0,
+    "local_cache_hit": 21504.0
+  },
+  "results": [
+    {
+      "name": "~8k",
+      "kind": "cold",
+      "http": 200,
+      "finish_reason": "stop",
+      "prompt_tokens": 7995,
+      "completion_tokens": 2,
+      "ttft_s": 10.355024347984,
+      "prefill_tok_s": 772.0889619691268,
+      "gen": "OK",
+      "gen_ok": true,
+      "metrics_delta": {
+        "prefix_cache_hits_total": 0.0,
+        "prefix_cache_queries_total": 7995.0,
+        "local_compute": 7995.0,
+        "local_cache_hit": 0.0
+      }
+    },
+    {
+      "name": "~8k follow-up",
+      "kind": "apc",
+      "http": 200,
+      "finish_reason": "stop",
+      "prompt_tokens": 8004,
+      "completion_tokens": 2,
+      "ttft_s": 1.2977978079870809,
+      "prefill_tok_s": 6167.3705647680345,
+      "gen": "OK",
+      "gen_ok": true,
+      "metrics_delta": {
+        "prefix_cache_hits_total": 7168.0,
+        "prefix_cache_queries_total": 8004.0,
+        "local_compute": 836.0,
+        "local_cache_hit": 7168.0
+      }
+    },
+    {
+      "name": "~12k",
+      "kind": "cold",
+      "http": 200,
+      "finish_reason": "stop",
+      "prompt_tokens": 11995,
+      "completion_tokens": 2,
+      "ttft_s": 13.382142284011934,
+      "prefill_tok_s": 896.3437800486402,
+      "gen": "OK",
+      "gen_ok": true,
+      "metrics_delta": {
+        "prefix_cache_hits_total": 0.0,
+        "prefix_cache_queries_total": 11995.0,
+        "local_compute": 11995.0,
+        "local_cache_hit": 0.0
+      }
+    },
+    {
+      "name": "~16k",
+      "kind": "cold",
+      "http": 200,
+      "finish_reason": "stop",
+      "prompt_tokens": 15995,
+      "completion_tokens": 2,
+      "ttft_s": 17.911350469017634,
+      "prefill_tok_s": 893.009157945267,
+      "gen": "OK",
+      "gen_ok": true,
+      "metrics_delta": {
+        "prefix_cache_hits_total": 0.0,
+        "prefix_cache_queries_total": 15995.0,
+        "local_compute": 15995.0,
+        "local_cache_hit": 0.0
+      }
+    },
+    {
+      "name": "~100k",
+      "kind": "cold",
+      "http": 200,
+      "finish_reason": "stop",
+      "prompt_tokens": 99995,
+      "completion_tokens": 2,
+      "ttft_s": 105.55738078200375,
+      "prefill_tok_s": 947.3046722001266,
+      "gen": "OK",
+      "gen_ok": true,
+      "metrics_delta": {
+        "prefix_cache_hits_total": 0.0,
+        "prefix_cache_queries_total": 99995.0,
+        "local_compute": 99995.0,
+        "local_cache_hit": 0.0
+      }
+    },
+    {
+      "name": "~256k",
+      "kind": "cold",
+      "http": 200,
+      "finish_reason": "stop",
+      "prompt_tokens": 255995,
+      "completion_tokens": 2,
+      "ttft_s": 273.4431502770167,
+      "prefill_tok_s": 936.1909403861807,
+      "gen": "OK",
+      "gen_ok": true,
+      "metrics_delta": {
+        "prefix_cache_hits_total": 0.0,
+        "prefix_cache_queries_total": 255995.0,
+        "local_compute": 255995.0,
+        "local_cache_hit": 0.0
+      }
+    },
+    {
+      "name": "~300k",
+      "kind": "cold",
+      "http": 200,
+      "finish_reason": "stop",
+      "prompt_tokens": 299995,
+      "completion_tokens": 2,
+      "ttft_s": 323.22955608999473,
+      "prefill_tok_s": 928.1174767213253,
+      "gen": "OK",
+      "gen_ok": true,
+      "metrics_delta": {
+        "prefix_cache_hits_total": 0.0,
+        "prefix_cache_queries_total": 299995.0,
+        "local_compute": 299995.0,
+        "local_cache_hit": 0.0
+      }
+    }
+  ]
+}

--- a/docs/_run_cold_prefill.py
+++ b/docs/_run_cold_prefill.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Live cold-prefill ladder for GLM-5.3-Flash-EXL3 on :8888.
+
+Protocol matches the published kit receipts: temp 0, thinking off via
+top-level chat_template_kwargs, stream + include_usage, max_tokens=8,
+unique salt per cold request, one-at-a-time, TTFT = first content token.
+"""
+from __future__ import annotations
+
+import json
+import secrets
+import time
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+
+BASE = "http://127.0.0.1:8888"
+SERVED = "GLM-5.3-Flash-EXL3"
+FILLER = "the "
+TASK = "Reply with OK."
+OUT_JSON = Path("/home/mia/NewModels/glm-5.3-flash-sm120/docs/_cold_prefill_raw.json")
+
+# target prompt_tokens, http timeout seconds
+LADDER = [
+    ("~8k", 8_000, 180),
+    ("~12k", 12_000, 180),
+    ("~16k", 16_000, 180),
+    ("~100k", 100_000, 600),
+    ("~256k", 256_000, 1_200),
+    ("~300k", 300_000, 1_200),
+]
+
+
+def http_get(path: str, timeout: float = 15.0):
+    req = urllib.request.Request(BASE + path)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.status, resp.read().decode("utf-8", "replace")
+
+
+def http_post(path: str, body: dict, timeout: float, stream: bool = False):
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        BASE + path,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    return urllib.request.urlopen(req, timeout=timeout)
+
+
+def tokenize_messages(messages: list[dict], timeout: float = 180.0) -> int:
+    body = {"model": SERVED, "messages": messages}
+    with http_post("/tokenize", body, timeout=timeout) as resp:
+        obj = json.loads(resp.read().decode())
+    return int(obj["count"])
+
+
+def parse_metrics(raw: str) -> dict[str, float]:
+    out: dict[str, float] = {}
+    for line in raw.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        # drop labels for the counters we care about
+        if line.startswith("vllm:prefix_cache_hits_total{"):
+            out["prefix_cache_hits_total"] = float(line.rsplit(" ", 1)[1])
+        elif line.startswith("vllm:prefix_cache_queries_total{"):
+            out["prefix_cache_queries_total"] = float(line.rsplit(" ", 1)[1])
+        elif line.startswith("vllm:prompt_tokens_total{"):
+            out["prompt_tokens_total"] = float(line.rsplit(" ", 1)[1])
+        elif 'source="local_compute"' in line and line.startswith(
+            "vllm:prompt_tokens_by_source_total{"
+        ):
+            out["local_compute"] = float(line.rsplit(" ", 1)[1])
+        elif 'source="local_cache_hit"' in line and line.startswith(
+            "vllm:prompt_tokens_by_source_total{"
+        ):
+            out["local_cache_hit"] = float(line.rsplit(" ", 1)[1])
+        elif line.startswith("vllm:gpu_cache_usage_perc{"):
+            out["gpu_cache_usage_perc"] = float(line.rsplit(" ", 1)[1])
+        elif line.startswith("vllm:num_requests_running{"):
+            out["num_requests_running"] = float(line.rsplit(" ", 1)[1])
+    return out
+
+
+def metrics_snapshot() -> dict[str, float]:
+    _, raw = http_get("/metrics")
+    return parse_metrics(raw)
+
+
+def unique_salt() -> str:
+    return f"COLD-PREFILL salt={uuid.uuid4()} pad={secrets.token_hex(24)}"
+
+
+def build_user_text(n_filler: int, salt: str) -> str:
+    return f"{salt}\n{FILLER * n_filler}\n{TASK}"
+
+
+def chat_messages(user_text: str, extra: list[dict] | None = None) -> list[dict]:
+    msgs = [{"role": "user", "content": user_text}]
+    if extra:
+        msgs.extend(extra)
+    return msgs
+
+
+def calibrate(target: int, salt: str, timeout: float = 180.0) -> tuple[int, int, str]:
+    """Pick filler count so tokenize(messages) is within ~2% of target."""
+    # overhead: salt + task + chat template, filler ≈ 1 token per "the "
+    overhead_text = build_user_text(0, salt)
+    overhead = tokenize_messages(chat_messages(overhead_text), timeout=timeout)
+    n = max(target - overhead, 1)
+    text = build_user_text(n, salt)
+    got = tokenize_messages(chat_messages(text), timeout=timeout)
+    # one correction step using measured ratio
+    if got > 0 and abs(got - target) / target > 0.005:
+        per = (got - overhead) / n if n else 1.0
+        if per <= 0:
+            per = 1.0
+        n = max(int(round((target - overhead) / per)), 1)
+        text = build_user_text(n, salt)
+        got = tokenize_messages(chat_messages(text), timeout=timeout)
+    # fine adjust by token delta (each filler ~1 token)
+    if abs(got - target) / target > 0.005:
+        n = max(n + (target - got), 1)
+        text = build_user_text(n, salt)
+        got = tokenize_messages(chat_messages(text), timeout=timeout)
+    rel = abs(got - target) / target
+    print(f"  calibrated tokenize={got} target={target} filler={n} rel={rel:.3%}", flush=True)
+    if rel > 0.02:
+        print("  WARNING: tokenize still >2% off target", flush=True)
+    return n, got, text
+
+
+def stream_chat(messages: list[dict], timeout: float) -> dict:
+    body = {
+        "model": SERVED,
+        "messages": messages,
+        "temperature": 0,
+        "max_tokens": 8,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    t0 = time.perf_counter()
+    first_content = None
+    chunks: list[str] = []
+    reasoning: list[str] = []
+    usage = None
+    finish = None
+    http = None
+    err = None
+    try:
+        with http_post("/v1/chat/completions", body, timeout=timeout) as resp:
+            http = resp.status
+            buf = b""
+            while True:
+                piece = resp.read(4096)
+                if not piece:
+                    break
+                buf += piece
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
+                    line = line.strip()
+                    if not line.startswith(b"data:"):
+                        continue
+                    payload = line[5:].strip()
+                    if payload == b"[DONE]":
+                        continue
+                    try:
+                        obj = json.loads(payload)
+                    except json.JSONDecodeError:
+                        continue
+                    if obj.get("usage"):
+                        usage = obj["usage"]
+                    choices = obj.get("choices") or []
+                    if not choices:
+                        continue
+                    delta = choices[0].get("delta") or {}
+                    content = delta.get("content") or ""
+                    reason = delta.get("reasoning") or delta.get("reasoning_content") or ""
+                    if reason:
+                        reasoning.append(reason)
+                    if content:
+                        if first_content is None:
+                            first_content = time.perf_counter()
+                        chunks.append(content)
+                    fr = choices[0].get("finish_reason")
+                    if fr:
+                        finish = fr
+    except Exception as exc:
+        err = f"{type(exc).__name__}: {exc}"
+    t1 = time.perf_counter()
+    text = "".join(chunks)
+    reason_text = "".join(reasoning)
+    prompt_tokens = int((usage or {}).get("prompt_tokens") or 0)
+    completion_tokens = int((usage or {}).get("completion_tokens") or 0)
+    ttft = None if first_content is None else (first_content - t0)
+    prefill = None
+    if ttft and ttft > 0 and prompt_tokens > 0:
+        prefill = prompt_tokens / ttft
+    gen_ok = bool(text) and ("ok" in text.lower()) and ("nan" not in text.lower())
+    cached = None
+    details = (usage or {}).get("prompt_tokens_details") or {}
+    if isinstance(details, dict) and details.get("cached_tokens") is not None:
+        cached = details.get("cached_tokens")
+    return {
+        "http": http,
+        "error": err,
+        "finish_reason": finish,
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "cached_tokens": cached,
+        "ttft_s": ttft,
+        "wall_s": t1 - t0,
+        "prefill_tok_s": prefill,
+        "gen": text,
+        "reasoning": reason_text,
+        "gen_ok": gen_ok,
+        "usage": usage,
+    }
+
+
+def delta_metrics(before: dict, after: dict) -> dict:
+    keys = (
+        "prefix_cache_hits_total",
+        "prefix_cache_queries_total",
+        "prompt_tokens_total",
+        "local_compute",
+        "local_cache_hit",
+    )
+    return {k: after.get(k, 0.0) - before.get(k, 0.0) for k in keys}
+
+
+def main() -> int:
+    st, body = http_get("/health")
+    print(f"GET /health -> {st} {body!r}", flush=True)
+    if st != 200:
+        print("STOP: health failed", flush=True)
+        return 1
+    global SERVED
+    st, raw = http_get("/v1/models")
+    models = json.loads(raw)
+    served = models["data"][0]["id"]
+    max_len = models["data"][0].get("max_model_len")
+    print(f"GET /v1/models -> {st} id={served} max_model_len={max_len}", flush=True)
+    if served != SERVED:
+        print(f"NOTE: using served id {served} (not {SERVED})", flush=True)
+    SERVED = served
+
+    m0 = metrics_snapshot()
+    print(f"metrics at start: {json.dumps(m0)}", flush=True)
+
+    results: list[dict] = []
+    eightk_user = None
+    eightk_assistant = None
+
+    for i, (name, target, timeout) in enumerate(LADDER):
+        salt = unique_salt()
+        print(f"\n=== {name} cold target={target} timeout={timeout}s ===", flush=True)
+        n, tok_est, user_text = calibrate(target, salt, timeout=min(timeout, 180))
+        msgs = chat_messages(user_text)
+        before = metrics_snapshot()
+        rec = stream_chat(msgs, timeout=timeout)
+        after = metrics_snapshot()
+        rec["name"] = name
+        rec["kind"] = "cold"
+        rec["target"] = target
+        rec["filler_count"] = n
+        rec["tokenize_est"] = tok_est
+        rec["salt"] = salt
+        rec["metrics_delta"] = delta_metrics(before, after)
+        rec["gpu_cache_usage_perc"] = after.get("gpu_cache_usage_perc")
+        results.append(rec)
+        print(json.dumps({k: rec[k] for k in rec if k not in ("usage", "salt")}, default=str), flush=True)
+
+        if i == 0:
+            eightk_user = user_text
+            eightk_assistant = rec.get("gen") or ""
+            print("\n=== ~8k APC follow-up (same user text + assistant + short user turn) ===", flush=True)
+            follow_msgs = chat_messages(
+                eightk_user,
+                extra=[
+                    {"role": "assistant", "content": eightk_assistant},
+                    {"role": "user", "content": "Confirm with OK."},
+                ],
+            )
+            before = metrics_snapshot()
+            follow = stream_chat(follow_msgs, timeout=timeout)
+            after = metrics_snapshot()
+            follow["name"] = "~8k follow-up"
+            follow["kind"] = "apc"
+            follow["target"] = target
+            follow["metrics_delta"] = delta_metrics(before, after)
+            follow["gpu_cache_usage_perc"] = after.get("gpu_cache_usage_perc")
+            follow["assistant_echo"] = eightk_assistant
+            results.append(follow)
+            print(json.dumps({k: follow[k] for k in follow if k not in ("usage",)}, default=str), flush=True)
+
+    payload = {
+        "served_model": SERVED,
+        "max_model_len": max_len,
+        "started_metrics": m0,
+        "ended_metrics": metrics_snapshot(),
+        "results": results,
+        "wall_clock": time.strftime("%Y-%m-%d %H:%M:%S %z"),
+    }
+    OUT_JSON.write_text(json.dumps(payload, indent=2) + "\n")
+    print(f"\nWrote {OUT_JSON}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/cold-prefill.md
+++ b/docs/cold-prefill.md
@@ -1,0 +1,72 @@
+# Cold prefill — live remeasure (2026-08-29)
+
+Live cold-prefill ladder on the **GLM-5.3-Flash EXL3** 2× DGX Spark serve. Serve flags were not changed. The server was not restarted.
+
+| | |
+|---|---|
+| Endpoint | `http://127.0.0.1:8888` |
+| `GET /health` | **200** (empty body) before and after |
+| Served id | **`GLM-5.3-Flash-EXL3`** (`GET /v1/models`) |
+| `max_model_len` | **1,000,000** |
+| KV pool (metrics) | **1,691,099** tokens, `cache_dtype=fp8`, prefix caching on, `block_size=64` |
+| When | 2026-08-29, UTC afternoon |
+
+Harness: `docs/_run_cold_prefill.py`. Raw JSON: `docs/_cold_prefill_raw.json`.
+
+## Protocol (matches the published kit receipts)
+
+- `temperature=0`
+- thinking **off** via top-level `"chat_template_kwargs": {"enable_thinking": false}` (not `extra_body`)
+- `stream=true` with `stream_options.include_usage=true`
+- `max_tokens=8` (prefill / TTFT, not decode)
+- unique salt (UUID + random pad) **first** in the user message so prefix cache cannot cheat
+- filler `"the "` + `"Reply with OK."`; `/tokenize` used only to pick filler count
+- one request at a time; each finished before the next started
+- **TTFT** = wall time from request start to first **content** token
+- **prompt_tokens** from the stream `usage` object (not an estimate)
+- **prefill tok/s** = `prompt_tokens / TTFT`
+- APC after ~8k: **same** user text + assistant reply + short follow-up user turn (`Confirm with OK.`)
+
+Every cold rung reported **0** prefix-cache hits. Usage `prompt_tokens` was within 0.1% of each target (well inside ~2%).
+
+## New vs old kit receipts
+
+Prefill tok/s is the comparable column. Old ~8k / APC used ~7.7k prompt tokens; this run targeted 8k.
+
+| Rung | Old TTFT / tok/s | New prompt tok | New TTFT | New tok/s | Δ tok/s |
+|---|---|---:|---:|---:|---:|
+| ~8k cold | 9.7 s / **793** | 7995 | 10.36 s | **772** | −2.6% |
+| ~12k cold | 13.4 s / **895** | 11995 | 13.38 s | **896** | +0.1% |
+| ~16k cold | 17.7 s / **904** | 15995 | 17.91 s | **893** | −1.2% |
+| ~100k cold | **934** tok/s | 99995 | 105.56 s | **947** | +1.4% |
+| ~256k cold | 305 s / **~839** | 255995 | 273.44 s | **936** | +11.6% |
+| ~300k cold | 356 s / **~840** | 299995 | 323.23 s | **928** | +10.5% |
+| ~8k follow-up (APC) | 1.17 s, **7168 / 7717** hits | 8004 | **1.30 s** | — | **7168 / 8004** hits |
+
+Short rungs sit on the old receipts (within a couple percent). Long rungs are faster: ~256k and ~300k moved from ~840 tok/s / 5-minute-class TTFT to ~930 tok/s.
+
+APC still hits the same **7168**-token block-aligned prefix (2 × 3584 hybrid align). This run’s prompt is longer (8004 vs 7717), so the uncached tail is **836** compute tokens vs the old **549**, which accounts for 1.30 s vs 1.17 s TTFT. Hit fraction is 7168/8004 = **89.6%** (old 7168/7717 = 92.9%).
+
+## Per-rung record
+
+| Rung | HTTP | finish | prompt_tokens | completion_tokens | TTFT s | prefill tok/s | hits / compute | gen |
+|---|---:|---|---:|---:|---:|---:|---|---|
+| ~8k cold | 200 | stop | 7995 | 2 | 10.355 | 772.1 | 0 / 7995 | `OK` |
+| ~8k follow-up | 200 | stop | 8004 | 2 | 1.298 | 6167.4 | **7168 / 836** | `OK` |
+| ~12k cold | 200 | stop | 11995 | 2 | 13.382 | 896.3 | 0 / 11995 | `OK` |
+| ~16k cold | 200 | stop | 15995 | 2 | 17.911 | 893.0 | 0 / 15995 | `OK` |
+| ~100k cold | 200 | stop | 99995 | 2 | 105.557 | 947.3 | 0 / 99995 | `OK` |
+| ~256k cold | 200 | stop | 255995 | 2 | 273.443 | 936.2 | 0 / 255995 | `OK` |
+| ~300k cold | 200 | stop | 299995 | 2 | 323.230 | 928.1 | 0 / 299995 | `OK` |
+
+Hits / compute are deltas of `vllm:prefix_cache_hits_total` and `vllm:prompt_tokens_by_source_total{source="local_compute"}` across that request. `usage.prompt_tokens_details.cached_tokens` was not populated (`--enable-prompt-tokens-details` is not required for this bench).
+
+All seven requests: HTTP 200, `finish_reason=stop`, completion 2 tokens, content exactly `OK`, empty reasoning (thinking stayed off), no `nan`.
+
+## Metrics sanity
+
+Start: queries 32668, hits 14336, prompt_tokens 32668, local_compute 18332.
+
+End: queries 732642, hits 21504, prompt_tokens 732642, local_compute 711138.
+
+Deltas: **+699974** queries / prompt tokens, **+7168** hits, **+692806** local compute. Sum of this ladder’s `usage.prompt_tokens` is 7995+8004+11995+15995+99995+255995+299995 = **699974**. Hits increased by exactly the APC 7168. `GET /health` still 200; `num_requests_running=0`.


### PR DESCRIPTION
## Summary
Applies the 2026-08-29 live cold-prefill ladder remeasure (GLM-5.3-Flash-EXL3, 2x DGX Spark, 1M serve, flags unchanged) to the README receipts:

- **Prefix-caching table** -> cold rungs remeasured with a new `Prefill tok/s` column:
  - ~8k cold 10.36 s / **772** (old 9.7 s / 793)
  - ~12k cold 13.38 s / **896** (old 13.4 s / 895)
  - ~16k cold 17.91 s / **893** (old 17.7 s / 904)
  - new long rungs: ~100k **105.6 s / 947**, ~256k **273.4 s / 936** (old 305 s / ~839), ~300k **323.2 s / 928** (old 356 s / ~840)
  - ~8k follow-up (APC): **7168 / 8004** hits, **1.30 s** TTFT (89.6% reuse)
- **Occupancy table**: ~300k streamed row notes the remeasure (**323 s** TTFT / ~928 tok/s; KV% unchanged from its own run).
- **Receipts added**: `docs/cold-prefill.md`, `docs/_cold_prefill_raw.json`, `docs/_run_cold_prefill.py` (referenced by the README).

Rows not re-measured by the ladder (~12k/~16k follow-ups, 4x concurrent follow-ups) are kept and labeled as from the earlier same-day retest.

## Protocol
temperature=0, thinking off, unique UUID salt first, max_tokens=8, one request at a time; every cold rung had **0** prefix-cache hits; all requests HTTP 200, finish_reason=stop, content OK. Metrics deltas cross-check (+699,974 prompt tokens, exactly +7168 hits).