### PR TITLE
fine-grained prefix-cache hits: exempt KpoolTailManager from the partial hash veto

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,6 +134,12 @@ ABLIT_INCLUDE_MTP=1
 # After /health, burn DFlash2 BLOCK / sampler / kpool shapes so TP=2 does
 # not JIT mid-collective. 0 = skip (nonfatal either way).
 GLM53_BOOT_SHAPE_WARMUP=1
+# [fork] 1 = exempt the KpoolTail scratch manager from the partial-hash-hit
+# veto so MLA/mamba(align) prefix hits reconcile at hash granularity
+# (follow-ups re-prefill the new tail only, not a full 3584-token block).
+# 0 = upstream behavior (block-aligned hits only).
+# 0 = revert to block-aligned-only hits (the exemption is on by default)
+GLM53_FINE_GRAINED_APC=1
 # GLM53_WARMUP_REQ_TIMEOUT=240
 # Suppress client stop strings until </think> (thinking-on default). 0 = off.
 GLM53_SUPPRESS_STOPS_IN_REASONING=1

--- a/docs/kv-continuity-findings.md
+++ b/docs/kv-continuity-findings.md
@@ -1,0 +1,48 @@
+# KV continuity findings (2026-08-30) — experiment, no code change needed
+
+## Question
+Does the follow-up turn re-prefill the previous turn's GENERATED assistant
+tokens, or does prefix caching reuse them? ("KV continuity between turns")
+
+## Method
+Controlled A/B on the production 2x DGX Spark serve (fine-grained APC active,
+hash grain 64, `partial_hash=True`):
+
+- Turn 1: unique 2.7k-token doc + task asking for a ~700-word fable,
+  `max_tokens=1100`, temp 0, thinking off → **910 generated tokens**.
+- Turn 2: same messages + the assistant reply + a 6-token instruction.
+  Prompt = **3,648 tokens**.
+
+Prefix-cache counters (`vllm:prefix_cache_hits/queries_total`) snapshotted
+immediately before/after each request; wall time via curl.
+
+## Result
+
+| Turn | Prompt tok | Wall time |
+|---|---:|---:|
+| 1 (cold, unique) | ~2,738 | 57.5 s (= 910-token generation at ~20 tok/s, non-streaming) |
+| 2 (full history + 910-token reply + new turn) | **3,648** | **0.415 s** |
+
+0.415 s budgets ~200-300 tokens of GPU prefill at ~900 tok/s. Had the 910
+generated tokens been re-prefilled, turn 2 would have taken >= 1.3 s.
+Counter deltas (+3,648 hits / +3,584 queries = full prompt / one scheduler
+block) are consistent with block-level reuse of the generated tokens.
+
+## Conclusion
+
+**Generated tokens are already KV-continuous across turns**: after each
+request completes, vLLM's prefix cache retains the generated blocks and the
+next turn's prompt (which embeds the assistant reply) hits them at hash
+granularity. With fine-grained APC the reuse grain is 64 tokens instead of
+the 3584-token scheduler block, so effectively only each turn's genuinely
+new tokens are computed.
+
+A KV-connector/session layer would therefore add little on this serve:
+the remaining per-turn costs are (a) the turn's own new tokens (irreducible
+under the stateless API), (b) client-side dynamic prompt mutations (e.g.
+injected context that shifts mid-prompt invalidates the shared prefix from
+that point), and (c) O(context) CPU work (tokenize + chat-template render),
+which a connector would not remove either.
+
+No code change shipped for this experiment; the fine-grained APC patch
+(`fine-grained-apc` branch) is what makes the reuse fine-grained.

