### PR TITLE
fix: pin the DFlash2 drafter revision — mutable Hub main silently drifts weights

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,8 @@ SERVED_MODEL_NAME=GLM-5.3-Flash-EXL3
 # Rollback: SPEC_METHOD=mtp
 SPEC_METHOD=dflash
 DFLASH_MODEL=incoai/GLM-5.3-Flash-DFlash2
+# Exact checkpoint behind the published 2026-08-30 TP=2 receipts.
+DFLASH_REVISION=dc77ff1c99eeb2df044ee3d4f0094eb033fee410
 DFLASH_TOKENS=7
 # Drafter TP. 2 = measured keep on this 2× GB10 kit (shard draft across ranks).
 # 1 = rank 0 only (skip CX7 on a 2.3 GiB draft). Empty = inherit TP.

--- a/start.sh
+++ b/start.sh
@@ -153,6 +153,10 @@ MTP_TOKENS="${MTP_TOKENS:-2}"
 SPEC_METHOD="${SPEC_METHOD:-dflash}"
 DFLASH_MODEL="${DFLASH_MODEL:-incoai/GLM-5.3-Flash-DFlash2}"
 DFLASH_CACHE_NAME="${DFLASH_CACHE_NAME:-models--${DFLASH_MODEL//\//--}}"
+# Receipt-matched DFlash2 checkpoint used by the 2026-08-30 TP=2 results.
+# A mutable Hub main has already changed weights, so fresh and warm installs
+# must resolve the same snapshot unless the operator deliberately overrides it.
+DFLASH_REVISION="${DFLASH_REVISION:-dc77ff1c99eeb2df044ee3d4f0094eb033fee410}"
 DFLASH_TOKENS="${DFLASH_TOKENS:-7}"
 # 2 = shard the ~2.3 GiB DFlash2 drafter across TP (C4 keep, 2026-08-30:
 # idle 8k 938 / 16k 972 / 100k 997; decode structured 65.1 / prose 27.1).
