### PR TITLE
Add bounded Pi configs for local GLM inference

### DIFF
--- a/examples/pi/models.json
+++ b/examples/pi/models.json
@@ -1,0 +1,47 @@
+{
+  "providers": {
+    "local-glm": {
+      "name": "Local GLM 5.3 Flash EXL3",
+      "baseUrl": "http://127.0.0.1:8888/v1",
+      "api": "openai-completions",
+      "apiKey": "local",
+      "authHeader": false,
+      "models": [
+        {
+          "id": "GLM-5.3-Flash-EXL3",
+          "name": "GLM 5.3 Flash EXL3",
+          "reasoning": false,
+          "input": [
+            "text"
+          ],
+          "contextWindow": 65536,
+          "maxTokens": 8192,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          },
+          "compat": {
+            "supportsStore": false,
+            "supportsDeveloperRole": false,
+            "supportsReasoningEffort": false,
+            "supportsUsageInStreaming": true,
+            "supportsFinishReason": true,
+            "supportsStrictMode": false,
+            "maxTokensField": "max_tokens",
+            "chatTemplateKwargs": {
+              "enable_thinking": false
+            }
+          }
+        }
+      ],
+      "compat": {
+        "supportsDeveloperRole": false,
+        "supportsReasoningEffort": false,
+        "supportsStrictMode": false,
+        "maxTokensField": "max_tokens"
+      }
+    }
+  }
+}

--- a/examples/pi/models.json
+++ b/examples/pi/models.json
@@ -14,7 +14,7 @@
           "input": [
             "text"
           ],
-          "contextWindow": 65536,
+          "contextWindow": 500000,
           "maxTokens": 8192,
           "cost": {
             "input": 0,

--- a/examples/pi/settings.json
+++ b/examples/pi/settings.json
@@ -1,0 +1,15 @@
+{
+  "defaultProvider": "local-glm",
+  "defaultModel": "GLM-5.3-Flash-EXL3",
+  "defaultThinkingLevel": "off",
+  "httpIdleTimeoutMs": 600000,
+  "compaction": {
+    "enabled": true,
+    "reserveTokens": 16384,
+    "keepRecentTokens": 8000
+  },
+  "packages": [
+    "npm:@tintinweb/pi-subagents",
+    "npm:context-mode"
+  ]
+}

--- a/examples/pi/settings.json
+++ b/examples/pi/settings.json
@@ -5,8 +5,8 @@
   "httpIdleTimeoutMs": 600000,
   "compaction": {
     "enabled": true,
-    "reserveTokens": 16384,
-    "keepRecentTokens": 8000
+    "reserveTokens": 65536,
+    "keepRecentTokens": 24000
   },
   "packages": [
     "npm:@tintinweb/pi-subagents",

--- a/examples/pi/subagents.json
+++ b/examples/pi/subagents.json
@@ -1,0 +1,13 @@
+{
+  "maxConcurrent": 2,
+  "maxConcurrentForeground": 1,
+  "defaultMaxTurns": 20,
+  "graceTurns": 2,
+  "toolDescriptionMode": "compact",
+  "agentMentions": "direct",
+  "schedulingEnabled": false,
+  "workflowsEnabled": false,
+  "maxSubagentDepth": 1,
+  "fallbackSubagent": "none",
+  "outputTranscript": false
+}


### PR DESCRIPTION
## Summary

This contribution adds a sanitized, configuration-only Pi setup for using `GLM-5.3-Flash-EXL3` through the repository's OpenAI-compatible endpoint.

The defaults retain long-context capability while bounding the most common sources of queue contention:

- expose a 500K Pi client context instead of the full 1M serving limit
- reserve 64K tokens for compaction and retain the most recent 24K
- cap generated output at 8K tokens
- limit background and foreground subagents to 2 and 1 respectively
- use the compact subagent tool description
- disable scheduled agents, independent workflows, and nested delegation in the conservative preset

## Why

During an extended Pi workload, tool error rates were comparable across local and hosted models; latency was dominated by context growth and queue contention rather than tool-call capability. Long prompts and unrestricted agent fan-out caused queue and prefill time to dominate end-to-end latency. The 500K profile preserves long sessions while keeping output and concurrency bounded, without changing the server-side GLM deployment recipe.

## Files

- `examples/pi/models.json`
- `examples/pi/settings.json`
- `examples/pi/subagents.json`

## Validation

- all files pass strict JSON parsing
- the provider/model fields match the OpenAI-compatible GLM endpoint and served model ID
- settings use options supported by Pi 0.84.x and `@tintinweb/pi-subagents`
- the diff contains configuration files only

## Privacy and security

The examples contain no API tokens, credentials, private network addresses, usernames, home-directory paths, machine identifiers, or runtime logs. `127.0.0.1:8888` is a generic local default and can be replaced when Pi runs on another host.
