### PR TITLE
Add KV cache offload to disk (per-node NVMe staging) — fixes #57

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -150,6 +150,31 @@ USE_HOST_NCCL=0
 # WORKER_NCCL_HOST_DIR=/home/you/nccl-2.30.7
 NCCL_SO_NAME=libnccl.so.2.30.7
 NCCL_IB_GID_INDEX=3
+# --- KV cache offload to disk (optional, default off) -----------------------
+# Backs vLLM's CPU offload staging region with a SPARSE FILE on this node's own
+# NVMe, so an evicted prefix is restored from disk instead of recomputed.
+# Per-node by construction, which is what makes it correct under 2-node TP —
+# vLLM's own secondary ("fs") tiers run scheduler-side on the head only and
+# silently corrupt rank 1 on restore (see issue #57).
+# Unset/empty = off (stock /dev/shm staging, no disk store).
+# GLM53_OFFLOAD_MMAP_DIR=/root/.cache/vllm/kv-mmap
+#
+# Bytes stored between msync + MADV_DONTNEED passes over the region. Required
+# with a large store on GB10: CPU and GPU share one memory pool, so unbounded
+# page cache starves the GPU and the worker rank dies mid-prefill with no
+# traceback. 2 GB measured good; lower it if the host runs tight.
+# GLM53_OFFLOAD_RELEASE_BYTES=2000000000
+#
+# Serve flag that turns it on (size the store here — capacity is the file, not
+# RAM). cpu_bytes_to_use / row_bytes = blocks; blocks * 3584 = tokens held.
+# 160 GiB ~= 3,162 blocks ~= 11.3M tokens on this build.
+# EXTRA_ARGS=--kv-transfer-config {"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":171798691840,"eviction_policy":"lru"}}
+#
+# The OffloadingConnector rejects expandable_segments:True, so offload runs need:
+# GLM53_ALLOC_CONF=expandable_segments:False
+# Do NOT set PYTHONHASHSEED with offload on — it invalidates the Triton JIT
+# cache keys and the mid-collective recompile kills the worker rank.
+
 # vLLM deducts a CUDA-graph memory estimate from the KV pool. Where the estimate
 # exceeds what the graphs actually use, 0 returns that memory to KV with graphs
 # still enabled. 1 = upstream default.

--- a/.env.example
+++ b/.env.example
@@ -170,8 +170,18 @@ NCCL_IB_GID_INDEX=3
 # 160 GiB ~= 3,162 blocks ~= 11.3M tokens on this build.
 # EXTRA_ARGS=--kv-transfer-config {"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":171798691840,"eviction_policy":"lru"}}
 #
-# The OffloadingConnector rejects expandable_segments:True, so offload runs need:
-# GLM53_ALLOC_CONF=expandable_segments:False
+# ⚠️ The OffloadingConnector REJECTS expandable_segments:True — but do NOT just
+# set it False to satisfy the check. On GB10 that is fatal: without expandable
+# segments the caching allocator keeps reserved blocks after a large prefill and
+# never returns them. Measured 2026-08-31, one 337k-token request took host
+# available 10358 MB -> 1352 MB, did not recover after the request finished, and
+# wedged both Sparks (physical power cycle). Six wedges before we isolated it.
+# Take the guard's own exemption instead: keep expandable_segments:True and add
+# --enable-cumem-allocator to the serve flags. CuMemAllocator disables expandable
+# segments around the KV pool, so KV lands on stable physical pages (exactly what
+# the guard protects) while the engine keeps them everywhere else. Same request
+# with that combination dipped ~560 MB and completed in 397 s.
+# GLM53_ALLOC_CONF=expandable_segments:True   (start.sh default; leave it alone)
 # Do NOT set PYTHONHASHSEED with offload on — it invalidates the Triton JIT
 # cache keys and the mid-collective recompile kills the worker rank.
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,66 @@ Keep **`SKIP_MM_PROFILING=1`** — a max-size image+video dummy profile OOMs thi
 **NVFP4 KV is not available here.** FlashInfer’s SM12x NVFP4 kernels are dense MHA,
 not sparse MLA. Do not confuse that with NVFP4 **weights** (`--moe-backend marlin`).
 
+## KV cache offload to disk (optional, `GLM53_OFFLOAD_MMAP_DIR`)
+
+Off by default. When set, vLLM's CPU offload staging region is backed by a
+**sparse file on each node's own NVMe**, so a prefix that has been evicted from
+the GPU pool is *restored from disk* instead of recomputed. Capacity becomes the
+size of that file rather than RAM — useful when several people share the box and
+the GPU pool alone cannot hold everyone's context.
+
+Measured on this kit (105k-token prompt, evicted by 6 × 168k-token floods,
+100 GB per-node store, thinking off, temp 0):
+
+| | |
+|---|---|
+| Restore | **8.54 s** vs **130 s** to recompute (**15×**) |
+| Output | byte-correct |
+| Read from disk | 1.68 GB (`kv_offload` `CPU_to_GPU`) |
+| Host | stable, 6–8 GB free throughout |
+| Capacity | 3,162 blocks ≈ **11.3M tokens** in 160 GB/node |
+
+Decode is unaffected with it enabled: `tests/bench_decode.py` (median of 5 × 400)
+gives structured **66.4** tok/s / prose **26.7** against the 65.1 / 27.1 above.
+
+```bash
+GLM53_OFFLOAD_MMAP_DIR=/root/.cache/vllm/kv-mmap \
+GLM53_OFFLOAD_RELEASE_BYTES=2000000000 \
+GLM53_ALLOC_CONF=expandable_segments:False \
+EXTRA_ARGS='--kv-transfer-config {"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":171798691840,"eviction_policy":"lru"}}' \
+./start.sh restart
+```
+
+`overlay/patch_kv_offload_groups.py` is what makes this possible; without it the
+engine aborts at boot (`KpoolTailSpec`'s 4-token block cannot align to the
+64-token hash granularity). It also:
+
+- excludes the kpool tail and the DFlash2 drafter from offloading — sub-block
+  groups otherwise emit ~56× more keys than the 3584-token groups and starve
+  the staging tier so the MLA/mamba chunks never reach disk. Drafter KV rebuilds
+  inside its own window after a restore; a stale draft costs acceptance, never
+  correctness, since the target verifies every token.
+- forces the per-layer copy path — the packed whole-row path clobbers other
+  groups' live pages on restore for a multi-block-size hybrid.
+- bounds the staging region's page cache (`msync` + `MADV_DONTNEED`). Required on
+  GB10: CPU and GPU share one pool, so an unbounded region starves the GPU and
+  the worker rank dies mid-prefill with no traceback.
+
+**Why per-node and not an `fs` secondary tier:** secondary tiers and their
+promotions run scheduler-side on the head only. Under 2-node TP rank 1's shard
+is never written (every file lands `..._r0`) and its restores return stale bytes
+— confidently wrong output, with healthy-looking `kv_offload` counters. Backing
+the CPU *primary* tier per node avoids that by construction. Details in #57.
+
+⚠️ Do **not** set `PYTHONHASHSEED` with offload on (the tier docs suggest it for
+cross-process key stability): it invalidates the Triton JIT cache keys and the
+mid-collective recompile kills the worker rank.
+
+⚠️ Sizing: a restore is admitted only when every group's chunks are resident
+together, so keep `cpu_bytes_to_use` ≥ `row_bytes × (restore_tokens / 3584 + 8)`.
+Undersized, stores still succeed and metrics still climb while no restore ever
+serves.
+
 ## Prefix caching (this kit, 2026-08-30)
 
 `--enable-prefix-caching` is on. The OpenAI API is **stateless**: the client

