### PR TITLE
Pin K-pool tail slot mapping to the one-block circular scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -448,6 +448,8 @@ COPY overlay/patch_hybrid_prefix_hit.py /opt/glm53/patch_hybrid_prefix_hit.py
 COPY tests/test_hybrid_prefix_hit.py /opt/glm53/test_hybrid_prefix_hit.py
 COPY overlay/patch_xgrammar_termination.py /opt/glm53/patch_xgrammar_termination.py
 COPY tests/test_xgrammar_termination.py /opt/glm53/test_xgrammar_termination.py
+COPY overlay/patch_kpool_tail_slotmap.py /opt/glm53/patch_kpool_tail_slotmap.py
+COPY tests/test_kpool_tail_slotmap.py /opt/glm53/test_kpool_tail_slotmap.py
 COPY overlay/ablit_runtime.py /opt/glm53/ablit_runtime.py
 COPY overlay/patch_ablit.py /opt/glm53/patch_ablit.py
 COPY tests/test_ablit.py /opt/glm53/test_ablit.py
@@ -460,6 +462,7 @@ RUN python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
 RUN python3 /opt/glm53/patch_scheduler_decode_floor.py
 RUN python3 /opt/glm53/patch_hybrid_prefix_hit.py
 RUN python3 /opt/glm53/patch_xgrammar_termination.py
+RUN python3 /opt/glm53/patch_kpool_tail_slotmap.py
 RUN python3 /opt/glm53/patch_ablit.py
 
 RUN EXL3_SELFCHECK_GPU=0 python3 /opt/glm53/test_exl3_overlay.py \
@@ -467,4 +470,5 @@ RUN EXL3_SELFCHECK_GPU=0 python3 /opt/glm53/test_exl3_overlay.py \
     && python3 /opt/glm53/test_scheduler_decode_floor.py \
     && python3 /opt/glm53/test_hybrid_prefix_hit.py \
     && python3 /opt/glm53/test_xgrammar_termination.py \
+    && python3 /opt/glm53/test_kpool_tail_slotmap.py \
     && python3 /opt/glm53/test_ablit.py

--- a/README.md
+++ b/README.md
@@ -206,6 +206,14 @@ mounted and run on both ranks. These address issue #19's matcher-error paths;
 they do not reinterpret a client request that combines GLM XML tool output
 with a JSON response schema, nor do they remove cold-prefill queue time.
 
+`overlay/patch_kpool_tail_slotmap.py` clamps the generic paged slot-map kernel
+so `KpoolTailSpec`'s one-block circular scratch cannot index past its single
+block-table entry. Without that clamp, every token at `pos >= block_size`
+fills the mapping with adjacent memory and the kpool seed/update kernels
+write through it — long generations (~2k tokens) crash or silently corrupt
+another layer's indexer. The clamp is identity for every other KV group.
+Fail-closed, idempotent, mounted and run on both ranks.
+
 `overlay/patch_glm_video_placeholders.py` routes Glm5Next video timestamps through
 the glm46v path and aligns placeholder blocks to encoder `grid_t`. The overlay
 also disables GB10 `persistent_topk` so long-history decode uses
@@ -523,6 +531,8 @@ this Dockerfile instead. After CUDA compile, Python overlay edits
 | `overlay/patch_scheduler_decode_floor.py` | skip (or cap) peer prefill while another seq is decoding |
 | `overlay/patch_xgrammar_termination.py` | source-exact vLLM #52805/#53046 backports; stop at termination and validate post-reasoning speculative drafts before FSM advance |
 | `tests/test_xgrammar_termination.py` | exact two-file patch, idempotence, cross-file fail-closed drift, termination/rollback/reset and post-reasoning draft behavior, launcher wiring |
+| `overlay/patch_kpool_tail_slotmap.py` | clamp KpoolTail one-block circular slot mapping; identity for other KV groups |
+| `tests/test_kpool_tail_slotmap.py` | circular addressing math, exact kernel patch, idempotence, fail-closed drift, launcher wiring |
 | `overlay/ablit_runtime.py` | load-time o_proj transplant / projection (`ABLIT=1`); no-op when off |
 | `overlay/patch_ablit.py` | install the load_weights hook; bind-mounted and run on both ranks |
 | `ablit/` | direction vectors + `LAYER_MAP.json` from drowzeys' published recipe; `fetch_transplant.py` + `transplant/` for the donor o_proj byte-copy |

