### PR TITLE
fix: keep VLLM_API_KEY out of argv and off the headless worker

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1100,12 +1100,8 @@ launch_cluster() {
              ABLIT ABLIT_METHOD ABLIT_DIRECTION ABLIT_LAYERS ABLIT_ALPHA ABLIT_INCLUDE_MTP; do
         serve_env+=" -e $v='${!v:-}'"
     done
-    # VLLM_API_KEY is read by the head (rank 0) API server for bearer auth; the
-    # worker runs --headless so it only needs the var for argv-parity, and
-    # start.sh below passes it explicitly on the head. Keep it out of the
-    # generic loop so the key never shows in process listings of either node
-    # beyond the container env (same as the DeepSeek deployment).
-    serve_env+=" -e VLLM_API_KEY='${VLLM_API_KEY:-}'"
+    # The worker is headless and serves no API, so do not propagate the API
+    # credential into its remote docker command or container environment.
 
     log "starting worker on ${WORKER_SSH} (NCCL if=${WORKER_CX7_IF} hca=${WORKER_CX7_IB}) ..."
     worker_ssh "docker run -d --name '$CONTAINER_WORKER' \
@@ -1139,7 +1135,7 @@ launch_cluster() {
         --entrypoint bash '$IMAGE' /start.sh" >/dev/null
 
     log "starting head (vLLM API :${PORT}; NCCL if=${HEAD_CX7_IF} hca=${HEAD_CX7_IB}) ..."
-    docker run -d --name "$CONTAINER_HEAD" \
+    VLLM_API_KEY="$VLLM_API_KEY" docker run -d --name "$CONTAINER_HEAD" \
         --gpus all --network host --ipc=host --shm-size 32g --stop-timeout 60 \
         --device /dev/infiniband --cap-add IPC_LOCK \
         --ulimit memlock=-1 --ulimit stack=67108864 \
@@ -1193,7 +1189,7 @@ launch_cluster() {
         -e ABLIT_ALPHA="$ABLIT_ALPHA" \
         -e ABLIT_INCLUDE_MTP="$ABLIT_INCLUDE_MTP" \
         -e MODEL_DIR="$MODEL_DIR" \
-        -e VLLM_API_KEY="$VLLM_API_KEY" \
+        -e VLLM_API_KEY \
         -e EXTRA_ARGS="${EXTRA_ARGS:-}" \
         --entrypoint bash "$IMAGE" /start.sh >/dev/null
 

--- a/tests/test_api_key_argv.py
+++ b/tests/test_api_key_argv.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Regression guard: VLLM_API_KEY stays out of argv and off the worker.
+
+Merged PR #30 promised the bearer token never lands in argv and is passed to
+the head container only (the worker runs --headless and serves no API). This
+locks in both properties.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+START = ROOT / "start.sh"
+
+
+def function(name: str) -> str:
+    text = START.read_text(encoding="utf-8")
+    match = re.search(rf"(?ms)^{re.escape(name)}\(\) \{{\n.*?^\}}\n", text)
+    assert match, f"missing function {name}"
+    return match.group(0)
+
+
+def test_api_key_is_head_only_and_not_in_docker_argv() -> None:
+    launch = function("launch_cluster")
+    # worker: no credential in the remote docker command at all
+    assert "serve_env+=\" -e VLLM_API_KEY=" not in launch
+    # head: value must come from the docker client's environment, not argv
+    assert '-e VLLM_API_KEY="$VLLM_API_KEY"' not in launch
+    assert 'VLLM_API_KEY="$VLLM_API_KEY" docker run' in launch
+    assert "-e VLLM_API_KEY \\" in launch
+
+
+if __name__ == "__main__":
+    test_api_key_is_head_only_and_not_in_docker_argv()
+    print("api-key argv guard OK")


### PR DESCRIPTION
## What
Restores the two security properties merged PR #30 promised: the bearer token is **env-only** (never in argv) and **head-only** (the worker runs `--headless` and serves no API). Current `main` violates both.

## The regression (reproduced on `main` @ 688b7ab)
- `serve_env+=" -e VLLM_API_KEY='...'"" interpolates the secret into the **worker's** remote docker command — it lands in the local `ssh` argv and the remote `docker` argv (visible in `/proc/*/cmdline`, subject to the host's `hidepid`), on a node that never needs the credential.
- The head's `-e VLLM_API_KEY="$VLLM_API_KEY"` puts the value in the docker client argv.

Safe reproducer (dummy key, no real host) — the key is captured verbatim from `/proc/<pid>/cmdline` of the ssh process:
```
DUMMY_KEY='dummy-key-NOT-A-SECRET'
REMOTE_CMD="docker run -e VLLM_API_KEY='$DUMMY_KEY' example/image /start.sh"
timeout 3s ssh -T -o BatchMode=yes -o 'ProxyCommand=sleep 10' dummy.invalid "$REMOTE_CMD" & sleep 0.2
tr '\0' ' ' < /proc/$!/cmdline   # -> contains the dummy key
```

## Fix
- Worker: drop the credential from the env loop entirely.
- Head: `VLLM_API_KEY="$VLLM_API_KEY" docker run ... -e VLLM_API_KEY ...` — docker reads the value from its own environment; argv carries only the variable name. vLLM's native env-var behavior is unchanged.

## Test
`tests/test_api_key_argv.py` locks both properties on `launch_cluster` (fails on unfixed main). Full suite: 26 passed.

Precisely-scoped claim: this removes the secret from ordinary process argv and the unnecessary worker copy; same-owner/root can still read a process's environment, as with any env-var secret.