### PR TITLE
preflight: check unified memory vs GPU_MEM_UTIL before bring-up

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -292,6 +292,48 @@ check_port_free() {
     fi
 }
 
+# GLM53 preflight memory guard (begin)
+read_meminfo_kib() {
+    local source_file="${1:-/proc/meminfo}"
+    awk '
+      /^MemTotal:/ { total=$2 }
+      /^MemAvailable:/ { available=$2 }
+      END {
+        if (!total || !available) exit 1
+        print total, available
+      }
+    ' "$source_file"
+}
+
+preflight_memory() {
+    local label="$1" total_kib="$2" available_kib="$3" util="$4"
+    local headroom_kib="${GLM53_PREFLIGHT_MEMORY_HEADROOM_KIB:-2097152}"
+    local total_gib available_gib requested_gib headroom_gib
+
+    if ! [[ "$total_kib" =~ ^[0-9]+$ && "$available_kib" =~ ^[0-9]+$ && "$headroom_kib" =~ ^[0-9]+$ ]]; then
+        echo "PREFLIGHT FAIL [$label]: invalid memory reading" >&2
+        return 2
+    fi
+    if ! [[ "$util" =~ ^(0([.][0-9]+)?|[.][0-9]+|1([.]0+)?)$ ]] \
+       || ! awk -v u="$util" 'BEGIN { exit !(u > 0 && u <= 1) }'; then
+        echo "PREFLIGHT FAIL [$label]: GPU_MEM_UTIL must be greater than 0 and at most 1: $util" >&2
+        return 2
+    fi
+
+    total_gib=$(awk -v k="$total_kib" 'BEGIN { printf "%.2f", k/1048576 }')
+    available_gib=$(awk -v k="$available_kib" 'BEGIN { printf "%.2f", k/1048576 }')
+    requested_gib=$(awk -v t="$total_kib" -v u="$util" 'BEGIN { printf "%.2f", (t*u)/1048576 }')
+    headroom_gib=$(awk -v k="$headroom_kib" 'BEGIN { printf "%.2f", k/1048576 }')
+
+    if ! awk -v a="$available_kib" -v t="$total_kib" -v u="$util" -v h="$headroom_kib" \
+        'BEGIN { exit !(a >= (t*u)+h) }'; then
+        echo "PREFLIGHT FAIL [$label]: MemAvailable=${available_gib} GiB of ${total_gib} GiB; GPU_MEM_UTIL=${util} requests ${requested_gib} GiB plus ${headroom_gib} GiB headroom" >&2
+        return 1
+    fi
+    echo "PREFLIGHT OK [$label]: MemAvailable=${available_gib}/${total_gib} GiB; request=${requested_gib} GiB plus ${headroom_gib} GiB headroom"
+}
+# GLM53 preflight memory guard (end)
+
 trap 'warn "interrupted — containers keep running ('"'"'./start.sh logs'"'"' to watch, '"'"'./start.sh stop'"'"' to stop)"; exit 130' INT
 
 # ------------------------------ preflight ----------------------------------
