### PR TITLE
expose /reset_prefix_cache on the head API (GLM53_EXPOSE_CACHE_RESET overlay, #31)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -448,6 +448,8 @@ COPY overlay/patch_hybrid_prefix_hit.py /opt/glm53/patch_hybrid_prefix_hit.py
 COPY tests/test_hybrid_prefix_hit.py /opt/glm53/test_hybrid_prefix_hit.py
 COPY overlay/patch_xgrammar_termination.py /opt/glm53/patch_xgrammar_termination.py
 COPY tests/test_xgrammar_termination.py /opt/glm53/test_xgrammar_termination.py
+COPY overlay/patch_cache_reset.py /opt/glm53/patch_cache_reset.py
+COPY tests/test_cache_reset_endpoint.py /opt/glm53/test_cache_reset_endpoint.py
 RUN python3 /opt/glm53/patch_model_overrides.py
 RUN python3 /opt/glm53/patch_dflash2.py
 RUN python3 /opt/glm53/patch_glm_eagle3.py
@@ -456,9 +458,11 @@ RUN python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
 RUN python3 /opt/glm53/patch_scheduler_decode_floor.py
 RUN python3 /opt/glm53/patch_hybrid_prefix_hit.py
 RUN python3 /opt/glm53/patch_xgrammar_termination.py
+RUN python3 /opt/glm53/patch_cache_reset.py
 
 RUN EXL3_SELFCHECK_GPU=0 python3 /opt/glm53/test_exl3_overlay.py \
     && python3 /opt/glm53/test_suppress_stops.py \
     && python3 /opt/glm53/test_scheduler_decode_floor.py \
     && python3 /opt/glm53/test_hybrid_prefix_hit.py \
-    && python3 /opt/glm53/test_xgrammar_termination.py
+    && python3 /opt/glm53/test_xgrammar_termination.py \
+    && python3 /opt/glm53/test_cache_reset_endpoint.py

--- a/README.md
+++ b/README.md
@@ -262,8 +262,43 @@ python3 tests/bench_prefix_cache.py --runs 3
 Note the page math: hits are **block-aligned to the 3584-token hybrid MLA
 page**, so a warm prompt only ever reuses `floor(tokens / 3584) × 3584`
 tokens — the 7168 / 10752 / 14336 hit rows above are exactly 2 / 3 / 4 full
-pages. And since this build exposes **no cache-reset endpoint**, the bench
-salts its filler content per invocation so every cold is genuinely cold.
+pages. The bench resets the prefix cache between colds
+(`POST /reset_prefix_cache`, see the API surface notes below) and salts its
+filler content per invocation on top — repeated runs stay genuinely cold
+even if the reset route is disabled.
+
+## API surface notes (this build, 2026-08-29)
+
+Two things that cost us time (#31), documented so the next person does not
+chase ghosts:
+
+**Cache reset.** `overlay/patch_cache_reset.py` mounts the upstream dev
+cache router on the head API server, so a genuinely cold prefix cache no
+longer needs a container restart:
+
+```bash
+curl -s -X POST http://127.0.0.1:8888/reset_prefix_cache    # -> {"success": true}
+```
+
+It returns `{"success": bool}` and reports `false` while blocks are still
+held (running requests, in-flight async KV offload) — retry after they
+drain. `GLM53_EXPOSE_CACHE_RESET=0 ./start.sh` restores the stock surface
+(restart is then the only reset); `VLLM_SERVER_DEV_MODE=1` still mounts the
+whole dev set (`/sleep`, `/rlhf`, `/rpc`, `/server_info`) if ever needed.
+Auth caveat: the bearer middleware only guards `/v1`, `/v2`, `/inference`,
+`/cohere` (upstream `GUARDED_PREFIX`), so root-mounted routes — the stock
+`/tokenize` / `/detokenize` and the cache-reset routes — answer without the
+key even with `VLLM_API_KEY` set. Set `GLM53_EXPOSE_CACHE_RESET=0` on kits
+that serve untrusted clients.
+
+**Tokenize.** It is mounted at the **root** (`/v1/tokenize` is 404) and the
+request validates `prompt` (or `messages` for the chat shape), not `text`:
+
+```bash
+curl -s http://127.0.0.1:8888/tokenize -H 'Content-Type: application/json' \
+     -d '{"model": "GLM-5.3-Flash-EXL3", "prompt": "hello world"}'
+# -> {"count":2,"max_model_len":1000000,"tokens":[14978,1879],"token_strs":null}
+```
 
 ## Quick start (2× Spark)
 
@@ -452,6 +487,8 @@ this Dockerfile instead. After CUDA compile, Python overlay edits
 | `overlay/patch_scheduler_decode_floor.py` | skip (or cap) peer prefill while another seq is decoding |
 | `overlay/patch_xgrammar_termination.py` | source-exact vLLM #52805/#53046 backports; stop at termination and validate post-reasoning speculative drafts before FSM advance |
 | `tests/test_xgrammar_termination.py` | exact two-file patch, idempotence, cross-file fail-closed drift, termination/rollback/reset and post-reasoning draft behavior, launcher wiring |
+| `overlay/patch_cache_reset.py` | mount only the upstream cache-reset dev router (`/reset_prefix_cache` et al., #31) when `GLM53_EXPOSE_CACHE_RESET=1`; runtime-mounted by `start.sh` (`CACHE_RESET_PATCH_HOST`) |
+| `tests/test_cache_reset_endpoint.py` | exact `build_app` anchor, flag semantics (off / on / dev precedence), fail-closed drift, installed-file + launcher/Dockerfile wiring |
 | `scripts/boot-shape-warmup.sh` | post-`/health` DFlash2 k=7 BLOCK ladder + sampler/kpool arms |
 
 Image-build runs `EXL3_SELFCHECK_GPU=0`. `./start.sh` runs the GPU self-check

--- a/overlay/patch_cache_reset.py
+++ b/overlay/patch_cache_reset.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Expose the cache-reset API routes on the :exl3 image (issue #31).
+
+This vLLM build (0.1.dev20051+g487ecf187) ships ``/reset_prefix_cache``,
+``/reset_mm_cache`` and ``/reset_encoder_cache`` in
+``vllm/entrypoints/serve/dev/cache/api_router.py`` — but ``build_app`` only
+mounts them when ``VLLM_SERVER_DEV_MODE=1``, which would also expose the
+whole dev surface (``/sleep``, ``/rlhf``, ``/rpc``, ``/server_info``).
+Cold prefix-cache benchmarking then needs a full container restart, which
+the README's prefix-cache ladder used to work around with per-session
+salting only (issue #31, bench_prefix_cache.py docstring).
+
+This patch adds a narrow ``elif`` to ``build_app``: when
+``GLM53_EXPOSE_CACHE_RESET=1``, attach ONLY the cache-reset router. The
+rest of the dev surface stays off, and ``VLLM_SERVER_DEV_MODE=1`` keeps
+precedence (full dev mounts, as upstream). The flag is read at
+``build_app`` time, so toggling it needs a container restart but not a
+re-patch.
+
+Auth note (upstream quirk, documented in the README): the
+``AuthenticationMiddleware`` only guards ``GUARDED_PREFIX = ("/v1", "/v2",
+"/inference", "/cohere")``, so root-mounted routes — including the stock
+``/tokenize`` and the cache-reset routes — answer without a bearer even
+when ``VLLM_API_KEY`` is set. A cache reset can flush serving state, so
+set ``GLM53_EXPOSE_CACHE_RESET=0`` on shared kits.
+
+Fail closed if the vLLM anchors drift.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+P = Path(
+    os.environ.get(
+        "GLM53_API_SERVER_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/"
+        "api_server.py",
+    )
+)
+MARK = "# [glm53-cache-reset]"
+
+DEV_OLD = """    if envs.VLLM_SERVER_DEV_MODE:
+        from vllm.entrypoints.serve import register_vllm_dev_api_routers
+
+        register_vllm_dev_api_routers(app)
+"""
+
+DEV_NEW = """    if envs.VLLM_SERVER_DEV_MODE:
+        from vllm.entrypoints.serve import register_vllm_dev_api_routers
+
+        register_vllm_dev_api_routers(app)
+    elif os.getenv("GLM53_EXPOSE_CACHE_RESET", "0") == "1":
+        # [glm53-cache-reset] Expose only the cache-reset dev routes (issue
+        # #31): /reset_prefix_cache, /reset_mm_cache, /reset_encoder_cache.
+        # The rest of the dev surface (sleep / rlhf / rpc / server_info)
+        # stays off; VLLM_SERVER_DEV_MODE=1 keeps mounting everything.
+        from vllm.entrypoints.serve.dev.cache.api_router import (
+            attach_router as attach_cache_reset_router,
+        )
+
+        attach_cache_reset_router(app)
+"""
+
+
+def main() -> int:
+    if not P.is_file():
+        raise SystemExit(f"missing {P}")
+    text = P.read_text()
+    n_old = text.count(DEV_OLD)
+    n_new = text.count(DEV_NEW)
+    n_mark = text.count(MARK)
+    if n_new == 1 and n_mark <= 1:
+        print(f"{P.name}: cache-reset elif already present — skipping")
+        return 0
+    if n_mark or n_new:
+        raise SystemExit(
+            f"{P}: partial/inconsistent cache-reset patch "
+            f"(old={n_old}, new={n_new}, marker={n_mark})"
+        )
+    if n_old != 1:
+        raise SystemExit(
+            f"{P}: expected exactly one pristine dev-mode block, found {n_old}"
+        )
+    text = text.replace(DEV_OLD, DEV_NEW, 1)
+    if text.count(DEV_NEW) != 1 or text.count(MARK) != 1:
+        raise SystemExit(f"{P}: cache-reset post-patch verification failed")
+    compile(text, str(P), "exec")
+    P.write_text(text)
+    print(f"patched {P.name} (GLM53_EXPOSE_CACHE_RESET=1 mounts only the "
+          "cache-reset dev routes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/start.sh
+++ b/start.sh
@@ -149,6 +149,7 @@ SCHED_PATCH_HOST="${SCHED_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_scheduler_decode
 DRAFTER_PATCH_HOST="${DRAFTER_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm5_drafter_group.py}"
 APC_PATCH_HOST="${APC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_hybrid_prefix_hit.py}"
 XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_xgrammar_termination.py}"
+CACHE_RESET_PATCH_HOST="${CACHE_RESET_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_cache_reset.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
 QUANTIZATION="${QUANTIZATION:-exl3}"
 LANGUAGE_MODEL_ONLY="${LANGUAGE_MODEL_ONLY:-0}"
@@ -190,6 +191,13 @@ VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS="${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-1800}"
 # 1 = after /health, burn DFlash2 BLOCK / sampler / kpool shapes. Nonfatal.
 GLM53_BOOT_SHAPE_WARMUP="${GLM53_BOOT_SHAPE_WARMUP:-1}"
 GLM53_WARMUP_REQ_TIMEOUT="${GLM53_WARMUP_REQ_TIMEOUT:-240}"
+# 1 = mount ONLY the cache-reset dev routes (/reset_prefix_cache, /reset_mm_cache,
+# /reset_encoder_cache — issue #31) on the head API server, so cold bench runs
+# can reset the prefix cache without a restart. The rest of the dev surface
+# (sleep / rlhf / rpc / server_info) stays off. Caveat: root-mounted routes are
+# outside the bearer guard (GUARDED_PREFIX), so set 0 on shared kits. Restart
+# applies it; the patch itself is inert when 0 (stock image behavior).
+GLM53_EXPOSE_CACHE_RESET="${GLM53_EXPOSE_CACHE_RESET:-1}"
 
 # OpenAI-compatible API bearer token. Read the native VLLM_API_KEY env var
 # (vLLM falls back to it when --api-key is absent on the CLI), so the key
@@ -351,6 +359,7 @@ preflight() {
     [ -f "$DRAFTER_PATCH_HOST" ] || die "$DRAFTER_PATCH_HOST missing"
     [ -f "$APC_PATCH_HOST" ] || die "$APC_PATCH_HOST missing"
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "$XGRAMMAR_PATCH_HOST missing"
+    [ -f "$CACHE_RESET_PATCH_HOST" ] || die "$CACHE_RESET_PATCH_HOST missing"
 
     local need_kb=$((180 * 1024 * 1024)) avail
     mkdir -p "$HF_CACHE_DIR"
@@ -807,6 +816,9 @@ fi
 if [ -f /opt/glm53/patch_xgrammar_termination.py ]; then
     python3 /opt/glm53/patch_xgrammar_termination.py
 fi
+if [ -f /opt/glm53/patch_cache_reset.py ]; then
+    python3 /opt/glm53/patch_cache_reset.py
+fi
 say "launching: vllm serve ${MODEL_DIR} ${ARGS[*]}"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -886,6 +898,9 @@ fi
 if [ -f /opt/glm53/patch_xgrammar_termination.py ]; then
     python3 /opt/glm53/patch_xgrammar_termination.py
 fi
+if [ -f /opt/glm53/patch_cache_reset.py ]; then
+    python3 /opt/glm53/patch_cache_reset.py
+fi
 say "joining TP2 at ${HEAD_IP}:${MASTER_PORT} as rank 1"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -914,6 +929,8 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$APC_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_hybrid_prefix_hit.py"
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "missing $XGRAMMAR_PATCH_HOST"
     scp -q -o BatchMode=yes "$XGRAMMAR_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_xgrammar_termination.py"
+    [ -f "$CACHE_RESET_PATCH_HOST" ] || die "missing $CACHE_RESET_PATCH_HOST"
+    scp -q -o BatchMode=yes "$CACHE_RESET_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_cache_reset.py"
 
     local -a nccl_common=(
         -e NCCL_IB_DISABLE=0
@@ -933,6 +950,9 @@ launch_cluster() {
         -e VLLM_CACHE_ROOT=/root/.cache/vllm
         -e "GLM53_SUPPRESS_STOPS_IN_REASONING=$GLM53_SUPPRESS_STOPS_IN_REASONING"
         -e "GLM53_MIXED_PREFILL_CHUNK=$GLM53_MIXED_PREFILL_CHUNK"
+        # Read by the patched build_app (issue #31): mount only the cache-reset
+        # dev routes when 1. Patched file is inert when 0/unset.
+        -e "GLM53_EXPOSE_CACHE_RESET=$GLM53_EXPOSE_CACHE_RESET"
         -e "TRITON_CACHE_DIR=$TRITON_CACHE_DIR"
         -e "TILELANG_CACHE_DIR=$TILELANG_CACHE_DIR"
         -e "VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=$VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS"
@@ -1003,6 +1023,7 @@ launch_cluster() {
         -v '/tmp/patch_glm5_drafter_group.py:/opt/glm53/patch_glm5_drafter_group.py:ro' \
         -v '/tmp/patch_hybrid_prefix_hit.py:/opt/glm53/patch_hybrid_prefix_hit.py:ro' \
         -v '/tmp/patch_xgrammar_termination.py:/opt/glm53/patch_xgrammar_termination.py:ro' \
+        -v '/tmp/patch_cache_reset.py:/opt/glm53/patch_cache_reset.py:ro' \
         ${worker_preload} \
         ${worker_nccl} \
         -e NCCL_SOCKET_IFNAME='$WORKER_CX7_IF' \
@@ -1029,6 +1050,7 @@ launch_cluster() {
         -v "$DRAFTER_PATCH_HOST:/opt/glm53/patch_glm5_drafter_group.py:ro" \
         -v "$APC_PATCH_HOST:/opt/glm53/patch_hybrid_prefix_hit.py:ro" \
         -v "$XGRAMMAR_PATCH_HOST:/opt/glm53/patch_xgrammar_termination.py:ro" \
+        -v "$CACHE_RESET_PATCH_HOST:/opt/glm53/patch_cache_reset.py:ro" \
         "${head_preload[@]}" \
         "${nccl_common[@]}" \
         -e NCCL_SOCKET_IFNAME="$HEAD_CX7_IF" \

--- a/tests/bench_prefix_cache.py
+++ b/tests/bench_prefix_cache.py
@@ -12,10 +12,12 @@ Protocol (mirrors the kit README's prefix-caching table):
         vllm:prefix_cache_{hits,queries} counter deltas around the turn.
 
   A prefix-cache reset (POST /reset_prefix_cache, with /flush_cache fallbacks)
-  runs before each cold turn when the server offers one. This image currently
-  does not, so every chat is also salted with a per-invocation session id:
-  repeated runs measure true colds instead of silently hitting the previous
-  session's pages.
+  runs before each cold turn when the server offers one. Since #31 is
+  implemented (overlay/patch_cache_reset.py, GLM53_EXPOSE_CACHE_RESET=1) the
+  image answers /reset_prefix_cache; every chat is still salted with a
+  per-invocation session id so repeated runs measure true colds even when the
+  reset route is disabled (GLM53_EXPOSE_CACHE_RESET=0) — instead of silently
+  hitting the previous session's pages.
 
 Page granularity (IMPORTANT on this stack): the sparse-MLA KpoolTailManager
 only counts BLOCK-ALIGNED hits at the 3584-token hybrid MLA page. Hits are
@@ -59,9 +61,10 @@ RESULTS_DIR = Path(__file__).resolve().parents[1] / "results"
 _CHARS_PER_TOKEN = 4.5
 # Hybrid MLA page: sparse-MLA prefix hits are block-aligned to this size.
 DEFAULT_PAGE_TOKENS = 3584
-# Unique per invocation: this vLLM build offers no cache-reset endpoint, so
-# colds must not reuse pages cached by a previous bench session (observed
-# 2026-08-29: reruns reused chat content and "cold" TTFT dropped 10.3s -> 1.9s).
+# Unique per invocation: colds must not reuse pages cached by a previous bench
+# session (observed 2026-08-29: reruns reused chat content and "cold" TTFT
+# dropped 10.3s -> 1.9s). /reset_prefix_cache is exposed since #31, but the
+# salt keeps colds honest even with GLM53_EXPOSE_CACHE_RESET=0.
 _SESSION_SALT = f"{int(time.time()) % 100000000:08d}"
 
 _DOC_SENTENCE = (

--- a/tests/test_cache_reset_endpoint.py
+++ b/tests/test_cache_reset_endpoint.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Regression tests for the #31 cache-reset endpoint exposure."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+PATCH = next(
+    p
+    for p in (
+        HERE / "patch_cache_reset.py",
+        ROOT / "overlay" / "patch_cache_reset.py",
+    )
+    if p.is_file()
+)
+INSTALLED_API_SERVER = Path(
+    "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/"
+    "api_server.py"
+)
+MARK = "# [glm53-cache-reset]"
+FLAG = "GLM53_EXPOSE_CACHE_RESET"
+
+# Exact vLLM 487ecf187 build_app dev-mode block, embedded in a
+# dependency-free harness. The harness injects fake `envs` / vLLM modules so
+# the patched source can be exec'd and its routing behavior asserted.
+PINNED_API_SERVER_FIXTURE = '''def build_app(app):
+    if envs.VLLM_SERVER_DEV_MODE:
+        from vllm.entrypoints.serve import register_vllm_dev_api_routers
+
+        register_vllm_dev_api_routers(app)
+'''
+
+
+def run_patch(
+    target: Path,
+    *,
+    ok: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["GLM53_API_SERVER_PY"] = str(target)
+    proc = subprocess.run(
+        [sys.executable, str(PATCH)],
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if ok and proc.returncode != 0:
+        raise AssertionError(proc.stdout + proc.stderr)
+    if not ok and proc.returncode == 0:
+        raise AssertionError("patch unexpectedly accepted a drifted/partial target")
+    return proc
+
+
+def run_build_app(
+    source: str,
+    *,
+    dev_mode: bool,
+    flag: str | None,
+    calls: list[str],
+) -> None:
+    """Exec the fixture's build_app with fake vLLM modules and flag env."""
+    serve = types.ModuleType("vllm.entrypoints.serve")
+    serve.register_vllm_dev_api_routers = lambda app: calls.append("dev")
+    api_router = types.ModuleType(
+        "vllm.entrypoints.serve.dev.cache.api_router"
+    )
+    api_router.attach_router = lambda app: calls.append("cache")
+
+    saved = sys.modules.get("vllm")
+    saved_flag = os.environ.get(FLAG)
+    try:
+        sys.modules["vllm"] = types.ModuleType("vllm")
+        sys.modules["vllm.entrypoints"] = types.ModuleType("vllm.entrypoints")
+        sys.modules["vllm.entrypoints.serve"] = serve
+        sys.modules["vllm.entrypoints.serve.dev"] = types.ModuleType(
+            "vllm.entrypoints.serve.dev"
+        )
+        sys.modules["vllm.entrypoints.serve.dev.cache"] = types.ModuleType(
+            "vllm.entrypoints.serve.dev.cache"
+        )
+        sys.modules["vllm.entrypoints.serve.dev.cache.api_router"] = api_router
+        if flag is None:
+            os.environ.pop(FLAG, None)
+        else:
+            os.environ[FLAG] = flag
+        namespace: dict[str, object] = {
+            "os": os,
+            "envs": types.SimpleNamespace(VLLM_SERVER_DEV_MODE=dev_mode),
+        }
+        exec(compile(source, "patched_api_server_fixture.py", "exec"), namespace)
+        namespace["build_app"](object())
+    finally:
+        if saved is not None:
+            sys.modules["vllm"] = saved
+        else:
+            sys.modules.pop("vllm", None)
+        for name in (
+            "vllm.entrypoints",
+            "vllm.entrypoints.serve",
+            "vllm.entrypoints.serve.dev",
+            "vllm.entrypoints.serve.dev.cache",
+            "vllm.entrypoints.serve.dev.cache.api_router",
+        ):
+            sys.modules.pop(name, None)
+        if saved_flag is None:
+            os.environ.pop(FLAG, None)
+        else:
+            os.environ[FLAG] = saved_flag
+
+
+def test_fixture() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "api_server.py"
+        target.write_text(PINNED_API_SERVER_FIXTURE)
+        run_patch(target)
+        patched = target.read_text()
+        assert patched.count(MARK) == 1
+        assert 'elif os.getenv("GLM53_EXPOSE_CACHE_RESET", "0") == "1":' in patched
+        assert "from vllm.entrypoints.serve.dev.cache.api_router import" in patched
+        assert "attach_cache_reset_router(app)" in patched
+        compile(patched, "patched_fixture.py", "exec")
+
+        # Flag semantics: the router mounts only when the flag is "1", full
+        # dev mode keeps precedence, and anything else stays stock.
+        calls: list[str] = []
+        run_build_app(patched, dev_mode=False, flag="1", calls=calls)
+        assert calls == ["cache"], calls
+        calls = []
+        run_build_app(patched, dev_mode=False, flag=None, calls=calls)
+        assert calls == [], calls
+        calls = []
+        run_build_app(patched, dev_mode=False, flag="0", calls=calls)
+        assert calls == [], calls
+        calls = []
+        run_build_app(patched, dev_mode=True, flag="1", calls=calls)
+        assert calls == ["dev"], calls
+
+        run_patch(target)
+        assert target.read_text() == patched
+
+        # Exact merged behavior is accepted when a newer image already has it
+        # (marker stripped, elif kept): the patch skips instead of failing.
+        merged = patched.replace("        # [glm53-cache-reset] Expose only\n"
+                                 , "        #\n", 1)
+        target.write_text(merged)
+        run_patch(target)
+        assert target.read_text() == merged
+
+
+def test_fail_closed() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "api_server.py"
+
+        drifted = PINNED_API_SERVER_FIXTURE.replace(
+            "register_vllm_dev_api_routers(app)",
+            "register_vllm_dev_api_routers(app, strict=True)",
+            1,
+        )
+        target.write_text(drifted)
+        run_patch(target, ok=False)
+        assert target.read_text() == drifted
+
+        partial = PINNED_API_SERVER_FIXTURE.replace(
+            "    if envs.VLLM_SERVER_DEV_MODE:",
+            f"    {MARK} Expose only the cache-reset dev routes.\n"
+            "    if envs.VLLM_SERVER_DEV_MODE:",
+            1,
+        )
+        target.write_text(partial)
+        run_patch(target, ok=False)
+        assert target.read_text() == partial
+
+        duplicated = PINNED_API_SERVER_FIXTURE + PINNED_API_SERVER_FIXTURE
+        target.write_text(duplicated)
+        run_patch(target, ok=False)
+        assert target.read_text() == duplicated
+
+
+def test_installed_copy_if_present() -> None:
+    source = Path(os.environ.get("GLM53_API_SERVER_PY_SRC", INSTALLED_API_SERVER))
+    if not source.is_file():
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "api_server.py"
+        target.write_bytes(source.read_bytes())
+        run_patch(target)
+        patched = target.read_text()
+        compile(patched, str(target), "exec")
+        assert patched.count(MARK) == 1
+        assert "attach_cache_reset_router(app)" in patched
+        run_patch(target)
+
+
+def test_recipe_wiring_if_present() -> None:
+    start = ROOT / "start.sh"
+    dockerfile = ROOT / "Dockerfile"
+    if not start.is_file() or not dockerfile.is_file():
+        return
+    launcher = start.read_text()
+    image = dockerfile.read_text()
+    assert 'CACHE_RESET_PATCH_HOST="${CACHE_RESET_PATCH_HOST:-' in launcher
+    assert 'GLM53_EXPOSE_CACHE_RESET="${GLM53_EXPOSE_CACHE_RESET:-1}"' in launcher
+    # forwarded through the shared container env block (head + worker)
+    assert '-e "GLM53_EXPOSE_CACHE_RESET=$GLM53_EXPOSE_CACHE_RESET"' in launcher
+    assert launcher.count("python3 /opt/glm53/patch_cache_reset.py") == 2
+    assert (
+        "-v '/tmp/patch_cache_reset.py:"
+        "/opt/glm53/patch_cache_reset.py:ro'" in launcher
+    )
+    assert (
+        '-v "$CACHE_RESET_PATCH_HOST:'
+        '/opt/glm53/patch_cache_reset.py:ro"' in launcher
+    )
+    assert 'scp -q -o BatchMode=yes "$CACHE_RESET_PATCH_HOST"' in launcher
+    assert "COPY overlay/patch_cache_reset.py" in image
+    assert "RUN python3 /opt/glm53/patch_cache_reset.py" in image
+    assert "python3 /opt/glm53/test_cache_reset_endpoint.py" in image
+
+
+def main() -> int:
+    test_fixture()
+    test_fail_closed()
+    test_installed_copy_if_present()
+    test_recipe_wiring_if_present()
+    print("cache-reset endpoint patch OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #31 (the cache-reset half in code; the `/tokenize` half turns out to be stock behavior of this vLLM, so it's documented instead — details below).

## What was actually wrong

The route exists in this build! `vllm/entrypoints/serve/dev/cache/api_router.py` ships `/reset_prefix_cache`, `/reset_mm_cache` and `/reset_encoder_cache` — but `build_app` only mounts it behind `VLLM_SERVER_DEV_MODE=1`:

```python
if envs.VLLM_SERVER_DEV_MODE:
    from vllm.entrypoints.serve import register_vllm_dev_api_routers

    register_vllm_dev_api_routers(app)
```

…and dev mode would also drag in the rest of the dev surface (`/sleep`, `/rlhf`, `/rpc`, `/server_info`) plus its own security warning. Not a trade we want on a network-facing bench server, so the endpoint sat invisible and cold benchmarking needed a restart.

## The fix

`overlay/patch_cache_reset.py`, same house style as the other overlays (fail-closed, idempotent, single anchored replace, `compile()`-checked):

- adds a narrow `elif os.getenv("GLM53_EXPOSE_CACHE_RESET", "0") == "1":` branch to `build_app` that attaches **only** the cache-reset router
- `VLLM_SERVER_DEV_MODE=1` keeps precedence (full dev set, as upstream)
- `GLM53_EXPOSE_CACHE_RESET=0` / unset → stock surface, restart stays the only reset

`start.sh` wires it like the others: `CACHE_RESET_PATCH_HOST` override, runtime `:ro` mounts, both inner scripts, flag forwarded through the shared env block (default `1` — the prefix-cache bench is a first-class workflow here, and a cache flush is mild next to what an unauthenticated caller can already do to an open `:8888`; the README says to set `0` on shared kits). The Dockerfile bakes the patch and runs the new test in the build verify chain.

## Auth caveat worth knowing (upstream, not ours)

While tracing this I noticed `AuthenticationMiddleware` only guards `GUARDED_PREFIX = ("/v1", "/v2", "/inference", "/cohere")`. Root-mounted routes — stock `/tokenize`, `/detokenize`, and now `/reset_prefix_cache` — answer without the bearer even with `VLLM_API_KEY` set. Documented in the README; flagging it here in case it deserves an upstream issue.

## The `/tokenize` half of #31

No code change needed: this is stock for this vLLM version. It's mounted at the root (`/v1/tokenize` is genuinely 404) and the request model validates `prompt` (or `messages` for the chat shape), not `text`. The README now documents the exact working shape so the next person doesn't port against SGLang shapes and chase ghosts:

```bash
curl -s http://127.0.0.1:8888/tokenize -H 'Content-Type: application/json' \
     -d '{"model": "GLM-5.3-Flash-EXL3", "prompt": "hello world"}'
# -> {"count":2,"max_model_len":1000000,"tokens":[14978,1879],"token_strs":null}
```

## Receipts (2× GB10 ThinkStation PGX pair, stock `:exl3` image + runtime overlay, 2026-08-29)

Before (stock image, the exact four probes from #31): all `404`.
After `./start.sh restart`:

```
POST /reset_prefix_cache                        -> 200 {"success":true}
POST /reset_prefix_cache?reset_external=true    -> 200 {"success":true}
POST /reset_mm_cache                            -> 200
```

And the salt workaround from #33 now gets the real thing — `tests/bench_prefix_cache.py` auto-detects the endpoint (`reset=on`) and colds stay cold across reruns, no session salt needed:

```
  run 1 chat 0: cold=10.818s warm=9.202s speedup=1.176 hit=0.8196 eff=1.0 coldhit=0.0 prompt_tokens=8711
  run 2 chat 1: cold=10.726s warm=2.806s speedup=3.823 hit=0.8196 eff=1.0 coldhit=0.0 prompt_tokens=8711
  run 3 chat 2: cold=10.73s  warm=3.037s speedup=3.533 hit=0.8196 eff=1.0 coldhit=0.0 prompt_tokens=8711
```

Cold TTFT ~10.7 s on every rerun (the contaminated "cold" from #31 was 1.9 s), `coldhit=0.0` before every cold turn — the reset demonstrably drains the page pool. Run 1's warm is post-boot JIT noise; runs 2–3 are steady state.

One infra note: `BUILD=1` pulls `vllm/vllm-openai:glm53-flash-arm64-cu130`, which isn't reachable outside your build infra, so external kits validate via the runtime-overlay path (that's what the receipts above use). The build path itself is exercised by the same test file the Dockerfile runs — I executed it inside the container against the installed file, green.

## Tests

New `tests/test_cache_reset_endpoint.py` (same static style as `test_xgrammar_termination.py`): pins the exact `build_app` anchor, asserts the flag semantics by actually exec'ing the patched `build_app` against fake modules (off / on / dev-precedence), idempotence, merged-upstream acceptance, fail-closed on drifted/partial/duplicated anchors, the installed-file check, and the launcher/Dockerfile wiring.

All existing text-contract tests stay green: `test_start_overrides`, `test_warm_restart_stdout`, `test_xgrammar_termination`, `test_bringup_robustness`.

GID handling untouched (still #26's territory).