--- a/README.md
+++ b/README.md
@@ -329,6 +329,16 @@ is never written (every file lands `..._r0`) and its restores return stale bytes
 — confidently wrong output, with healthy-looking `kv_offload` counters. Backing
 the CPU *primary* tier per node avoids that by construction. Details in #57.
 
+⚠️ **Offload rejects `expandable_segments:True` — do not simply switch it off.**
+Running without expandable segments is fatal on GB10: the caching allocator
+retains reserved blocks after a large prefill and never returns them. A
+337k-token request took host available memory 10358 MB → 1352 MB, did not
+recover once the request finished, and wedged both Sparks. Take the guard's
+documented exemption — keep `expandable_segments:True` and add
+`--enable-cumem-allocator`, which puts the KV pool on stable physical pages
+(what the guard actually protects) while the rest of the engine keeps expandable
+segments. The same request then dipped ~560 MB and completed in 397 s.
+
 ⚠️ Do **not** set `PYTHONHASHSEED` with offload on (the tier docs suggest it for
 cross-process key stability): it invalidates the Triton JIT cache keys and the
 mid-collective recompile kills the worker rank.

--- a/overlay/patch_kv_offload_groups.py
+++ b/overlay/patch_kv_offload_groups.py
@@ -1,0 +1,538 @@
+#!/usr/bin/env python3
+"""patch_kv_offload_groups.py — let OffloadingConnector serve GLM-5.3's
+hybrid layout by excluding per-request scratch groups from offload scheduling.
+
+GLM-5.3-Flash (this fork) exposes 7 KV cache groups:
+  0 MLA (UniformType, block 3584)  2-5 Mamba/GDN (block 3584, align mode)
+  6 DFlash drafter SWA (block 64, EAGLE)   -> all offloadable
+  1 indexer/kpool tail (UniformType, block 4, 11 layers)
+    -> per-request circular scratch. GPU prefix caching already treats it as
+       rebuild-on-hit (it opts out of the hybrid hit min), so external KV
+       loads need nothing from it. Its 4-token block cannot align with the
+       64-token hash granularity, which stock build_offloading_config asserts
+       on. This patch marks such groups as scratch and skips them at every
+       scheduler touchpoint instead of failing the boot.
+
+Also unwraps UniformTypeKVCacheSpecs in the window classifier (this fork wraps
+group specs) and makes unknown spec classes classify as full-attention instead
+of asserting.
+
+Fail-closed: all anchors verified, compile-checked, original restored on error.
+Idempotent. Kill switch: GLM53_SKIP_KV_OFFLOAD_GROUPS_PATCH=1.
+"""
+import os
+import sys
+from pathlib import Path
+
+MARK = "# [glm53-kv-offload-scratch]"
+
+
+cfg_edits = [
+    (
+        "from typing import TYPE_CHECKING",
+        "from typing import TYPE_CHECKING\n\nfrom vllm.logger import init_logger",
+    ),
+    (
+        "from vllm.v1.kv_offload.config import (",
+        "logger = init_logger(__name__)  # [glm53-kv-offload-scratch-logger]\n\nfrom vllm.v1.kv_offload.config import (",
+    ),
+    (
+        """    _, tokens_per_hash = resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)
+    for group in groups:
+        assert group.tokens_per_block % tokens_per_hash == 0, (
+            f"tokens_per_block={group.tokens_per_block} not divisible by "
+            f"tokens_per_hash={tokens_per_hash}. "
+            f"Hybrid models (e.g. Mamba+Attention) need "
+            f"--enable-prefix-caching to align block sizes."
+        )""",
+        """    _, tokens_per_hash = resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)
+    # [glm53-kv-offload-scratch] groups that cannot align with the hash
+    # granularity are per-request scratch (e.g. GLM kpool tail, block=4).
+    # The scheduler excludes them from offload scheduling; do not assert.
+    _max_tpb = max(g.tokens_per_block for g in groups)
+    for _idx, group in enumerate(groups):
+        if (group.tokens_per_block % tokens_per_hash != 0
+                or group.tokens_per_block < _max_tpb):
+            logger.warning(
+                "[kv-offload-scratch] group %d (tokens_per_block=%d, %d layers)"
+                " is not hash-aligned (tokens_per_hash=%d) - treating as"
+                " per-request scratch, excluded from offloading",
+                _idx, group.tokens_per_block, len(group.layer_names),
+                tokens_per_hash,
+            )""",
+    ),
+]
+
+sch_edits = [
+    # 1) import UniformTypeKVCacheSpecs
+    (
+        "from vllm.v1.kv_cache_interface import (",
+        "from vllm.v1.kv_cache_interface import (\n    UniformTypeKVCacheSpecs,",
+    ),
+    # 2) unwrap UniformType + tolerate unknown specs in window classifier
+    (
+        """def get_sliding_window_size_in_chunks(
+    kv_cache_spec: KVCacheSpec, tokens_per_chunk: int
+) -> int | None:
+    if isinstance(kv_cache_spec, SlidingWindowSpec):""",
+        """def get_sliding_window_size_in_chunks(
+    kv_cache_spec: KVCacheSpec, tokens_per_chunk: int
+) -> int | None:
+    # [glm53-kv-offload-scratch] this fork wraps group specs in
+    # UniformTypeKVCacheSpecs; classify by the wrapped per-layer spec.
+    if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+        kv_cache_spec = next(iter(kv_cache_spec.kv_cache_specs.values()))
+    if isinstance(kv_cache_spec, SlidingWindowSpec):""",
+    ),
+    (
+        """    assert isinstance(kv_cache_spec, FullAttentionSpec)
+    return None""",
+        """    if not isinstance(kv_cache_spec, FullAttentionSpec):
+        logger.warning_once(
+            "[kv-offload-scratch] spec %s treated as full attention",
+            type(kv_cache_spec).__name__,
+        )
+    return None""",
+    ),
+    # 3) GroupOffloadConfig scratch flag
+    (
+        """    # True for EAGLE/MTP draft-model attention groups. The trailing chunk
+    # of these groups is volatile and lacks a stable hash, so it must
+    # be excluded from store and load scheduling.
+    is_eagle_group: bool = False""",
+        """    # True for EAGLE/MTP draft-model attention groups. The trailing chunk
+    # of these groups is volatile and lacks a stable hash, so it must
+    # be excluded from store and load scheduling.
+    is_eagle_group: bool = False
+    # [glm53-kv-offload-scratch] per-request scratch group: contributes
+    # nothing to offload stores/loads/lookups (e.g. GLM kpool tail).
+    is_scratch: bool = False""",
+    ),
+    # 4) from_spec: skip scratch in alignment scan
+    (
+        """        full_attn_tokens_per_chunk: set[int] = set()
+        for idx, tokens_per_block in enumerate(spec.tokens_per_block):
+            kv_spec = kv_cache_config.kv_cache_groups[idx].kv_cache_spec
+            sw = get_sliding_window_size_in_chunks(
+                kv_spec, tokens_per_block * spec.blocks_per_chunk
+            )
+            if sw is None:
+                full_attn_tokens_per_chunk.add(tokens_per_block * spec.blocks_per_chunk)""",
+        """        full_attn_tokens_per_chunk: set[int] = set()
+        for idx, tokens_per_block in enumerate(spec.tokens_per_block):
+            if (tokens_per_block % spec.tokens_per_hash != 0
+                    or tokens_per_block < max(spec.tokens_per_block)):
+                continue  # [glm53-kv-offload-scratch]
+            kv_spec = kv_cache_config.kv_cache_groups[idx].kv_cache_spec
+            sw = get_sliding_window_size_in_chunks(
+                kv_spec, tokens_per_block * spec.blocks_per_chunk
+            )
+            if sw is None:
+                full_attn_tokens_per_chunk.add(tokens_per_block * spec.blocks_per_chunk)""",
+    ),
+    # 5) from_spec: emit scratch config entries
+    (
+        """        kv_group_configs_list: list[GroupOffloadConfig] = []
+        for idx, tokens_per_block in enumerate(spec.tokens_per_block):
+            kv_cache_group = kv_cache_config.kv_cache_groups[idx]
+            kv_spec = kv_cache_group.kv_cache_spec
+            sw = get_sliding_window_size_in_chunks(""",
+        """        kv_group_configs_list: list[GroupOffloadConfig] = []
+        for idx, tokens_per_block in enumerate(spec.tokens_per_block):
+            kv_cache_group = kv_cache_config.kv_cache_groups[idx]
+            kv_spec = kv_cache_group.kv_cache_spec
+            if (tokens_per_block % spec.tokens_per_hash != 0
+                    or tokens_per_block < max(spec.tokens_per_block)):
+                # [glm53-kv-offload-scratch] per-request scratch group
+                kv_group_configs_list.append(
+                    GroupOffloadConfig(
+                        group_idx=idx,
+                        tokens_per_block=tokens_per_block,
+                        tokens_per_chunk=tokens_per_block * spec.blocks_per_chunk,
+                        hashes_per_chunk=1,
+                        sliding_window_size_in_chunks=None,
+                        alignment_chunk_count=None,
+                        kv_event_group_spec=get_offloading_event_group_spec(
+                            kv_cache_group
+                        ),
+                        is_eagle_group=False,
+                        is_scratch=True,
+                    )
+                )
+                continue
+            sw = get_sliding_window_size_in_chunks(""",
+    ),
+    # 6) ctor lookup-group lists skip scratch
+    (
+        """        for group_config in self.config.kv_group_configs:
+            if group_config.sliding_window_size_in_chunks is None:
+                full_attention_groups.append(group_config.group_idx)
+            else:
+                sliding_window_groups.append(group_config.group_idx)""",
+        """        for group_config in self.config.kv_group_configs:
+            if group_config.is_scratch:  # [glm53-kv-offload-scratch]
+                continue
+            if group_config.sliding_window_size_in_chunks is None:
+                full_attention_groups.append(group_config.group_idx)
+            else:
+                sliding_window_groups.append(group_config.group_idx)""",
+    ),
+    # 7) update_offload_keys skip
+    (
+        """    def update_offload_keys(self) -> None:
+        for group_config, group_state in zip(
+            self.config.kv_group_configs, self.group_states
+        ):
+            for req_block_hash in islice(""",
+        """    def update_offload_keys(self) -> None:
+        for group_config, group_state in zip(
+            self.config.kv_group_configs, self.group_states
+        ):
+            if group_config.is_scratch:  # [glm53-kv-offload-scratch]
+                continue
+            for req_block_hash in islice(""",
+    ),
+    # 8) storable_chunks -> 0 for scratch
+    (
+        """        num_chunks = num_offloadable_tokens // group_config.tokens_per_chunk
+        is_decoding = num_offloadable_tokens > self.req.num_prompt_tokens""",
+        """        if group_config.is_scratch:  # [glm53-kv-offload-scratch]
+            return 0
+        num_chunks = num_offloadable_tokens // group_config.tokens_per_chunk
+        is_decoding = num_offloadable_tokens > self.req.num_prompt_tokens""",
+    ),
+    # 9) update_num_hit_chunks skip
+    (
+        """        for group_config, group_state in zip(
+            self.config.kv_group_configs, self.group_states
+        ):
+            group_state.num_hit_chunks = (
+                num_cached_tokens // group_config.tokens_per_chunk
+            )""",
+        """        for group_config, group_state in zip(
+            self.config.kv_group_configs, self.group_states
+        ):
+            if group_config.is_scratch:  # [glm53-kv-offload-scratch]
+                continue
+            group_state.num_hit_chunks = (
+                num_cached_tokens // group_config.tokens_per_chunk
+            )""",
+    ),
+    # 10) _touch skip
+    (
+        """        for group_config, group_state in zip(
+            self.config.kv_group_configs, req_status.group_states
+        ):
+            if group_config.sliding_window_size_in_chunks is None:
+                self.manager.touch(group_state.offload_keys, req_status.req_context)""",
+        """        for group_config, group_state in zip(
+            self.config.kv_group_configs, req_status.group_states
+        ):
+            if group_config.is_scratch:  # [glm53-kv-offload-scratch]
+                continue
+            if group_config.sliding_window_size_in_chunks is None:
+                self.manager.touch(group_state.offload_keys, req_status.req_context)""",
+    ),
+    # 11) update_state_after_alloc: zero contribution
+    (
+        """            self._current_batch_allocated_block_ids.update(
+                block.block_id for block in group_blocks if block.block_id != 0
+            )
+
+            tokens_per_block = group_config.tokens_per_block""",
+        """            self._current_batch_allocated_block_ids.update(
+                block.block_id for block in group_blocks if block.block_id != 0
+            )
+
+            if group_config.is_scratch:  # [glm53-kv-offload-scratch]
+                group_sizes.append(0)
+                block_indices.append(0)
+                continue
+
+            tokens_per_block = group_config.tokens_per_block""",
+    ),
+    # 12) _build_store_jobs key-collection loop skip
+    (
+        """            for group_config, group_state in zip(
+                self.config.kv_group_configs, req_status.group_states
+            ):
+                num_chunks = req_status.storable_chunks(
+                    group_config, group_state, num_offloadable_tokens
+                )
+
+                start_chunk_idx = group_state.next_stored_chunk_idx
+                if num_chunks <= start_chunk_idx:
+                    continue""",
+        """            for group_config, group_state in zip(
+                self.config.kv_group_configs, req_status.group_states
+            ):
+                if group_config.is_scratch:  # [glm53-kv-offload-scratch]
+                    continue
+                num_chunks = req_status.storable_chunks(
+                    group_config, group_state, num_offloadable_tokens
+                )
+
+                start_chunk_idx = group_state.next_stored_chunk_idx
+                if num_chunks <= start_chunk_idx:
+                    continue""",
+    ),
+    # 13) _build_store_jobs src-block loop: zero contribution
+    (
+        """            for group_config, group_state in zip(
+                self.config.kv_group_configs, req_status.group_states
+            ):
+                is_sliding_window = (
+                    group_config.sliding_window_size_in_chunks is not None
+                )""",
+        """            for group_config, group_state in zip(
+                self.config.kv_group_configs, req_status.group_states
+            ):
+                if group_config.is_scratch:  # [glm53-kv-offload-scratch]
+                    group_sizes.append(0)
+                    block_indices.append(0)
+                    continue
+                is_sliding_window = (
+                    group_config.sliding_window_size_in_chunks is not None
+                )""",
+    ),
+]
+
+
+def apply(path: Path, edits, needs_logger: bool = False) -> bool:
+    src = path.read_text()
+    if MARK in src:
+        print(f"[kv-offload-scratch] {path.name} already patched")
+        return True
+    original = src
+    for old, new in edits:
+        if old not in src:
+            print(f"[kv-offload-scratch] ANCHOR MISSING in {path.name}:\n{old[:120]}",
+                  file=sys.stderr)
+            return False
+        if src.count(old) != 1:
+            print(f"[kv-offload-scratch] anchor not unique ({src.count(old)}) in "
+                  f"{path.name}: {old[:80]}", file=sys.stderr)
+            return False
+        src = src.replace(old, new, 1)
+    try:
+        compile(src, str(path), "exec")
+    except SyntaxError as e:
+        print(f"[kv-offload-scratch] compile failed for {path.name}: {e}",
+              file=sys.stderr)
+        path.write_text(original)
+        return False
+    path.write_text(src)
+    print(f"[kv-offload-scratch] applied to {path.name} ({len(edits)} edits)")
+    return True
+
+
+
+# --- v4: worker-side coherence fixes ---
+wrk_edits = [
+    # (a) Bypass the packed whole-row fast path. Groups allocate block ids
+    # independently over shared rows, so whole-row loads clobber the other
+    # groups' live pages in the destination row (proven: corrupted restores).
+    # The generic per-layer path copies only each group's own byte ranges.
+    (
+        """        if packed_kv_cache_tensor is not None:""",
+        """        packed_kv_cache_tensor = None  # [glm53-kv-offload-scratch] whole-row
+        # fast path is incoherent for multi-block-size hybrids; force the
+        # per-layer path below.
+        if packed_kv_cache_tensor is not None:""",
+    ),
+    # (b) Mamba layers in packed layouts are registered as strided views;
+    # plain .view() requires contiguity. Build a byte-strided view instead.
+    (
+        """                elif isinstance(layer_kv_cache_spec, MambaSpec):
+                    layer_kv_cache = kv_caches[layer_name]
+                    assert layer_kv_cache.dtype == torch.int8
+                    tensors_per_block[layer_name] = (
+                        layer_kv_cache.view(
+                            num_blocks, layer_kv_cache_spec.page_size_bytes
+                        ),
+                    )""",
+        """                elif isinstance(layer_kv_cache_spec, MambaSpec):
+                    layer_kv_cache = kv_caches[layer_name]
+                    assert layer_kv_cache.dtype == torch.int8
+                    # [glm53-kv-offload-scratch] strided-safe view
+                    _page = layer_kv_cache_spec.page_size_bytes
+                    _raw = torch.empty(
+                        0, dtype=torch.int8, device=layer_kv_cache.device
+                    ).set_(layer_kv_cache.untyped_storage())
+                    _stride0 = (
+                        layer_kv_cache.stride(0)
+                        if layer_is_packed.get(layer_name)
+                        else _page
+                    )
+                    tensors_per_block[layer_name] = (
+                        torch.as_strided(
+                            _raw,
+                            (num_blocks, _page),
+                            (_stride0, 1),
+                            layer_kv_cache.storage_offset(),
+                        ),
+                    )""",
+    ),
+    # (c) Tolerate certified-mapping size mismatches instead of asserting:
+    # fall back to no mapping (direct copies do not use it).
+    (
+        """                    assert (
+                        mapping is None
+                        or mapping.local_page_size_bytes
+                        == unpadded_page_size_bytes[layer_name]
+                    )""",
+        """                    if (
+                        mapping is not None
+                        and mapping.local_page_size_bytes
+                        != unpadded_page_size_bytes[layer_name]
+                    ):  # [glm53-kv-offload-scratch]
+                        logger.warning_once(
+                            "[kv-offload-scratch] dropping certified mapping for"
+                            " %s (size mismatch)", layer_name)
+                        mapping = None""",
+    ),
+]
+
+
+# --- v5: NVMe-backed staging region (disk tier that is per-rank correct) ---
+sor_edits = [
+    (
+        '''        self.mmap_path = f"/dev/shm/vllm_offload_{engine_id}.mmap"''',
+        '''        _mmap_dir = os.environ.get("GLM53_OFFLOAD_MMAP_DIR")  # [glm53-kv-offload-scratch]
+        self._glm53_disk_backed = bool(_mmap_dir)
+        if _mmap_dir:
+            os.makedirs(_mmap_dir, exist_ok=True)
+        else:
+            _mmap_dir = "/dev/shm"
+        self.mmap_path = f"{_mmap_dir}/vllm_offload_{engine_id}.mmap"''',
+    ),
+    (
+        '''                check_shm_free_space(self.total_size_bytes)
+                os.ftruncate(self.fd, self.total_size_bytes)''',
+        '''                if not self._glm53_disk_backed:  # [glm53-kv-offload-scratch]
+                    check_shm_free_space(self.total_size_bytes)
+                os.ftruncate(self.fd, self.total_size_bytes)''',
+    ),
+    (
+        '''        populate_write_fn = _get_populate_write_fn(self.mmap_obj)
+
+        if rank is not None:''',
+        '''        if self._glm53_disk_backed:  # [glm53-kv-offload-scratch] sparse file:
+            # pre-faulting would materialize the whole region on NVMe.
+            populate_write_fn = lambda *_a, **_k: None
+            _skip_populate = True
+        else:
+            populate_write_fn = _get_populate_write_fn(self.mmap_obj)
+            _skip_populate = False
+
+        if _skip_populate:
+            pass
+        elif rank is not None:''',
+    ),
+]
+
+gwk_edits = [
+    (
+        '''    if not current_platform.is_cuda_alike():''',
+        '''    import os as _os  # [glm53-kv-offload-scratch]
+    if _os.environ.get("GLM53_OFFLOAD_MMAP_DIR"):
+        logger.info("[kv-offload-scratch] disk-backed staging region: "
+                    "skipping cudaHostRegister")
+        return
+    if not current_platform.is_cuda_alike():''',
+    ),
+]
+
+
+# --- v6: bound page cache for disk-backed staging (msync + MADV_DONTNEED) ---
+sor_edits.append(
+    (
+        '''    def create_next_worker_view(self, tensor_page_size: int) -> torch.Tensor:''',
+        '''    def glm53_release_page_cache(self) -> None:  # [glm53-kv-offload-scratch]
+        """Flush and drop this region's resident pages.
+
+        Disk-backed staging grows the page cache with every store; on GB10 that
+        memory is taken from the same pool the GPU allocates out of. msync makes
+        the bytes durable, MADV_DONTNEED returns the pages; later reads re-fault
+        from NVMe, which is the point of a disk tier.
+        """
+        if self.mmap_obj is None:
+            return
+        try:
+            self.mmap_obj.flush()
+            self.mmap_obj.madvise(mmap.MADV_DONTNEED, 0, self.total_size_bytes)
+        except (OSError, ValueError) as exc:
+            logger.warning("[kv-offload-scratch] page-cache release failed: %s", exc)
+
+    def create_next_worker_view(self, tensor_page_size: int) -> torch.Tensor:''',
+    )
+)
+
+gwk_edits.append(
+    (
+        '''        self._mmap_region = mmap_region
+        pin_memory = PIN_MEMORY''',
+        '''        self._mmap_region = mmap_region
+        import os as _os  # [glm53-kv-offload-scratch]
+        self._glm53_release_bytes = int(
+            _os.environ.get("GLM53_OFFLOAD_RELEASE_BYTES") or 0
+        )
+        self._glm53_unreleased = 0
+        if self._glm53_release_bytes:
+            logger.info(
+                "[kv-offload-scratch] releasing staging page cache every %.1f GB",
+                self._glm53_release_bytes / 1e9,
+            )
+        pin_memory = PIN_MEMORY''',
+    )
+)
+
+gwk_edits.append(
+    (
+        '''    def get_finished(self) -> list[TransferResult]:
+        return self._store_handler.get_finished() + self._load_handler.get_finished()''',
+        '''    def get_finished(self) -> list[TransferResult]:
+        results = (
+            self._store_handler.get_finished() + self._load_handler.get_finished()
+        )
+        # [glm53-kv-offload-scratch] keep disk-backed staging from filling RAM
+        if self._glm53_release_bytes and self._mmap_region is not None:
+            for _r in results:
+                if _r.transfer_size:
+                    self._glm53_unreleased += _r.transfer_size
+            if self._glm53_unreleased >= self._glm53_release_bytes:
+                self._glm53_unreleased = 0
+                self._mmap_region.glm53_release_page_cache()
+        return results''',
+    )
+)
+
+def targets(root: Path | None = None) -> list[tuple[Path, list]]:
+    """(file, edits) pairs resolved against the vLLM install root."""
+    v = root or Path(
+        os.environ.get(
+            "GLM53_VLLM_ROOT", "/usr/local/lib/python3.12/dist-packages/vllm"
+        )
+    )
+    kvc = v / "distributed/kv_transfer/kv_connector/v1/offloading"
+    return [
+        (kvc / "config.py", cfg_edits),
+        (kvc / "scheduler.py", sch_edits),
+        (kvc / "worker.py", wrk_edits),
+        (v / "v1/kv_offload/cpu/shared_offload_region.py", sor_edits),
+        (v / "v1/kv_offload/cpu/gpu_worker.py", gwk_edits),
+    ]
+
+
+def main() -> int:
+    if os.environ.get("GLM53_SKIP_KV_OFFLOAD_GROUPS_PATCH") == "1":
+        print("[kv-offload-scratch] skipped via env")
+        return 0
+    for path, edits in targets():
+        if not apply(path, edits):
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/start.sh
+++ b/start.sh
@@ -175,6 +175,7 @@ DRAFTER_PATCH_HOST="${DRAFTER_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm5_drafter
 APC_PATCH_HOST="${APC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_hybrid_prefix_hit.py}"
 XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_xgrammar_termination.py}"
 KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kpool_tail_slotmap.py}"
