### PR TITLE
start.sh: validate serving numeric knobs before restart stops the service

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -226,6 +226,40 @@ log()  { printf '\033[1;36m[glm53-exl3]\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m[glm53-exl3]\033[0m %s\n' "$*" >&2; }
 die()  { printf '\033[1;31m[glm53-exl3]\033[0m ERROR: %s\n' "$*" >&2; exit 1; }
 
+# GLM53 numeric config guard (begin)
+_glm53_canonical_positive_int() {
+    local name="$1" value="$2" maximum="$3" canonical
+    if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+        echo "$name must be a positive base-10 integer (got: $value)" >&2
+        return 2
+    fi
+    canonical="$value"
+    while [ "${canonical#0}" != "$canonical" ]; do canonical="${canonical#0}"; done
+    [ -n "$canonical" ] || canonical=0
+    if [ "$canonical" = 0 ] \
+       || [ "${#canonical}" -gt "${#maximum}" ] \
+       || [ "$canonical" -gt "$maximum" ]; then
+        echo "$name must be between 1 and $maximum (got: $value)" >&2
+        return 2
+    fi
+    printf -v "$name" '%s' "$canonical"
+    # $name is one of three fixed names below.
+    # shellcheck disable=SC2163
+    export "$name"
+}
+
+validate_numeric_config() {
+    if ! [[ "$GPU_MEM_UTIL" =~ ^(0([.][0-9]+)?|[.][0-9]+|1([.]0+)?)$ ]] \
+       || ! awk -v u="$GPU_MEM_UTIL" 'BEGIN { exit !(u > 0 && u <= 1) }'; then
+        echo "GPU_MEM_UTIL must be greater than 0 and at most 1 (got: $GPU_MEM_UTIL)" >&2
+        return 2
+    fi
+    _glm53_canonical_positive_int MAX_MODEL_LEN "$MAX_MODEL_LEN" 1000000 || return
+    _glm53_canonical_positive_int MAX_NUM_SEQS "$MAX_NUM_SEQS" 4096 || return
+    _glm53_canonical_positive_int MAX_NUM_BATCHED_TOKENS "$MAX_NUM_BATCHED_TOKENS" 8388608 || return
+}
+# GLM53 numeric config guard (end)
+
 banner() {
     local label="${1:-start.sh}"
     printf '\n'
@@ -1249,6 +1283,9 @@ logs() {
 # ------------------------------- main --------------------------------------
 main() {
     local cmd="${1:-start}"
+    case "$cmd" in
+        start|restart) validate_numeric_config ;;
+    esac
     case "$cmd" in
         stop)     banner stop.sh ;;
         download) banner download.sh ;;

