### PR TITLE
docs: GB10 UVM livelock runbook + spec-acceptance gate script

### DIFF
--- a/docs/uvm-livelock-gb10.md
+++ b/docs/uvm-livelock-gb10.md
@@ -1,0 +1,78 @@
+# GB10 UVM livelock: prevention, detection, recovery
+
+Field notes from running this kit's lineage on DGX Spark (GB10, unified
+memory). Two incidents on a 4x TP=4 deployment (2026-08-26 unclean node
+reboots; 2026-08-31 mid-serve wedge) plus the recovery that worked. The
+failure class is the one tonyd2wild's OPEN-PROBLEMS #4 describes — this doc
+adds the part that was unknown there: it is survivable without a power cycle.
+
+## The failure
+
+If the kernel pages vLLM memory out (or back in) under memory pressure, the
+UVM driver can enter an unrecoverable spin:
+
+- every engine step stalls; `shm_broadcast.py` logs
+  `No available shared memory broadcast block found in 60 seconds` every 60 s
+- `nvidia-smi` shows **~96% GPU utilization at idle wattage (~12–20 W)** —
+  busy-looking, doing nothing
+- the stuck request stays in `num_requests_running` forever;
+  `VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS` does not fire
+- worst case the node drops off SSH (sshd cannot fork) and needs a power cycle
+
+**`/health` stays 200 the whole time.** vLLM's V1 check_health only reads an
+errored flag; it never probes workers. Do not use `/health` as a liveness
+signal for this failure class.
+
+## Prevention
+
+```bash
+# /etc/sysctl.d/95-glm53-uvm.conf
+vm.swappiness = 0
+```
+
+- **Keep the swap file.** With no swap at all, allocation spikes kill the
+  worker outright (marlin repack, big prefill bursts).
+- **Cycle residual swap before every start** (`swapoff -a && swapon -a`
+  while containers are down). `swappiness=0` stops new page-outs but does
+  nothing about pages already swapped: our 08-31 wedge was triggered by a
+  ~236k-token prefill touching pages parked in swap days earlier.
+- A boot-window page-cache flusher (unconditional `drop_caches` loop) keeps
+  MemFree honest for the NVRM allocator during load.
+
+## Detection (works while /health lies)
+
+Poll `/metrics` every 60 s and alert when both hold for N consecutive ticks
+(N=10 is calm):
+
+- `num_requests_running + num_requests_waiting > 0`, and
+- `prompt_tokens_total + generation_tokens_total` frozen.
+
+Summing prompt+generation keeps long chunked prefills from false-alarming.
+Stand down while the service is loading or the container is young.
+
+## Recovery (18 minutes, no machine-room trip)
+
+1. Capture logs first (`docker logs --tail 300` per node).
+2. Graceful stop will hang — go straight to `docker kill` on every node.
+3. Cycle swap on every node (RAM is free now): `swapoff -a && swapon -a`.
+4. `nvidia-smi` may **still read 96%** with nothing running. That reading is
+   cosmetic after the kill — verify with a trivial CUDA probe before assuming
+   the driver is wedged:
+
+   ```bash
+   docker run --rm --gpus all --entrypoint python3 <serving-image> \
+     -c "import torch; a=torch.ones(2048,2048,device=0); print('CUDA_OK', float((a@a).sum()))"
+   ```
+
+   `CUDA_OK` → just restart the stack; the utilization counter resets with
+   the next real workload. Probe hangs → that node needs a reboot.
+5. Restart. Wait for MemFree to settle first if the teardown just returned
+   ~80 GiB of weights (the vLLM startup pre-check is the real gate).
+
+## Related: speculative-acceptance sanity after any graph-enabled boot
+
+vllm#53030 can silently pin per-position acceptance at exactly 1.00 under
+CUDA graphs. `scripts/spec-accept-gate.sh` checks the decay curve from
+`/metrics` once >100 drafts have accumulated; healthy looks like
+0.85 → 0.70 → 0.56 → … monotone decay, and an exact 1.00 at pos0 is the bug,
+not a win.

