### PR TITLE
docs: publish shared-head GLM_NEXT B12X A/B

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ python3 tests/bench_decode.py --phase structured --structured --runs 5 --max-tok
 python3 tests/bench_decode.py --phase prose --runs 5 --max-tokens 400 --skip-coherence --out /tmp/glm53-prose.json
 ```
 
+A separate [matched native B12X experiment](docs/b12x-matched-ab.md) kept the
+weights, DFlash K=7 width, prompts, and 750K site-specific context fixed. It is
+documented separately because its TP1 and memory-constrained deployment does
+not match the official 1M-context results above.
+
 ## Quality (KLD)
 
 Independent teacher-logit panel from

--- a/docs/_b12x_matched_ab.json
+++ b/docs/_b12x_matched_ab.json
@@ -1,0 +1,221 @@
+{
+  "schema_version": 1,
+  "experiment": {
+    "date_utc": "2026-08-30",
+    "hardware": {
+      "systems": 2,
+      "system_type": "NVIDIA DGX Spark",
+      "accelerator": "GB10",
+      "interconnect": "200 GbE CX7"
+    },
+    "other_head_workload": {
+      "name": "co-resident service",
+      "resident": true,
+      "approximate_memory_gib": 4.6
+    },
+    "software": {
+      "head": {
+        "os": "Ubuntu 24.04.4 LTS",
+        "kernel": "6.17.0-1026-nvidia",
+        "nvidia_driver": "580.173.02",
+        "gpu_vbios": "9A.0B.2D.00.00",
+        "docker_server": "29.2.1"
+      },
+      "worker": {
+        "os": "Ubuntu 24.04.4 LTS",
+        "kernel": "6.17.0-1021-nvidia",
+        "nvidia_driver": "580.159.03",
+        "gpu_vbios": "9A.0B.1E.00.00",
+        "docker_server": "29.2.1"
+      }
+    },
+    "artifact_hashes": {
+      "chat_template_sha256": "96ed83160b243de213e95eb2fa19bde4ac13b676661cfec477d18e45e9fcca3a",
+      "site_local_transplant_manifest_sha256": "9415dd1934a6f614516505e637f2a01e63ca5c374c4cf4eb9a0ca876bcd278a9",
+      "overlay_sha256_manifest_sha256": "0ab931357a6d370c24ef02aa5061016583f2dfa60ef7262c1edd933bb65077e9"
+    }
+  },
+  "licenses": {
+    "target": {
+      "name": "ShapleyMcg License v1.0",
+      "canonical_url": "https://github.com/brandonmmusic-max/shapleymcg",
+      "attribution_notice": "https://github.com/brandonmmusic-max/shapleymcg/blob/main/LICENSE#schedule-b--attribution-notice-and-citation"
+    },
+    "draft": {
+      "name": "CC BY-NC-ND 4.0",
+      "use": "research and evaluation",
+      "url": "https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2#license"
+    }
+  },
+  "fixed_conditions": {
+    "target": {
+      "repository": "brandonmusic/GLM-5.3-Flash-tr3-4bpw",
+      "snapshot": "61e26e1484e16d7a603f77040cda9b43cc4a31d6"
+    },
+    "draft": {
+      "repository": "incoai/GLM-5.3-Flash-DFlash2",
+      "snapshot": "dc77ff1c99eeb2df044ee3d4f0094eb033fee410"
+    },
+    "max_model_len": 750000,
+    "temperature": 0,
+    "thinking": false,
+    "generated_tokens": 400,
+    "dflash_physical_k": 7,
+    "target_verification_k": 7,
+    "draft_tensor_parallel_size": 1,
+    "draft_sample_method": "probabilistic",
+    "rejection_sample_method": "standard",
+    "same_chat_template": true,
+    "same_load_time_behavior_profile": true
+  },
+  "profiles": {
+    "control": {
+      "recipe_commit": "02e46f2a5f28e2003655c5cf916b72cec0efbb37",
+      "attention_backend": "FLASHINFER_MLA_SPARSE_SM120",
+      "max_num_batched_tokens": 1024
+    },
+    "candidate": {
+      "attention_backend": "B12X_MLA_SPARSE",
+      "kv_cache_dtype": "fp8_ds_mla",
+      "kv_cache_dtype_skip_layers": "sliding_window",
+      "kv_cache_memory_bytes": 6600000000,
+      "max_num_batched_tokens": 1024,
+      "max_num_seqs": 4,
+      "block_size": 2304,
+      "mm_processor_cache_gb": 0,
+      "gpu_memory_utilization_admission_ceiling": 0.75,
+      "image": "ghcr.io/entrpi/glm-5.3-flash-exl3-2x-spark@sha256:284142c5833cbfd540ad42bb8f32cb340451db05a3b84029eaebae54579e9135",
+      "vllm_commit": "59c1a0c4c3142a303b6f46ef5f7784731c11074d",
+      "b12x_commit": "cd5e8a50ac106b7e32a7d90965d600dd71eb7131",
+      "entrpi_recipe_commit": "3a7c13fa5a5b9373bb91651e61c810ce1912bada"
+    }
+  },
+  "results": {
+    "structured_decode": {
+      "unit": "tok/s",
+      "aggregation": "median",
+      "prompt": "count from 1 to 200, output numbers only",
+      "control_runs": [
+        62.56187888274371,
+        62.585844464367774,
+        61.56325696513495
+      ],
+      "candidate_runs": [
+        68.52879757645825,
+        68.64996072453485,
+        66.62384594456799
+      ],
+      "control": 62.56187888274371,
+      "candidate": 68.52879757645825,
+      "change_percent": 9.537627066632703,
+      "control_ttft_median_s": 0.49583436781540513,
+      "candidate_ttft_median_s": 0.4617794309742749
+    },
+    "prose_decode": {
+      "unit": "tok/s",
+      "aggregation": "median",
+      "prompt": "detailed explanation of a hash map",
+      "control_runs": [
+        27.272441113433963,
+        27.41512307586824,
+        24.276258337222963
+      ],
+      "candidate_runs": [
+        31.3479473069127,
+        27.7043392742929,
+        28.770876996718094
+      ],
+      "control": 27.272441113433963,
+      "candidate": 28.770876996718094,
+      "change_percent": 5.494322554595321,
+      "control_ttft_median_s": 0.4949018703773618,
+      "candidate_ttft_median_s": 0.396616886369884
+    },
+    "four_client_wall_throughput": {
+      "unit": "tok/s",
+      "aggregation": "one matched first run per profile",
+      "formula": "sum(completion_tokens) / group_wall_seconds",
+      "control": 87.16184063536556,
+      "candidate": 101.53214373013112,
+      "change_percent": 16.486920182058284,
+      "control_wall_s": 18.356656861957163,
+      "candidate_wall_s": 15.758556268177927,
+      "control_completion_tokens": [400, 400, 400, 400],
+      "candidate_completion_tokens": [400, 400, 400, 400],
+      "control_sum_per_request_decode_tok_s": 174.81274564070313,
+      "candidate_sum_per_request_decode_tok_s": 165.33032490126257,
+      "control_per_request_ttft_s": [
+        8.109648548066616,
+        0.4175906456075609,
+        8.109081635251641,
+        8.108765441924334
+      ],
+      "candidate_per_request_ttft_s": [
+        5.909774912055582,
+        5.9097382398322225,
+        5.909331631846726,
+        5.908606397919357
+      ],
+      "candidate_run_tagged_repeat_excluded": 138.06445410579096
+    }
+  },
+  "validation": {
+    "arithmetic": true,
+    "native_tool_call": true,
+    "strict_json_schema": true,
+    "prefix_cache": true,
+    "coherence": true,
+    "nan_detected": false,
+    "health_before_and_after": true,
+    "native_b12x_on_both_ranks": true,
+    "runtime_errors_detected": false,
+    "measured_kv_tokens": 779702,
+    "post_gate_memory_snapshot": {
+      "available_bytes": 5601017856,
+      "available_gib": 5.2163543701171875,
+      "normal_swap_used_bytes": 7877513216,
+      "normal_swap_used_gib": 7.336505889892578
+    },
+    "load_only_swap_present_during_benchmark": false
+  },
+  "limitations": {
+    "decode_runs_per_profile": 3,
+    "matched_concurrency_runs_per_profile": 1,
+    "full_750k_request_tested": false,
+    "quality_evaluations_not_run": [
+      "KLD",
+      "MATH-500",
+      "GPQA",
+      "vision",
+      "refusal",
+      "broad tool-use"
+    ],
+    "claim_scope": "one matched shared-head deployment, not current upstream main"
+  },
+  "rejected_profiles": [
+    {
+      "profile": "B12X K=7, batch 1024, 11.6 GB KV",
+      "structured_change_percent": 9.8,
+      "prose_change_percent": 3.8,
+      "four_client_change_percent": 4.3,
+      "reason": "control chat template was missing and prose gate missed"
+    },
+    {
+      "profile": "B12X K=7, batch 8192, 11.6 GB KV",
+      "structured_change_percent": 8.1,
+      "prose_change_percent": 5.6,
+      "four_client_change_percent": 1.2,
+      "reason": "steady-state memory rejected"
+    },
+    {
+      "profile": "B12X target K=3, physical draft K=7",
+      "structured_change_percent": -30.6,
+      "prose_change_percent": 13.3,
+      "four_client_first_tok_s": 74.9805174462376,
+      "four_client_first_change_percent": -13.975523119213983,
+      "four_client_repeat_tok_s": 102.0000954682447,
+      "four_client_repeat_change_percent": 17.023797024839983,
+      "reason": "structured speed rejected"
+    }
+  ]
+}

--- a/docs/b12x-matched-ab.md
+++ b/docs/b12x-matched-ab.md
@@ -1,0 +1,233 @@
+# Matched native B12X experiment on two DGX Sparks
+
+On 2026-08-30, we compared the existing FlashInfer compatibility attention
+path with the native B12X `GLM_NEXT` path on the same two GB10 systems. The
+candidate kept the target weights, DFlash2 weights, prompts, sampling, chat
+template, speculative width, and declared context fixed.
+
+This is a site-specific matched A/B test. It is not a replacement for the
+official results in the main README. The current recipe uses a different
+1M-context and draft-TP2 shape, so its published concurrency figures are not
+directly comparable with the measurements below.
+
+## License and attribution
+
+These measurements used the ShapleyMcg-based EXL3/TR3 checkpoint created by
+[Brandon M. Music](https://github.com/brandonmmusic-max/shapleymcg).
+ShapleyMcg uses the attribution-required
+[ShapleyMcg License v1.0](https://github.com/brandonmmusic-max/shapleymcg/blob/main/LICENSE),
+which includes a named exclusion. The required attribution notice and citation
+are in [Schedule B of that license](https://github.com/brandonmmusic-max/shapleymcg/blob/main/LICENSE#schedule-b--attribution-notice-and-citation).
+
+```bibtex
+@misc{music2026shapleymcg,
+  author = {Music, Brandon M.},
+  title = {ShapleyMCG: An Auditable Calibration-to-Encoding Pipeline for Low-Bit Mixture-of-Experts Models},
+  year = {2026},
+  url = {https://github.com/brandonmmusic-max/shapleymcg},
+  note = {ShapleyMcg License v1.0}
+}
+```
+
+The DFlash2 draft checkpoint belongs to Inco AI and is licensed under
+[CC BY-NC-ND 4.0](https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2#license)
+for research and evaluation. This report distributes no model weights,
+checkpoint fragments, donor tensors, or modified DFlash2 artifacts.
+
+## Test scope
+
+| Item | Fixed value |
+|---|---|
+| Hardware | 2x DGX Spark, NVIDIA GB10, 200 GbE CX7 link |
+| Target checkpoint | `brandonmusic/GLM-5.3-Flash-tr3-4bpw` at `61e26e1484e16d7a603f77040cda9b43cc4a31d6` |
+| Draft checkpoint | `incoai/GLM-5.3-Flash-DFlash2` at `dc77ff1c99eeb2df044ee3d4f0094eb033fee410` |
+| Control recipe | MiaAI-Lab commit `02e46f2a5f28e2003655c5cf916b72cec0efbb37` |
+| Context declaration | 750,000 tokens |
+| Speculation | DFlash2 K=7, target verification K=7, draft TP1 |
+| Decode request | Temperature 0, thinking off, 400 generated tokens |
+| Concurrency request | Four independent structured prompts, 400 generated tokens each |
+| Other head workload | A co-resident service remained loaded and used about 4.6 GiB |
+
+Both profiles mounted the same target and draft snapshots read-only. No
+replacement weights were downloaded, and nothing was requantized. A site-local
+load-time `o_proj` transplant was enabled in both profiles. The transplant was
+held constant, is not included here, and is not part of the measured change.
+Runtime logs recorded the same 30 tensor edits on both ranks. We did not run a
+separate behavioral evaluation of that profile.
+
+## What changed
+
+The control used MiaAI-Lab's FlashInfer compatibility path. The candidate used
+the native B12X sparse-MLA implementation and its native KV record:
+
+```text
+--attention-backend B12X_MLA_SPARSE
+--kv-cache-dtype fp8_ds_mla
+--kv-cache-dtype-skip-layers sliding_window
+--kv-cache-memory 6600000000
+--gpu-memory-utilization 0.75
+--max-model-len 750000
+--max-num-seqs 4
+--max-num-batched-tokens 1024
+--block-size 2304
+--mm-processor-cache-gb 0
+--cudagraph-capture-sizes 1 2 4 8 16 24 32
+--speculative-config '{"method":"dflash","num_speculative_tokens":7,"draft_tensor_parallel_size":1,"kv_cache_dtype":"auto","draft_sample_method":"probabilistic","rejection_sample_method":"standard"}'
+```
+
+The complete candidate profile produced the measured result. The experiment
+does not isolate the attention backend by itself. It also changes the runtime
+stack, explicit KV allocation, processor-cache budget, and startup admission
+setting. The 0.75 memory-utilization value is an admission ceiling. The
+explicit 6.6 GB setting controls the KV allocation.
+
+The multimodal processor cache setting disables reuse of processed multimodal
+inputs. It does not disable image or video inputs. The candidate kept the
+existing multimodal limits and skipped dummy multimodal profiling.
+
+The candidate used these pinned sources:
+
+| Component | Pin |
+|---|---|
+| Entrpi image | `ghcr.io/entrpi/glm-5.3-flash-exl3-2x-spark@sha256:284142c5833cbfd540ad42bb8f32cb340451db05a3b84029eaebae54579e9135` |
+| Entrpi vLLM fork | [`59c1a0c4c3142a303b6f46ef5f7784731c11074d`](https://github.com/Entrpi/vllm-glm-5.3-flash-spark/commit/59c1a0c4c3142a303b6f46ef5f7784731c11074d) |
+| Entrpi B12X backport | [`cd5e8a50ac106b7e32a7d90965d600dd71eb7131`](https://github.com/Entrpi/sparkinfer-glmrt/commit/cd5e8a50ac106b7e32a7d90965d600dd71eb7131) |
+| Entrpi deployment recipe | [`3a7c13fa5a5b9373bb91651e61c810ce1912bada`](https://github.com/Entrpi/glm-5.3-flash-exl3-2x-spark/commit/3a7c13fa5a5b9373bb91651e61c810ce1912bada) |
+
+The published image predates the complete `GLM_NEXT` path used here. We
+mounted a bounded set of Python files from the pinned vLLM revision, mounted
+the pinned B12X package, and loaded Entrpi's standalone `persistent_topk`
+extension. The B12X master revision available during the test no longer
+accepted the `exl3_trellis_mcg` source format, so the experiment used Entrpi's
+EXL3-compatible `glm-next-backport` branch.
+
+Checkpoint loading on the head used a throttled read-only NFS mount from the
+worker. A temporary 48 GiB load-only swap file covered the transient unified
+memory peak. The launcher removed that file before any benchmark. Per-shard
+`POSIX_FADV_DONTNEED`, Python garbage collection, and `malloc_trim(0)` ran only
+during checkpoint loading. They were inactive during inference.
+
+## Results
+
+Decode speed is `(completion_tokens - 1) / (end - first_content_token)`.
+Structured and prose results are medians of three runs. Four-client wall
+throughput is total completion tokens divided by elapsed wall time for the
+whole request group.
+
+| Matched test | Control | Native B12X K=7 | Change |
+|---|---:|---:|---:|
+| Structured count-prompt decode | 62.56 tok/s | 68.53 tok/s | +9.5% |
+| Prose decode | 27.27 tok/s | 28.77 tok/s | +5.5% |
+| Four-client wall throughput | 87.16 tok/s | 101.53 tok/s | +16.5% |
+
+The individual decode runs were:
+
+| Workload | Control tok/s | Native B12X tok/s |
+|---|---|---|
+| Structured | 62.5619, 62.5858, 61.5633 | 68.5288, 68.6500, 66.6238 |
+| Prose | 27.2724, 27.4151, 24.2763 | 31.3479, 27.7043, 28.7709 |
+
+The four-client comparison is one matched first run per profile, not a median.
+The control completed 1,600 tokens in 18.3567 seconds. The candidate completed
+1,600 tokens in 15.7586 seconds. An immediately repeated candidate run with a
+fresh run tag reached 138.06 tok/s. We excluded it from the change calculation
+because there was no matching run-tagged control repeat.
+
+The sum of overlapping per-request post-TTFT decode rates changed from 174.81
+to 165.33 tok/s. That sum fell by 5.4%, but it double-counts simultaneous time
+and depends on completion order. We retain it as a diagnostic rather than use
+it as a server-capacity result.
+
+The sanitized source data is in
+[`docs/_b12x_matched_ab.json`](_b12x_matched_ab.json). Future four-client runs
+can use [`tests/bench_concurrency.py`](../tests/bench_concurrency.py):
+
+```bash
+python3 tests/bench_concurrency.py \
+  --clients 4 --runs 3 --max-tokens 400 \
+  --out /tmp/glm53-concurrency.json
+```
+
+Three decode runs and one matched concurrency run are enough to report this
+deployment result, but not enough to claim a general GB10 speedup. An upstream
+evaluation should repeat both profiles with five or more decode runs and at
+least three cache-unique concurrency runs.
+
+## Validation
+
+The final candidate passed these checks:
+
+- Arithmetic response
+- Native GLM tool call
+- Strict JSON schema response
+- Prefix-cache reuse
+- Coherence probes and NaN scan
+- API health before and after the benchmark
+- Native `B12X_MLA_SPARSE` and `GLM_NEXT` backend selection on both ranks
+- Full K=7 target and draft execution
+- No CUDA graph, NCCL, KV geometry, cooperative launch, or OOM errors
+
+The runtime measured a 779,702-token KV pool, which exceeded the 750,000-token
+service declaration. One post-gate snapshot reported 5.22 GiB available and
+7.34 GiB in the normal swap file. The temporary load-only swap file was absent
+during all reported measurements.
+
+The test did not send a 750K-token request. The 750K statement covers the
+declared limit and measured allocation capacity, not long-context retrieval or
+coherence at that length. The validation set also did not include KLD,
+MATH-500, GPQA, vision, refusal, or broad tool-use evaluation. "All checks
+passed" means only the checks listed above.
+
+The public manifest binds the report to the chat-template hash, site-local
+transplant-manifest hash, overlay hash manifest, OS, kernel, driver, and Docker
+versions. The transplant manifest carried a legacy donor label but no donor
+commit. Upstream later corrected that attribution. We therefore treat the
+transplant as a fixed site-local input, publish no donor identity claim, and
+recommend an `ABLIT=0` rerun before proposing this profile as an upstream
+default.
+
+## Rejected profiles
+
+We kept failed and inconclusive profiles out of production:
+
+| Profile | Structured | Prose | Four-client wall throughput | Decision |
+|---|---:|---:|---:|---|
+| B12X K=7, batch 1024, 11.6 GB KV | +9.8% | +3.8% | +4.3% | Missing control template; prose gate missed |
+| B12X K=7, batch 8192, 11.6 GB KV | +8.1% | +5.6% | +1.2% | Steady-state memory rejected |
+| B12X target K=3, physical draft K=7 | -30.6% | +13.3% | -14.0% first, +17.0% repeat | Structured speed rejected |
+| B12X K=7, batch 1024, 6.6 GB KV | +9.5% | +5.5% | +16.5% | Promoted locally |
+
+Static K=3 is not a safe default for mixed workloads. It improved this prose
+prompt but cut structured speed by almost one third. Its four-client runs also
+varied from 74.98 to 102.00 tok/s. We did not deploy the generic adaptive
+controller because it had no calibrated GB10 cost model for this batch shape.
+
+Memory boundary tests also mattered. A 7.0 GB KV allocation produced only
+746,341 tokens and missed the declared context. A 7.2 GB allocation exceeded
+750K but left too little steady-state headroom. The final 6.6 GB layout used a
+smaller 1,024-token prefill arena and produced the measured 779,702-token pool.
+
+## Reproducing the comparison
+
+1. Start from the pinned control recipe and record its structured, prose, and
+   four-client results.
+2. Keep the target checkpoint, draft checkpoint, chat template, K=7 width,
+   draft TP1, sampling inputs, and 750K context fixed.
+3. Build the pinned Entrpi B12X backport and `persistent_topk` extension for
+   `sm_121a`.
+4. Select `B12X_MLA_SPARSE`, `fp8_ds_mla`, and the settings listed above.
+5. Verify backend selection, the actual KV pool, and a post-gate memory
+   snapshot from runtime logs.
+6. Remove all load-only resources, then run the semantic and speed checks.
+7. Compare medians and whole-group wall throughput. Do not sum overlapping
+   per-request decode rates as a server-capacity metric.
+
+This report documents an optional experimental path. It does not change the
+repository's default image, launch script, context declaration, or draft TP.
+
+## Credits
+
+- MiaAI-Lab for the EXL3 two-Spark recipe and benchmark harness
+- Entrpi for the native B12X `GLM_NEXT` runtime, vLLM fork, and deployment work
+- brandonmusic for the EXL3/TR3 checkpoint
+- IncoAI for the DFlash2 draft checkpoint

--- a/tests/bench_concurrency.py
+++ b/tests/bench_concurrency.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Measure whole-group throughput for concurrent structured requests."""
+
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+import json
+from pathlib import Path
+import statistics
+import threading
+import time
+import uuid
+
+import bench_decode as bench
+
+
+def run_trial(args: argparse.Namespace, run_tag: str) -> dict:
+    barrier = threading.Barrier(args.clients + 1)
+    prompts = [
+        f"Benchmark run {run_tag}, lane {lane}. Count from 1 to 200. "
+        "Output only the numbers, separated by spaces. No other text."
+        for lane in range(1, args.clients + 1)
+    ]
+
+    def run_one(prompt: str) -> dict:
+        barrier.wait()
+        return bench.stream_bench(args.max_tokens, prompt)
+
+    before = bench.spec_snapshot()
+    with ThreadPoolExecutor(max_workers=args.clients) as pool:
+        futures = [pool.submit(run_one, prompt) for prompt in prompts]
+        started = time.perf_counter()
+        barrier.wait()
+        results = [future.result() for future in futures]
+    wall_s = time.perf_counter() - started
+    after = bench.spec_snapshot()
+
+    completion_tokens = [result["completion_tokens"] for result in results]
+    return {
+        "run_tag": run_tag,
+        "wall_s": wall_s,
+        "wall_throughput_tok_s": sum(completion_tokens) / wall_s,
+        "sum_per_request_decode_tok_s": sum(
+            result["tok_s"]
+            for result in results
+            if result["tok_s"] is not None
+        ),
+        "per_request_tok_s": [result["tok_s"] for result in results],
+        "per_request_ttft_s": [result["ttft_s"] for result in results],
+        "completion_tokens": completion_tokens,
+        "http_status": [result["http"] for result in results],
+        "finish_reason": [result["finish_reason"] for result in results],
+        "any_nan": any(result["nan"] for result in results),
+        "speculative": bench.spec_delta(before, after),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default=bench.BASE)
+    parser.add_argument("--model", default=bench.MODEL)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--run-tag")
+    parser.add_argument("--clients", type=int, default=4)
+    parser.add_argument("--runs", type=int, default=3)
+    parser.add_argument("--max-tokens", type=int, default=400)
+    args = parser.parse_args()
+
+    if args.clients < 1:
+        parser.error("--clients must be at least 1")
+    if args.max_tokens < 1:
+        parser.error("--max-tokens must be at least 1")
+    if args.runs < 1:
+        parser.error("--runs must be at least 1")
+
+    bench.BASE = args.base_url.rstrip("/")
+    bench.MODEL = args.model
+    base_tag = args.run_tag or uuid.uuid4().hex
+    runs = [
+        run_trial(args, f"{base_tag}-r{run_number}")
+        for run_number in range(1, args.runs + 1)
+    ]
+    record = {
+        "phase": "structured-concurrency",
+        "clients": args.clients,
+        "unique_prompts": True,
+        "base_run_tag": base_tag,
+        "runs_requested": args.runs,
+        "max_tokens": args.max_tokens,
+        "wall_throughput_median_tok_s": statistics.median(
+            run["wall_throughput_tok_s"] for run in runs
+        ),
+        "runs": runs,
+    }
+
+    output = Path(args.out)
+    output.write_text(json.dumps(record, indent=2) + "\n")
+    print(json.dumps(record, indent=2))
+    failed = any(
+        run["any_nan"]
+        or any(status != 200 for status in run["http_status"])
+        or any(tokens != args.max_tokens for tokens in run["completion_tokens"])
+        or any(reason != "length" for reason in run["finish_reason"])
+        for run in runs
+    )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This draft publishes a matched local A/B of MiaAI-Lab's FlashInfer-based profile and a pinned native B12X `GLM_NEXT` profile on two DGX Sparks. It adds:

- A report with the exact test scope, runtime pins, rejected profiles, and limitations
- Sanitized per-run JSON with no private topology or container environment
- A synchronized four-client benchmark that reports whole-group wall throughput across repeated, cache-unique trials
- A short README link under the existing decode section

This PR does not change the default image, launcher, context declaration, draft TP, or model behavior settings.

## Observed local results

| Matched test | Local control | B12X profile | Change |
|---|---:|---:|---:|
| Count-to-200 decode, median of 3 | 62.56 tok/s | 68.53 tok/s | +9.5% |
| Hash-map prose decode, median of 3 | 27.27 tok/s | 28.77 tok/s | +5.5% |
| Four-client end-to-end wall throughput, one trial | 87.16 tok/s | 101.53 tok/s | +16.5% |

Both profiles used the same target and DFlash2 snapshots, K=7, draft TP1, chat template, sampling inputs, 750,000-token configured limit, and site-local load-time behavior profile. The B12X runtime reported a 779,702-token KV pool.

The result belongs to the complete candidate profile. The profile changed the runtime stack, attention backend, explicit KV allocation, processor-cache budget, and startup admission setting.

## Limits stated in the report

- The control is pinned MiaAI-Lab commit `02e46f2`, not current main.
- Current upstream uses a different 1M-context, draft-TP2 shape. Its published concurrency result uses a different metric and is not compared here.
- "Structured" means one count-to-200 prompt. It is not guided JSON decoding.
- The four-client change comes from one matched first run per profile. A candidate repeat reached 138.06 tok/s and is disclosed but excluded.
- The summed overlapping post-TTFT rates changed from 174.81 to 165.33 tok/s. The report keeps that value as a diagnostic, not a capacity metric.
- No 750K request, KLD, MATH-500, GPQA, vision, refusal, or broad tool-use evaluation was run.
- The site-local transplant manifest has a stable hash but did not record a donor commit. No donor artifact or behavioral claim is published. An `ABLIT=0` rerun is recommended before considering an upstream default.

## Validation

- `python3 -m pytest -q`: 25 passed
- JSON syntax and benchmark arithmetic verified independently
- Python compilation and CLI help verified for `tests/bench_concurrency.py`
- `git diff --check`: clean
- Allowlist-based public bundle. No private paths, addresses, credentials, service names, or donor tensors
- Structured Codex autoreview: no accepted or actionable findings

## License and credit

The target checkpoint uses ShapleyMcg by Brandon M. Music. See the attribution-required [ShapleyMcg License v1.0 and Schedule B notice](https://github.com/brandonmmusic-max/shapleymcg/blob/main/LICENSE#schedule-b--attribution-notice-and-citation).

The DFlash2 draft belongs to Inco AI and is licensed under [CC BY-NC-ND 4.0](https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2#license) for research and evaluation. This contribution contains no weights or modified model artifacts.

MiaAI-Lab provided the EXL3 two-Spark recipe and benchmark harness. Entrpi provided the native B12X `GLM_NEXT` runtime, vLLM fork, and deployment work.

## Review request

The main question for this draft is whether the matched report and repeated concurrency harness are useful to keep in this repository. A maintained shared-head runtime profile would fit Entrpi's B12X repository better and can follow separately.
