### PR TITLE
Start model-agnostic EXL3 SM121 kernel lab

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -372,6 +372,9 @@ PY
 COPY overlay/patch_exl3_ext_aarch64.py /opt/glm53/patch_exl3_ext_aarch64.py
 
 ARG EXLLAMAV3_COMMIT=c5d9c657966ffeeaa9353f0cc899f18629da4a13
+ARG RUNTIME_SOURCE_COMMIT=unknown
+ENV EXLLAMAV3_COMMIT=${EXLLAMAV3_COMMIT}
+ENV RUNTIME_SOURCE_COMMIT=${RUNTIME_SOURCE_COMMIT}
 ENV TORCH_CUDA_ARCH_LIST=12.1a
 ENV FLASHINFER_CUDA_ARCH_LIST=12.1a
 ENV MAX_JOBS=8
@@ -426,6 +429,10 @@ RUN set -eux; \
       pip install --no-deps --no-build-isolation --no-cache-dir .; \
     python3 -c "import torch; import exllamav3_ext; assert hasattr(exllamav3_ext, 'exl3_moe'), dir(exllamav3_ext); print('exllamav3_ext', exllamav3_ext.__file__, 'exl3_moe=yes')"; \
     rm -rf /tmp/exllamav3 /root/.cache/pip
+
+# Keep the benchmark Python outside the CUDA build layer. Execute it from
+# /opt/glm53 so the local kernel_lab package is importable.
+COPY kernel_lab /opt/glm53/kernel_lab
 
 # Keep this AFTER the CUDA compile layer so Python-only hook edits do not
 # rebuild exllamav3_ext. Exl3Config.override_quantization_method requires

--- a/README.md
+++ b/README.md
@@ -439,6 +439,8 @@ this Dockerfile instead. After CUDA compile, Python overlay edits
 | `overlay/patch_model_overrides.py` | `"exl3"` in ModelConfig overrides |
 | `tests/test_exl3_overlay.py` | registry, TP shard, `sm_121a` cubin, fused vs loop GEMM, `EXL3_FUSED_MOE=0` |
 | `tests/bench_decode.py` | streaming decode + coherence; `--structured` is the count-1→200 median |
+| `kernel_lab/exl3/` | model-agnostic EXL3 K1-K8 oracle, SM121 tactic sweep, and Atlas receipt producer |
+| `docs/exl3-sm121-kernel-lab.md` | kernel ABI, measurements, upstream sources, decisions, and next gate |
 | `start.sh` / `stop.sh` / `download.sh` | 2-node launch; Hub fetch on the head only |
 | `files/chat_template.jinja` | GLM-5.3 MM template (`<|image|>` / `<|video|>`); checkpoint jinja is language-only |
 | `overlay/qwen3_dflash2.py` | DFlash2 draft (grouped conv + candidate selector) |
@@ -455,6 +457,11 @@ this Dockerfile instead. After CUDA compile, Python overlay edits
 
 Image-build runs `EXL3_SELFCHECK_GPU=0`. `./start.sh` runs the GPU self-check
 (`docker run --gpus all`) before shipping unless `SKIP_OVERLAY_VERIFY=1`.
+
+The kernel lab accepts arbitrary `OPERATOR:K:N` shapes or a JSON workload file;
+GLM/Hy4 names are optional historical fixtures, not a supported-model list.
+See [`kernel_lab/README.md`](kernel_lab/README.md) for the portable correctness
+gate and isolated SM121 tuning command.
 
 ## Do not
 

--- a/docs/exl3-sm121-kernel-lab.md
+++ b/docs/exl3-sm121-kernel-lab.md
@@ -1,0 +1,164 @@
+# Atlas EXL3 SM121 Kernel Lab — engineering log
+
+Last updated: 2026-08-31
+
+## Status
+
+The first optimization stage is implemented but not yet timed on an isolated
+SM121 device:
+
+- reuse ExLlamaV3's packed ABI and direct CUDA kernels;
+- accept arbitrary model/operator shapes rather than a model registry;
+- validate MCG K1-K8 with independent materialized and streaming CPU oracles;
+- enumerate ExLlamaV3's built-in tile shapes and SM quotas;
+- emit native Atlas receipts for every exact measured tactic;
+- keep the production ExLlamaV3 pin unchanged while enabling an isolated
+  current-upstream comparison image.
+
+No speedup is claimed until the checked-in sweep runs on SM121.
+
+## Repository and architecture boundary
+
+CUDA/runtime work belongs in this serving repository. Atlas owns profiling,
+candidate decisions, receipt import, and promotion gates. This lab is the
+bridge: it produces `atlas.kernel-benchmark/v1` measurements that Atlas can
+rank without importing CUDA infrastructure.
+
+The surrounding deployment remains GLM-specific, but the kernel-lab API is
+not. `model_id`, `operator`, and `phase` are receipt provenance strings.
+Compatibility is based on hardware/software identity, representation ABI,
+M/N/K, tensor-parallel world size, grouped state, and backend commit.
+
+The five unrelated untracked download/cutover scripts discovered in this
+checkout were preserved and are not part of the kernel-lab branch.
+
+## ABI decision
+
+The lab reuses ExLlamaV3's serialized MCG ABI without modification:
+
+| Field | Dtype | Shape |
+|---|---|---|
+| `trellis` | int16 | `[K/16, N/16, 16*bits]` |
+| `suh` | fp16 | `[K]` |
+| `svh` | fp16 | `[N]` |
+| `mcg` | int32 | scalar marker `0xCBAC1FED` / `-877912083` |
+
+The matrix convention is `A[M,K] @ W[K,N]`. Trellis tiles are 16×16 in
+ExLlamaV3 tensor-core lane order. The direct MCG adapter now accepts every
+integer upstream bitrate K1-K8. Fractional model-wide rates remain allocations
+across integer-rate tensors, not an invented fractional tensor format.
+
+Production remains pinned to ExLlamaV3
+`c5d9c657966ffeeaa9353f0cc899f18629da4a13`. The Docker build argument can
+select a different immutable upstream commit for an isolated experiment, and
+the selected commit is embedded into benchmark receipts.
+
+## Reference and direct paths
+
+`kernel_lab/exl3/reference.py` implements the authoritative bit order,
+tensor-core permutation, MCG procedural codebook, and 128-wide
+Hadamard/scaling transforms in NumPy.
+
+Two correctness paths are intentionally independent:
+
+1. decode and materialize the complete weight, then multiply;
+2. transform activations, decode one packed 16×16 tile, consume it immediately,
+   and discard it.
+
+The SM121 direct path calls ExLlamaV3 `exl3_gemm` with packed trellis tensors.
+Full reconstruction is used only for separately timed correctness and
+diagnostic baselines. It is outside the direct CUDA event range and receipts
+set `full_precision_materialized=false` for the measured execution path.
+
+## First SM121 tactic surface
+
+The pinned extension already exposes controls that production normally hides:
+
+- automatic dispatch/autotuning;
+- four compiled GEMM tile shapes, filtered by exact K/N compatibility;
+- an explicit number of participating SMs.
+
+The lab now measures automatic dispatch plus each compatible tile at quarter,
+half, and full-device SM quotas. This yields a hardware-derived dispatch table
+instead of rules tied to a model name.
+
+The current upstream ExLlamaV3 candidate at
+`0c49587a7c235e6303a6bbedc8b665272ad3a2ea` additionally contains a QTIP-style
+small-M FP16 GEMV and a fused mul1 int8-activation GEMV. Those are candidate
+experiments, not silently adopted production code.
+
+SM121 is consumer Blackwell. NVIDIA's current CuTe implementation directs
+SM120/121 kernels to warp-level `mma.sync`, not datacenter-Blackwell
+`tcgen05`. Therefore the first experiment stays on ExLlamaV3's CUDA
+`mma.sync` path. CuTe/CUTLASS remains useful for layout and medium-M scheduling
+once measurements demonstrate a gap.
+
+## Workload input
+
+The benchmark accepts any exact shape as `OPERATOR:K:N` or a JSON workload
+list. No code change is needed for a future model. Defaults are generic
+square/expand/contract shape classes. Early GLM-5.2 and Hy4 shapes remain only
+under explicit `--fixture` names for reproducibility.
+
+The default M sweep is `1,2,4,8,16,32,64,128`. The first performance gate
+should focus on M=1/2/4/8; wider M values locate the direct-to-reconstruction
+crossover.
+
+## Evidence so far
+
+### Measured — portable host
+
+- Focused kernel-lab suite: 19 passed.
+- K1-K8 deterministic pack/unpack: passed.
+- K1-K8 streaming matmul versus materialized oracle: passed.
+- Worst maximum absolute error across that sweep: `1.08e-6`.
+- No dense tensor exists in the streaming oracle.
+
+### Previously measured — GB10 compatibility
+
+- NumPy K3 packing matched the official ExLlamaV3 CUDA packer byte-for-byte on
+  deterministic and randomized fixtures.
+- NumPy MCG decoding matched the CUDA decoder for all 65,536 states.
+
+### Not measured
+
+- Direct tactic latency on an isolated SM121.
+- Effective bandwidth/TFLOP/s and reconstruction overhead on target shapes.
+- Pinned 0.0.43 versus current-upstream small-M GEMV.
+- mul1 int8-activation crossover.
+
+The current development host exposes no NVIDIA CUDA device. Earlier available
+Sparks were occupied by an unrelated two-node service, so no disruptive timing
+run was attempted.
+
+## Decision gate
+
+Run the automatic path and tactic sweep on an isolated Spark, import the
+generated catalog into Atlas, then choose the next patch from measured data:
+
+- `reconstruction`: optimize bit extraction/register prefetch and K splitting;
+- `memory_bandwidth_or_pipeline`: prioritize packed layout, coalescing, and
+  multi-matrix fusion;
+- `compute_or_launch`: reduce cooperative synchronization/launch work or move
+  next to grouped MoE;
+- direct loses to reconstruct-then-GEMM: investigate a medium-M tile-local
+  decode/MMA kernel or move the crossover rather than forcing direct execution.
+
+Only after that gate should a new CUDA schedule be promoted into the runtime.
+
+## Upstream primary references
+
+- ExLlamaV3 production pin:
+  <https://github.com/turboderp-org/exllamav3/tree/c5d9c657966ffeeaa9353f0cc899f18629da4a13>
+- ExLlamaV3 current small-M kernel:
+  <https://github.com/turboderp-org/exllamav3/blob/0c49587a7c235e6303a6bbedc8b665272ad3a2ea/exllamav3/exllamav3_ext/quant/exl3_gemv_kernel.cuh>
+- ExLlamaV3 current int8-activation kernel:
+  <https://github.com/turboderp-org/exllamav3/blob/0c49587a7c235e6303a6bbedc8b665272ad3a2ea/exllamav3/exllamav3_ext/quant/exl3_gemv_int8_kernel.cuh>
+- QTIP: <https://arxiv.org/abs/2406.11235>
+- FLUTE: <https://arxiv.org/abs/2407.10960>
+- CUTLASS SM121 GEMM:
+  <https://github.com/NVIDIA/cutlass/blob/dc45f979ae336a235da1676b311f35efeb30149a/examples/79_blackwell_geforce_gemm/79a_blackwell_geforce_nvfp4_bf16_gemm.cu>
+- CUTLASS consumer-Blackwell MMA guidance:
+  <https://github.com/NVIDIA/cutlass/blob/dc45f979ae336a235da1676b311f35efeb30149a/python/CuTeDSL/cutlass/cute/nvgpu/tcgen05/mma.py>
+- FlashInfer SM12x W4A16 MoE:
+  <https://github.com/flashinfer-ai/flashinfer/blob/2cc51dcf67ee71aade7074c64e84f13b7b7b117b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_w4a16_kernel.py>

