### PR TITLE
Honor remaining inline launch overrides

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -67,6 +67,9 @@ _cli_image="${IMAGE-}"
 _cli_util="${GPU_MEM_UTIL-}"
 _cli_lm="${LANGUAGE_MODEL_ONLY-}"
 _cli_max_num_seqs="${MAX_NUM_SEQS-}"
+_cli_dflash_tokens="${DFLASH_TOKENS-}"
+_cli_max_model_len="${MAX_MODEL_LEN-}"
+_cli_cg_estimate="${CG_ESTIMATE-}"
 set -a
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/.env"
@@ -82,6 +85,9 @@ set +a
 [ -n "${_cli_util}" ] && GPU_MEM_UTIL="$_cli_util"
 [ -n "${_cli_lm}" ] && LANGUAGE_MODEL_ONLY="$_cli_lm"
 [ -n "${_cli_max_num_seqs}" ] && MAX_NUM_SEQS="$_cli_max_num_seqs"
+[ -n "${_cli_dflash_tokens}" ] && DFLASH_TOKENS="$_cli_dflash_tokens"
+[ -n "${_cli_max_model_len}" ] && MAX_MODEL_LEN="$_cli_max_model_len"
+[ -n "${_cli_cg_estimate}" ] && CG_ESTIMATE="$_cli_cg_estimate"
 
 # ----------------------------- configuration -------------------------------
 MODEL="${MODEL:-Mia-AiLab/GLM-5.3-Flash-EXL3-TR3-4bpw}"

--- a/tests/test_start_overrides.py
+++ b/tests/test_start_overrides.py
@@ -41,6 +41,45 @@ def test_max_num_seqs_inline_override_wins() -> None:
     assert result.stdout.strip() == "MAX_NUM_SEQS=4"
 
 
+def test_other_inline_overrides_win() -> None:
+    source = (ROOT / "start.sh").read_text()
+    marker = "# ----------------------------- configuration -------------------------------"
+    preamble, separator, _rest = source.partition(marker)
+    assert separator, "start.sh configuration marker is missing"
+
+    values = {
+        "DFLASH_TOKENS": ("3", "7"),
+        "MAX_MODEL_LEN": ("800000", "900000"),
+        "MAX_NUM_BATCHED_TOKENS": ("512", "1024"),
+        "CG_ESTIMATE": ("1", "0"),
+    }
+    output = "".join(f'{name}=${{{name}:-unset}}\\n' for name in values)
+
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        tmp = Path(raw_tmp)
+        script = tmp / "start.sh"
+        script.write_text(preamble + f'\nprintf "{output}"\n')
+        script.chmod(0o755)
+        (tmp / ".env").write_text(
+            "".join(f"{name}={from_env}\\n" for name, (from_env, _) in values.items())
+        )
+
+        env = os.environ.copy()
+        env.update({name: inline for name, (_, inline) in values.items()})
+        result = subprocess.run(
+            ["bash", str(script)],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    assert result.stdout.splitlines() == [
+        f"{name}={inline}" for name, (_, inline) in values.items()
+    ]
+
+
 if __name__ == "__main__":
     test_max_num_seqs_inline_override_wins()
+    test_other_inline_overrides_win()
     print("start.sh caller override regression OK")


### PR DESCRIPTION
## Summary

- Preserve caller-exported `DFLASH_TOKENS`, `MAX_MODEL_LEN`, and `CG_ESTIMATE` across `.env` loading using the established launcher pattern.
- Retain regression coverage for `MAX_NUM_BATCHED_TOKENS`, whose capture/restore landed independently in #40 while this follow-up was being prepared.
- Add a dependency-free table-driven regression proving all four values beat conflicting synthetic `.env` values, including the operationally important caller `CG_ESTIMATE=0`.

## Why

The review on #28 noted that these launch knobs still fell outside the caller-export allowlist. Silent `.env` precedence makes one-off tuning and benchmark reproduction misleading.

Current main already fixes the batch-token case through #40, so this PR does not duplicate that code. It adds only the three remaining capture/restores and tests the complete four-knob contract.

## Validation

- `python3 tests/test_start_overrides.py`
- `python3 tests/test_bringup_robustness.py`
- Existing dependency-free chat-template, suppress-stops, warm-restart, and XGrammar tests
- `bash -n` on every tracked shell file
- In-memory compilation of all 26 tracked Python files
- `git diff --check`

No live restart was performed: this is launcher precedence only, the downstream rank plumbing is unchanged, and #28 already live-validated the same capture/restore mechanism. The real `.env` was not read or changed.