@@ -345,6 +387,16 @@ preflight() {
 
     check_port_free "$PORT" PORT
     check_port_free "$MASTER_PORT" MASTER_PORT
+
+    local head_mem worker_mem head_total head_available worker_total worker_available
+    head_mem="$(read_meminfo_kib /proc/meminfo)" \
+        || die "cannot read MemTotal/MemAvailable on head"
+    worker_mem="$(worker_ssh "cat /proc/meminfo" | read_meminfo_kib /dev/stdin)" \
+        || die "cannot read MemTotal/MemAvailable on worker"
+    read -r head_total head_available <<< "$head_mem"
+    read -r worker_total worker_available <<< "$worker_mem"
+    preflight_memory head "$head_total" "$head_available" "$GPU_MEM_UTIL" || return
+    preflight_memory worker "$worker_total" "$worker_available" "$GPU_MEM_UTIL" || return
 
     [ -f "$STOP_PATCH_HOST" ] || die "$STOP_PATCH_HOST missing"
     [ -f "$SCHED_PATCH_HOST" ] || die "$SCHED_PATCH_HOST missing"

--- a/tests/test_preflight_memory.py
+++ b/tests/test_preflight_memory.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""CPU-only tests for the GB10 MemAvailable preflight guard."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+START = ROOT / "start.sh"
+GIB_KIB = 1048576
+
+
+def guard_source() -> str:
+    source = START.read_text()
+    begin = source.index("# GLM53 preflight memory guard (begin)")
+    end_marker = "# GLM53 preflight memory guard (end)"
+    end = source.index(end_marker, begin) + len(end_marker)
+    return source[begin:end]
+
+
+def call_memory(total: int, available: int, util: str) -> subprocess.CompletedProcess[str]:
+    script = guard_source() + '\npreflight_memory worker "$1" "$2" "$3"\n'
+    return subprocess.run(
+        ["bash", "-c", script, "test", str(total), str(available), util],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def expect_rc(total_gib: int, available_gib: int, util: str, expected: int) -> None:
+    result = call_memory(total_gib * GIB_KIB, available_gib * GIB_KIB, util)
+    assert result.returncode == expected, (result.returncode, result.stdout, result.stderr)
+
+
+def test_matrix() -> None:
+    expect_rc(122, 102, "0.87", 1)
+    expect_rc(122, 116, "0.87", 0)
+    expect_rc(122, 117, "0.87", 0)
+    expect_rc(122, 100, "1.0", 1)
+    result = call_memory(122 * GIB_KIB, 1024, "0.87")
+    assert result.returncode == 1
+    expect_rc(100, 52, "0.5", 0)
+    result = call_memory(100 * GIB_KIB, 52 * GIB_KIB - 1, "0.5")
+    assert result.returncode == 1
+    result = call_memory(122 * GIB_KIB, 116 * GIB_KIB, "bad")
+    assert result.returncode == 2
+    result = call_memory(122 * GIB_KIB, 116 * GIB_KIB, "0")
+    assert result.returncode == 2
+    result = call_memory(122 * GIB_KIB, 116 * GIB_KIB, "1.1")
+    assert result.returncode == 2
+
+
+def test_reads_memavailable_not_memfree() -> None:
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        fixture = Path(raw_tmp) / "meminfo"
+        fixture.write_text(
+            "MemTotal:       127926272 kB\n"
+            "MemFree:             1024 kB\n"
+            "MemAvailable:    121634816 kB\n"
+        )
+        script = guard_source() + '\nread_meminfo_kib "$1"\n'
+        result = subprocess.run(
+            ["bash", "-c", script, "test", str(fixture)],
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+    assert result.stdout.strip() == "127926272 121634816"
+
+
+def test_guard_is_wired_after_port_checks() -> None:
+    source = START.read_text()
+    port = source.index('check_port_free "$MASTER_PORT" MASTER_PORT')
+    head = source.index('preflight_memory head "$head_total"')
+    worker = source.index('preflight_memory worker "$worker_total"')
+    assert port < head < worker
+
+
+if __name__ == "__main__":
+    test_matrix()
+    test_reads_memavailable_not_memfree()
+    test_guard_is_wired_after_port_checks()
+    print("preflight memory tests: PASS")


### PR DESCRIPTION
## What

`preflight()` checks disk, ports, and *containers* on the worker, but not **free
unified memory**. On GB10 the GPU shares the ~122 GiB pool with the host, so a
host process holding memory (**not** a container — the existing "other
containers" check misses it) leaves less than `GPU_MEM_UTIL × MemTotal` free. The
worker rank then dies **mid-bring-up** with a `ValueError: Free memory on device
... less than desired` — *after* the image pull, weight load, and sync, in a
hard-to-read worker log.

## Fix

`preflight_memory()`, run **after the port checks, before image/download/sync**:
- parses `MemTotal` + **`MemAvailable`** from `/proc/meminfo` (KiB),
- compares **raw KiB** against `GPU_MEM_UTIL × MemTotal + headroom` on **both** nodes,
- fails early with a node-specific, actionable message.

`MemAvailable` (not `MemFree`) so it does not false-fail after a large weight
`rsync` fills reclaimable page cache — that distinction is load-bearing on this
recipe. Headroom defaults to 2 GiB, overridable via
`GLM53_PREFLIGHT_MEMORY_HEADROOM_KIB`.

## Open questions for you

- **Headroom size** — 2 GiB is provisional. A healthy boot here shows ~3.7 GiB
  slack over the request on both nodes, but one boot isn't a universal margin.
- **Fatal vs override** — currently fatal (with the env override above). Given the
  failure is delayed and expensive, fatal-by-default seemed the more useful
  policy, but happy to make it a warning if you prefer.
- Known limitation documented, not fixed: a time-of-check/time-of-use window
  (another process can allocate after preflight); swap is not counted as UMA.

## Honesty note

This establishes the gap by the **formula + unguarded pass-through + missing
check**, plus a healthy boot's own `Free memory on device (~109.6/121.69 GiB)`
line matching `util × total`. It does **not** claim to reproduce a specific
prior OOM.

## Tests

`tests/test_preflight_memory.py`: ordinary matrix, boundary cases (one KiB under
threshold, exact-equal), `MemAvailable`-vs-`MemFree` fixture, and a wiring
assertion that the check runs after port checks. Mutation-checked: deleting the
calls fails the suite. `bash -n` clean; 0 new ShellCheck findings vs `main`.

## Notes

Rebased onto current `main` (applies cleanly on top of the merged #34, which also
touched `preflight()`). Separate from #38 (numeric-knob validation) so each lands
independently.