--- a/overlay/patch_fine_grained_apc.py
+++ b/overlay/patch_fine_grained_apc.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""[glm53-fgapc] Fine-grained APC for the GLM-5.3 hybrid: exempt the KpoolTail
+scratch manager from the partial-hash-hit veto.
+
+Upstream disables fine-grained prefix-cache hits whenever ANY cache manager
+lacks `supports_fine_grained_hash_lookup` and is not already hash-grained.
+On this hybrid the only such manager is KpoolTailManager — a one-block
+circular scratch per request that (a) never has block hashes computed,
+(b) already opts out of the hybrid hit min (KpoolTailSpec), and (c) whose
+group is reseeded fresh when the cached window does not cover the hit. Its
+veto therefore zeroes a capability the MLA + mamba(align) managers do
+support, and every follow-up re-prefills up to a full 3584-token hybrid
+block. Exempting it lets the MLA/mamba hit reconcile at hash granularity.
+
+On by default (fix, not feature). GLM53_FINE_GRAINED_APC=0 reverts to
+block-aligned-only hits. Idempotent via the [glm53-fgapc] marker;
+ast.parse-validated after edit.
+"""
+
+import ast
+import os
+import sys
+
+MARKER = "[glm53-fgapc]"
+
+VETO_OLD = """            unsupported_partial_hit_managers = {
+                type(manager).__name__
+                for manager in self.single_type_managers
+                if not manager.supports_fine_grained_hash_lookup
+                and manager.block_size != hash_block_size
+            }"""
+
+VETO_NEW = """            unsupported_partial_hit_managers = {
+                type(manager).__name__
+                for manager in self.single_type_managers
+                if not manager.supports_fine_grained_hash_lookup
+                and manager.block_size != hash_block_size
+                # [glm53-fgapc] KpoolTail is a 1-block/req scratch: it never
+                # sees block hashes and already opts out of the hybrid hit
+                # min, so its block-aligned-only lookup must not veto
+                # fine-grained hits for the managers that do participate.
+                and type(manager).__name__ != "KpoolTailManager"
+            }"""
+
+DIAG_OLD = """        self.verify_and_split_kv_cache_groups()"""
+
+DIAG_NEW = """        logger.info(
+            # [glm53-fgapc]
+            "[glm53-fgapc] partial_hash=%s hash_block=%s managers=%s",
+            self.enable_partial_hash_hits,
+            hash_block_size,
+            sorted(
+                (
+                    type(manager).__name__,
+                    manager.block_size,
+                    bool(
+                        getattr(
+                            manager, "supports_fine_grained_hash_lookup", False
+                        )
+                    ),
+                )
+                for manager in self.single_type_managers
+            ),
+        )
+        self.verify_and_split_kv_cache_groups()"""
+
+
+def patch_file(path: str, dry_run: bool = False) -> int:
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+
+    if MARKER in text:
+        print(f"[patch_fine_grained_apc] {path}: already patched; no-op.")
+        return 0
+
+    if VETO_OLD not in text:
+        raise AssertionError(
+            f"{path}: partial-hash veto block not found (upstream layout "
+            "changed?); refusing to guess."
+        )
+    text = text.replace(VETO_OLD, VETO_NEW, 1)
+
+    if text.count(DIAG_OLD) != 1:
+        raise AssertionError(
+            f"{path}: expected exactly one verify_and_split call site, "
+            f"found {text.count(DIAG_OLD)}."
+        )
+    text = text.replace(DIAG_OLD, DIAG_NEW, 1)
+
+    try:
+        ast.parse(text, filename=path)
+    except SyntaxError as e:
+        raise AssertionError(f"POST-EDIT ast.parse FAILED for {path}: {e}") from e
+
+    if dry_run:
+        print(f"[patch_fine_grained_apc] DRY RUN -- {path} not written.")
+    else:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(text)
+        print(f"[patch_fine_grained_apc] {path}: fine-grained APC exemption applied.")
+    return 1
+
+
+def main() -> int:
+    # On by default (this is a fix, not a feature): the KpoolTail veto zeroes
+    # fine-grained hits the MLA/mamba(align) managers support. Set
+    # GLM53_FINE_GRAINED_APC=0 to revert to block-aligned-only hits.
+    if os.environ.get("GLM53_FINE_GRAINED_APC", "1") == "0":
+        print(
+            "[patch_fine_grained_apc] GLM53_FINE_GRAINED_APC=0 — "
+            "skipping (block-aligned-only upstream behavior)."
+        )
+        return 0
+
+    candidates = [
+        "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/kv_cache_coordinator.py",
+    ]
+    patched = 0
+    for path in candidates:
+        if os.path.isfile(path):
+            patched += patch_file(path, dry_run=os.environ.get("DRY_RUN") == "1")
+    if patched == 0:
+        print("[patch_fine_grained_apc] no candidate files found; nothing to do.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/start.sh
+++ b/start.sh
@@ -175,6 +175,7 @@ DRAFTER_PATCH_HOST="${DRAFTER_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm5_drafter
 APC_PATCH_HOST="${APC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_hybrid_prefix_hit.py}"
 XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_xgrammar_termination.py}"
 KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kpool_tail_slotmap.py}"
+FGAPC_PATCH_HOST="${FGAPC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_fine_grained_apc.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
 QUANTIZATION="${QUANTIZATION:-exl3}"
 LANGUAGE_MODEL_ONLY="${LANGUAGE_MODEL_ONLY:-0}"
@@ -403,6 +404,7 @@ preflight() {
     [ -f "$APC_PATCH_HOST" ] || die "$APC_PATCH_HOST missing"
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "$XGRAMMAR_PATCH_HOST missing"
     [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "$KPOOL_TAIL_PATCH_HOST missing"
+    [ -f "$FGAPC_PATCH_HOST" ] || die "$FGAPC_PATCH_HOST missing"
     [ -f "$SCRIPT_DIR/overlay/patch_ablit.py" ] || die "$SCRIPT_DIR/overlay/patch_ablit.py missing"
     [ -f "$SCRIPT_DIR/overlay/ablit_runtime.py" ] || die "$SCRIPT_DIR/overlay/ablit_runtime.py missing"
     [ -f "$SCRIPT_DIR/ablit/LAYER_MAP.json" ] || die "$SCRIPT_DIR/ablit/LAYER_MAP.json missing"
@@ -868,6 +870,9 @@ fi
 if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
     python3 /opt/glm53/patch_kpool_tail_slotmap.py
 fi
+if [ "${GLM53_FINE_GRAINED_APC:-1}" != "0" ] && [ -f /opt/glm53/patch_fine_grained_apc.py ]; then
+    python3 /opt/glm53/patch_fine_grained_apc.py
+fi
 if [ -f /opt/glm53/patch_ablit.py ]; then
     python3 /opt/glm53/patch_ablit.py
 fi
@@ -958,6 +963,9 @@ fi
 if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
     python3 /opt/glm53/patch_kpool_tail_slotmap.py
 fi
+if [ "${GLM53_FINE_GRAINED_APC:-1}" != "0" ] && [ -f /opt/glm53/patch_fine_grained_apc.py ]; then
+    python3 /opt/glm53/patch_fine_grained_apc.py
+fi
 if [ -f /opt/glm53/patch_ablit.py ]; then
     python3 /opt/glm53/patch_ablit.py
 fi
@@ -996,6 +1004,8 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$XGRAMMAR_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_xgrammar_termination.py"
     [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "missing $KPOOL_TAIL_PATCH_HOST"
     scp -q -o BatchMode=yes "$KPOOL_TAIL_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kpool_tail_slotmap.py"
+    [ -f "$FGAPC_PATCH_HOST" ] || die "missing $FGAPC_PATCH_HOST"
+    scp -q -o BatchMode=yes "$FGAPC_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_fine_grained_apc.py"
 
     worker_ssh "rm -rf /tmp/glm53-ablit"
     scp -q -r -o BatchMode=yes "$SCRIPT_DIR/ablit" "${WORKER_SSH}:/tmp/glm53-ablit"
@@ -1063,7 +1073,8 @@ launch_cluster() {
              DFLASH_DRAFT_TP \
              LANGUAGE_MODEL_ONLY SKIP_MM_PROFILING \
              LIMIT_MM CHAT_TEMPLATE ENFORCE_EAGER EXL3_FUSED_MOE EXL3_MOE_ROW_TILE EXL3_TEMP_ROWS_FUSED MODEL_DIR EXTRA_ARGS \
-             ABLIT ABLIT_METHOD ABLIT_DIRECTION ABLIT_LAYERS ABLIT_ALPHA ABLIT_INCLUDE_MTP; do
+             ABLIT ABLIT_METHOD ABLIT_DIRECTION ABLIT_LAYERS ABLIT_ALPHA ABLIT_INCLUDE_MTP \
+             GLM53_FINE_GRAINED_APC; do
         serve_env+=" -e $v='${!v:-}'"
     done
     # VLLM_API_KEY is read by the head (rank 0) API server for bearer auth; the
@@ -1091,6 +1102,7 @@ launch_cluster() {
         -v '/tmp/patch_hybrid_prefix_hit.py:/opt/glm53/patch_hybrid_prefix_hit.py:ro' \
         -v '/tmp/patch_xgrammar_termination.py:/opt/glm53/patch_xgrammar_termination.py:ro' \
         -v '/tmp/patch_kpool_tail_slotmap.py:/opt/glm53/patch_kpool_tail_slotmap.py:ro' \
+        -v '/tmp/patch_fine_grained_apc.py:/opt/glm53/patch_fine_grained_apc.py:ro' \
         -v '/tmp/glm53-ablit:/opt/glm53/ablit:ro' \
         -v '/tmp/glm53-ablit_runtime.py:/opt/glm53/ablit_runtime.py:ro' \
         -v '/tmp/patch_ablit.py:/opt/glm53/patch_ablit.py:ro' \
@@ -1122,6 +1134,7 @@ launch_cluster() {
         -v "$APC_PATCH_HOST:/opt/glm53/patch_hybrid_prefix_hit.py:ro" \
         -v "$XGRAMMAR_PATCH_HOST:/opt/glm53/patch_xgrammar_termination.py:ro" \
         -v "$KPOOL_TAIL_PATCH_HOST:/opt/glm53/patch_kpool_tail_slotmap.py:ro" \
+        -v "$FGAPC_PATCH_HOST:/opt/glm53/patch_fine_grained_apc.py:ro" \
         -v "$SCRIPT_DIR/ablit:/opt/glm53/ablit:ro" \
         -v "$SCRIPT_DIR/overlay/ablit_runtime.py:/opt/glm53/ablit_runtime.py:ro" \
         -v "$SCRIPT_DIR/overlay/patch_ablit.py:/opt/glm53/patch_ablit.py:ro" \
@@ -1133,6 +1146,7 @@ launch_cluster() {
         -e NCCL_IB_GID_INDEX="$HEAD_GID" \
         -e VLLM_HOST_IP="$HEAD_IP" \
         -e SERVED_MODEL_NAME="$SERVED_MODEL_NAME" \
+        -e GLM53_FINE_GRAINED_APC="${GLM53_FINE_GRAINED_APC:-1}" \
         -e PORT="$PORT" -e TP="$TP" -e NNODES="$NNODES" \
         -e HEAD_IP="$HEAD_IP" -e MASTER_PORT="$MASTER_PORT" \
         -e QUANTIZATION="$QUANTIZATION" \


### PR DESCRIPTION
Upstream disables fine-grained prefix-cache hits whenever any cache manager lacks supports_fine_grained_hash_lookup and is not already hash-grained. On the GLM-5.3 hybrid the only such manager is KpoolTailManager, a 1-block/req circular scratch that never sees block hashes and already opts out of the hybrid hit min. Its veto forces block-aligned (3584-token) hits, so every follow-up re-prefills up to a full hybrid block of already-cached history.

The exemption ships ON (it is a fix, not a feature, consistent with the other hybrid patches in this repo). GLM53_FINE_GRAINED_APC=0 reverts to block-aligned-only hits. The MLA + mamba(align) managers both report supports_fine_grained_hash_lookup=True and reconcile the hit at hash_block granularity (64 tokens measured) instead of the 3584-token scheduler block.

start.sh wires the patch + env to BOTH ranks, the head container takes an explicit -e list, not serve_env (the worker-only env flow silently left the head vetoed). Adds a [glm53-fgapc] boot diagnostic. Idempotent, fail-closed on upstream layout drift.