### PR TITLE
fix(template): emit Reasoning Effort unconditionally to keep the prefix cache

### DIFF
--- a/files/chat_template.jinja
+++ b/files/chat_template.jinja
@@ -5,7 +5,7 @@
 {%- set thinking_enabled = true -%}
 {%- endif -%}
 {%- set effective_reasoning_effort = reasoning_effort if reasoning_effort is defined and reasoning_effort in ['low', 'high'] else 'max' -%}
-{%- if thinking_enabled and effective_reasoning_effort is not none -%}<|system|>Reasoning Effort: {{ effective_reasoning_effort | capitalize }}{%- endif -%}
+{%- if effective_reasoning_effort is not none -%}<|system|>Reasoning Effort: {{ effective_reasoning_effort | capitalize }}{%- endif -%}
 {%- set clear_thinking = clear_thinking if clear_thinking is defined else false -%}
 {%- if tools -%}
 {%- macro tool_to_json(tool) -%}

--- a/tests/test_chat_template.py
+++ b/tests/test_chat_template.py
@@ -1,25 +1,63 @@
 #!/usr/bin/env python3
 """Regression checks for GLM-5.3 chat-template reasoning controls."""
 
+import json
 import unittest
 from pathlib import Path
 
 from jinja2 import Environment
 
 
+def _tojson(value, ensure_ascii=False, indent=None, **_kwargs):
+    """vLLM's renderer supplies a tojson accepting ensure_ascii; bare Jinja2
+    does not. Register the same shape so the template renders standalone."""
+    return json.dumps(value, ensure_ascii=ensure_ascii, indent=indent)
+
+
+def _environment() -> Environment:
+    env = Environment(extensions=["jinja2.ext.loopcontrols"])
+    env.filters["tojson"] = _tojson
+    return env
+
+
 TEMPLATE = Path(__file__).parents[1] / "files" / "chat_template.jinja"
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "multiply",
+            "description": "Multiply two numbers",
+            "parameters": {
+                "type": "object",
+                "properties": {"a": {"type": "number"}, "b": {"type": "number"}},
+                "required": ["a", "b"],
+            },
+        },
+    }
+]
+
+CONVERSATION = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "hello"},
+    {"role": "assistant", "content": "Hi. How can I help?"},
+    {"role": "user", "content": "and 3+3?"},
+]
 
 
 def render_generation_prompt(**kwargs: object) -> str:
-    template = Environment(extensions=["jinja2.ext.loopcontrols"]).from_string(
-        TEMPLATE.read_text()
-    )
+    template = _environment().from_string(TEMPLATE.read_text())
     return template.render(
         messages=[{"role": "user", "content": "hello"}],
         tools=None,
         add_generation_prompt=True,
         **kwargs,
     )
+
+
+def render_conversation(**kwargs: object) -> str:
+    template = _environment().from_string(TEMPLATE.read_text())
+    return template.render(add_generation_prompt=True, **kwargs)
 
 
 class ChatTemplateTests(unittest.TestCase):
@@ -30,12 +68,14 @@ class ChatTemplateTests(unittest.TestCase):
 
     def test_thinking_can_be_disabled(self) -> None:
         rendered = render_generation_prompt(enable_thinking=False)
-        self.assertNotIn("Reasoning Effort:", rendered)
+        # The head line stays: it is what keeps the cached prefix stable across
+        # a thinking toggle. Thinking is disabled by the closed block instead.
+        self.assertIn("<|system|>Reasoning Effort: Max", rendered)
         self.assertTrue(rendered.endswith("<|assistant|><think></think>"), rendered)
 
     def test_thinking_alias_matches_parser_behavior(self) -> None:
         rendered = render_generation_prompt(thinking=False)
-        self.assertNotIn("Reasoning Effort:", rendered)
+        self.assertIn("<|system|>Reasoning Effort: Max", rendered)
         self.assertTrue(rendered.endswith("<|assistant|><think></think>"), rendered)
 
     def test_explicit_thinking_preserves_reasoning_effort(self) -> None:
@@ -45,6 +85,56 @@ class ChatTemplateTests(unittest.TestCase):
         )
         self.assertIn("<|system|>Reasoning Effort: Low", rendered)
         self.assertTrue(rendered.endswith("<|assistant|><think>"), rendered)