--- a/tests/test_numeric_config.py
+++ b/tests/test_numeric_config.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""CPU-only tests for launcher numeric type/range validation."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+START = ROOT / "start.sh"
+
+
+def guard_source() -> str:
+    source = START.read_text()
+    begin = source.index("# GLM53 numeric config guard (begin)")
+    end_marker = "# GLM53 numeric config guard (end)"
+    end = source.index(end_marker, begin) + len(end_marker)
+    return source[begin:end]
+
+
+def validate(util: str, model: str, seqs: str, batch: str) -> subprocess.CompletedProcess[str]:
+    script = (
+        guard_source()
+        + '\nGPU_MEM_UTIL="$1"; MAX_MODEL_LEN="$2"; MAX_NUM_SEQS="$3"; '
+        + 'MAX_NUM_BATCHED_TOKENS="$4"\n'
+        + 'validate_numeric_config || exit $?\n'
+        + 'printf "%s|%s|%s|%s\\n" "$GPU_MEM_UTIL" "$MAX_MODEL_LEN" '
+        + '"$MAX_NUM_SEQS" "$MAX_NUM_BATCHED_TOKENS"\n'
+    )
+    return subprocess.run(
+        ["bash", "-c", script, "test", util, model, seqs, batch],
+        text=True,
+        capture_output=True,
+        check=False,
+        env={**os.environ, "LC_ALL": "C"},
+    )
+
+
+def expect_rc(values: tuple[str, str, str, str], expected: int) -> None:
+    result = validate(*values)
+    assert result.returncode == expected, (values, result.returncode, result.stdout, result.stderr)
+
+
+def test_matrix() -> None:
+    expect_rc(("0.87", "1000000", "4", "1024"), 0)
+    expect_rc((".87", "01000000", "0004", "01024"), 0)
+    expect_rc(("1.0", "1000000", "4096", "8388608"), 0)
+    expect_rc(("0", "1000000", "4", "1024"), 2)
+    expect_rc(("8.7", "1000000", "4", "1024"), 2)
+    expect_rc(("nope", "1000000", "4", "1024"), 2)
+    expect_rc(("0.87", "0", "4", "1024"), 2)
+    expect_rc(("0.87", "1000001", "4", "1024"), 2)
+    expect_rc(("0.87", "1000000", "O4", "1024"), 2)
+    expect_rc(("0.87", "1000000", "4097", "1024"), 2)
+    expect_rc(("0.87", "1000000", "4", "1024\r"), 2)
+    expect_rc(("0.87", "1000000", "4", "18446744073709551615"), 2)
+
+
+def test_decimal_normalization() -> None:
+    result = validate(".87", "01000000", "0004", "01024")
+    assert result.returncode == 0
+    assert result.stdout.strip() == ".87|1000000|4|1024"
+
+
+def test_restart_validates_before_stop() -> None:
+    source = START.read_text()
+    main = source.index("main() {")
+    validation = source.index("start|restart) validate_numeric_config", main)
+    restart = source.index("restart)  stop; start", main)
+    assert validation < restart
+
+
+if __name__ == "__main__":
+    test_matrix()
+    test_decimal_normalization()
+    test_restart_validates_before_stop()
+    print("numeric config tests: PASS")


### PR DESCRIPTION
## What

`GPU_MEM_UTIL`, `MAX_MODEL_LEN`, `MAX_NUM_SEQS`, and `MAX_NUM_BATCHED_TOKENS` are
assigned defaults and passed straight into both rank commands with **no type,
range, or normalization check**. A typo fails deep in vLLM — and because
`./start.sh restart` runs `stop` before any vLLM parse error can surface, a bad
value **takes down a healthy 2-node deployment before it is diagnosed**.

## Fix

`validate_numeric_config()`, called at the top of the `start|restart` dispatch,
**before** `restart) stop; start`. Invalid serving config is rejected while the
service stays up; `stop`/`status`/`logs`/`help` remain usable. Integer knobs are
normalized (leading zeros stripped as strings, oversized digit strings rejected
before bash arithmetic can overflow), so no unbounded input reaches `$(( ))`.

Proposed contract (happy to adjust bounds):

| Variable | Accepted |
|---|---|
| `GPU_MEM_UTIL` | decimal `0 < v <= 1` |
| `MAX_MODEL_LEN` | integer 1–1,000,000 (the recipe's documented 1M ceiling) |
| `MAX_NUM_SEQS` | integer 1–4,096 |
| `MAX_NUM_BATCHED_TOKENS` | integer 1–8,388,608 |

The two larger maxima follow the accepted DeepSeek recipe precedent
(MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark#124) — happy to tune to whatever
GLM contract you prefer.

## Tests

`tests/test_numeric_config.py`: accepted/rejected matrix incl. `.87`, leading-zero
normalization (`01000000`→`1000000`), an **actual carriage-return byte**, a
2^64-1 overflow string, and a wiring assertion that validation precedes the
`restart) stop`. Mutation-checked: deleting the wiring fails the suite.
`bash -n` clean; 0 new ShellCheck findings vs `main`.

## Notes

Rebased onto current `main` (applies cleanly post-#34). Kept separate from a
memory-preflight change I'm preparing so each lands independently.