+KVOFF_PATCH_HOST="${KVOFF_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kv_offload_groups.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
 QUANTIZATION="${QUANTIZATION:-exl3}"
 LANGUAGE_MODEL_ONLY="${LANGUAGE_MODEL_ONLY:-0}"
@@ -902,6 +903,9 @@ fi
 if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
     python3 /opt/glm53/patch_kpool_tail_slotmap.py
 fi
+if [ -f /opt/glm53/patch_kv_offload_groups.py ]; then
+    python3 /opt/glm53/patch_kv_offload_groups.py
+fi
 if [ -f /opt/glm53/patch_ablit.py ]; then
     python3 /opt/glm53/patch_ablit.py
 fi
@@ -992,6 +996,9 @@ fi
 if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
     python3 /opt/glm53/patch_kpool_tail_slotmap.py
 fi
+if [ -f /opt/glm53/patch_kv_offload_groups.py ]; then
+    python3 /opt/glm53/patch_kv_offload_groups.py
+fi
 if [ -f /opt/glm53/patch_ablit.py ]; then
     python3 /opt/glm53/patch_ablit.py
 fi
@@ -1030,6 +1037,8 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$XGRAMMAR_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_xgrammar_termination.py"
     [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "missing $KPOOL_TAIL_PATCH_HOST"
     scp -q -o BatchMode=yes "$KPOOL_TAIL_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kpool_tail_slotmap.py"
+    [ -f "$KVOFF_PATCH_HOST" ] || die "missing $KVOFF_PATCH_HOST"
+    scp -q -o BatchMode=yes "$KVOFF_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kv_offload_groups.py"
 
     worker_ssh "rm -rf /tmp/glm53-ablit"
     scp -q -r -o BatchMode=yes "$SCRIPT_DIR/ablit" "${WORKER_SSH}:/tmp/glm53-ablit"
@@ -1055,11 +1064,13 @@ launch_cluster() {
         -e "GLM53_MIXED_PREFILL_CHUNK=$GLM53_MIXED_PREFILL_CHUNK"
         -e "TRITON_CACHE_DIR=$TRITON_CACHE_DIR"
         -e "TILELANG_CACHE_DIR=$TILELANG_CACHE_DIR"
+        -e "GLM53_OFFLOAD_MMAP_DIR=${GLM53_OFFLOAD_MMAP_DIR:-}"
+        -e "GLM53_OFFLOAD_RELEASE_BYTES=${GLM53_OFFLOAD_RELEASE_BYTES:-}"
         -e "VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=$VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS"
         -e "TORCH_CUDA_ARCH_LIST=$TORCH_CUDA_ARCH_LIST"
         -e "FLASHINFER_CUDA_ARCH_LIST=$FLASHINFER_CUDA_ARCH_LIST"
         -e FLASHINFER_DISABLE_VERSION_CHECK=1
-        -e PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+        -e "PYTORCH_CUDA_ALLOC_CONF=${GLM53_ALLOC_CONF:-expandable_segments:True}"
         -e "VLLM_ENGINE_READY_TIMEOUT_S=$READY_TIMEOUT"
         # py-cpuinfo JSON-parses empty output on Grace/aarch64; the usage
         # thread then dumps JSONDecodeError. Stats are off on this private kit.
@@ -1125,6 +1136,7 @@ launch_cluster() {
         -v '/tmp/patch_hybrid_prefix_hit.py:/opt/glm53/patch_hybrid_prefix_hit.py:ro' \
         -v '/tmp/patch_xgrammar_termination.py:/opt/glm53/patch_xgrammar_termination.py:ro' \
         -v '/tmp/patch_kpool_tail_slotmap.py:/opt/glm53/patch_kpool_tail_slotmap.py:ro' \
+        -v '/tmp/patch_kv_offload_groups.py:/opt/glm53/patch_kv_offload_groups.py:ro' \
         -v '/tmp/glm53-ablit:/opt/glm53/ablit:ro' \
         -v '/tmp/glm53-ablit_runtime.py:/opt/glm53/ablit_runtime.py:ro' \
         -v '/tmp/patch_ablit.py:/opt/glm53/patch_ablit.py:ro' \
@@ -1156,6 +1168,7 @@ launch_cluster() {
         -v "$APC_PATCH_HOST:/opt/glm53/patch_hybrid_prefix_hit.py:ro" \
         -v "$XGRAMMAR_PATCH_HOST:/opt/glm53/patch_xgrammar_termination.py:ro" \
         -v "$KPOOL_TAIL_PATCH_HOST:/opt/glm53/patch_kpool_tail_slotmap.py:ro" \
+        -v "$KVOFF_PATCH_HOST:/opt/glm53/patch_kv_offload_groups.py:ro" \
         -v "$SCRIPT_DIR/ablit:/opt/glm53/ablit:ro" \
         -v "$SCRIPT_DIR/overlay/ablit_runtime.py:/opt/glm53/ablit_runtime.py:ro" \
         -v "$SCRIPT_DIR/overlay/patch_ablit.py:/opt/glm53/patch_ablit.py:ro" \

--- a/tests/test_kv_offload_groups.py
+++ b/tests/test_kv_offload_groups.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Regression tests for the KV-offload group/staging patch."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+PATCH = next(
+    p
+    for p in (
+        HERE / "patch_kv_offload_groups.py",
+        ROOT / "overlay" / "patch_kv_offload_groups.py",
+    )
+    if p.is_file()
+)
+sys.path.insert(0, str(PATCH.parent))
+from patch_kv_offload_groups import MARK, apply, targets  # noqa: E402
+
+INSTALLED = Path("/usr/local/lib/python3.12/dist-packages/vllm")
+
+# Exact fragments from vLLM 487ecf187 / glm53-flash image. Each is the anchor a
+# corresponding edit pins; if upstream reflows any of them the patch must fail
+# closed rather than silently serve an unpatched engine.
+CONFIG_FIXTURE = '''from typing import TYPE_CHECKING
+
+from vllm.v1.kv_offload.config import (
+    OffloadingConfig,
+)
+
+
+def build_offloading_config(vllm_config, kv_cache_config):
+    _, tokens_per_hash = resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)
+    for group in groups:
+        assert group.tokens_per_block % tokens_per_hash == 0, (
+            f"tokens_per_block={group.tokens_per_block} not divisible by "
+            f"tokens_per_hash={tokens_per_hash}. "
+            f"Hybrid models (e.g. Mamba+Attention) need "
+            f"--enable-prefix-caching to align block sizes."
+        )
+'''
+
+
+def _write(tmp_path: Path, rel: str, text: str) -> Path:
+    p = tmp_path / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+    return p
+
+
+def test_targets_cover_the_five_patched_files(tmp_path: Path) -> None:
+    names = [p.name for p, _ in targets(tmp_path)]
+    assert names == [
+        "config.py",
+        "scheduler.py",
+        "worker.py",
+        "shared_offload_region.py",
+        "gpu_worker.py",
+    ]
+    # every target is resolved under the supplied root, never a live install
+    assert all(str(p).startswith(str(tmp_path)) for p, _ in targets(tmp_path))
+
+
+def test_apply_is_idempotent_and_marks_the_file(tmp_path: Path) -> None:
+    f = _write(tmp_path, "config.py", CONFIG_FIXTURE)
+    edits = dict((p.name, e) for p, e in targets(tmp_path))["config.py"]
+
+    assert apply(f, edits) is True
+    once = f.read_text()
+    assert MARK in once
+    # the hash-alignment assert is what aborts the boot on KpoolTailSpec
+    assert "assert group.tokens_per_block % tokens_per_hash == 0" not in once
+
+    assert apply(f, edits) is True
+    assert f.read_text() == once, "second apply must be a no-op"
+
+
+def test_apply_fails_closed_on_a_drifted_anchor(tmp_path: Path) -> None:
+    f = _write(tmp_path, "config.py", CONFIG_FIXTURE.replace("tokens_per_hash", "tph"))
+    edits = dict((p.name, e) for p, e in targets(tmp_path))["config.py"]
+    before = f.read_text()
+
+    assert apply(f, edits) is False, "drifted anchor must not be patched"
+    assert f.read_text() == before, "a failed apply must leave the file untouched"
+
+
+def test_env_kill_switch_skips_everything() -> None:
+    env = dict(os.environ, GLM53_SKIP_KV_OFFLOAD_GROUPS_PATCH="1")
+    out = subprocess.run(
+        [sys.executable, str(PATCH)], env=env, capture_output=True, text=True
+    )
+    assert out.returncode == 0
+    assert "skipped via env" in out.stdout
+
+
+def test_patch_applies_to_the_installed_vllm() -> None:
+    """Runs only inside the image: every anchor must still be present."""
+    if not INSTALLED.is_dir():
+        return  # not in the container; the fixture tests above still ran
+    for path, edits in targets(INSTALLED):
+        src = path.read_text()
+        if MARK in src:
+            continue  # already patched by start.sh
+        for old, _new in edits:
+            assert src.count(old) == 1, f"anchor drifted in {path.name}: {old[:60]!r}"


### PR DESCRIPTION
Experimental offload candidate for #57; not current-image runtime qualification.

Off by default. `GLM53_OFFLOAD_MMAP_DIR` backs the CPU offload staging region with a **sparse file on each node's own NVMe**, so a prefix that has been evicted from the GPU pool is restored from disk instead of recomputed. Capacity becomes the size of that file rather than RAM, which is what makes a shared box practical.

### Historical author measurements (August 2026 image)

105k-token prompt, evicted by 6 × 168k-token floods, 100 GB per-node store, thinking off, temp 0:

| | |
|---|---|
| Restore | **8.54 s** vs **130 s** to recompute (**15×**) |
| Output | byte-correct |
| Read from disk | 1.68 GB (`kv_offload` `CPU_to_GPU`) |
| Host | stable, 6–8 GB free throughout |
| Capacity | 3,162 blocks ≈ **11.3M tokens** in 160 GB/node |

Historical decode observations (not a current-stack equivalence claim) — `tests/bench_decode.py`, median of 5 × 400, offload **on**: structured **66.4** tok/s (0.938 accept / 6.57 per step), prose **26.7**, against the 65.1 / 27.1 in the README. Also re-run at 1M context on our launcher: boots clean, `GPU KV cache size: 1,347,826 tokens`.

### What the patch does

`overlay/patch_kv_offload_groups.py`, 27 anchored edits over 5 vLLM files:

1. **Unblocks the boot.** `build_offloading_config` asserts every group is hash-aligned; `KpoolTailSpec`'s 4-token block never can be. Non-alignable groups are treated as per-request scratch instead of aborting.
2. **Stops drafter starvation.** Sub-block groups (kpool tail block=4, DFlash2 drafter block=64) emit ~56× more offload keys than the 3584-token groups and consume the whole staging tier, so MLA/mamba chunks never reach disk — on one 256 GB run *every* file on disk was `_g6`. Both are excluded. Drafter KV rebuilds inside its own window after a restore, and the target verifies every token, so this costs acceptance at worst, never correctness.
3. **Fixes restore coherence.** The packed whole-row copy path registers one whole-row ref per group; since groups allocate block ids independently over shared rows, a restore's row-write clobbers other groups' live pages. Forces the per-layer path (also ~10× less data moved).
4. **Bounds the staging page cache** (`msync` + `MADV_DONTNEED` every `GLM53_OFFLOAD_RELEASE_BYTES`). Required on GB10: CPU and GPU share one pool, so an unbounded region starves the GPU and the worker rank dies mid-prefill with no traceback.

### Why per-node instead of an `fs` secondary tier

Secondary tiers and their promotions run **scheduler-side on the head only**. Under 2-node TP that means rank 1's shard is never written (every file lands `..._r0`) and its restores read stale bytes — the request is admitted as a hit and generates confidently wrong output while `kv_offload` counters look healthy. Ours degenerated into `"lockhandlehandle..."`. Backing the CPU *primary* tier per node sidesteps this by construction, since store/load jobs are broadcast to every rank. Detail in #57.

### Safety

- **Per-file fail-closed on fresh source**: missing/nonunique anchors leave that file unchanged; syntax failure restores that file and exits nonzero. Earlier files are not rolled back if a later file fails. Existing marker presence short-circuits revalidation; this is not an all-file transaction or canonical validation of already-marked source.
- **Idempotent**, marked with `# [glm53-kv-offload-scratch]`.
- **Kill switch**: `GLM53_SKIP_KV_OFFLOAD_GROUPS_PATCH=1`.
- **Inert unless enabled** — without `GLM53_OFFLOAD_MMAP_DIR` and the `--kv-transfer-config` flag, behaviour is unchanged.
- `tests/test_kv_offload_groups.py` covers idempotency, fail-closed drift, the kill switch, and (inside the image) that every anchor is still present. The original `30 passed` suite claim is historical, not the current review result.

### Notes for anyone testing

- Keep `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` and add `--enable-cumem-allocator`. The launcher uses its existing caller override: unset selects that default; explicit empty disables it. Do not disable expandable segments merely to bypass the connector guard.
- Do **not** set `PYTHONHASHSEED` (the tier docs suggest it for cross-process key stability) — it invalidates the Triton JIT cache keys and the mid-collective recompile kills the worker rank.
- Sizing: a restore is admitted only when every group's chunks are resident together, so keep `cpu_bytes_to_use ≥ row_bytes × (restore_tokens / 3584 + 8)`. Undersized, stores still succeed and metrics still climb while no restore ever serves.
- On GB10, bound `vm.dirty_bytes` (we use 4 GB / 1 GB background). Unbounded dirty pages livelocked both our Sparks twice; `drop_caches` can't help because the pages are dirty.

Tested on 2× DGX Spark (GB10, 121 GiB unified), TP=2 over CX7, DFlash2 k=7, `KV_CACHE_DTYPE=fp8`, at 400k and 1M context.


### Maintainer source review — publication under HOLD

Published source head `6662b7d7aa5837340be6f3299e5310abf616c015` preserves author history through normal main merges and a fast-forward publication; integrated base is `a9bbbadc4c7253870d0d519c3d445e4ee7b97540`, **not current main**. Maintainer `plotarmordev` owns current-main integration and any later qualification scheduling; SIX-GlmLandingE alone owns the merge lane. `merge-hold` remains.

Corrected both allocator recipes, retained main caller precedence and replay/retention wiring, and added the missing KVOFF artifact-table/preflight admission. Main's supplied receipts report launcher parity passing and four offload tests passing on copies of all five Python sources from the immutable wheel-layer pin; absent runtime source explicitly skips its source-dependent test. These establish patch/compile/idempotence only, not allocator behavior or eviction/restore qualification. The final commit changes README historical scoping only.

Unresolved source contract: `GLM53_OFFLOAD_RELEASE_BYTES` is forwarded without launcher pre-stop validation. Runtime uses `int(value or 0)`: empty/zero disables release, noninteger raises ValueError during worker construction, and negative values are accepted and trigger release on each completion poll with a region. Both load and store transfer sizes contribute, so the old “bytes stored” wording is imprecise. No positive-only restriction was invented in this review. Maintainer owns deciding/documenting the supported domain and pre-stop admission before live qualification.

Unblock requires separately reviewed current-main integration and separately authorized current-image forced eviction/restore showing actual disk-to-GPU transfer, correct output, and host allocator behavior under a selected scheduling policy. Historical tables are retained as historical author observations; stores/counters alone are insufficient, and no author rebase or benchmark is requested.
