### PR TITLE
fix: scope weight completeness to the active snapshot (cross-snapshot false-pass)

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -317,7 +317,15 @@ worker_ssh() { ssh -T -o BatchMode=yes -o ConnectTimeout=15 "$WORKER_SSH" "$@"; 
 usage() { sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
 
 count_shards() {
-    find "$1/snapshots" -name '*.safetensors' 2>/dev/null | wc -l | tr -d '[:space:]' || true
+    local repo_path="$1" ref
+    ref="$(cat "$repo_path/refs/main" 2>/dev/null || true)"
+    [ -n "$ref" ] || ref="$(ls -1t "$repo_path/snapshots" 2>/dev/null | head -n 1 || true)"
+    if [ -z "$ref" ]; then
+        printf '0'
+        return
+    fi
+    find "$repo_path/snapshots/$ref" -maxdepth 1 -type f -name '*.safetensors' 2>/dev/null \
+        | wc -l | tr -d '[:space:]' || true
 }
 
 ensure_refs_main() {

--- a/tests/test_snapshot_scoped_count.py
+++ b/tests/test_snapshot_scoped_count.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Regression guard: weight completeness is scoped to the active snapshot.
+
+A repo-wide count can accept 119 stale shards in snapshots/old plus one shard
+in the active snapshot as "120 present", then resolve the incomplete active
+snapshot and fail deep in vLLM load. Related: issue #52 (stale refs/main).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+START = ROOT / "start.sh"
+
+
+def function(name: str) -> str:
+    text = START.read_text(encoding="utf-8")
+    match = re.search(rf"(?ms)^{re.escape(name)}\(\) \{{\n.*?^\}}\n", text)
+    assert match, f"missing function {name}"
+    return match.group(0)
+
+
+def run_bash(script: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=False
+    )
+
+
+def test_target_completeness_is_scoped_to_active_snapshot() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp) / "repo"
+        active = repo / "snapshots" / "active"
+        old = repo / "snapshots" / "old"
+        active.mkdir(parents=True)
+        old.mkdir(parents=True)
+        (repo / "refs").mkdir()
+        (repo / "refs" / "main").write_text("active", encoding="utf-8")
+        (active / "model-00120-of-00120.safetensors").touch()
+        for index in range(1, 120):
+            (old / f"model-{index:05d}-of-00120.safetensors").touch()
+
+        result = run_bash(
+            "set -euo pipefail\n"
+            + function("count_shards")
+            + f"count_shards {str(repo)!r}\n"
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "1", result.stdout
+
+
+def test_empty_repo_counts_zero() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp) / "repo"
+        repo.mkdir()
+        result = run_bash(
+            "set -euo pipefail\n"
+            + function("count_shards")
+            + f"count_shards {str(repo)!r}\n"
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "0", result.stdout
+
+
+if __name__ == "__main__":
+    test_target_completeness_is_scoped_to_active_snapshot()
+    test_empty_repo_counts_zero()
+    print("snapshot-scoped count guard OK")


### PR DESCRIPTION
## What
`count_shards()` counts every `*.safetensors` recursively under `snapshots/`, but `resolve_model_dir()` later resolves exactly **one** snapshot via `refs/main`. The completeness check can therefore be satisfied by files the launcher will never load.

## Reproduced false-pass (fixture, from `main` @ 688b7ab)
- `refs/main -> active`; `snapshots/active/` holds `config.json` + **1** shard; `snapshots/old/` holds **119** stale shards
- `count_shards` returns **120** → "weights already present (120 shards)" → download/sync skipped → resolver selects the incomplete `active` → vLLM fails minutes later mid-load instead of seconds early with an actionable message

`download_dflash` has the same shape (any `model.safetensors` anywhere under `snapshots/` satisfies the guard) — fixed separately in the DFlash revision-pin PR, which requires the weight in the selected snapshot.

## Fix
Resolve the ref first (`refs/main`, falling back to the newest snapshot, matching the launcher's existing style), then count only regular files in that one snapshot directory.

## Relationship to #52
Distinct but adjacent: #52 is `refs/main` pointing **away** from a fully-staged pinned snapshot; this is the count being satisfied **across** snapshots even when the selected ref has `config.json`. Happy to align the resolver with whatever shape #52 settles on. A stronger follow-up could parse `model.safetensors.index.json` and require every `weight_map` filename to exist instead of trusting any count.

## Test
`tests/test_snapshot_scoped_count.py`: the 1-active/119-stale fixture must count **1** (mutation-checked — unfixed main returns 120), plus an empty-repo → 0 case. Full suite: 27 passed.