--- a/kernel_lab/README.md
+++ b/kernel_lab/README.md
@@ -1,0 +1,106 @@
+# Atlas EXL3 SM121 Kernel Lab
+
+This lab measures and tunes the existing ExLlamaV3 packed EXL3 CUDA path. It
+does not define a second weight format, materialize a full weight during direct
+timing, or put CUDA implementation code in the Atlas profiler.
+
+The workload interface is model-agnostic. Model IDs and operator names are
+receipt provenance; arbitrary future models provide their actual `M/N/K`
+shapes without being added to a registry.
+
+## Portable correctness
+
+The NumPy oracle supports the upstream MCG trellis at every integer bitrate
+K1-K8. It compares a materialized reference with a tile-streaming matmul that
+never constructs the complete decoded weight.
+
+```bash
+python3 -m kernel_lab.exl3.benchmark \
+  --backend cpu-oracle --bits 1 2 3 4 5 6 7 8
+python3 -m pytest tests/test_exl3_kernel_lab.py -q
+```
+
+## Arbitrary workload input
+
+Pass shapes directly as `OPERATOR:K:N`:
+
+```bash
+python3 -m kernel_lab.exl3.benchmark \
+  --backend sm121 \
+  --model-id publisher/new-model \
+  --shape experts.gate:7168:2304 \
+  --shape experts.down:2304:7168 \
+  --tp 4 --bits 2 3 4 --m 1 2 4 8
+```
+
+Or pass a JSON file exported from a profiler/model census:
+
+```json
+{
+  "workloads": [
+    {
+      "model_id": "publisher/new-model",
+      "operator": "layers.0.mlp.experts.gate",
+      "phase": "decode",
+      "k": 7168,
+      "n": 2304,
+      "tp_world_size": 4,
+      "grouped_moe": false
+    }
+  ]
+}
+```
+
+`m` belongs on the command line because one operator is normally swept over
+several routed-row counts. Workload-file objects therefore contain `K/N` and
+provenance, while `--m` controls the tuning sweep.
+
+## SM121 tactic sweep
+
+For every exact shape, the runner measures:
+
+- ExLlamaV3's automatic dispatch;
+- every compatible built-in GEMM tile shape;
+- quarter, half, and full-device SM quotas;
+- dense FP16, reconstruction-only, and reconstruct-then-GEMM diagnostics;
+- correctness, direct latency, effective bandwidth/TFLOP/s, reconstruction
+  overhead, and a bottleneck classification.
+
+Direct timings call `exl3_gemm` on packed trellis tensors. Dense and
+reconstruction baselines are outside the CUDA event range. The output is an
+`atlas.kernel-catalog/v1` document containing exact
+`atlas.kernel-benchmark/v1` receipts:
+
+```bash
+python3 -m kernel_lab.exl3.benchmark \
+  --backend sm121 \
+  --shape linear.square:4096:4096 \
+  --bits 3 --m 1 2 4 8 \
+  --warmup 10 --iterations 50 \
+  --output /tmp/atlas-exl3-sm121.json
+```
+
+Use `--no-tactic-sweep` to time only automatic dispatch. The optional legacy
+fixtures under `--fixture` reproduce early GLM/Hy4 measurements; they are not
+the supported-model set.
+
+## Upstream comparison
+
+The production image remains pinned to ExLlamaV3 `c5d9c657` (0.0.43). The
+Docker build already accepts an alternate immutable revision, and now exposes
+that revision to receipts through `EXLLAMAV3_COMMIT`:
+
+```bash
+docker build \
+  --build-arg RUNTIME_SOURCE_COMMIT="$(git rev-parse HEAD)" \
+  --build-arg EXLLAMAV3_COMMIT=0c49587a7c235e6303a6bbedc8b665272ad3a2ea \
+  -t exl3-sm121-candidate .
+```
+
+That current upstream candidate adds the QTIP-style small-M GEMV and fused
+mul1 int8-activation GEMV. It must be built and self-checked as an isolated
+candidate; this branch does not silently replace the production pin.
+
+Grouped MoE, prefill, mixed EXL3/NVFP4 dispatch, vLLM/SGLang-wide integration,
+attention, KV, scheduling, and networking remain outside this first measured
+decode gate.

--- a/kernel_lab/__init__.py
+++ b/kernel_lab/__init__.py
@@ -1,0 +1,1 @@
+"""Atlas Runtime Compiler kernel-lab prototypes."""

--- a/kernel_lab/exl3/__init__.py
+++ b/kernel_lab/exl3/__init__.py
@@ -1,0 +1,21 @@
+"""Stable EXL3 ABI, reference oracle, and direct-runtime adapter."""
+
+from .abi import MCG_MARKER_SIGNED_INT32, PackedExl3Metadata, PackedExl3Weight
+from .reference import (
+    matmul_materialized_reference,
+    matmul_streaming_reference,
+    pack_trellis,
+    reconstruct_weight,
+    unpack_trellis,
+)
+
+__all__ = [
+    "MCG_MARKER_SIGNED_INT32",
+    "PackedExl3Metadata",
+    "PackedExl3Weight",
+    "matmul_materialized_reference",
+    "matmul_streaming_reference",
+    "pack_trellis",
+    "reconstruct_weight",
+    "unpack_trellis",
+]