+
+
+class PrefixStabilityTests(unittest.TestCase):
+    """Toggling thinking must not change the prompt before the final token.
+
+    vLLM chains prefix-cache block hashes forward from token 0, so any
+    divergence near the head invalidates the whole prompt. The off-shape must
+    therefore be a strict extension of the on-shape.
+    """
+
+    def _assert_strict_extension(self, tools) -> None:
+        on = render_conversation(
+            messages=CONVERSATION, tools=tools, enable_thinking=True
+        )
+        off = render_conversation(
+            messages=CONVERSATION, tools=tools, enable_thinking=False
+        )
+        self.assertTrue(
+            off.startswith(on),
+            "thinking-off prompt must extend thinking-on prompt, but they "
+            f"diverge at char {len(_common_prefix(on, off))} of {len(on)}",
+        )
+        self.assertEqual(off[len(on) :], "</think>")
+
+    def test_toggle_is_prefix_stable_without_tools(self) -> None:
+        self._assert_strict_extension(None)
+
+    def test_toggle_is_prefix_stable_with_tools(self) -> None:
+        # Agent traffic always carries tools; the tools block renders after the
+        # reasoning-effort line, so this is the case that actually regressed.
+        self._assert_strict_extension(TOOLS)
+
+    def test_effort_levels_share_the_prompt_up_to_the_effort_word(self) -> None:
+        low = render_conversation(
+            messages=CONVERSATION, tools=TOOLS, enable_thinking=True,
+            reasoning_effort="low",
+        )
+        high = render_conversation(
+            messages=CONVERSATION, tools=TOOLS, enable_thinking=True,
+            reasoning_effort="high",
+        )
+        self.assertEqual(len(_common_prefix(low, high)), len("[gMASK]<sop><|system|>Reasoning Effort: "))
+
+
+def _common_prefix(a: str, b: str) -> str:
+    limit = min(len(a), len(b))
+    index = 0
+    while index < limit and a[index] == b[index]:
+        index += 1
+    return a[:index]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The reasoning-effort head line is gated on `thinking_enabled`:

```jinja
{%- if thinking_enabled and effective_reasoning_effort is not none -%}<|system|>Reasoning Effort: {{ effective_reasoning_effort | capitalize }}{%- endif -%}
```

It renders at roughly token 2, immediately after `[gMASK]<sop>` and **before** the tools block. So toggling thinking adds or removes ~7 tokens at the very head of the prompt.

vLLM chains prefix-cache block hashes forward from token 0 over token ids, so a divergence that early invalidates the entire prompt. On this kit the MLA `KpoolTailManager` only counts block-aligned hits, so there is no partial credit either — it is a total miss, not a degraded one.

Rendering the current template on a 4-message conversation with a system prompt, thinking on vs off:

| | shared prefix |
|---|---|
| without tools | 22 / 219 chars |
| with tools | 22 / 855 chars |

Agent traffic always carries a system prompt and tools, so in practice **every thinking toggle is a full re-prefill**.

## Change

Drop the `thinking_enabled` guard so the line is always emitted. Both shapes then share an identical head, and the thinking-off prompt becomes a *strict extension* of the thinking-on prompt, differing only by the trailing `</think>`. After the change both cases above share 100% of the on-prompt.

This also restores the behaviour of the upstream `zai-org/GLM-5.3-Flash` template, which emits this line unconditionally — the guard is a local addition here.

The control itself is unchanged: thinking is still disabled by the closed `<think></think>` block in the generation prompt. Only its cache cost changes. With thinking off the prompt still reads `Reasoning Effort: Max`, which is inert — the model cannot reason through an already-closed block.

## Measured

2× GB10, TP=2, EXL3 4bpw, DFlash2 k=7, 1M context, prefix caching on. 21,642-token prompt, `max_tokens=1`:

| step | effort | time |
|---|---|---|
| cold, first sight | high | **26.54 s** |
| warm, same effort | high | 0.62 s |
| **toggle high → none** | none | **0.42 s** |
| toggle none → high | high | 0.62 s |
| toggle high → low | low | 0.60 s |

Every toggle now hits warm. Before the change, row 3 cost a full re-prefill.

## Tests

Two existing tests in `tests/test_chat_template.py` asserted the line was *absent* when thinking was off, which encoded the divergence. They now assert the head stays stable while the tail carries the toggle.

Added `PrefixStabilityTests`: the off-shape must be a strict extension of the on-shape, with and without tools. The with-tools case is the one that actually regressed, since the tools block renders after the effort line.

Also registers a `tojson` filter accepting `ensure_ascii` in the test environment, so the template renders under bare Jinja2 the way vLLM's renderer supplies it. Without it these tests error out on the tools path.

```
$ python3 -m unittest tests.test_chat_template
Ran 7 tests — OK
```

## Known limitation, not addressed here

Changing effort *level* (`low` ↔ `high`) still rewrites the head, since the level word is in that line. Making that cache-stable too would mean moving the instruction to the last user turn, the way NVIDIA's Nemotron 3 templates do — a larger change with a real question attached about whether effort adherence survives the move, given the model was trained with it at the head. Deliberately out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)