### PR TITLE
GB10: opt-in SpinCondition busy_loop 1 s -> 2 ms (GLM53_SPINWAIT_2MS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -155,3 +155,8 @@ NCCL_IB_GID_INDEX=3
 # still enabled. 1 = upstream default.
 CG_ESTIMATE=1
 NCCL_DEBUG=WARN
+
+# GB10 core relief: shrink vLLM SpinCondition reader spin from 1 s to 2 ms.
+# Readers park on the zmq notify poller sooner instead of sched_yield-spinning,
+# freeing cores for NCCL proxy threads. Validated on 4x TP=4; A/B on your pair.
+# GLM53_SPINWAIT_2MS=1

--- a/overlay/patch_spinwait_gb10.py
+++ b/overlay/patch_spinwait_gb10.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""GB10: shrink SpinCondition busy_loop_s 1 s -> 2 ms (opt-in via GLM53_SPINWAIT_2MS=1).
+
+The vLLM build in this image ships shm_broadcast.py with SpinCondition
+busy_loop_s defaulting to 1 second: after every read, each reader thread
+sched_yield()-spins for a full second before falling back to the zmq notify
+socket.  On GB10 (20-core Grace, unified memory) those spinning readers
+compete with NCCL proxy threads and the engine loop for cores.
+
+Precedent on the same silicon: the DeepSeek-V4-Flash DSpark image was patched
+from 1 s to 2 ms in 2026-08 and validated on four Sparks (analysis:
+https://nacyot.github.io/artifacts/vllm-spin-wait-gb10/).  The newer
+SpinCondition here keeps a zmq wake-up path, so shrinking the spin window is
+safe: readers just park on the poller 2 ms after the last read instead of
+1 s, and the writer's notify ping wakes them.
+
+Measured on a 4x DGX Spark TP=4 deployment of this kit (CRS804 switch
+fabric): no regression in any decode tier; code 4-stream aggregate +8%,
+70k-token cold prefill TTFT -19% in the same A/B window.  Numbers are from
+TP=4 -- treat as directional for TP=2 and A/B on your pair.
+
+Default OFF (no behavior change unless GLM53_SPINWAIT_2MS=1).
+Anchor drift fails closed so a vLLM bump cannot silently half-apply.
+"""
+import os
+import sys
+
+PATH = ("/usr/local/lib/python3.12/dist-packages/vllm/distributed/"
+        "device_communicators/shm_broadcast.py")
+OLD = "busy_loop_s: float = 1,"
+NEW = "busy_loop_s: float = 0.002,"
+
+if os.environ.get("GLM53_SPINWAIT_2MS", "0") != "1":
+    print("spinwait: GLM53_SPINWAIT_2MS!=1, leaving busy_loop_s as-is")
+    sys.exit(0)
+
+with open(PATH, encoding="utf-8") as f:
+    src = f.read()
+
+if NEW in src:
+    print("spinwait: already patched (busy_loop_s=0.002)")
+    sys.exit(0)
+
+n = src.count(OLD)
+if n != 1:
+    print(f"spinwait FATAL: anchor {OLD!r} found {n} times (expected 1)",
+          file=sys.stderr)
+    sys.exit(1)
+
+with open(PATH, "w", encoding="utf-8") as f:
+    f.write(src.replace(OLD, NEW))
+print("spinwait: busy_loop_s 1 -> 0.002 patched")

--- a/start.sh
+++ b/start.sh
@@ -175,6 +175,7 @@ DRAFTER_PATCH_HOST="${DRAFTER_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm5_drafter
 APC_PATCH_HOST="${APC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_hybrid_prefix_hit.py}"
 XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_xgrammar_termination.py}"
 KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kpool_tail_slotmap.py}"
+SPINWAIT_PATCH_HOST="${SPINWAIT_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_spinwait_gb10.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
 QUANTIZATION="${QUANTIZATION:-exl3}"
 LANGUAGE_MODEL_ONLY="${LANGUAGE_MODEL_ONLY:-0}"
@@ -227,6 +228,8 @@ GLM53_SUPPRESS_STOPS_IN_REASONING="${GLM53_SUPPRESS_STOPS_IN_REASONING:-1}"
 # Mixed-step prefill policy when a peer is already decoding (issue #6).
 # skip = do not mix; N>0 = cap tokens; 0 = off.
 GLM53_MIXED_PREFILL_CHUNK="${GLM53_MIXED_PREFILL_CHUNK:-skip}"
+# 1 = shrink vLLM SpinCondition busy_loop_s 1 s -> 2 ms (GB10 core relief). Off by default.
+GLM53_SPINWAIT_2MS="${GLM53_SPINWAIT_2MS:-0}"
 # EngineCore stock timeout is 300s; mid-serve Triton/TileLang JIT on TP=2 can
 # exceed that without being a true hang. NCCL watchdog is still 600s.
 VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS="${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-1800}"
@@ -902,6 +905,9 @@ fi
 if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
     python3 /opt/glm53/patch_kpool_tail_slotmap.py
 fi
+if [ -f /opt/glm53/patch_spinwait_gb10.py ]; then
+    python3 /opt/glm53/patch_spinwait_gb10.py
+fi
 if [ -f /opt/glm53/patch_ablit.py ]; then
     python3 /opt/glm53/patch_ablit.py
 fi
@@ -992,6 +998,9 @@ fi
 if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
     python3 /opt/glm53/patch_kpool_tail_slotmap.py
 fi
+if [ -f /opt/glm53/patch_spinwait_gb10.py ]; then
+    python3 /opt/glm53/patch_spinwait_gb10.py
+fi
 if [ -f /opt/glm53/patch_ablit.py ]; then
     python3 /opt/glm53/patch_ablit.py
 fi
@@ -1030,6 +1039,7 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$XGRAMMAR_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_xgrammar_termination.py"
     [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "missing $KPOOL_TAIL_PATCH_HOST"
     scp -q -o BatchMode=yes "$KPOOL_TAIL_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kpool_tail_slotmap.py"
+    scp -q -o BatchMode=yes "$SPINWAIT_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_spinwait_gb10.py"
 
     worker_ssh "rm -rf /tmp/glm53-ablit"
     scp -q -r -o BatchMode=yes "$SCRIPT_DIR/ablit" "${WORKER_SSH}:/tmp/glm53-ablit"
@@ -1053,6 +1063,7 @@ launch_cluster() {
         -e VLLM_CACHE_ROOT=/root/.cache/vllm
         -e "GLM53_SUPPRESS_STOPS_IN_REASONING=$GLM53_SUPPRESS_STOPS_IN_REASONING"
         -e "GLM53_MIXED_PREFILL_CHUNK=$GLM53_MIXED_PREFILL_CHUNK"
+        -e "GLM53_SPINWAIT_2MS=$GLM53_SPINWAIT_2MS"
         -e "TRITON_CACHE_DIR=$TRITON_CACHE_DIR"
         -e "TILELANG_CACHE_DIR=$TILELANG_CACHE_DIR"
         -e "VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=$VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS"
@@ -1125,6 +1136,7 @@ launch_cluster() {
         -v '/tmp/patch_hybrid_prefix_hit.py:/opt/glm53/patch_hybrid_prefix_hit.py:ro' \
         -v '/tmp/patch_xgrammar_termination.py:/opt/glm53/patch_xgrammar_termination.py:ro' \
         -v '/tmp/patch_kpool_tail_slotmap.py:/opt/glm53/patch_kpool_tail_slotmap.py:ro' \
+        -v '/tmp/patch_spinwait_gb10.py:/opt/glm53/patch_spinwait_gb10.py:ro' \
         -v '/tmp/glm53-ablit:/opt/glm53/ablit:ro' \
         -v '/tmp/glm53-ablit_runtime.py:/opt/glm53/ablit_runtime.py:ro' \
         -v '/tmp/patch_ablit.py:/opt/glm53/patch_ablit.py:ro' \
@@ -1156,6 +1168,7 @@ launch_cluster() {
         -v "$APC_PATCH_HOST:/opt/glm53/patch_hybrid_prefix_hit.py:ro" \
         -v "$XGRAMMAR_PATCH_HOST:/opt/glm53/patch_xgrammar_termination.py:ro" \
         -v "$KPOOL_TAIL_PATCH_HOST:/opt/glm53/patch_kpool_tail_slotmap.py:ro" \
+        -v "$SPINWAIT_PATCH_HOST:/opt/glm53/patch_spinwait_gb10.py:ro" \
         -v "$SCRIPT_DIR/ablit:/opt/glm53/ablit:ro" \
         -v "$SCRIPT_DIR/overlay/ablit_runtime.py:/opt/glm53/ablit_runtime.py:ro" \
         -v "$SCRIPT_DIR/overlay/patch_ablit.py:/opt/glm53/patch_ablit.py:ro" \


### PR DESCRIPTION
## What

Opt-in patch shrinking vLLM's `SpinCondition.busy_loop_s` from **1 s to 2 ms** inside the serving container, gated by `GLM53_SPINWAIT_2MS=1`. **Default OFF — merging changes nothing** until an operator opts in.

## Why

The bundled vLLM ships `shm_broadcast.py` with `busy_loop_s: float = 1`: after every read, each reader thread `sched_yield()`-spins for a full second before parking on the zmq notify poller. On a 20-core GB10 those spinners compete with NCCL proxy threads and the engine loop for cores.

Same-silicon precedent: the DeepSeek-V4-Flash DSpark image was patched 1 s → 2 ms in Aug 2026 and validated on four Sparks ([analysis](https://nacyot.github.io/artifacts/vllm-spin-wait-gb10/)). The newer `SpinCondition` in this tree keeps the zmq wake-up path, so the shrink is safe: readers just park on the poller 2 ms after the last read and the writer's ping wakes them.

## Measured

On a 4x DGX Spark TP=4 deployment of this kit's lineage (CRS804 switch fabric), spinwait-only A/B window: no regression in any decode tier; code 4-stream aggregate +8%; 70k-token cold-prefill TTFT −19%. These are TP=4 numbers — treat as directional for TP=2, which is why the default is off.

## How

Wired exactly like `patch_kpool_tail_slotmap`: overlay file, `*_PATCH_HOST` var, worker scp, both container mounts, both patch-exec blocks, one entry in the shared env array, `.env.example` documentation. The patch is idempotent and fails closed on anchor drift (a vLLM bump can't silently half-apply). `bash -n start.sh` passes.

## Verify on your pair

```bash
GLM53_SPINWAIT_2MS=1 ./start.sh
# boot log should show: "spinwait: busy_loop_s 1 -> 0.002 patched" on both ranks
docker exec <head> grep -n "busy_loop_s: float" \
  /usr/local/lib/python3.12/dist-packages/vllm/distributed/device_communicators/shm_broadcast.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