--- a/overlay/patch_kpool_tail_slotmap.py
+++ b/overlay/patch_kpool_tail_slotmap.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Clamp K-pool tail slot mapping to the one-block circular contract.
+
+``KpoolTailSpec`` is a one-block circular scratch cache: both
+``max_admission_blocks_per_request`` and ``max_num_blocks_per_req`` return 1,
+so its block-table row is a single entry. Slot mapping still uses the generic
+paged Triton kernel, which does::
+
+    block_indices = pos // block_size
+    block_numbers = block_table[req, block_indices]
+
+The mask only guards token validity. Nothing bounds ``block_indices`` against
+the row width. For the tail group every token at ``pos >= block_size`` reads
+past that one entry; the kpool seed/update kernels then write through the
+garbage block id. Long generations (~2k tokens) hit this reliably. A finished
+request is not proof the writes were in-bounds — most overruns land inside the
+shared pool and silently corrupt another layer's indexer.
+
+The fix clamps the index to the row::
+
+    block_indices = tl.minimum(block_indices, block_table_stride - 1)
+
+For the tail group ``block_table_stride == 1``, so the slot becomes
+``block_table[req, 0] * block_size + pos % block_size`` — the addressing
+``_kpool_tail_seed_kernel`` already documents. For every other group a request
+never legitimately needs more blocks than its row holds, so the clamp is
+identity.
+
+Mechanism from vcruz305/GLM-5.3-Flash-EXL3-K2-DGX-Spark-recipe
+(docs/KPOOL_TAIL_BUG.md). Fail-closed, idempotent, preflights the pinned
+anchor before writing.
+"""
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+
+TARGET = Path(
+    os.environ.get(
+        "GLM53_BLOCK_TABLE_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/block_table.py",
+    )
+)
+MARK = "    # [glm53-kpool-tail-slotmap] Never index past the request's\n"
+
+ANCHOR = """        block_indices = (
+            virtual_block_indices * BLOCKS_PER_KV_BLOCK
+            + local_block_offsets // block_size
+        )
+        block_numbers = tl.load(
+            block_table_ptr + row_offset + block_indices,
+            mask=mask & is_local,
+            other=0,
+        ).to(tl.int64)
+"""
+
+PATCHED = """        block_indices = (
+            virtual_block_indices * BLOCKS_PER_KV_BLOCK
+            + local_block_offsets // block_size
+        )
+        # [glm53-kpool-tail-slotmap] Never index past the request's
+        # block-table row. KpoolTailSpec is a one-block circular scratch
+        # whose row is a single entry; without this clamp every token at
+        # pos >= block_size reads adjacent memory and the kpool kernels
+        # write through garbage. Clamping pins that group to entry 0:
+        # block_table[req, 0] * block_size + pos % block_size.
+        # For every other group this is identity.
+        block_indices = tl.minimum(block_indices, block_table_stride - 1)
+        block_numbers = tl.load(
+            block_table_ptr + row_offset + block_indices,
+            mask=mask & is_local,
+            other=0,
+        ).to(tl.int64)
+"""
+
+
+def count_overruns(
+    positions: list[int], *, block_size: int, stride: int
+) -> int:
+    """How many positions the unpatched kernel would index past ``stride``."""
+    if block_size < 1 or stride < 1:
+        raise ValueError("block_size and stride must be >= 1")
+    return sum(1 for pos in positions if (pos // block_size) >= stride)
+
+
+def circular_slot_ids(
+    positions: list[int],
+    block_table_row: list[int],
+    block_size: int,
+    *,
+    clamp: bool,
+) -> list[int]:
+    """CPU replica of the Triton mapping, with or without the row clamp."""
+    if not block_table_row:
+        raise ValueError("block_table_row must be non-empty")
+    stride = len(block_table_row)
+    out: list[int] = []
+    for pos in positions:
+        idx = pos // block_size
+        if clamp:
+            idx = min(idx, stride - 1)
+        elif idx < 0 or idx >= stride:
+            raise IndexError(
+                f"pos={pos} indexes block {idx} past stride {stride}"
+            )
+        out.append(block_table_row[idx] * block_size + (pos % block_size))
+    return out
+
+
+def verified_state(text: str) -> bool:
+    return (
+        text.count(ANCHOR) == 0
+        and text.count(PATCHED) == 1
+        and text.count(MARK) == 1
+        and "tl.minimum(block_indices, block_table_stride - 1)" in text
+    )
+
+
+def prepare(source: str) -> tuple[str, str]:
+    marker_count = source.count(MARK)
+    if marker_count:
+        if marker_count != 1 or not verified_state(source):
+            raise ValueError(
+                "partial/inconsistent kpool tail slot-map patch "
+                f"(marker={marker_count})"
+            )
+        return source, "already present"
+    if verified_state(source):
+        return source, "already patched"
+    n_anchor = source.count(ANCHOR)
+    if n_anchor != 1:
+        raise ValueError(
+            "pinned block_table slot-mapping anchor drifted "
+            f"(anchor={n_anchor})"
+        )
+    if "tl.minimum(block_indices, block_table_stride - 1)" in source:
+        raise ValueError(
+            "block_table already clamps block_indices but the pinned "
+            "anchor was not found — re-derive the patch"
+        )
+    patched = source.replace(ANCHOR, PATCHED, 1)
+    if not verified_state(patched):
+        raise ValueError("kpool tail slot-map post-patch verification failed")
+    return patched, "patched"
+
+
+def replace_file(target: Path, source: str) -> None:
+    tmp = target.with_name(f".{target.name}.glm53-kpool-tail.tmp")
+    try:
+        tmp.write_text(source)
+        os.chmod(tmp, stat.S_IMODE(target.stat().st_mode))
+        os.replace(tmp, target)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def clear_pyc(target: Path) -> None:
+    cache = target.parent / "__pycache__"
+    if not cache.is_dir():
+        return
+    for pyc in cache.glob("block_table*.pyc"):
+        pyc.unlink(missing_ok=True)
+
+
+def main() -> int:
+    if not TARGET.is_file():
+        raise SystemExit(f"missing {TARGET}")
+    source = TARGET.read_text()
+    try:
+        patched, action = prepare(source)
+    except ValueError as exc:
+        raise SystemExit(f"kpool tail slot-map preflight failed: {exc}") from exc
+    compile(patched, str(TARGET), "exec")
+    if patched != source:
+        replace_file(TARGET, patched)
+        clear_pyc(TARGET)
+    print(f"{TARGET.name}: kpool tail slot-map {action}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/start.sh
+++ b/start.sh
@@ -169,6 +169,7 @@ SCHED_PATCH_HOST="${SCHED_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_scheduler_decode
 DRAFTER_PATCH_HOST="${DRAFTER_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm5_drafter_group.py}"
 APC_PATCH_HOST="${APC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_hybrid_prefix_hit.py}"
 XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_xgrammar_termination.py}"
+KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kpool_tail_slotmap.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
 QUANTIZATION="${QUANTIZATION:-exl3}"
 LANGUAGE_MODEL_ONLY="${LANGUAGE_MODEL_ONLY:-0}"
@@ -388,6 +389,7 @@ preflight() {
     [ -f "$DRAFTER_PATCH_HOST" ] || die "$DRAFTER_PATCH_HOST missing"
     [ -f "$APC_PATCH_HOST" ] || die "$APC_PATCH_HOST missing"
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "$XGRAMMAR_PATCH_HOST missing"
+    [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "$KPOOL_TAIL_PATCH_HOST missing"
     [ -f "$SCRIPT_DIR/overlay/patch_ablit.py" ] || die "$SCRIPT_DIR/overlay/patch_ablit.py missing"
     [ -f "$SCRIPT_DIR/overlay/ablit_runtime.py" ] || die "$SCRIPT_DIR/overlay/ablit_runtime.py missing"
     [ -f "$SCRIPT_DIR/ablit/LAYER_MAP.json" ] || die "$SCRIPT_DIR/ablit/LAYER_MAP.json missing"
@@ -850,6 +852,9 @@ fi
 if [ -f /opt/glm53/patch_xgrammar_termination.py ]; then
     python3 /opt/glm53/patch_xgrammar_termination.py
 fi
+if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
+    python3 /opt/glm53/patch_kpool_tail_slotmap.py
+fi
 if [ -f /opt/glm53/patch_ablit.py ]; then
     python3 /opt/glm53/patch_ablit.py
 fi
@@ -937,6 +942,9 @@ fi
 if [ -f /opt/glm53/patch_xgrammar_termination.py ]; then
     python3 /opt/glm53/patch_xgrammar_termination.py
 fi
+if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
+    python3 /opt/glm53/patch_kpool_tail_slotmap.py
+fi
 if [ -f /opt/glm53/patch_ablit.py ]; then
     python3 /opt/glm53/patch_ablit.py
 fi
@@ -973,6 +981,8 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$APC_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_hybrid_prefix_hit.py"
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "missing $XGRAMMAR_PATCH_HOST"
     scp -q -o BatchMode=yes "$XGRAMMAR_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_xgrammar_termination.py"
+    [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "missing $KPOOL_TAIL_PATCH_HOST"
+    scp -q -o BatchMode=yes "$KPOOL_TAIL_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kpool_tail_slotmap.py"
 
     worker_ssh "rm -rf /tmp/glm53-ablit"
     scp -q -r -o BatchMode=yes "$SCRIPT_DIR/ablit" "${WORKER_SSH}:/tmp/glm53-ablit"
@@ -1068,6 +1078,7 @@ launch_cluster() {
         -v '/tmp/patch_glm5_drafter_group.py:/opt/glm53/patch_glm5_drafter_group.py:ro' \
         -v '/tmp/patch_hybrid_prefix_hit.py:/opt/glm53/patch_hybrid_prefix_hit.py:ro' \
         -v '/tmp/patch_xgrammar_termination.py:/opt/glm53/patch_xgrammar_termination.py:ro' \
+        -v '/tmp/patch_kpool_tail_slotmap.py:/opt/glm53/patch_kpool_tail_slotmap.py:ro' \
         -v '/tmp/glm53-ablit:/opt/glm53/ablit:ro' \
         -v '/tmp/glm53-ablit_runtime.py:/opt/glm53/ablit_runtime.py:ro' \
         -v '/tmp/patch_ablit.py:/opt/glm53/patch_ablit.py:ro' \
@@ -1097,6 +1108,7 @@ launch_cluster() {
         -v "$DRAFTER_PATCH_HOST:/opt/glm53/patch_glm5_drafter_group.py:ro" \
         -v "$APC_PATCH_HOST:/opt/glm53/patch_hybrid_prefix_hit.py:ro" \
         -v "$XGRAMMAR_PATCH_HOST:/opt/glm53/patch_xgrammar_termination.py:ro" \
+        -v "$KPOOL_TAIL_PATCH_HOST:/opt/glm53/patch_kpool_tail_slotmap.py:ro" \
         -v "$SCRIPT_DIR/ablit:/opt/glm53/ablit:ro" \
         -v "$SCRIPT_DIR/overlay/ablit_runtime.py:/opt/glm53/ablit_runtime.py:ro" \
         -v "$SCRIPT_DIR/overlay/patch_ablit.py:/opt/glm53/patch_ablit.py:ro" \

--- a/tests/test_kpool_tail_slotmap.py
+++ b/tests/test_kpool_tail_slotmap.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Regression tests for the K-pool tail one-block circular slot-map clamp."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+PATCH = next(
+    p
+    for p in (
+        HERE / "patch_kpool_tail_slotmap.py",
+        ROOT / "overlay" / "patch_kpool_tail_slotmap.py",
+    )
+    if p.is_file()
+)
+sys.path.insert(0, str(PATCH.parent))
+from patch_kpool_tail_slotmap import (  # noqa: E402
+    ANCHOR,
+    MARK,
+    PATCHED,
+    circular_slot_ids,
+    count_overruns,
+    prepare,
+    verified_state,
+)
+
+INSTALLED = Path(
+    "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/block_table.py"
+)
+
+# Exact vLLM 487ecf187 / glm53-flash image kernel fragment.
+PINNED_FIXTURE = '''import triton
+import triton.language as tl
+
+
+@triton.jit
+def _compute_slot_mapping_kernel(
+    num_tokens,
+    max_num_tokens,
+    query_start_loc_ptr,
+    positions_ptr,
+    block_table_ptr,
+    block_table_stride,
+    block_size,
+    slot_mapping_ptr,
+    KV_CACHE_BLOCK_SIZE: tl.constexpr,
+    BLOCKS_PER_KV_BLOCK: tl.constexpr,
+    TOTAL_CP_WORLD_SIZE: tl.constexpr,
+    TOTAL_CP_RANK: tl.constexpr,
+    CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
+    PAD_ID: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+    start_idx = tl.load(query_start_loc_ptr + req_idx).to(tl.int64)
+    end_idx = tl.load(query_start_loc_ptr + req_idx + 1).to(tl.int64)
+    virtual_block_size = KV_CACHE_BLOCK_SIZE * TOTAL_CP_WORLD_SIZE
+    row_offset = req_idx * block_table_stride
+    for i in range(start_idx, end_idx, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < end_idx
+        pos = tl.load(positions_ptr + offsets, mask=mask, other=0)
+        virtual_block_indices = pos // virtual_block_size
+        virtual_block_offsets = pos - virtual_block_indices * virtual_block_size
+        is_local = (
+            virtual_block_offsets // CP_KV_CACHE_INTERLEAVE_SIZE
+        ) % TOTAL_CP_WORLD_SIZE == TOTAL_CP_RANK
+        local_block_offsets = (
+            virtual_block_offsets // (TOTAL_CP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
+        ) * CP_KV_CACHE_INTERLEAVE_SIZE + (
+            virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE
+        )
+''' + ANCHOR
+
+
+def _run_patch(target: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["GLM53_BLOCK_TABLE_PY"] = str(target)
+    return subprocess.run(
+        [sys.executable, str(PATCH)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_circular_math() -> None:
+    # Tail group: one entry, block_size == index_kpool == 4.
+    row = [17]
+    positions = list(range(0, 64))
+    assert count_overruns(positions, block_size=4, stride=1) == 60
+    patched = circular_slot_ids(positions, row, 4, clamp=True)
+    assert patched[:4] == [68, 69, 70, 71]  # 17*4 + 0..3
+    # Circular: pos 4, 8, 12 map back onto the same four slots.
+    assert patched[4:8] == patched[:4]
+    assert patched[60:64] == patched[:4]
+    unpatched = circular_slot_ids(positions[:4], row, 4, clamp=False)
+    assert unpatched == patched[:4]
+    try:
+        circular_slot_ids([4], row, 4, clamp=False)
+    except IndexError:
+        pass
+    else:
+        raise AssertionError("unpatched mapping must IndexError at pos >= block_size")
+
+    # Full-attention group: clamp is identity inside the row.
+    wide = list(range(10))
+    pos = [0, 63, 64, 639]  # block_size 64, last index 9
+    assert count_overruns(pos, block_size=64, stride=10) == 0
+    assert circular_slot_ids(pos, wide, 64, clamp=True) == circular_slot_ids(
+        pos, wide, 64, clamp=False
+    )
+
+
+def test_fixture() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        target = Path(raw) / "block_table.py"
+        target.write_text(PINNED_FIXTURE)
+        first = _run_patch(target)
+        assert first.returncode == 0, first.stderr
+        text = target.read_text()
+        assert verified_state(text)
+        assert MARK in text
+        assert "tl.minimum(block_indices, block_table_stride - 1)" in text
+        assert "already present" not in first.stdout
+        second = _run_patch(target)
+        assert second.returncode == 0, second.stderr
+        assert "already present" in second.stdout
+        assert second.stdout.count("already present") == 1
+        again, action = prepare(text)
+        assert action == "already present"
+        assert again == text
+
+
+def test_fail_closed() -> None:
+    drifted = PINNED_FIXTURE.replace(
+        "local_block_offsets // block_size",
+        "local_block_offsets // kernel_block_size",
+        1,
+    )
+    with tempfile.TemporaryDirectory() as raw:
+        target = Path(raw) / "block_table.py"
+        target.write_text(drifted)
+        result = _run_patch(target)
+        assert result.returncode != 0
+        assert "preflight failed" in result.stderr
+        assert target.read_text() == drifted
+
+    partial = PINNED_FIXTURE.replace(ANCHOR, MARK + ANCHOR, 1)
+    with tempfile.TemporaryDirectory() as raw:
+        target = Path(raw) / "block_table.py"
+        target.write_text(partial)
+        result = _run_patch(target)
+        assert result.returncode != 0
+        assert "partial/inconsistent" in result.stderr
+
+
+def test_installed_copy_if_present() -> None:
+    src = Path(os.environ.get("GLM53_BLOCK_TABLE_PY_SRC", INSTALLED))
+    if not src.is_file():
+        return
+    with tempfile.TemporaryDirectory() as raw:
+        target = Path(raw) / "block_table.py"
+        target.write_text(src.read_text())
+        result = _run_patch(target)
+        assert result.returncode == 0, result.stderr
+        assert verified_state(target.read_text())
+
+
+def test_recipe_wiring_if_present() -> None:
+    start = ROOT / "start.sh"
+    dockerfile = ROOT / "Dockerfile"
+    if not start.is_file() or not dockerfile.is_file():
+        return
+    launcher = start.read_text()
+    image = dockerfile.read_text()
+    assert 'KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-' in launcher
+    assert launcher.count("python3 /opt/glm53/patch_kpool_tail_slotmap.py") == 2
+    assert (
+        "-v '/tmp/patch_kpool_tail_slotmap.py:"
+        "/opt/glm53/patch_kpool_tail_slotmap.py:ro'" in launcher
+    )
+    assert (
+        '-v "$KPOOL_TAIL_PATCH_HOST:'
+        '/opt/glm53/patch_kpool_tail_slotmap.py:ro"' in launcher
+    )
+    assert 'scp -q -o BatchMode=yes "$KPOOL_TAIL_PATCH_HOST"' in launcher
+    assert "COPY overlay/patch_kpool_tail_slotmap.py" in image
+    assert "RUN python3 /opt/glm53/patch_kpool_tail_slotmap.py" in image
+    assert "python3 /opt/glm53/test_kpool_tail_slotmap.py" in image
+
+
+def main() -> int:
+    test_circular_math()
+    test_fixture()
+    test_fail_closed()
+    test_installed_copy_if_present()
+    test_recipe_wiring_if_present()
+    print("kpool tail slot-map patch OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Clamp the generic paged slot-map kernel so GLM-5.3's `KpoolTailSpec` one-block circular scratch cannot index past its single block-table entry on long generations.
- Fail-closed overlay (`overlay/patch_kpool_tail_slotmap.py`) is baked in the image and remounted on both TP ranks at boot.
- Tests cover circular addressing, the pinned kernel text, idempotence, drift fail-closed, and launcher wiring.

This is the slot-map bug documented in the 1× Spark K2 recipe. Without the clamp, `pos >= block_size` fills the mapping with adjacent memory and the kpool seed/update kernels write through it (crash or silent indexer corruption). The clamp is identity for every other KV group.

## Test plan
- [x] `python3 tests/test_kpool_tail_slotmap.py` (including live image `block_table.py`)
- [x] Restart serve: both ranks log `block_table.py: kpool tail slot-map patched`
- [x] Decode guard: structured 5×400 median 66.1 tok/s / accept 0.978; prose 27.4 / 0.352; no NaN
- [x] Long gen 2500 tokens (past the ~2.2k field crash line), HTTP 200, `/health` 200
- [x] Cold ~100k prefill (99,995 tokens, above the 98,304 line from that other recipe), gen `OK`


Made with [Cursor](https://cursor.com)