@@ -351,10 +355,15 @@ ensure_dflash_refs_main() {
 
 resolve_dflash_dir() {
     local ref="$DFLASH_PATH/refs/main" hash dir
-    ensure_dflash_refs_main
-    hash="$(<"$ref")"
+    if [ -n "${DFLASH_REVISION:-}" ] && [ -d "$DFLASH_PATH/snapshots/$DFLASH_REVISION" ]; then
+        hash="$DFLASH_REVISION"
+    else
+        ensure_dflash_refs_main
+        hash="$(<"$ref")"
+    fi
     dir="$DFLASH_PATH/snapshots/$hash"
     [ -f "$dir/config.json" ] || die "DFlash2 config.json missing in $dir"
+    [ -f "$dir/model.safetensors" ] || die "DFlash2 model.safetensors missing in $dir"
     printf '/root/.cache/huggingface/hub/%s/snapshots/%s' "$DFLASH_CACHE_NAME" "$hash"
 }
 
@@ -730,8 +739,13 @@ download_weights() {
 download_dflash() {
     [ "$SPEC_METHOD" = "dflash" ] || return 0
     [ "${SKIP_DOWNLOAD:-0}" = "1" ] && { log "SKIP_DOWNLOAD=1 — skipping DFlash2 download check"; return; }
-    local have
-    have="$(find "$DFLASH_PATH/snapshots" -name 'model.safetensors' 2>/dev/null | wc -l | tr -d '[:space:]' || true)"
+    local have=0 selected=""
+    if [ -n "${DFLASH_REVISION:-}" ]; then
+        selected="$DFLASH_PATH/snapshots/$DFLASH_REVISION"
+    elif [ -s "$DFLASH_PATH/refs/main" ]; then
+        selected="$DFLASH_PATH/snapshots/$(<"$DFLASH_PATH/refs/main")"
+    fi
+    [ -n "$selected" ] && [ -f "$selected/model.safetensors" ] && have=1
     if [ "${have:-0}" -ge 1 ] && [ "${REFRESH_WEIGHTS:-0}" != "1" ]; then
         log "DFlash2 already present: $DFLASH_PATH"
         ensure_dflash_refs_main
@@ -740,9 +754,11 @@ download_dflash() {
     resolve_hf_bin || die "no 'hf' / 'huggingface-cli' on PATH and no python huggingface_hub — pip install --user -U 'huggingface_hub[cli]' (or set HF_BIN=/path/to/hf)"
     mkdir -p "$HF_CACHE_DIR"
     log "downloading ${DFLASH_MODEL} (~2.3 GiB) into ${HF_CACHE_DIR} ..."
-    HF_HOME="$HF_CACHE_DIR" "${HF_BIN_CMD[@]}" download "$DFLASH_MODEL"
-    ensure_dflash_refs_main
-    have="$(find "$DFLASH_PATH/snapshots" -name 'model.safetensors' 2>/dev/null | wc -l | tr -d '[:space:]' || true)"
+    local -a dflash_args=("$DFLASH_MODEL")
+    [ -n "${DFLASH_REVISION:-}" ] && dflash_args+=(--revision "$DFLASH_REVISION")
+    HF_HOME="$HF_CACHE_DIR" "${HF_BIN_CMD[@]}" download "${dflash_args[@]}"
+    selected="$(resolve_dflash_dir)"
+    have=1
     [ "${have:-0}" -ge 1 ] || die "DFlash2 download finished without model.safetensors"
     log "DFlash2 download complete"
 }
@@ -785,19 +801,23 @@ download_only() {
 # (issue #22, item 2). FORCE_SYNC=1 bypasses the marker; deleting the
 # marker file on the worker has the same effect.
 sync_repo_marker_rev() {
-    local src="$1"
+    local src="$1" preferred="${2:-}"
     local rev
-    rev="$(cat "$src/refs/main" 2>/dev/null || true)"
+    if [ -n "$preferred" ] && [ -d "$src/snapshots/$preferred" ]; then
+        rev="$preferred"
+    else
+        rev="$(cat "$src/refs/main" 2>/dev/null || true)"
+    fi
     [ -n "$rev" ] || rev="$(ls -1t "$src/snapshots" 2>/dev/null | head -n 1 || true)"
     [ -n "$rev" ] || rev="unknown"
     printf '%s' "$rev"
 }
 
 sync_repo_to_worker() {
-    local src="$1" cache_name="$2" label="$3"
+    local src="$1" cache_name="$2" label="$3" preferred="${4:-}"
     local marker rev
     marker="${WORKER_CACHE_DIR}/hub/${cache_name}/.glm53-exl3-synced"
-    rev="$(sync_repo_marker_rev "$src")"
+    rev="$(sync_repo_marker_rev "$src" "$preferred")"
     if [ "${FORCE_SYNC:-0}" != "1" ] \
        && [ "$(worker_ssh "cat '$marker' 2>/dev/null" || true)" = "$rev" ]; then
         log "worker ${cache_name} already at ${rev} — rsync skipped (FORCE_SYNC=1 to force)"
@@ -816,7 +836,7 @@ sync_weights() {
     sync_repo_to_worker "$MODEL_PATH" "$MODEL_CACHE_NAME" "weights"
     if [ "$SPEC_METHOD" = "dflash" ]; then
         [ -d "$DFLASH_PATH" ] || die "DFlash2 weights missing at $DFLASH_PATH"
-        sync_repo_to_worker "$DFLASH_PATH" "$DFLASH_CACHE_NAME" "DFlash2 draft"
+        sync_repo_to_worker "$DFLASH_PATH" "$DFLASH_CACHE_NAME" "DFlash2 draft" "$DFLASH_REVISION"
     fi
     log "worker weights in sync"
 }

--- a/tests/test_dflash_revision_pin.py
+++ b/tests/test_dflash_revision_pin.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Regression guard: the DFlash2 drafter resolves a pinned revision.
+
+incoai/GLM-5.3-Flash-DFlash2 has shipped three different model.safetensors
+under the same model ID (7d74cdd -> dc77ff1 -> bf582e4). Without a pin, a
+fresh install resolves whatever Hub main means that day, so fresh and warm
+deployments run different drafter bytes while claiming the same recipe. The
+default pin is the checkpoint behind the published 2026-08-30 TP=2 receipts.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+START = ROOT / "start.sh"
+
+PIN = "dc77ff1c99eeb2df044ee3d4f0094eb033fee410"
+
+
+def source() -> str:
+    return START.read_text(encoding="utf-8")
+
+
+def function(name: str) -> str:
+    text = source()
+    match = re.search(rf"(?ms)^{re.escape(name)}\(\) \{{\n.*?^\}}\n", text)
+    assert match, f"missing function {name}"
+    return match.group(0)
+
+
+def run_bash(script: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=False
+    )
+
+
+def test_pin_is_declared_and_threaded_through() -> None:
+    text = source()
+    assert f'DFLASH_REVISION="${{DFLASH_REVISION:-{PIN}}}"' in text
+    assert 'dflash_args+=(--revision "$DFLASH_REVISION")' in text
+    assert '[ -f "$dir/model.safetensors" ]' in function("resolve_dflash_dir")
+    # worker sync marker keyed on the pin so a ref flip cannot skip the rsync
+    assert 'sync_repo_to_worker "$DFLASH_PATH" "$DFLASH_CACHE_NAME" "DFlash2 draft" "$DFLASH_REVISION"' in text
+
+
+def test_download_and_resolution_use_the_pin() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        args_file = Path(tmp) / "hf-args"
+        script = f"""
+set -euo pipefail
+log() {{ :; }}
+die() {{ printf 'DIE:%s\\n' "$*" >&2; exit 97; }}
+{function("ensure_dflash_refs_main")}
+{function("resolve_dflash_dir")}
+{function("download_dflash")}
+resolve_hf_bin() {{ HF_BIN_CMD=(mock_hf); }}
+mock_hf() {{
+    printf '%s\\n' "$@" > "$ARGS_FILE"
+    mkdir -p "$DFLASH_PATH/snapshots/$DFLASH_REVISION"
+    touch "$DFLASH_PATH/snapshots/$DFLASH_REVISION/config.json"
+    touch "$DFLASH_PATH/snapshots/$DFLASH_REVISION/model.safetensors"
+}}
+ARGS_FILE={shlex.quote(str(args_file))}
+DFLASH_PATH={shlex.quote(str(Path(tmp) / "dflash"))}
+DFLASH_CACHE_NAME=models--incoai--DFlash
+DFLASH_MODEL=incoai/DFlash
+DFLASH_REVISION={PIN}
+HF_CACHE_DIR={shlex.quote(tmp)}
+SPEC_METHOD=dflash
+SKIP_DOWNLOAD=0
+REFRESH_WEIGHTS=0
+download_dflash
+printf 'resolved=%s\\n' "$(resolve_dflash_dir)"
+"""
+        result = run_bash(script)
+        assert result.returncode == 0, result.stderr
+        assert args_file.read_text(encoding="utf-8").splitlines() == [
+            "download",
+            "incoai/DFlash",
+            "--revision",
+            PIN,
+        ]
+        assert result.stdout.strip().endswith(f"/snapshots/{PIN}")
+
+
+if __name__ == "__main__":
+    test_pin_is_declared_and_threaded_through()
+    test_download_and_resolution_use_the_pin()
+    print("dflash revision-pin guard OK")


### PR DESCRIPTION
## What
Adds `DFLASH_REVISION` (documented in `.env.example`) so fresh and warm installs resolve the **same drafter bytes**. Today the launcher runs `hf download $DFLASH_MODEL` with no `--revision`.

## Why it matters (verified against the Hub API)
`incoai/GLM-5.3-Flash-DFlash2` has shipped **three different `model.safetensors`** under the same model ID and filename:

| commit | date (UTC) | LFS sha256 (prefix) |
|---|---|---|
| `7d74cdd` | 2026-08-27 | `8931dc52…` |
| `dc77ff1` | 2026-08-28 | `b33c0347…` |
| `bf582e4` | 2026-08-31 | `b038e1d9…` |

A warm cache keeps serving whatever it downloaded; a fresh clone gets today's `main`. Two deployments of the same recipe run different drafters while the README's performance receipts describe only one of them.

## Fix
- `DFLASH_REVISION` env knob, default **`dc77ff1`** — the checkpoint the deployment behind the 2026-08-30 `DFLASH_DRAFT_TP=2` receipts is pinned to (verified via `refs/main` in that deployment's HF cache). If you'd rather adopt `bf582e4`, benchmark it and change pin + receipts together — the defect is the silent drift, not the specific checkpoint.
- `--revision` passed to `hf download`; resolution prefers the pinned snapshot even if `refs/main` points elsewhere; `model.safetensors` required in the selected snapshot; worker sync marker keyed on the pin so a ref flip can't skip the rsync.
- Operators can override or empty `DFLASH_REVISION` to track `main` deliberately.

## Test
`tests/test_dflash_revision_pin.py` drives `download_dflash`/`resolve_dflash_dir` against a mock `hf` CLI and asserts the exact `--revision` argv and pinned resolution path (fails on unfixed main). Full suite: 27 passed.