### PR TITLE
Default DFLASH_DRAFT_TP to 2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,8 +80,9 @@ SERVED_MODEL_NAME=GLM-5.3-Flash-EXL3
 SPEC_METHOD=dflash
 DFLASH_MODEL=incoai/GLM-5.3-Flash-DFlash2
 DFLASH_TOKENS=7
-# Drafter TP. 1 = rank 0 only (default; skip CX7 on a 2.3 GiB draft). Empty = inherit TP.
-# DFLASH_DRAFT_TP=1
+# Drafter TP. 2 = measured keep on this 2× GB10 kit (shard draft across ranks).
+# 1 = rank 0 only (skip CX7 on a 2.3 GiB draft). Empty = inherit TP.
+DFLASH_DRAFT_TP=2
 MTP_TOKENS=2
 MAX_MODEL_LEN=1000000
 MAX_NUM_SEQS=4

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ that are now documented/enforced:
 | `SPEC_METHOD` | `dflash` | `dflash` / `mtp` / `none`. Rollback: `SPEC_METHOD=mtp ./start.sh restart` |
 | `DFLASH_MODEL` | `incoai/GLM-5.3-Flash-DFlash2` | DFlash2 draft Hub repo (~2.3 GiB BF16) |
 | `DFLASH_TOKENS` | `7` | DFlash2 speculative tokens (trained block 8) |
-| `DFLASH_DRAFT_TP` | `1` | keep the 2.3 GiB drafter on rank 0 (no CX7 per draft step). Empty = inherit TP |
+| `DFLASH_DRAFT_TP` | `2` | shard DFlash2 across TP (C4 keep: 8k 938 / decode 65.1). `1` = rank 0 only. Empty = inherit TP |
 | DFlash2 draft KV | `auto` (bf16) | target stays `fp8`/`fp8_ds_mla`; dense draft has no MLA FP8 backend on SM121 |
 | DFlash2 attention | *(unset)* | SM121 picks FLASH_ATTN for non-causal SWA. Do not pin `TRITON_ATTN` |
 | `ENFORCE_EAGER` | `0` | CUDA graphs; MTP capture `1 2 3 4 6 8 12`, DFlash2 `1 2 4 8 16 24 32` |

--- a/start.sh
+++ b/start.sh
@@ -149,11 +149,12 @@ SPEC_METHOD="${SPEC_METHOD:-dflash}"
 DFLASH_MODEL="${DFLASH_MODEL:-incoai/GLM-5.3-Flash-DFlash2}"
 DFLASH_CACHE_NAME="${DFLASH_CACHE_NAME:-models--${DFLASH_MODEL//\//--}}"
 DFLASH_TOKENS="${DFLASH_TOKENS:-7}"
-# 1 = keep the ~2.3 GiB drafter on rank 0 (no CX7 on every draft step).
-# Empty = inherit target TP. Do not pin attention_backend: SM121 already
-# prefers FLASH_ATTN for non-causal dense SWA. TRITON_ATTN was an SM120
-# mask-fix copy this image does not have.
-DFLASH_DRAFT_TP="${DFLASH_DRAFT_TP-1}"
+# 2 = shard the ~2.3 GiB DFlash2 drafter across TP (C4 keep, 2026-08-30:
+# idle 8k 938 / 16k 972 / 100k 997; decode structured 65.1 / prose 27.1).
+# 1 = rank 0 only (no CX7 on every draft step). Empty = inherit target TP.
+# Do not pin attention_backend: SM121 already prefers FLASH_ATTN for
+# non-causal dense SWA. TRITON_ATTN was an SM120 mask-fix this image lacks.
+DFLASH_DRAFT_TP="${DFLASH_DRAFT_TP-2}"
 MAX_MODEL_LEN="${MAX_MODEL_LEN:-1000000}"
 GPU_MEM_UTIL="${GPU_MEM_UTIL:-0.87}"
 MAX_NUM_SEQS="${MAX_NUM_SEQS:-4}"


### PR DESCRIPTION
## Summary
- Make `DFLASH_DRAFT_TP=2` the recipe default so the DFlash2 drafter shards across both GB10 ranks.
- Night C4 keep vs rank-0 draft: idle 8k **938** / 16k **972** / 100k **997**; decode structured **65.1** / prose **27.1**. Roll back with `DFLASH_DRAFT_TP=1`.

## Test plan
- [x] Live serve already running with `DFLASH_DRAFT_TP=2` (argv `draft_tensor_parallel_size: 2`)
- [x] Idle 8k+APC / 16k / 100k + decode pair on 2026-08-30
- [ ] After merge, a naive `./start.sh restart` without a stale `.env` `=1` picks up 2


Made with [Cursor](https://cursor.com)