--- a/kernel_lab/exl3/abi.py
+++ b/kernel_lab/exl3/abi.py
@@ -1,0 +1,139 @@
+"""Versioned contract for the existing ExLlamaV3 EXL3/MCG tensor ABI.
+
+This module does not define a new quantization format.  It makes the exact
+layout already consumed by ``overlay/exl3.py`` and ExLlamaV3 explicit and
+machine-checkable for the kernel lab.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import numpy as np
+
+ABI_NAME = "exllamav3.exl3.mcg"
+ABI_VERSION = 1
+TILE_SIZE = 16
+DEFAULT_BITS = 3
+MCG_MULTIPLIER = 0xCBAC1FED
+MCG_MARKER_SIGNED_INT32 = -877912083
+PINNED_EXLLAMAV3_COMMIT = "c5d9c657966ffeeaa9353f0cc899f18629da4a13"
+SUPPORTED_BITS = tuple(range(1, 9))
+
+
+@dataclass(frozen=True)
+class PackedExl3Metadata:
+    """Serializable metadata for one K-major ``A @ W`` packed matrix."""
+
+    in_features: int
+    out_features: int
+    bits: int = DEFAULT_BITS
+    codebook: str = "mcg"
+    abi_name: str = ABI_NAME
+    abi_version: int = ABI_VERSION
+    tile_size: int = TILE_SIZE
+    trellis_dtype: str = "int16"
+    scale_dtype: str = "float16"
+    marker_dtype: str = "int32"
+    matrix_layout: str = "k_major_16x16_tensor_core_permuted"
+    exllamav3_commit: str = os.environ.get(
+        "EXLLAMAV3_COMMIT", PINNED_EXLLAMAV3_COMMIT
+    )
+
+    def __post_init__(self) -> None:
+        if self.in_features <= 0 or self.out_features <= 0:
+            raise ValueError("in_features and out_features must be positive")
+        if self.in_features % self.tile_size:
+            raise ValueError("in_features must be divisible by 16")
+        if self.out_features % 128:
+            raise ValueError("out_features must be divisible by 128 for the direct kernel")
+        if self.bits not in SUPPORTED_BITS:
+            raise ValueError("EXL3 trellis bits must be in [1, 8]")
+        if self.codebook != "mcg":
+            raise ValueError("the portable kernel-lab oracle currently supports MCG only")
+        if self.abi_name != ABI_NAME or self.abi_version != ABI_VERSION:
+            raise ValueError("unsupported EXL3 ABI name or version")
+        if self.tile_size != TILE_SIZE:
+            raise ValueError("EXL3 trellis tiles must be 16x16")
+
+    @property
+    def trellis_shape(self) -> tuple[int, int, int]:
+        return (
+            self.in_features // self.tile_size,
+            self.out_features // self.tile_size,
+            self.bits * self.tile_size,
+        )
+
+    @property
+    def encoded_shape(self) -> tuple[int, int, int]:
+        return (*self.trellis_shape[:2], self.tile_size * self.tile_size)
+
+    @property
+    def trellis_payload_bytes(self) -> int:
+        return int(np.prod(self.trellis_shape, dtype=np.int64)) * np.dtype(np.int16).itemsize
+
+    @property
+    def total_payload_bytes(self) -> int:
+        return self.trellis_payload_bytes + 2 * (self.in_features + self.out_features) + 4
+
+    @property
+    def effective_bpw(self) -> float:
+        return 8.0 * self.total_payload_bytes / (self.in_features * self.out_features)
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), sort_keys=True, separators=(",", ":"))
+
+    @classmethod
+    def from_json(cls, value: str) -> PackedExl3Metadata:
+        payload = json.loads(value)
+        if not isinstance(payload, dict):
+            raise TypeError("EXL3 metadata JSON must contain an object")
+        return cls(**payload)
+
+
+@dataclass(frozen=True)
+class PackedExl3Weight:
+    """Validated NumPy view of one serialized EXL3 matrix."""
+
+    metadata: PackedExl3Metadata
+    trellis: np.ndarray
+    suh: np.ndarray
+    svh: np.ndarray
+    mcg: np.ndarray
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> None:
+        expected = self.metadata.trellis_shape
+        if self.trellis.shape != expected or self.trellis.dtype != np.int16:
+            raise ValueError(f"trellis must be int16 with shape {expected}, got {self.trellis.dtype} {self.trellis.shape}")
+        if self.suh.shape != (self.metadata.in_features,) or self.suh.dtype != np.float16:
+            raise ValueError("suh must be float16 with one entry per input feature")
+        if self.svh.shape != (self.metadata.out_features,) or self.svh.dtype != np.float16:
+            raise ValueError("svh must be float16 with one entry per output feature")
+        if self.mcg.shape not in {(), (1,)} or self.mcg.dtype != np.int32:
+            raise ValueError("mcg must be a scalar/length-one int32 marker")
+        if int(self.mcg.reshape(-1)[0]) != MCG_MARKER_SIGNED_INT32:
+            raise ValueError("mcg marker does not select the pinned MCG codebook")
+        for name, tensor in (("trellis", self.trellis), ("suh", self.suh), ("svh", self.svh), ("mcg", self.mcg)):
+            if not tensor.flags.c_contiguous:
+                raise ValueError(f"{name} must be contiguous")
+
+    @property
+    def payload_nbytes(self) -> int:
+        return sum(t.nbytes for t in (self.trellis, self.suh, self.svh, self.mcg))
+
+    def tensor_manifest(self) -> dict[str, dict[str, Any]]:
+        return {
+            name: {"dtype": str(tensor.dtype), "shape": list(tensor.shape), "nbytes": tensor.nbytes}
+            for name, tensor in (
+                ("trellis", self.trellis),
+                ("suh", self.suh),
+                ("svh", self.svh),
+                ("mcg", self.mcg),
+            )
+        }

--- a/kernel_lab/exl3/backend.py
+++ b/kernel_lab/exl3/backend.py
@@ -1,0 +1,274 @@
+"""Strict adapter and tactic surface for ExLlamaV3's direct EXL3 kernel."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from .abi import PackedExl3Weight
+from .interfaces import KernelKey, ServingPhase
+
+
+@dataclass(frozen=True)
+class CapabilityReceipt:
+    available: bool
+    reason: str
+    torch_version: str | None = None
+    cuda_version: str | None = None
+    compute_capability: tuple[int, int] | None = None
+    device_name: str | None = None
+    device_uuid: str | None = None
+    driver_version: str | None = None
+    multiprocessor_count: int | None = None
+    extension_path: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def inspect_capability() -> CapabilityReceipt:
+    try:
+        import torch
+    except ImportError:
+        return CapabilityReceipt(False, "PyTorch is not installed")
+    if not torch.cuda.is_available():
+        return CapabilityReceipt(
+            False,
+            "CUDA is not available",
+            torch_version=torch.__version__,
+            cuda_version=torch.version.cuda,
+        )
+    capability = tuple(int(v) for v in torch.cuda.get_device_capability())
+    properties = torch.cuda.get_device_properties(torch.cuda.current_device())
+    device_name = str(properties.name)
+    device_uuid = str(getattr(properties, "uuid", "")) or None
+    multiprocessor_count = int(properties.multi_processor_count)
+    driver_version = _driver_version()
+    if capability != (12, 1):
+        return CapabilityReceipt(
+            False,
+            f"Milestone 0 requires SM121, found sm_{capability[0]}{capability[1]}",
+            torch_version=torch.__version__,
+            cuda_version=torch.version.cuda,
+            compute_capability=capability,
+            device_name=device_name,
+            device_uuid=device_uuid,
+            driver_version=driver_version,
+            multiprocessor_count=multiprocessor_count,
+        )
+    try:
+        import exllamav3_ext
+    except ImportError as exc:
+        return CapabilityReceipt(
+            False,
+            f"exllamav3_ext is unavailable: {exc}",
+            torch_version=torch.__version__,
+            cuda_version=torch.version.cuda,
+            compute_capability=capability,
+            device_name=device_name,
+            device_uuid=device_uuid,
+            driver_version=driver_version,
+            multiprocessor_count=multiprocessor_count,
+        )
+    return CapabilityReceipt(
+        True,
+        "native SM121 EXL3 extension is available",
+        torch_version=torch.__version__,
+        cuda_version=torch.version.cuda,
+        compute_capability=capability,
+        device_name=device_name,
+        device_uuid=device_uuid,
+        driver_version=driver_version,
+        multiprocessor_count=multiprocessor_count,
+        extension_path=getattr(exllamav3_ext, "__file__", None),
+    )
+
+
+def _driver_version() -> str | None:
+    """Read the installed driver identity without guessing from CUDA runtime."""
+
+    try:
+        completed = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=driver_version",
+                "--format=csv,noheader",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return None
+    value = completed.stdout.splitlines()[0].strip() if completed.stdout else ""
+    return value or None
+
+
+@dataclass(frozen=True)
+class KernelTactic:
+    """One directly measurable ExLlamaV3 launch configuration."""
+
+    name: str
+    force_shape_idx: int
+    force_num_sms: int
+
+    @property
+    def kernel_name(self) -> str:
+        if self.force_shape_idx <= 0:
+            return "exl3_gemm.autotuned"
+        return f"exl3_gemm.shape{self.force_shape_idx}.sms{self.force_num_sms}"
+
+
+class DirectExllamaBackend:
+    """Single-matrix direct path; grouped MoE and prefill are out of scope."""
+
+    name = "exllamav3_direct_exl3"
+    max_m = 144
+
+    def supports(self, key: KernelKey) -> tuple[bool, str]:
+        receipt = inspect_capability()
+        if not receipt.available:
+            return False, receipt.reason
+        if key.phase != ServingPhase.DECODE:
+            return False, "the first direct-kernel sweep implements decode only"
+        representation = key.representation
+        if (
+            representation.format != "exl3"
+            or representation.abi_name != "exllamav3.exl3.mcg"
+            or representation.abi_version != 1
+            or representation.codebook != "mcg"
+            or not representation.bits_per_weight.is_integer()
+            or not 1 <= int(representation.bits_per_weight) <= 8
+        ):
+            return False, "the portable direct adapter requires EXL3 MCG ABI v1 at integer K1-K8"
+        if key.grouped:
+            return False, "this tactic sweep measures one matrix; grouped MoE is a later phase"
+        if key.m < 1 or key.m > self.max_m:
+            return False, f"the pinned direct kernel requires 1 <= M <= {self.max_m}"
+        return True, "supported"
+
+    @staticmethod
+    def _linear_class():
+        try:
+            from overlay.exl3 import load_linear_exl3_cls
+
+            return load_linear_exl3_cls()
+        except ImportError:
+            from exllamav3.modules.quant.exl3 import LinearEXL3
+
+            return LinearEXL3
+
+    @staticmethod
+    def _extension():
+        try:
+            from overlay.exl3 import load_exllamav3_ext
+
+            return load_exllamav3_ext()
+        except ImportError:
+            import exllamav3_ext
+
+            return exllamav3_ext
+
+    def build(self, weight: PackedExl3Weight):
+        receipt = inspect_capability()
+        if not receipt.available:
+            raise RuntimeError(receipt.reason)
+        import torch
+
+        weight.validate()
+        device = torch.device("cuda")
+        linear_class = self._linear_class()
+        return linear_class(
+            config=None,
+            in_features=weight.metadata.in_features,
+            out_features=weight.metadata.out_features,
+            trellis=torch.from_numpy(weight.trellis).to(device=device),
+            suh=torch.from_numpy(weight.suh).to(device=device),
+            svh=torch.from_numpy(weight.svh).to(device=device),
+            mcg=torch.from_numpy(weight.mcg.reshape(1)).to(device=device),
+            out_dtype=torch.float16,
+            transformers_fix=True,
+        )
+
+    def run(self, x, linear):
+        """Run the direct path and fail if ExLlama attempts full reconstruction."""
+
+        import torch
+
+        if x.ndim != 2 or not (1 <= x.shape[0] <= self.max_m):
+            raise ValueError(f"x must be [M,K] with 1 <= M <= {self.max_m}")
+
+        def reconstruction_is_forbidden(*_args, **_kwargs):
+            raise RuntimeError("direct EXL3 backend attempted a full weight reconstruction")
+
+        original = linear.reconstruct_hgemm
+        linear.reconstruct_hgemm = reconstruction_is_forbidden
+        try:
+            return linear.forward(x.contiguous().half(), {"reconstruct": False}, out_dtype=torch.float32)
+        finally:
+            linear.reconstruct_hgemm = original
+
+    def tactics(self, key: KernelKey) -> tuple[KernelTactic, ...]:
+        """Enumerate compatible tile shapes and conservative SM quotas."""
+
+        supported, reason = self.supports(key)
+        if not supported:
+            raise RuntimeError(reason)
+        extension = self._extension()
+        receipt = inspect_capability()
+        if receipt.multiprocessor_count is None:
+            raise RuntimeError("SM count is unavailable")
+        sm_total = receipt.multiprocessor_count
+        sm_counts = sorted({max(1, sm_total // 4), max(1, sm_total // 2), sm_total})
+        bits = int(key.representation.bits_per_weight)
+        tactics = [KernelTactic("auto", -1, 0)]
+        for shape_idx in range(1, int(extension.exl3_gemm_num_kernel_shapes()) + 1):
+            if not extension.exl3_gemm_shape_compat(
+                shape_idx, key.m, key.k, key.n, bits
+            ):
+                continue
+            tactics.extend(
+                KernelTactic(f"shape{shape_idx}-sms{sms}", shape_idx, sms)
+                for sms in sm_counts
+            )
+        return tuple(tactics)
+
+    def run_tactic(
+        self,
+        x,
+        linear,
+        tactic: KernelTactic,
+        *,
+        output=None,
+        x_hadamard=None,
+    ):
+        """Run one direct launch; no reconstruction fallback is reachable."""
+
+        import torch
+
+        if x.ndim != 2 or not (1 <= x.shape[0] <= self.max_m):
+            raise ValueError(f"x must be [M,K] with 1 <= M <= {self.max_m}")
+        extension = self._extension()
+        if output is None:
+            output = torch.empty(
+                (x.shape[0], linear.out_features),
+                dtype=torch.float32,
+                device=x.device,
+            )
+        if x_hadamard is None:
+            x_hadamard = torch.empty_like(x)
+        selected_shape = extension.exl3_gemm(
+            x.contiguous().half(),
+            linear.trellis,
+            output,
+            linear.suh,
+            x_hadamard,
+            linear.svh,
+            tactic.force_shape_idx,
+            linear.mcg,
+            linear.mul1,
+            tactic.force_num_sms,
+        )
+        return output, int(selected_shape)

--- a/kernel_lab/exl3/benchmark.py
+++ b/kernel_lab/exl3/benchmark.py
@@ -1,0 +1,349 @@
+"""Correctness and model-agnostic SM121 tactic sweep for direct EXL3 CUDA."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Callable, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+import numpy as np
+
+from .abi import MCG_MARKER_SIGNED_INT32, PackedExl3Metadata, PackedExl3Weight
+from .backend import DirectExllamaBackend, KernelTactic, inspect_capability
+from .interfaces import KernelKey, Representation
+from .receipts import (
+    TacticMeasurement,
+    build_atlas_receipt,
+    build_catalog,
+    git_commit,
+)
+from .reference import (
+    matmul_materialized_reference,
+    matmul_streaming_reference,
+    pack_trellis,
+)
+from .shapes import (
+    DECODE_M_SWEEP,
+    GENERIC_WORKLOADS,
+    LEGACY_FIXTURES,
+    GemmWorkload,
+    load_workload_file,
+    parse_shape_spec,
+)
+
+
+def synthetic_weight(
+    k: int,
+    n: int,
+    *,
+    bits: int = 3,
+    seed: int,
+    pack_codes: bool,
+) -> PackedExl3Weight:
+    metadata = PackedExl3Metadata(in_features=k, out_features=n, bits=bits)
+    rng = np.random.default_rng(seed)
+    if pack_codes:
+        encoded = rng.integers(
+            0, 1 << metadata.bits, size=metadata.encoded_shape, dtype=np.int16
+        )
+        trellis = np.ascontiguousarray(pack_trellis(encoded, metadata.bits))
+    else:
+        # Every bit pattern is a valid packed trellis payload. This avoids a
+        # slow CPU pack before a large GPU-only performance sweep.
+        trellis = rng.integers(
+            -32768, 32767, size=metadata.trellis_shape, dtype=np.int16
+        )
+    signs_k = rng.choice(np.array([-1.0, 1.0], dtype=np.float16), size=k)
+    signs_n = rng.choice(np.array([-1.0, 1.0], dtype=np.float16), size=n)
+    suh = np.ascontiguousarray(signs_k * np.float16(0.1))
+    svh = np.ascontiguousarray(signs_n * np.float16(0.1))
+    mcg = np.array([MCG_MARKER_SIGNED_INT32], dtype=np.int32)
+    return PackedExl3Weight(metadata, trellis, suh, svh, mcg)
+
+
+def run_cpu_oracle_check(*, seed: int = 0, bits: int = 3) -> dict[str, Any]:
+    """Small deterministic identity check suitable for non-CUDA hosts."""
+
+    weight = synthetic_weight(128, 128, bits=bits, seed=seed, pack_codes=True)
+    x = np.random.default_rng(seed + 1).standard_normal((2, 128), dtype=np.float32)
+    started = perf_counter()
+    materialized = matmul_materialized_reference(x, weight)
+    streaming = matmul_streaming_reference(x, weight)
+    elapsed_ms = (perf_counter() - started) * 1000.0
+    delta = np.abs(materialized - streaming)
+    return {
+        "evidence": "measured",
+        "representation": {
+            "format": "exl3",
+            "bits": bits,
+            "codebook": "mcg",
+        },
+        "shape": {"m": 2, "n": 128, "k": 128},
+        "max_abs_error": float(delta.max()),
+        "mean_abs_error": float(delta.mean()),
+        "elapsed_ms": elapsed_ms,
+        "passed": bool(np.allclose(materialized, streaming, rtol=2e-5, atol=2e-5)),
+    }
+
+
+def _time_cuda(fn: Callable[[], Any], *, warmup: int, iterations: int) -> float:
+    import torch
+
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    stop = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iterations):
+        fn()
+    stop.record()
+    stop.synchronize()
+    return float(start.elapsed_time(stop) / iterations)
+
+
+def _classify_bottleneck(
+    direct_ms: float, dense_ms: float, reconstruct_ms: float
+) -> str:
+    if direct_ms <= dense_ms * 1.25:
+        return "compute_or_launch"
+    if reconstruct_ms >= direct_ms * 0.75:
+        return "reconstruction"
+    return "memory_bandwidth_or_pipeline"
+
+
+def _baseline_measurements(linear, x, *, warmup: int, iterations: int):
+    """Time diagnostic baselines outside every direct-kernel event range."""
+
+    import torch
+
+    reconstructed = linear.get_weight_tensor().half()
+    dense_output = torch.matmul(x, reconstructed).float()
+    dense_ms = _time_cuda(
+        lambda: torch.matmul(x, reconstructed), warmup=warmup, iterations=iterations
+    )
+    slower_iterations = max(1, iterations // 5)
+    reconstruct_ms = _time_cuda(
+        linear.get_weight_tensor, warmup=1, iterations=slower_iterations
+    )
+    naive_ms = _time_cuda(
+        lambda: torch.matmul(x, linear.get_weight_tensor().half()),
+        warmup=1,
+        iterations=slower_iterations,
+    )
+    return dense_output, dense_ms, reconstruct_ms, naive_ms
+
+
+def run_sm121_workload(
+    *,
+    workload: GemmWorkload,
+    bits: int,
+    m: int,
+    seed: int,
+    warmup: int,
+    iterations: int,
+    runtime_commit: str,
+    command: list[str],
+    tactic_sweep: bool = True,
+) -> list[dict[str, Any]]:
+    """Measure every compatible direct tactic and return canonical receipts."""
+
+    import torch
+
+    packed = synthetic_weight(
+        workload.k, workload.n, bits=bits, seed=seed, pack_codes=False
+    )
+    backend = DirectExllamaBackend()
+    key = KernelKey(
+        (12, 1),
+        workload.phase,
+        Representation.exl3_mcg(bits),
+        m,
+        workload.n,
+        workload.k,
+        grouped=workload.grouped_moe,
+        model_id=workload.model_id,
+        operator=workload.operator,
+        tp_world_size=workload.tp_world_size,
+    )
+    supported, reason = backend.supports(key)
+    if not supported:
+        raise RuntimeError(reason)
+    linear = backend.build(packed)
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed + 1)
+    x = torch.randn(
+        (m, workload.k), generator=generator, dtype=torch.float16, device="cuda"
+    )
+    dense_output, dense_ms, reconstruct_ms, naive_ms = _baseline_measurements(
+        linear, x, warmup=warmup, iterations=iterations
+    )
+    tactics = backend.tactics(key)
+    if not tactic_sweep:
+        tactics = (tactics[0],)
+
+    capability = inspect_capability()
+    generated_at = datetime.now(timezone.utc)
+    bytes_per_call = packed.payload_nbytes + 2 * m * workload.k + 4 * m * workload.n
+    flops = 2 * m * workload.n * workload.k
+    receipts: list[dict[str, Any]] = []
+    for tactic in tactics:
+        output = torch.empty(
+            (m, workload.n), dtype=torch.float32, device="cuda"
+        )
+        x_hadamard = torch.empty_like(x)
+        direct_fn = lambda: backend.run_tactic(
+            x,
+            linear,
+            tactic,
+            output=output,
+            x_hadamard=x_hadamard,
+        )
+        direct_output, selected_shape = direct_fn()
+        direct_ms = _time_cuda(direct_fn, warmup=warmup, iterations=iterations)
+        difference = (direct_output - dense_output).abs().float()
+        passed = bool(
+            torch.allclose(direct_output, dense_output, rtol=2e-2, atol=2e-2)
+        )
+        measurement = TacticMeasurement(
+            latency_ms=direct_ms,
+            effective_bandwidth_gbps=bytes_per_call / (direct_ms * 1.0e6),
+            achieved_tflops=flops / (direct_ms * 1.0e9),
+            reconstruction_overhead_pct=100.0 * reconstruct_ms / naive_ms,
+            max_abs_error=float(difference.max().item()),
+            mean_abs_error=float(difference.mean().item()),
+            bottleneck=_classify_bottleneck(direct_ms, dense_ms, reconstruct_ms),
+            selected_shape=selected_shape,
+            passed=passed,
+        )
+        receipts.append(
+            build_atlas_receipt(
+                generated_at=generated_at,
+                capability=capability,
+                metadata=packed.metadata,
+                workload=workload,
+                m=m,
+                tactic=tactic,
+                measurement=measurement,
+                runtime_commit=runtime_commit,
+                command=command,
+                seed=seed,
+            )
+        )
+    return receipts
+
+
+def _resolve_workloads(args: argparse.Namespace) -> tuple[GemmWorkload, ...]:
+    workloads: list[GemmWorkload] = []
+    for path in args.workload_file or ():
+        workloads.extend(load_workload_file(path))
+    for fixture in args.fixture or ():
+        workloads.append(LEGACY_FIXTURES[fixture])
+    for shape in args.shape or ():
+        workloads.append(
+            parse_shape_spec(
+                shape,
+                model_id=args.model_id,
+                tp_world_size=args.tp,
+                phase=args.phase,
+                grouped_moe=args.grouped_moe,
+            )
+        )
+    return tuple(workloads) if workloads else GENERIC_WORKLOADS
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--backend", choices=("cpu-oracle", "sm121"), default="cpu-oracle")
+    parser.add_argument(
+        "--shape",
+        action="append",
+        help="arbitrary workload as OPERATOR:K:N; repeat as needed",
+    )
+    parser.add_argument(
+        "--workload-file",
+        action="append",
+        type=Path,
+        help="JSON list of arbitrary workload objects",
+    )
+    parser.add_argument(
+        "--fixture",
+        action="append",
+        choices=tuple(LEGACY_FIXTURES),
+        help="optional reproducibility fixture; not a supported-model registry",
+    )
+    parser.add_argument("--model-id", default="unbound")
+    parser.add_argument("--phase", default="decode")
+    parser.add_argument("--tp", type=int, default=1)
+    parser.add_argument("--grouped-moe", action="store_true")
+    parser.add_argument("--bits", nargs="+", type=int, default=[3])
+    parser.add_argument("--m", nargs="+", type=int, default=list(DECODE_M_SWEEP))
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iterations", type=int, default=50)
+    parser.add_argument("--no-tactic-sweep", action="store_true")
+    parser.add_argument("--runtime-commit")
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    raw_argv = list(argv) if argv is not None else sys.argv[1:]
+    args = build_parser().parse_args(raw_argv)
+    if any(bits < 1 or bits > 8 for bits in args.bits):
+        raise SystemExit("--bits values must be in [1, 8]")
+    workloads = _resolve_workloads(args)
+    if args.backend == "cpu-oracle":
+        report: dict[str, Any] = {
+            "schema_version": 1,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "backend": "cpu-oracle",
+            "capability": inspect_capability().as_dict(),
+            "cases": [
+                run_cpu_oracle_check(seed=args.seed, bits=bits) for bits in args.bits
+            ],
+        }
+    else:
+        embedded_commit = os.environ.get("RUNTIME_SOURCE_COMMIT", "")
+        runtime_commit = args.runtime_commit or (
+            embedded_commit if len(embedded_commit) == 40 else None
+        )
+        runtime_commit = runtime_commit or git_commit(Path(__file__).parents[2])
+        command = [sys.executable, "-m", "kernel_lab.exl3.benchmark", *raw_argv]
+        receipts: list[dict[str, Any]] = []
+        for workload in workloads:
+            for bits in args.bits:
+                for m in args.m:
+                    receipts.extend(
+                        run_sm121_workload(
+                            workload=workload,
+                            bits=bits,
+                            m=m,
+                            seed=args.seed,
+                            warmup=args.warmup,
+                            iterations=args.iterations,
+                            runtime_commit=runtime_commit,
+                            command=command,
+                            tactic_sweep=not args.no_tactic_sweep,
+                        )
+                    )
+        report = build_catalog(receipts)
+
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
+    if args.backend == "cpu-oracle":
+        return 0 if all(case["passed"] for case in report["cases"]) else 1
+    return 0 if all(row["run_status"] == "passed" for row in report["receipts"]) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kernel_lab/exl3/interfaces.py
+++ b/kernel_lab/exl3/interfaces.py
@@ -1,0 +1,68 @@
+"""Model-agnostic extension seams for Atlas runtime kernel work.
+
+Only single-matrix decode is implemented in Milestone 0.  These typed keys
+prevent that prototype from hard-coding assumptions that would block grouped
+MoE, prefill, mixed representation dispatch, or runtime adapters later.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+class ServingPhase:
+    """Convenience phase names, not an allowlist."""
+
+    DECODE = "decode"
+    PREFILL = "prefill"
+
+
+@dataclass(frozen=True)
+class Representation:
+    """The exact packed ABI consumed by a kernel candidate."""
+
+    format: str
+    abi_name: str
+    abi_version: int
+    bits_per_weight: float
+    codebook: str | None = None
+
+    @classmethod
+    def exl3_mcg(cls, bits: int) -> Representation:
+        return cls("exl3", "exllamav3.exl3.mcg", 1, float(bits), "mcg")
+
+
+@dataclass(frozen=True)
+class KernelKey:
+    compute_capability: tuple[int, int]
+    phase: str
+    representation: Representation
+    m: int
+    n: int
+    k: int
+    grouped: bool = False
+    model_id: str = "unbound"
+    operator: str = "linear"
+    tp_world_size: int = 1
+
+
+@dataclass(frozen=True)
+class KernelCandidate:
+    name: str
+    backend: str
+    tactic: dict[str, Any]
+
+
+class KernelOracle(Protocol):
+    def candidates(self, key: KernelKey) -> tuple[KernelCandidate, ...]: ...
+
+    def select(self, key: KernelKey) -> KernelCandidate: ...
+
+
+class RuntimeBackend(Protocol):
+    name: str
+
+    def supports(self, key: KernelKey) -> tuple[bool, str]: ...
+
+    def run(self, *args: Any, **kwargs: Any) -> Any: ...

--- a/kernel_lab/exl3/receipts.py
+++ b/kernel_lab/exl3/receipts.py
@@ -1,0 +1,178 @@
+"""Canonical Atlas receipt generation for direct EXL3 measurements."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .abi import PackedExl3Metadata
+from .backend import CapabilityReceipt, KernelTactic
+from .shapes import GemmWorkload
+
+ATLAS_RECEIPT_SCHEMA = "atlas.kernel-benchmark/v1"
+ATLAS_CATALOG_SCHEMA = "atlas.kernel-catalog/v1"
+RUNTIME_REPOSITORY = (
+    "https://github.com/MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks"
+)
+EXLLAMAV3_REPOSITORY = "https://github.com/turboderp-org/exllamav3"
+
+
+@dataclass(frozen=True)
+class TacticMeasurement:
+    latency_ms: float
+    effective_bandwidth_gbps: float
+    achieved_tflops: float
+    reconstruction_overhead_pct: float
+    max_abs_error: float
+    mean_abs_error: float
+    bottleneck: str
+    selected_shape: int
+    passed: bool
+
+
+def git_commit(path: str | Path) -> str:
+    """Return the exact runtime commit or fail instead of inventing provenance."""
+
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path(path),
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError) as exc:
+        raise RuntimeError("unable to resolve the runtime source commit") from exc
+    commit = completed.stdout.strip()
+    if len(commit) != 40 or any(char not in "0123456789abcdef" for char in commit):
+        raise RuntimeError("runtime source commit is not a full Git SHA")
+    return commit
+
+
+def build_atlas_receipt(
+    *,
+    generated_at: datetime,
+    capability: CapabilityReceipt,
+    metadata: PackedExl3Metadata,
+    workload: GemmWorkload,
+    m: int,
+    tactic: KernelTactic,
+    measurement: TacticMeasurement,
+    runtime_commit: str,
+    command: list[str],
+    seed: int,
+) -> dict[str, Any]:
+    """Build one exact-shape, direct-packed, measured receipt."""
+
+    if generated_at.tzinfo is None or generated_at.utcoffset() is None:
+        raise ValueError("generated_at must be timezone-aware")
+    if not capability.available:
+        raise ValueError("a measured receipt requires an available CUDA capability")
+    if not capability.device_name or not capability.compute_capability:
+        raise ValueError("a measured receipt requires hardware identity")
+    if not capability.cuda_version or not capability.driver_version:
+        raise ValueError("a measured receipt requires CUDA and driver versions")
+    if len(runtime_commit) != 40 or any(
+        char not in "0123456789abcdef" for char in runtime_commit
+    ):
+        raise ValueError("runtime_commit must be a full Git SHA")
+
+    identity = {
+        "at": generated_at.isoformat(),
+        "device": capability.device_name,
+        "model": workload.model_id,
+        "operator": workload.operator,
+        "m": m,
+        "n": workload.n,
+        "k": workload.k,
+        "bits": metadata.bits,
+        "tactic": tactic.name,
+        "runtime_commit": runtime_commit,
+    }
+    digest = hashlib.sha256(
+        json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()[:20]
+    cc = f"{capability.compute_capability[0]}.{capability.compute_capability[1]}"
+    kernel_name = _resolved_kernel_name(tactic, measurement.selected_shape)
+    return {
+        "schema_version": ATLAS_RECEIPT_SCHEMA,
+        "receipt_id": f"exl3-sm121-{digest}",
+        "generated_at": generated_at.isoformat(),
+        "evidence_kind": "measured",
+        "run_status": "passed" if measurement.passed else "failed",
+        "hardware": {
+            "vendor": "nvidia",
+            "device_name": capability.device_name,
+            "compute_capability": cc,
+            "device_uuid": capability.device_uuid,
+            "cuda_version": capability.cuda_version,
+            "driver_version": capability.driver_version,
+        },
+        "representation": {
+            "format": "exl3",
+            "abi_name": metadata.abi_name,
+            "abi_version": metadata.abi_version,
+            "bits_per_weight": float(metadata.bits),
+            "codebook": metadata.codebook,
+            "fused_transform": True,
+            "full_precision_materialized": False,
+        },
+        "workload": {
+            "model_id": workload.model_id,
+            "operator": workload.operator,
+            "phase": workload.phase,
+            "m": m,
+            "n": workload.n,
+            "k": workload.k,
+            "tp_world_size": workload.tp_world_size,
+            "grouped_moe": workload.grouped_moe,
+        },
+        "backend": {
+            "name": "exllamav3_direct_exl3",
+            "kernel_name": kernel_name,
+            "repository": EXLLAMAV3_REPOSITORY,
+            "commit": metadata.exllamav3_commit,
+            "execution_path": "direct_packed",
+        },
+        "metrics": {
+            "latency_ms": measurement.latency_ms,
+            "effective_bandwidth_gbps": measurement.effective_bandwidth_gbps,
+            "achieved_tflops": measurement.achieved_tflops,
+            "reconstruction_overhead_pct": measurement.reconstruction_overhead_pct,
+            "max_abs_error": measurement.max_abs_error,
+            "mean_abs_error": measurement.mean_abs_error,
+            "bottleneck": measurement.bottleneck,
+        },
+        "provenance": {
+            "producer_schema": ATLAS_RECEIPT_SCHEMA,
+            "source_repository": RUNTIME_REPOSITORY,
+            "source_commit": runtime_commit,
+            "command": command,
+            "seed": seed,
+            "source_receipt_sha256": None,
+            "notes": [
+                "dense and reconstruct baselines were timed separately from direct latency",
+                f"extension selected EXL3 kernel shape {measurement.selected_shape}",
+            ],
+        },
+    }
+
+
+def build_catalog(receipts: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"schema_version": ATLAS_CATALOG_SCHEMA, "receipts": receipts}
+
+
+def _resolved_kernel_name(tactic: KernelTactic, selected_shape: int) -> str:
+    if tactic.force_shape_idx > 0:
+        return tactic.kernel_name
+    if selected_shape == 90:
+        return "exl3_gemv.qtip_small_m"
+    if selected_shape == 0:
+        return "exl3_gemv.specialized"
+    return f"exl3_gemm.shape{selected_shape}.autotuned"

--- a/kernel_lab/exl3/reference.py
+++ b/kernel_lab/exl3/reference.py
@@ -1,0 +1,231 @@
+"""Deterministic, dependency-light EXL3 pack/unpack and correctness oracle.
+
+The implementation is intentionally slow and explicit.  It is an independent
+CPU oracle for tests and diagnostics, not a serving implementation.
+"""
+
+from __future__ import annotations
+
+import math
+from functools import lru_cache
+
+import numpy as np
+
+from .abi import MCG_MULTIPLIER, TILE_SIZE, PackedExl3Weight
+
+
+def _as_u16(array: np.ndarray) -> np.ndarray:
+    return np.ascontiguousarray(array).view(np.uint16)
+
+
+def pack_trellis(encoded: np.ndarray, bits: int = 3) -> np.ndarray:
+    """Pack ExLlamaV3 tensor-core-ordered states exactly as ``pack.cu``.
+
+    Each 256-state tile is split into 16 independently aligned spans.  Values
+    are written most-significant-bit first, then adjacent uint16 words are
+    swapped to match the CUDA kernel's little-endian ``SWAP16`` store.
+    """
+
+    if encoded.dtype != np.int16 or encoded.ndim < 1 or encoded.shape[-1] != 256:
+        raise ValueError("encoded must be an int16 array ending in 256 states")
+    if bits < 1 or bits > 8:
+        raise ValueError("EXL3 trellis bits must be in [1, 8]")
+    values = _as_u16(encoded)
+    if np.any(values > ((1 << bits) - 1)):
+        raise ValueError("encoded state exceeds the requested trellis bitrate")
+
+    flat = values.reshape(-1, 256)
+    raw = np.empty((flat.shape[0], TILE_SIZE * bits), dtype=np.uint16)
+    mask = (1 << bits) - 1
+    for row_index, row in enumerate(flat):
+        for span in range(TILE_SIZE):
+            accumulator = 0
+            start = span * TILE_SIZE
+            for value in row[start : start + TILE_SIZE]:
+                accumulator = (accumulator << bits) | (int(value) & mask)
+            for word in range(bits):
+                shift = 16 * (bits - 1 - word)
+                raw[row_index, span * bits + word] = (accumulator >> shift) & 0xFFFF
+
+    packed = raw.copy()
+    packed[:, 0::2] = raw[:, 1::2]
+    packed[:, 1::2] = raw[:, 0::2]
+    return packed.reshape(*encoded.shape[:-1], TILE_SIZE * bits).view(np.int16)
+
+
+def unpack_trellis(packed: np.ndarray, bits: int | None = None) -> np.ndarray:
+    """Inverse of :func:`pack_trellis`, preserving the official state order."""
+
+    if packed.dtype != np.int16 or packed.ndim < 1:
+        raise ValueError("packed must be an int16 array")
+    if bits is None:
+        if packed.shape[-1] % TILE_SIZE:
+            raise ValueError("packed word count is not divisible by 16")
+        bits = packed.shape[-1] // TILE_SIZE
+    if bits < 1 or bits > 8 or packed.shape[-1] != TILE_SIZE * bits:
+        raise ValueError("packed shape does not match the requested bitrate")
+
+    words = _as_u16(packed).reshape(-1, TILE_SIZE * bits)
+    raw = words.copy()
+    raw[:, 0::2] = words[:, 1::2]
+    raw[:, 1::2] = words[:, 0::2]
+    decoded = np.empty((words.shape[0], 256), dtype=np.uint16)
+    mask = (1 << bits) - 1
+    for row_index, row in enumerate(raw):
+        for span in range(TILE_SIZE):
+            accumulator = 0
+            for word in row[span * bits : (span + 1) * bits]:
+                accumulator = (accumulator << 16) | int(word)
+            base = span * TILE_SIZE
+            for index in range(TILE_SIZE):
+                shift = bits * (TILE_SIZE - 1 - index)
+                decoded[row_index, base + index] = (accumulator >> shift) & mask
+    return decoded.reshape(*packed.shape[:-1], 256).view(np.int16)
+
+
+def _lop3(a: np.ndarray, b: int, c: int, lut: int) -> np.ndarray:
+    """Portable PTX ``lop3.b32`` truth-table evaluation."""
+
+    a = np.asarray(a, dtype=np.uint32)
+    b_u = np.uint32(b)
+    c_u = np.uint32(c)
+    out = np.zeros_like(a, dtype=np.uint32)
+    for index in range(8):
+        if not ((lut >> index) & 1):
+            continue
+        a_term = a if (index & 4) else ~a
+        b_term = b_u if (index & 2) else ~b_u
+        c_term = c_u if (index & 1) else ~c_u
+        out |= a_term & b_term & c_term
+    return out
+
+
+def decode_mcg(states: np.ndarray) -> np.ndarray:
+    """Decode uint16 trellis states with the pinned MCG procedural codebook."""
+
+    state_u32 = np.asarray(states, dtype=np.uint16).astype(np.uint32)
+    product = (state_u32.astype(np.uint64) * MCG_MULTIPLIER) & 0xFFFFFFFF
+    words = _lop3(product.astype(np.uint32), 0x8FFF8FFF, 0x3B603B60, 0x6A)
+    low = (words & 0xFFFF).astype(np.uint16).view(np.float16)
+    high = (words >> 16).astype(np.uint16).view(np.float16)
+    with np.errstate(over="ignore", invalid="ignore"):
+        return np.add(low, high, dtype=np.float16)
+
+
+@lru_cache(maxsize=1)
+def tensor_core_permutation() -> tuple[np.ndarray, np.ndarray]:
+    """Return the official row-major→MMA permutation and its inverse."""
+
+    permutation = np.empty(256, dtype=np.int64)
+    for thread in range(32):
+        r0 = (thread % 4) * 2
+        rows = (r0, r0 + 1, r0 + 8, r0 + 9)
+        c0 = thread // 4
+        cols = (c0, c0 + 8)
+        values = (
+            rows[0] * 16 + cols[0],
+            rows[1] * 16 + cols[0],
+            rows[2] * 16 + cols[0],
+            rows[3] * 16 + cols[0],
+            rows[0] * 16 + cols[1],
+            rows[1] * 16 + cols[1],
+            rows[2] * 16 + cols[1],
+            rows[3] * 16 + cols[1],
+        )
+        permutation[thread * 8 : (thread + 1) * 8] = values
+    return permutation, np.argsort(permutation)
+
+
+def decode_tiles(packed: np.ndarray, bits: int = 3) -> np.ndarray:
+    """Decode packed tiles to row-major ``[..., 16, 16]`` FP16 values."""
+
+    states = unpack_trellis(packed, bits)
+    values_tc = decode_mcg(states)
+    _, inverse = tensor_core_permutation()
+    return values_tc[..., inverse].reshape(*packed.shape[:-1], 16, 16)
+
+
+@lru_cache(maxsize=8)
+def hadamard(dimension: int) -> np.ndarray:
+    """Normalized Sylvester Hadamard used by EXL3 for the 128-wide blocks."""
+
+    if dimension < 1 or dimension & (dimension - 1):
+        raise ValueError("Hadamard dimension must be a positive power of two")
+    matrix = np.ones((1, 1), dtype=np.float32)
+    while matrix.shape[0] < dimension:
+        matrix = np.block([[matrix, matrix], [matrix, -matrix]])
+    return matrix / math.sqrt(dimension)
+
+
+def _right_hadamard_blocks(array: np.ndarray, block: int = 128) -> np.ndarray:
+    if array.shape[-1] % block:
+        raise ValueError("feature dimension must be divisible by the Hadamard block")
+    original_shape = array.shape
+    view = np.asarray(array, dtype=np.float32).reshape(-1, original_shape[-1] // block, block)
+    result = view @ hadamard(block)
+    return result.reshape(original_shape)
+
+
+def _left_hadamard_blocks(array: np.ndarray, block: int = 128) -> np.ndarray:
+    if array.shape[0] % block:
+        raise ValueError("input dimension must be divisible by the Hadamard block")
+    matrix = np.asarray(array, dtype=np.float32)
+    result = np.empty_like(matrix)
+    transform = hadamard(block)
+    for start in range(0, matrix.shape[0], block):
+        result[start : start + block] = transform @ matrix[start : start + block]
+    return result
+
+
+def reconstruct_inner(weight: PackedExl3Weight) -> np.ndarray:
+    """Materialize the MCG-decoded inner matrix before Hadamard/scales."""
+
+    tiles = decode_tiles(weight.trellis, weight.metadata.bits)
+    return tiles.transpose(0, 2, 1, 3).reshape(
+        weight.metadata.in_features, weight.metadata.out_features
+    )
+
+
+def reconstruct_weight(weight: PackedExl3Weight) -> np.ndarray:
+    """Materialize the complete reference matrix in FP32."""
+
+    inner = reconstruct_inner(weight)
+    transformed = _left_hadamard_blocks(inner)
+    transformed *= weight.suh.astype(np.float32)[:, None]
+    transformed = _right_hadamard_blocks(transformed)
+    transformed *= weight.svh.astype(np.float32)[None, :]
+    return transformed
+
+
+def matmul_materialized_reference(x: np.ndarray, weight: PackedExl3Weight) -> np.ndarray:
+    """Independent dense correctness oracle (allowed to materialize weights)."""
+
+    x = np.asarray(x, dtype=np.float32)
+    if x.shape[-1] != weight.metadata.in_features:
+        raise ValueError("activation K does not match packed weight metadata")
+    return x @ reconstruct_weight(weight)
+
+
+def matmul_streaming_reference(x: np.ndarray, weight: PackedExl3Weight) -> np.ndarray:
+    """Direct packed oracle that never constructs a full dequantized weight.
+
+    This mirrors the serving dataflow at CPU-oracle speed: transform the input,
+    decode one 16x16 trellis tile, consume it immediately, and discard it.
+    """
+
+    x = np.asarray(x, dtype=np.float32)
+    if x.ndim != 2 or x.shape[1] != weight.metadata.in_features:
+        raise ValueError("x must be [M, in_features]")
+    xh = _right_hadamard_blocks(x * weight.suh.astype(np.float32)[None, :])
+    output = np.zeros((x.shape[0], weight.metadata.out_features), dtype=np.float32)
+    for tile_k in range(weight.trellis.shape[0]):
+        k0 = tile_k * TILE_SIZE
+        k1 = k0 + TILE_SIZE
+        for tile_n in range(weight.trellis.shape[1]):
+            n0 = tile_n * TILE_SIZE
+            n1 = n0 + TILE_SIZE
+            tile = decode_tiles(weight.trellis[tile_k, tile_n], weight.metadata.bits)
+            output[:, n0:n1] += xh[:, k0:k1] @ tile.astype(np.float32)
+    output = _right_hadamard_blocks(output)
+    output *= weight.svh.astype(np.float32)[None, :]
+    return output

--- a/kernel_lab/exl3/shapes.py
+++ b/kernel_lab/exl3/shapes.py
@@ -1,0 +1,121 @@
+"""Model-agnostic GEMM workload descriptions and optional legacy fixtures."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class GemmWorkload:
+    """One exact ``A[M,K] @ W[K,N]`` operator shape.
+
+    Model and operator names are provenance only. Kernel compatibility is
+    determined by the numerical shape and runtime/representation fields.
+    """
+
+    operator: str
+    k: int
+    n: int
+    model_id: str = "unbound"
+    tp_world_size: int = 1
+    phase: str = "decode"
+    grouped_moe: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.operator:
+            raise ValueError("operator must be non-empty")
+        if self.k <= 0 or self.n <= 0:
+            raise ValueError("K and N must be positive")
+        if self.k % 16:
+            raise ValueError("EXL3 K must be divisible by 16")
+        if self.n % 128:
+            raise ValueError("the direct EXL3 kernel requires N divisible by 128")
+        if self.tp_world_size < 1:
+            raise ValueError("tp_world_size must be positive")
+        if not self.phase:
+            raise ValueError("phase must be non-empty")
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> GemmWorkload:
+        allowed = {
+            "operator",
+            "k",
+            "n",
+            "model_id",
+            "tp_world_size",
+            "phase",
+            "grouped_moe",
+        }
+        extra = set(payload) - allowed
+        if extra:
+            raise ValueError(f"unknown workload fields: {sorted(extra)}")
+        return cls(**payload)
+
+
+def parse_shape_spec(
+    value: str,
+    *,
+    model_id: str = "unbound",
+    tp_world_size: int = 1,
+    phase: str = "decode",
+    grouped_moe: bool = False,
+) -> GemmWorkload:
+    """Parse ``OPERATOR:K:N`` without consulting a model registry."""
+
+    try:
+        operator, raw_k, raw_n = value.rsplit(":", 2)
+        k, n = int(raw_k), int(raw_n)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("shape must use OPERATOR:K:N") from exc
+    return GemmWorkload(
+        operator=operator,
+        k=k,
+        n=n,
+        model_id=model_id,
+        tp_world_size=tp_world_size,
+        phase=phase,
+        grouped_moe=grouped_moe,
+    )
+
+
+def load_workload_file(path: str | Path) -> tuple[GemmWorkload, ...]:
+    """Load either a JSON list or ``{"workloads": [...]}`` document."""
+
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    rows = payload.get("workloads") if isinstance(payload, dict) else payload
+    if not isinstance(rows, list) or not rows:
+        raise ValueError("workload file must contain a non-empty workload list")
+    if not all(isinstance(row, dict) for row in rows):
+        raise ValueError("each workload must be a JSON object")
+    return tuple(GemmWorkload.from_dict(row) for row in rows)
+
+
+# Defaults are hardware-oriented shape classes, not a supported-model list.
+GENERIC_WORKLOADS = (
+    GemmWorkload("linear.square", 4096, 4096),
+    GemmWorkload("linear.expand", 4096, 11008),
+    GemmWorkload("linear.contract", 11008, 4096),
+)
+
+
+# Kept only as reproducible fixtures for the original M0 measurements.
+LEGACY_FIXTURES = {
+    "glm52.tp2.gate": GemmWorkload(
+        "experts.gate", 6144, 1024, "zai-org/GLM-5.2", 2
+    ),
+    "glm52.tp2.down": GemmWorkload(
+        "experts.down", 1024, 6144, "zai-org/GLM-5.2", 2
+    ),
+    "hy4.tp2.gate": GemmWorkload(
+        "experts.gate", 6144, 1024, "tencent/Hy4-preview", 2
+    ),
+    "hy4.tp2.down": GemmWorkload(
+        "experts.down", 1024, 6144, "tencent/Hy4-preview", 2
+    ),
+}
+
+
+DECODE_M_SWEEP = (1, 2, 4, 8, 16, 32, 64, 128)

--- a/tests/test_exl3_kernel_lab.py
+++ b/tests/test_exl3_kernel_lab.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+
+import numpy as np
+import pytest
+
+import kernel_lab.exl3.backend as backend_module
+from kernel_lab.exl3.abi import (
+    MCG_MARKER_SIGNED_INT32,
+    PackedExl3Metadata,
+    PackedExl3Weight,
+)
+from kernel_lab.exl3.backend import (
+    CapabilityReceipt,
+    DirectExllamaBackend,
+    KernelTactic,
+    inspect_capability,
+)
+from kernel_lab.exl3.benchmark import run_cpu_oracle_check, synthetic_weight
+from kernel_lab.exl3.interfaces import KernelKey, Representation, ServingPhase
+from kernel_lab.exl3.receipts import TacticMeasurement, build_atlas_receipt, build_catalog
+from kernel_lab.exl3.reference import decode_mcg, pack_trellis, unpack_trellis
+from kernel_lab.exl3.shapes import GemmWorkload, load_workload_file, parse_shape_spec
+
+
+def test_metadata_roundtrip_and_exact_k3_geometry() -> None:
+    metadata = PackedExl3Metadata(in_features=6144, out_features=2048)
+
+    assert metadata.trellis_shape == (384, 128, 48)
+    assert metadata.trellis_payload_bytes == 4_718_592
+    assert 3.0 < metadata.effective_bpw < 3.011
+    assert PackedExl3Metadata.from_json(metadata.to_json()) == metadata
+
+
+@pytest.mark.parametrize("bits", range(1, 9))
+def test_pack_unpack_roundtrip_for_all_upstream_bitrates(bits: int) -> None:
+    rng = np.random.default_rng(bits)
+    encoded = rng.integers(0, 1 << bits, size=(2, 3, 256), dtype=np.int16)
+
+    packed = pack_trellis(encoded, bits)
+    unpacked = unpack_trellis(packed, bits)
+
+    assert packed.shape == (2, 3, bits * 16)
+    assert packed.dtype == np.int16
+    assert np.array_equal(unpacked, encoded)
+
+
+def test_k3_pack_matches_official_cuda_golden_digest() -> None:
+    """Golden was measured against ExLlamaV3's CUDA packer on a GB10."""
+
+    encoded = np.arange(2 * 3 * 256, dtype=np.int16).reshape(2, 3, 256) % 8
+    packed = pack_trellis(encoded, 3)
+
+    assert hashlib.sha256(packed.tobytes()).hexdigest() == (
+        "e543cefbeede83f0d0b015ad8bd1b85918f8f7d74966f557c9065490f36d15e5"
+    )
+
+
+def test_mcg_decode_matches_official_cuda_golden_values() -> None:
+    expected = np.array(
+        [
+            1.84375,
+            0.134521484375,
+            -0.75927734375,
+            0.83984375,
+            0.6650390625,
+            -0.460693359375,
+            -1.66015625,
+            -1.1103515625,
+            0.123046875,
+            0.4638671875,
+            -1.703125,
+            -0.6083984375,
+            -0.184814453125,
+            0.9404296875,
+            0.1552734375,
+            -0.623046875,
+        ],
+        dtype=np.float16,
+    )
+
+    actual = decode_mcg(np.arange(16, dtype=np.int16))
+
+    assert np.array_equal(actual, expected)
+
+
+def test_weight_validation_fails_closed_on_wrong_marker() -> None:
+    metadata = PackedExl3Metadata(128, 128)
+    with pytest.raises(ValueError, match="marker"):
+        PackedExl3Weight(
+            metadata,
+            np.zeros(metadata.trellis_shape, dtype=np.int16),
+            np.ones(128, dtype=np.float16),
+            np.ones(128, dtype=np.float16),
+            np.array([0], dtype=np.int32),
+        )
+
+
+def test_streaming_matmul_matches_materialized_oracle() -> None:
+    result = run_cpu_oracle_check(seed=17)
+
+    assert result["passed"]
+    assert result["max_abs_error"] < 3e-6
+
+
+def test_unknown_future_model_shape_requires_no_registry() -> None:
+    workload = parse_shape_spec(
+        "novel_moe.branch_17:7168:2304",
+        model_id="publisher/model-released-after-kernel-lab",
+        tp_world_size=4,
+        phase="vision_decode_v2",
+    )
+
+    assert workload == GemmWorkload(
+        operator="novel_moe.branch_17",
+        k=7168,
+        n=2304,
+        model_id="publisher/model-released-after-kernel-lab",
+        tp_world_size=4,
+        phase="vision_decode_v2",
+    )
+
+
+def test_arbitrary_workload_file(tmp_path) -> None:
+    path = tmp_path / "workloads.json"
+    path.write_text(
+        '{"workloads":[{"operator":"future.linear","k":5120,"n":1280,'
+        '"model_id":"future/model","tp_world_size":8,"phase":"decode"}]}',
+        encoding="utf-8",
+    )
+
+    assert load_workload_file(path) == (
+        GemmWorkload("future.linear", 5120, 1280, "future/model", 8),
+    )
+
+
+def test_synthetic_weight_has_no_dense_payload() -> None:
+    weight = synthetic_weight(128, 128, seed=3, pack_codes=True)
+
+    assert weight.tensor_manifest() == {
+        "trellis": {"dtype": "int16", "shape": [8, 8, 48], "nbytes": 6144},
+        "suh": {"dtype": "float16", "shape": [128], "nbytes": 256},
+        "svh": {"dtype": "float16", "shape": [128], "nbytes": 256},
+        "mcg": {"dtype": "int32", "shape": [1], "nbytes": 4},
+    }
+    assert int(weight.mcg[0]) == MCG_MARKER_SIGNED_INT32
+
+
+def test_future_dispatch_key_is_explicit_without_implementing_later_phases() -> None:
+    key = KernelKey(
+        compute_capability=(12, 1),
+        phase=ServingPhase.DECODE,
+        representation=Representation.exl3_mcg(3),
+        m=1,
+        n=2048,
+        k=6144,
+    )
+
+    assert not key.grouped
+    assert key.representation.abi_name == "exllamav3.exl3.mcg"
+    assert isinstance(inspect_capability().reason, str)
+
+
+def test_metadata_accepts_every_upstream_integer_bitrate() -> None:
+    for bits in range(1, 9):
+        metadata = PackedExl3Metadata(128, 128, bits=bits)
+        assert metadata.bits == bits
+        assert metadata.trellis_shape == (8, 8, 16 * bits)
+
+
+def test_direct_backend_has_no_model_or_operator_allowlist(monkeypatch) -> None:
+    capability = CapabilityReceipt(
+        available=True,
+        reason="test",
+        cuda_version="13.0",
+        compute_capability=(12, 1),
+        device_name="NVIDIA GB10",
+        driver_version="580.00",
+        multiprocessor_count=20,
+    )
+    monkeypatch.setattr(backend_module, "inspect_capability", lambda: capability)
+    key = KernelKey(
+        compute_capability=(12, 1),
+        phase="decode",
+        representation=Representation.exl3_mcg(7),
+        m=128,
+        n=2304,
+        k=7168,
+        model_id="publisher/model-from-the-future",
+        operator="unseen.operator.branch",
+        tp_world_size=16,
+    )
+
+    assert DirectExllamaBackend().supports(key) == (True, "supported")
+
+
+def test_grouped_workload_fails_closed_before_grouped_kernel_phase(monkeypatch) -> None:
+    capability = CapabilityReceipt(
+        available=True,
+        reason="test",
+        cuda_version="13.0",
+        compute_capability=(12, 1),
+        device_name="NVIDIA GB10",
+        driver_version="580.00",
+        multiprocessor_count=20,
+    )
+    monkeypatch.setattr(backend_module, "inspect_capability", lambda: capability)
+    key = KernelKey(
+        (12, 1),
+        "decode",
+        Representation.exl3_mcg(3),
+        1,
+        2048,
+        4096,
+        grouped=True,
+    )
+
+    supported, reason = DirectExllamaBackend().supports(key)
+    assert not supported
+    assert "grouped MoE" in reason
+
+
+def test_canonical_atlas_receipt_is_model_agnostic() -> None:
+    generated_at = datetime.now(timezone.utc)
+    capability = CapabilityReceipt(
+        available=True,
+        reason="test",
+        torch_version="2.test",
+        cuda_version="13.0",
+        compute_capability=(12, 1),
+        device_name="NVIDIA GB10",
+        device_uuid="GPU-test",
+        driver_version="580.00",
+        multiprocessor_count=20,
+        extension_path="/test/exllamav3_ext.so",
+    )
+    workload = GemmWorkload(
+        "future.operator", 7168, 2304, "publisher/future-model", 4
+    )
+    receipt = build_atlas_receipt(
+        generated_at=generated_at,
+        capability=capability,
+        metadata=PackedExl3Metadata(7168, 2304, bits=3),
+        workload=workload,
+        m=2,
+        tactic=KernelTactic("shape2-sms20", 2, 20),
+        measurement=TacticMeasurement(
+            latency_ms=0.1,
+            effective_bandwidth_gbps=500.0,
+            achieved_tflops=1.0,
+            reconstruction_overhead_pct=70.0,
+            max_abs_error=0.001,
+            mean_abs_error=0.0001,
+            bottleneck="memory_bandwidth_or_pipeline",
+            selected_shape=2,
+            passed=True,
+        ),
+        runtime_commit="a" * 40,
+        command=["python", "-m", "kernel_lab.exl3.benchmark"],
+        seed=0,
+    )
+
+    assert receipt["schema_version"] == "atlas.kernel-benchmark/v1"
+    assert receipt["workload"]["model_id"] == "publisher/future-model"
+    assert receipt["workload"]["operator"] == "future.operator"
+    assert receipt["backend"]["kernel_name"] == "exl3_gemm.shape2.sms20"
+    assert receipt["representation"]["full_precision_materialized"] is False
+    assert build_catalog([receipt])["receipts"] == [receipt]
+
+
+def test_receipt_names_current_upstream_small_m_path() -> None:
+    receipt = build_atlas_receipt(
+        generated_at=datetime.now(timezone.utc),
+        capability=CapabilityReceipt(
+            True,
+            "test",
+            cuda_version="13.0",
+            compute_capability=(12, 1),
+            device_name="NVIDIA GB10",
+            driver_version="580.00",
+            multiprocessor_count=20,
+        ),
+        metadata=PackedExl3Metadata(4096, 4096, bits=3),
+        workload=GemmWorkload("linear", 4096, 4096),
+        m=1,
+        tactic=KernelTactic("auto", -1, 0),
+        measurement=TacticMeasurement(
+            0.1,
+            400.0,
+            1.0,
+            50.0,
+            0.001,
+            0.0001,
+            "memory_bandwidth_or_pipeline",
+            90,
+            True,
+        ),
+        runtime_commit="b" * 40,
+        command=["benchmark"],
+        seed=0,
+    )
+
+    assert receipt["backend"]["kernel_name"] == "exl3_gemv.qtip_small_m"


### PR DESCRIPTION
## Summary

- formalize the existing ExLlamaV3 EXL3/MCG packed ABI without inventing a new format
- add deterministic K1-K8 pack/unpack and streaming matmul correctness oracles
- add a direct packed EXL3 SM121 tactic sweep over compatible upstream kernel shapes and SM quotas
- emit model-agnostic Atlas kernel benchmark receipts for arbitrary operator/K/N workloads
- document the current production pin and an opt-in current-upstream QTIP/dp4a candidate build

## Validation

- `python3 -m pytest tests/test_exl3_kernel_lab.py -q`: 22 passed
- runnable repository suite excluding the pre-existing optional chat-template dependency: 35 passed
- CPU oracle K1-K8: 8/8 passed; worst max absolute error 1.07288361e-06

## Hardware gate

This development host has no NVIDIA GPU. The PR intentionally makes no SM121 speed claim; the next step is to run the included isolated tactic sweep on a GB10/SM121 host and choose reconstruction, launch, or representation work from the measured bottleneck. The production ExLlamaV3 pin is unchanged.