--- a/scripts/spec-accept-gate.sh
+++ b/scripts/spec-accept-gate.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# vllm#53030 gate: piecewise-graph BatchDescriptor collision can silently pin
+# spec-decode acceptance at exactly 1.00 per position. Run after EVERY
+# graph-enabled boot, once real traffic (or a bench) has produced >100 drafts.
+# Healthy: pos0 ratio well below 1.0 and monotone decay across positions.
+# Source: tonyd2wild/GLM-5.3-Flash-NVFP4-1M-KV-4x-DGX-Spark docs/OPEN-PROBLEMS.md #7.
+set -euo pipefail
+BASE="${1:-http://192.168.100.126:8888}"
+
+metrics=$(curl --noproxy '*' -fsS --max-time 10 "${BASE}/metrics")
+drafts=$(printf '%s\n' "$metrics" | grep -F 'spec_decode_num_drafts_total{' | grep -oE '[0-9.e+]+$' || echo 0)
+drafts=${drafts%%.*}
+if [ "${drafts:-0}" -lt 100 ]; then
+  echo "SKIP: only ${drafts:-0} drafts since boot (<100); send a bench round first"
+  exit 0
+fi
+
+echo "drafts_total=${drafts}"
+fail=0
+printf '%s\n' "$metrics" | grep -F 'accepted_tokens_per_pos_total{' | while IFS= read -r line; do
+  pos=$(printf '%s' "$line" | grep -oE 'position="[0-9]+"' | grep -oE '[0-9]+')
+  val=$(printf '%s' "$line" | grep -oE '[0-9.e+]+$'); val=${val%%.*}
+  ratio=$(awk -v a="$val" -v d="$drafts" 'BEGIN{printf "%.4f", a/d}')
+  echo "pos${pos}: accepted=${val} ratio=${ratio}"
+done
+
+pos0=$(printf '%s\n' "$metrics" | grep -F 'accepted_tokens_per_pos_total{' | grep -F 'position="0"' | grep -oE '[0-9.e+]+$'); pos0=${pos0%%.*}
+ratio0=$(awk -v a="$pos0" -v d="$drafts" 'BEGIN{printf "%.4f", a/d}')
+pinned=$(awk -v r="$ratio0" 'BEGIN{print (r>0.999)?1:0}')
+if [ "$pinned" = "1" ]; then
+  echo "FAIL: pos0 acceptance ${ratio0} pinned at ~1.00 over ${drafts} drafts — vllm#53030 signature."
+  echo "      Spec decode is silently broken under CUDA graphs. Restart with ENFORCE_EAGER=1 to confirm, then investigate capture sizes."
+  exit 1
+fi
+echo "PASS: pos0 acceptance ${ratio0} (healthy decay expected across positions)"


### PR DESCRIPTION
## What

Docs + one read-only script, no serving-path changes:

- `docs/uvm-livelock-gb10.md` — field runbook for the GB10 UVM livelock class (prevention / detection / recovery), from two incidents on a 4x TP=4 deployment of this kit's lineage.
- `scripts/spec-accept-gate.sh` — post-boot check for the vllm#53030 signature (CUDA graphs silently pinning per-position spec acceptance at exactly 1.00). Reads `/metrics`, prints the decay curve, fails on the pinned shape.

## Why this might save someone's night

This failure class is the one tonyd2wild's OPEN-PROBLEMS #4 describes as "it never recovers". Our contribution is the part that was unknown there — **both of our incidents recovered without a power cycle**, and the triage that makes that possible:

- `/health` stays **200 the whole time** the engine is wedged (V1 `check_health` never probes workers) — the doc gives a `/metrics`-based stall detector that actually fires.
- After `docker kill`, `nvidia-smi` can keep reading ~96% util at idle wattage with nothing running. That reading is cosmetic: a 10-second CUDA matmul probe distinguishes it from a truly wedged driver, and in our two incidents the probe said healthy → plain restart, 18 minutes end to end, no machine-room trip.
- Prevention detail that cost us a mid-serve wedge: `vm.swappiness=0` stops new page-outs but does nothing about pages **already** in swap — a ~236k-token prefill touching week-old swapped pages triggered the spiral. Cycle residual swap (`swapoff -a && swapon -a`) while containers are down, and keep the swap file itself (no swap at all gets the worker killed on allocation spikes).

All numbers and symptoms are from DGX Spark GB10 hardware running this kit's image lineage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
