### PR TITLE
perf(exl3): accelerate fat-expert prefill

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,12 @@ EXL3_FUSED_MOE=1
 # EXL3_MOE_ROW_TILE=0
 # Fused temp rows/expert. 1024 lost the MNBT=1024 A/B (P2b); keep 128.
 # EXL3_TEMP_ROWS_FUSED=128
+# Sorted routing tier; 0 falls back to legacy scans unless a higher tier is on.
+# EXL3_FAT_SORTED=0
+# E1 batched tier: persistent scratch + combined gate/up; implies SORTED=1.
+# EXL3_FAT_BATCHED=0
+# E2 direct kernel tier; implies BATCHED=1 and SORTED=1; needs patched extension.
+# EXL3_FAT_KERNEL=0
 SERVED_MODEL_NAME=GLM-5.3-Flash-EXL3
 
 # Winner on this 2× GB10 kit with DFlash2: fused MoE + DFlash2 k=7.

--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,8 @@ MODEL_REVISION=25a44fdbf16862a46b7cc9921142c6c81350af2f
 # the worker if that node can reach GHCR; otherwise docker save
 # --platform | ssh docker load. No login required.
 # Overlay rebuild from this repo: BUILD=1 ./start.sh
+# start.sh also rebuilds once when Dockerfile/overlay change after git pull
+# (recipe stamp). Keep a pulled GHCR tag: SKIP_BUILD=1
 # Skip the pull (use whatever is already local): SKIP_PULL=1
 # Skip copying to the worker: SKIP_SHIP=1
 # Force the ~164 GiB rsync even when the worker revision marker matches:
@@ -80,8 +82,10 @@ EXL3_FUSED_MOE=1
 # EXL3_FAT_SORTED=0
 # E1 batched tier: persistent scratch + combined gate/up; implies SORTED=1.
 # EXL3_FAT_BATCHED=0
-# E2 direct kernel tier; implies BATCHED=1 and SORTED=1; needs patched extension.
-# EXL3_FAT_KERNEL=0
+# E2 direct kernel (default on). Implies BATCHED=1 and SORTED=1.
+# Needs the patched extension — start.sh rebuilds when the overlay recipe drifts.
+# EXL3_FAT_KERNEL=0 restores the legacy fat-expert path without a rebuild.
+EXL3_FAT_KERNEL=1
 SERVED_MODEL_NAME=GLM-5.3-Flash-EXL3
 
 # Winner on this 2× GB10 kit with DFlash2: fused MoE + DFlash2 k=7.
@@ -96,8 +100,9 @@ DFLASH_DRAFT_TP=2
 MTP_TOKENS=2
 MAX_MODEL_LEN=1000000
 MAX_NUM_SEQS=4
-# P1 keep 2048. 3584/4096 lost (fat-expert LinearEXL3). Never 8192 (indexer smem).
-MAX_NUM_BATCHED_TOKENS=2048
+# Prefill chunk. E2 one-shot keep on this 2× GB10 kit (2026-09-01): 7168.
+# 2048/3548 were similar or slower on 100k–300k. Never 8192 (indexer smem).
+MAX_NUM_BATCHED_TOKENS=7168
 GPU_MEM_UTIL=0.87
 KV_CACHE_DTYPE=fp8
 # 0 = load vision tower (image + video). 1 = language-only.

--- a/Dockerfile
+++ b/Dockerfile
@@ -370,6 +370,9 @@ PY
 # Python overlay (exl3.py) is copied AFTER the CUDA compile so edits do not
 # rebuild exllamav3_ext. The aarch64 stub patch must stay in this layer.
 COPY overlay/patch_exl3_ext_aarch64.py /opt/glm53/patch_exl3_ext_aarch64.py
+COPY overlay/patch_exl3_fat_kernel.py /opt/glm53/patch_exl3_fat_kernel.py
+COPY overlay/exl3_fat_gemm.cu /opt/glm53/exl3-fat-kernel/exl3_fat_gemm.cu
+COPY overlay/exl3_fat_gemm.cuh /opt/glm53/exl3-fat-kernel/exl3_fat_gemm.cuh
 
 ARG EXLLAMAV3_COMMIT=c5d9c657966ffeeaa9353f0cc899f18629da4a13
 ENV TORCH_CUDA_ARCH_LIST=12.1a
@@ -418,13 +421,14 @@ RUN set -eux; \
       | tar -xz -C /tmp/exllamav3 --strip-components=1; \
     python3 -c "from pathlib import Path; assert (Path('/tmp/exllamav3')/'exllamav3/modules/quant/exl3.py').is_file()"; \
     python3 /opt/glm53/patch_exl3_ext_aarch64.py /tmp/exllamav3/exllamav3/exllamav3_ext; \
+    python3 /opt/glm53/patch_exl3_fat_kernel.py /tmp/exllamav3/exllamav3/exllamav3_ext /opt/glm53/exl3-fat-kernel; \
     export CPATH="/usr/local/lib/python3.12/dist-packages/nvidia/cu13/include${CPATH:+:$CPATH}"; \
     export CPLUS_INCLUDE_PATH="/usr/local/lib/python3.12/dist-packages/nvidia/cu13/include${CPLUS_INCLUDE_PATH:+:$CPLUS_INCLUDE_PATH}"; \
     export C_INCLUDE_PATH="/usr/local/lib/python3.12/dist-packages/nvidia/cu13/include${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"; \
     cd /tmp/exllamav3; \
     TORCH_CUDA_ARCH_LIST=12.1a MAX_JOBS=8 \
       pip install --no-deps --no-build-isolation --no-cache-dir .; \
-    python3 -c "import torch; import exllamav3_ext; assert hasattr(exllamav3_ext, 'exl3_moe'), dir(exllamav3_ext); print('exllamav3_ext', exllamav3_ext.__file__, 'exl3_moe=yes')"; \
+    python3 -c "import torch; import exllamav3_ext; assert hasattr(exllamav3_ext, 'exl3_moe'), dir(exllamav3_ext); assert hasattr(exllamav3_ext, 'exl3_fat_gemm'), dir(exllamav3_ext); assert hasattr(exllamav3_ext, 'exl3_fat_gemm_scatter'), dir(exllamav3_ext); print('exllamav3_ext', exllamav3_ext.__file__, 'exl3_moe=yes fat_gemm=yes')"; \
     rm -rf /tmp/exllamav3 /root/.cache/pip
 
 # Keep this AFTER the CUDA compile layer so Python-only hook edits do not

--- a/Dockerfile
+++ b/Dockerfile
@@ -476,3 +476,8 @@ RUN EXL3_SELFCHECK_GPU=0 python3 /opt/glm53/test_exl3_overlay.py \
     && python3 /opt/glm53/test_xgrammar_termination.py \
     && python3 /opt/glm53/test_kpool_tail_slotmap.py \
     && python3 /opt/glm53/test_ablit.py
+
+# Baked by start.sh --build-arg so a git pull that changes overlay/Dockerfile
+# misses this label and rebuilds once. Keep last so stamp-only rebuilds are cheap.
+ARG GLM53_RECIPE_STAMP=unknown
+LABEL glm53.recipe.stamp=${GLM53_RECIPE_STAMP}

--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ does **not** let that group shrink the MLA+mamba hit. Mamba stays in the min
 | 4× ~7.5k concurrent follow-ups | **7168 each** (28672 total) | rest | 7515 each | **1.86–2.50 s** | — |
 
 An ~8k follow-up still reuses **7168 / 8004 ≈ 90%** of the prompt, not 46%. MNBT=2048 vs the 1024 ladder (draft TP=1): ~8k 10.36 s / 772 → 8.93 s / 895; ~100k 105.6 s / 947 → 102.5 s / 975; ~256k 273 s / 936 → **263 s / 973**; ~300k 323 s / 928 → **319 s / 941**. C4 keep (`DFLASH_DRAFT_TP=2`): ~8k **8.53 s / 938**; ~16k **16.45 s / 972**; ~100k **100.3 s / 997**. Coarser decode interleave (2k-token chunks vs 1k).
+
+**Default from this checkout:** E2 fat kernel on (`EXL3_FAT_KERNEL=1`) and `MAX_NUM_BATCHED_TOKENS=7168`. The table above is the pre-E2 C4 keep at 2048.
 Hits work **below** UserHIJ’s 14,336-token floor (that floor is 896-chunk ×
 2048-align LCM on a different geometry; this kit’s 3584 is 4×896). Isolation
 held (`STILL_READY_S` / `STILL_C0`…`C3`). Idle chats are not reserved; after
@@ -368,7 +370,7 @@ SPEC_METHOD=mtp ./start.sh restart      # MTP k=2
 `./start.sh` will:
 
 1. Preflight docker/ssh/disk on both nodes
-2. `docker pull` `ghcr.io/miaai-lab/glm-5.3-flash-2x-dgx-sparks:exl3` (public; no login) on the head, then the same pull on the worker if GHCR is reachable. If the worker cannot pull, `docker save --platform linux/arm64 | ssh docker load`. `SKIP_PULL=1` keeps a local copy. `SKIP_SHIP=1` never copies.
+2. `docker pull` `ghcr.io/miaai-lab/glm-5.3-flash-2x-dgx-sparks:exl3` (public; no login) on the head, then the same pull on the worker if GHCR is reachable — **unless** the local image's `glm53.recipe.stamp` does not match this checkout (Dockerfile/overlay change after `git pull`), in which case it rebuilds from this Dockerfile once. If the worker cannot pull, `docker save --platform linux/arm64 | ssh docker load`. `SKIP_PULL=1` keeps a local copy. `SKIP_BUILD=1` keeps GHCR even when the stamp drifts. `SKIP_SHIP=1` never copies.
 3. Download the TR3 EXL3 repo into `$HF_HOME` / `~/.cache/huggingface` (~164 GiB, 120 shards) if missing. Same job as `./download.sh`, which stops here (head only).
 4. `rsync` that cache to `${WORKER_HOME}/.cache/huggingface`
 5. Start rank 1 `--headless` on the worker, rank 0 + API on the head
@@ -380,7 +382,8 @@ The worker does not need GHCR access — start.sh pulls there when it can, other
 ./download.sh                              # head HF cache only (no worker); same as ./start.sh download
 SKIP_DOWNLOAD=1 SKIP_SYNC=1 ./start.sh     # weights already local on both nodes
 SKIP_PULL=1 SKIP_DOWNLOAD=1 SKIP_SYNC=1 ./start.sh restart  # keep local image, no GHCR
-BUILD=1 SKIP_DOWNLOAD=1 SKIP_SYNC=1 ./start.sh restart  # rebuild overlay from this repo + ship
+# overlay/Dockerfile change after git pull rebuilds once; SKIP_BUILD=1 skips that
+BUILD=1 SKIP_DOWNLOAD=1 SKIP_SYNC=1 ./start.sh restart  # force rebuild overlay + ship
 ./start.sh status
 ./start.sh logs                # head
 ./start.sh logs worker
@@ -461,7 +464,7 @@ that are now documented/enforced:
 | `MODEL` | `Mia-AiLab/GLM-5.3-Flash-EXL3-TR3-4bpw` | Hub repo into the HF cache (mirror) |
 | `MODEL_FALLBACK` | `brandonmusic/GLM-5.3-Flash-tr3-4bpw` | Used if the mirror 404s or has fewer than 120 shards |
 | `SERVED_MODEL_NAME` | `GLM-5.3-Flash-EXL3` | OpenAI `model` id (`/v1/models`) |
-| `IMAGE` | `ghcr.io/miaai-lab/glm-5.3-flash-2x-dgx-sparks:exl3` | public GHCR tag; pulled on every start. `SKIP_PULL=1` skips. `BUILD=1` rebuilds the overlay |
+| `IMAGE` | `ghcr.io/miaai-lab/glm-5.3-flash-2x-dgx-sparks:exl3` | public GHCR tag. Rebuilt when the overlay recipe stamp drifts (`BUILD=1` forces; `SKIP_BUILD=1` keeps GHCR). `SKIP_PULL=1` skips pull |
 | `GHCR_TOKEN` / `GHCR_USER` | *(unset)* | optional login if anonymous GHCR pull is rate-limited |
 | `PORT` | `8888` | OpenAI API on the head |
 | `VLLM_API_KEY` | *(unset)* | opt-in Bearer token for `/v1`. Empty = open API. `/health` stays keyless |
@@ -482,12 +485,13 @@ that are now documented/enforced:
 | DFlash2 attention | *(unset)* | SM121 picks FLASH_ATTN for non-causal SWA. Do not pin `TRITON_ATTN` |
 | `ENFORCE_EAGER` | `0` | CUDA graphs; MTP capture `1 2 3 4 6 8 12`, DFlash2 `1 2 4 8 16 24 32` |
 | `EXL3_FUSED_MOE` | `1` | `exl3_moe` per layer; `0` = LinearEXL3 loop |
+| `EXL3_FAT_KERNEL` | `1` | E2 fat-expert prefill kernel (implies batched+sorted). `0` = legacy fat path |
 | `KV_CACHE_DTYPE` | `fp8` | packed `fp8_ds_mla`; not `nvfp4`, not bf16 |
 | `GPU_MEM_UTIL` | `0.87` | GB10 UMA budget (DFlash2 + vision; live pool **1,754,237** tokens / **1.75×** at 1M / 690 blocks / 18.67 GiB) |
 | `MAX_MODEL_LEN` | `1000000` | default context. 1M allocates on the 1.75M padded-slot-share pool. Do not drop to 256k to “free” KV — logged tokens ≈ concurrency × this cap; hybrid block-id overhead then shrinks the pool |
 | `MAX_NUM_SEQS` | `4` | decode batch; MTP adds k+1 tokens/seq |
-| `MAX_NUM_BATCHED_TOKENS` | `2048` | prefill chunk (P1 keep). 3584/4096 lost; 8192 oversubscribes GB10 indexer topk |
-| `GLM53_MIXED_PREFILL_CHUNK` | `skip` | do not mix a peer prefill into a decode step (issue #6). `N>0` = cap tokens; `0` = off. Solo prefill stays MNBT (2048) |
+| `MAX_NUM_BATCHED_TOKENS` | `7168` | prefill chunk (E2 keep 2026-09-01). 2048/3548 were similar or slower; 8192 oversubscribes GB10 indexer topk |
+| `GLM53_MIXED_PREFILL_CHUNK` | `skip` | do not mix a peer prefill into a decode step (issue #6). `N>0` = cap tokens; `0` = off. Solo prefill stays MNBT (7168) |
 | `GLM53_SUPPRESS_STOPS_IN_REASONING` | `1` | ignore client `stop` strings until `</think>` (thinking-on default) |
 | `GLM53_BOOT_SHAPE_WARMUP` | `1` | after `/health`, burn DFlash2 BLOCK / sampler / kpool shapes (nonfatal) |
 | `TRITON_HOST_CACHE` / `TILELANG_HOST_CACHE` | `$CACHE_ROOT/triton` / `tilelang` | persist JIT caches across container recreate |
@@ -505,16 +509,15 @@ docker build -t glm53-flash-sm121:local .
 # or: BUILD=1 ./start.sh
 ```
 
-`./start.sh` **pulls** `ghcr.io/miaai-lab/glm-5.3-flash-2x-dgx-sparks:exl3`
-(public) on every start unless `SKIP_PULL=1`. `BUILD=1` rebuilds the overlay from
-this Dockerfile instead. After CUDA compile, Python overlay edits
-(`overlay/exl3.py`, tests) are a cheap layer so they do not rebuild
-`exllamav3_ext`.
+`./start.sh` **rebuilds** from this Dockerfile when the image label `glm53.recipe.stamp` does not match the current overlay/Dockerfile hash — that is what makes a `git pull` pick up `exl3_fat_gemm` instead of staying on the public GHCR tag (which predates E2). `SKIP_BUILD=1` keeps GHCR. `BUILD=1` forces a rebuild. `SKIP_PULL=1` skips `docker pull` only.
+
+After CUDA compile, Python overlay edits (`overlay/exl3.py`, tests) are a cheap layer so they do not rebuild `exllamav3_ext`.
 
 | Path | Role |
 |---|---|
 | `Dockerfile` | NoPE sparse-MLA patches + EXL3 install (`sm_121a`) + self-check |
-| `overlay/exl3.py` | `Exl3Config` / packed load / TP shard / fused `exl3_moe` apply |
+| `overlay/exl3.py` | `Exl3Config` / packed load / TP shard / fused `exl3_moe` apply / E2 fat kernel |
+| `overlay/exl3_fat_gemm.cu` | additive `exl3_fat_gemm` / `_scatter` compiled into `exllamav3_ext` |
 | `overlay/patch_exl3_ext_aarch64.py` | stub AVX CPU allreduce so the ext builds on GB10 |
 | `overlay/patch_model_overrides.py` | `"exl3"` in ModelConfig overrides |
 | `tests/test_exl3_overlay.py` | registry, TP shard, `sm_121a` cubin, fused vs loop GEMM, `EXL3_FUSED_MOE=0` |

--- a/overlay/exl3.py
+++ b/overlay/exl3.py
@@ -55,6 +55,8 @@ TEMP_ROWS_FUSED = 128
 MOE_ACT_SILU = 0
 # Shared fused scratch: decode is sequential across layers.
 _FUSED_TEMP_CACHE: dict[tuple, tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]] = {}
+_FAT_SCRATCH_CACHE: dict[tuple, dict[str, torch.Tensor]] = {}
+_FAT_COUNT_CACHE: dict[tuple, tuple[torch.Tensor, torch.cuda.Stream]] = {}
 _FAT_BUCKET_EDGES = (16, 32, 64, 128, 256, 512, 1024, 2048)
 _FAT_STATS: dict[str, Any] = {
     "layers": 0,
@@ -81,6 +83,18 @@ def temp_rows_fused() -> int:
         return int(TEMP_ROWS_FUSED)
     return max(1, int(raw))
 
+def sorted_fat_fallback_enabled() -> bool:
+    """Use the existing expert-sorted buffers for oversized prefill experts."""
+    return os.environ.get("EXL3_FAT_SORTED", "0") != "0"
+
+def batched_fat_fallback_enabled() -> bool:
+    """Enable E1 batched fat experts; implies expert-sorted routing."""
+    return os.environ.get("EXL3_FAT_BATCHED", "0") != "0"
+
+def fat_kernel_enabled() -> bool:
+    """Enable the E2 fat kernel; implies E1 batching and sorted routing."""
+    return os.environ.get("EXL3_FAT_KERNEL", "0") != "0"
+
 
 def fat_expert_log_enabled() -> bool:
     return os.environ.get("EXL3_FAT_EXPERT_LOG", "1") != "0"
@@ -103,12 +117,21 @@ def _fat_bucket(n: int) -> int:
 
 
 def record_exl3_fat_expert_stats(
-    counts: torch.Tensor, *, max_rows: int | None = None
+    counts: torch.Tensor,
+    *,
+    max_rows: int | None = None,
+    counts_host: list[int] | None = None,
 ) -> dict[str, Any]:
-    """Prefill-only. `counts` is (n_exp,) GPU int64. Syncs if max_rows is omitted."""
-    if max_rows is None:
-        max_rows = int(counts.max().item())
-    n_fat = int((counts > temp_rows_fused()).sum().item())
+    """Prefill-only routing stats. Reuse an existing host copy when available."""
+    if counts_host is None:
+        if max_rows is None:
+            max_rows = int(counts.max().item())
+        n_fat = int((counts > temp_rows_fused()).sum().item())
+    else:
+        if max_rows is None:
+            max_rows = max(counts_host, default=0)
+        cap = temp_rows_fused()
+        n_fat = sum(n > cap for n in counts_host)
     st = _FAT_STATS
     st["layers"] += 1
     st["sum_max_rows"] += max_rows
@@ -350,6 +373,227 @@ def apply_exl3_python_loop(
         out.index_add_(0, token_idx, down * scale)
     return out
 
+def apply_exl3_sorted_fat(
+    xh: torch.Tensor,
+    token_sorted: torch.Tensor,
+    weight_sorted: torch.Tensor,
+    counts_host: list[int],
+    inners: list[dict[str, Any]],
+    limit: float,
+    cap: int,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    """Run oversized experts from contiguous slices of the existing sort.
+
+    One `counts.tolist()` in the caller replaces the legacy per-expert
+    `unique.tolist()`, expert-map `.item()`, and `(ids == expert).nonzero()`
+    synchronizations. Slices are views; only the LinearEXL3 inputs and outputs
+    allocate, as they do in the legacy fallback.
+    """
+    offset = 0
+    for e, n_rows in enumerate(counts_host):
+        start = offset
+        offset += n_rows
+        if n_rows <= cap:
+            continue
+        token_idx = token_sorted[start:offset]
+        h = xh.index_select(0, token_idx)
+        pack = inners[e]
+        gate = pack["gate"].forward(h, {}, out_dtype=torch.float32)
+        up = pack["up"].forward(h, {}, out_dtype=torch.float32)
+        act = F.silu(gate.clamp(max=limit)) * up.clamp(min=-limit, max=limit)
+        down = pack["down"].forward(
+            act.contiguous().half(), {}, out_dtype=torch.float32
+        )
+        scale = weight_sorted[start:offset].unsqueeze(-1).to(dtype=torch.float32)
+        out.index_add_(0, token_idx, down * scale)
+    return out
+
+
+def _fat_scratch(
+    device: torch.device,
+    rows: int,
+    gate: Any,
+) -> dict[str, torch.Tensor]:
+    """Return shared prefill scratch, growing once if the configured chunk grows."""
+    hidden = int(gate.in_features)
+    intermediate = int(gate.out_features)
+    configured = int(
+        os.environ.get(
+            "EXL3_FAT_SCRATCH_ROWS",
+            os.environ.get("MAX_NUM_BATCHED_TOKENS", "0"),
+        )
+        or 0
+    )
+    needed = max(256, rows, configured)
+    capacity = 1 << (needed - 1).bit_length()
+    key = (
+        str(device),
+        hidden,
+        intermediate,
+        int(gate.K),
+        int(gate.trellis.shape[-1]),
+    )
+    scratch = _FAT_SCRATCH_CACHE.get(key)
+    if scratch is not None and int(scratch["h"].shape[0]) >= rows:
+        return scratch
+
+    in_tiles, out_tiles, k_words = map(int, gate.trellis.shape)
+    scratch = {
+        "packed13": torch.empty(
+            (in_tiles, 2 * out_tiles, k_words),
+            dtype=torch.int16,
+            device=device,
+        ),
+        "svh13": torch.empty(
+            2 * intermediate, dtype=torch.float16, device=device
+        ),
+        "w13": torch.empty(
+            (hidden, 2 * intermediate), dtype=torch.float16, device=device
+        ),
+        "w2": torch.empty(
+            (intermediate, hidden), dtype=torch.float16, device=device
+        ),
+        "h": torch.empty(
+            (capacity, hidden), dtype=torch.float16, device=device
+        ),
+        "h13": torch.empty(
+            (capacity, hidden), dtype=torch.float16, device=device
+        ),
+        "gate_up": torch.empty(
+            (capacity, 2 * intermediate), dtype=torch.float32, device=device
+        ),
+        "act": torch.empty(
+            (capacity, intermediate), dtype=torch.float32, device=device
+        ),
+        "act_h": torch.empty(
+            (capacity, intermediate), dtype=torch.float16, device=device
+        ),
+        "h2": torch.empty(
+            (capacity, intermediate), dtype=torch.float16, device=device
+        ),
+        "down": torch.empty(
+            (capacity, hidden), dtype=torch.float32, device=device
+        ),
+    }
+    _FAT_SCRATCH_CACHE[key] = scratch
+    return scratch
+
+
+def _stage_counts_to_host(
+    counts: torch.Tensor,
+) -> tuple[torch.Tensor, torch.cuda.Stream]:
+    """Copy routing counts on a side stream before launching thin experts."""
+    key = (str(counts.device), int(counts.numel()))
+    cached = _FAT_COUNT_CACHE.get(key)
+    if cached is None:
+        host = torch.empty(
+            int(counts.numel()), dtype=counts.dtype, device="cpu", pin_memory=True
+        )
+        stream = torch.cuda.Stream(device=counts.device)
+        cached = (host, stream)
+        _FAT_COUNT_CACHE[key] = cached
+    host, stream = cached
+    current = torch.cuda.current_stream(counts.device)
+    with torch.cuda.stream(stream):
+        stream.wait_stream(current)
+        host.copy_(counts, non_blocking=True)
+    return host, stream
+
+
+def apply_exl3_batched_fat(
+    xh: torch.Tensor,
+    token_sorted: torch.Tensor,
+    weight_sorted: torch.Tensor,
+    counts_host: list[int],
+    inners: list[dict[str, Any]],
+    limit: float,
+    cap: int,
+    out: torch.Tensor,
+    use_kernel: bool = False,
+) -> torch.Tensor:
+    """Run fat experts with persistent buffers and optional direct trellis GEMM."""
+    ext = load_exllamav3_ext()
+    offset = 0
+    for e, n_rows in enumerate(counts_host):
+        start = offset
+        offset += n_rows
+        if n_rows <= cap:
+            continue
+
+        token_idx = token_sorted[start:offset]
+        gate = inners[e]["gate"]
+        up = inners[e]["up"]
+        down = inners[e]["down"]
+        scratch = _fat_scratch(xh.device, n_rows, gate)
+        intermediate = int(gate.out_features)
+
+        h = scratch["h"][:n_rows]
+        h13 = scratch["h13"][:n_rows]
+        torch.index_select(xh, 0, token_idx, out=h)
+        ext.had_r_128(h, h13, gate.suh, None, 1.0)
+
+        packed13 = scratch["packed13"]
+        out_tiles = int(gate.trellis.shape[1])
+        packed13[:, :out_tiles].copy_(gate.trellis)
+        packed13[:, out_tiles:].copy_(up.trellis)
+        gate_up = scratch["gate_up"][:n_rows]
+        svh13 = scratch["svh13"]
+        svh13[:intermediate].copy_(gate.svh)
+        svh13[intermediate:].copy_(up.svh)
+        if use_kernel:
+            if not hasattr(ext, "exl3_fat_gemm"):
+                raise RuntimeError(
+                    "EXL3_FAT_KERNEL=1 requires exllamav3_ext.exl3_fat_gemm"
+                )
+            ext.exl3_fat_gemm(
+                h13, packed13, gate_up, svh13, gate.K, gate.mcg, gate.mul1
+            )
+        else:
+            w13 = scratch["w13"]
+            ext.reconstruct(w13, packed13, gate.K, gate.mcg, gate.mul1)
+            ext.hgemm(h13, w13, gate_up)
+            ext.had_r_128(gate_up, gate_up, None, svh13, 1.0)
+
+        gate_out = gate_up[:, :intermediate]
+        up_out = gate_up[:, intermediate:]
+        gate_out.clamp_(max=limit)
+        up_out.clamp_(min=-limit, max=limit)
+        act = scratch["act"][:n_rows]
+        torch.sigmoid(gate_out, out=act)
+        act.mul_(gate_out).mul_(up_out)
+        act_h = scratch["act_h"][:n_rows]
+        act_h.copy_(act)
+
+        h2 = scratch["h2"][:n_rows]
+        ext.had_r_128(act_h, h2, down.suh, None, 1.0)
+        if use_kernel:
+            if not hasattr(ext, "exl3_fat_gemm_scatter"):
+                raise RuntimeError(
+                    "EXL3_FAT_KERNEL=1 requires "
+                    "exllamav3_ext.exl3_fat_gemm_scatter"
+                )
+            ext.exl3_fat_gemm_scatter(
+                h2,
+                down.trellis,
+                out,
+                down.svh,
+                token_idx,
+                weight_sorted[start:offset],
+                down.K,
+                down.mcg,
+                down.mul1,
+            )
+        else:
+            w2 = scratch["w2"]
+            ext.reconstruct(w2, down.trellis, down.K, down.mcg, down.mul1)
+            down_out = scratch["down"][:n_rows]
+            ext.hgemm(h2, w2, down_out)
+            ext.had_r_128(down_out, down_out, None, down.svh, 1.0)
+            down_out.mul_(weight_sorted[start:offset].unsqueeze(-1))
+            out.index_add_(0, token_idx, down_out)
+    return out
+
 
 def build_exl3_fused_state(layer: torch.nn.Module, inners: list[dict[str, Any]]) -> None:
     """Pointer tables + fused temps, once after load. No per-token alloc."""
@@ -515,8 +759,9 @@ def apply_exl3_fused_moe(
     """One exl3_moe launch per layer when tokens or hottest expert fit temp rows.
 
     Cap is temps dim1 (`EXL3_TEMP_ROWS_FUSED`, default 128). Overflow uses GPU
-    row tiles if EXL3_MOE_ROW_TILE=1, else LinearEXL3 for fat experts only.
-    Decode (tokens ≤ cap) stays a single graph-safe launch: no .item() / .tolist().
+    row tiles if `EXL3_MOE_ROW_TILE=1`; otherwise fat experts use the highest
+    enabled tier: kernel implies batched, batched implies sorted, then legacy.
+    Decode (tokens ≤ cap) stays a single graph-safe launch.
     """
     import exllamav3_ext
 
@@ -557,42 +802,105 @@ def apply_exl3_fused_moe(
         )
         return out
 
-    # Prefill larger than temps: one extra sync to know the hottest expert.
+    # Prefill larger than temps. E1 copies routing counts on a side stream and
+    # launches thin experts immediately, overlapping the D2H synchronization.
     # Decode never reaches here (capture sizes << cap).
-    max_rows = int(counts.max().item())
-    if fat_expert_log_enabled():
-        record_exl3_fat_expert_stats(counts, max_rows=max_rows)
-
-    if max_rows <= cap:
+    want_fat_kernel = fat_kernel_enabled()
+    want_batched_fat = batched_fat_fallback_enabled() or want_fat_kernel
+    use_sorted_fat = sorted_fat_fallback_enabled() or want_batched_fat
+    use_batched_fat = (
+        want_batched_fat
+        and bool(getattr(layer, "_exl3_shared_w13_suh", False))
+    )
+    use_fat_kernel = use_batched_fat and want_fat_kernel
+    use_row_tiles = fused_moe_row_tile_enabled()
+    launched = False
+    counts_host = None
+    if use_batched_fat and not use_row_tiles:
+        counts_cpu, count_stream = _stage_counts_to_host(counts)
         _exl3_moe_launch(
             fn, xh, out, expert_count, token_sorted, weight_sorted,
             temps, ptrs, k, limit, n_active_host,
         )
+        launched = True
+        count_stream.synchronize()
+        counts_host = counts_cpu.tolist()
+    elif use_sorted_fat:
+        counts_host = counts.tolist()
+
+    max_rows = (
+        max(counts_host, default=0)
+        if counts_host is not None
+        else int(counts.max().item())
+    )
+    if fat_expert_log_enabled():
+        record_exl3_fat_expert_stats(
+            counts, max_rows=max_rows, counts_host=counts_host
+        )
+
+    if max_rows <= cap:
+        if not launched:
+            _exl3_moe_launch(
+                fn, xh, out, expert_count, token_sorted, weight_sorted,
+                temps, ptrs, k, limit, n_active_host,
+            )
         return out
 
-    if fused_moe_row_tile_enabled():
+    if use_row_tiles:
         _exl3_moe_row_tiles(
             fn, xh, out, counts, token_sorted, weight_sorted,
             temps, ptrs, k, limit, n_active_host, max_rows,
         )
         return out
 
-    _exl3_moe_launch(
-        fn, xh, out, expert_count, token_sorted, weight_sorted,
-        temps, ptrs, k, limit, n_active_host,
-    )
-    fat = (counts > cap).nonzero(as_tuple=False).view(-1)
-    if fat.numel():
-        apply_exl3_python_loop(
-            x2d,
-            ids,
-            weights,
-            inners,
-            expert_map,
-            limit,
-            only_experts=set(int(i) for i in fat.tolist()),
-            out=out,
+    if not launched:
+        _exl3_moe_launch(
+            fn, xh, out, expert_count, token_sorted, weight_sorted,
+            temps, ptrs, k, limit, n_active_host,
         )
+    if use_batched_fat:
+        layer._exl3_last_fat_fallback = (
+            "kernel" if use_fat_kernel else "batched"
+        )
+        assert counts_host is not None
+        apply_exl3_batched_fat(
+            xh,
+            token_sorted,
+            weight_sorted,
+            counts_host,
+            inners,
+            limit,
+            cap,
+            out,
+            use_kernel=use_fat_kernel,
+        )
+    elif use_sorted_fat:
+        layer._exl3_last_fat_fallback = "sorted"
+        assert counts_host is not None
+        apply_exl3_sorted_fat(
+            xh,
+            token_sorted,
+            weight_sorted,
+            counts_host,
+            inners,
+            limit,
+            cap,
+            out,
+        )
+    else:
+        layer._exl3_last_fat_fallback = "legacy"
+        fat = (counts > cap).nonzero(as_tuple=False).view(-1)
+        if fat.numel():
+            apply_exl3_python_loop(
+                x2d,
+                ids,
+                weights,
+                inners,
+                expert_map,
+                limit,
+                only_experts=set(int(i) for i in fat.tolist()),
+                out=out,
+            )
     return out
 
 
@@ -895,6 +1203,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             )
 
         n_exp = int(layer.w13_trellis.shape[0])
+        layer._exl3_shared_w13_suh = bool(
+            torch.equal(layer.w13_suh[:, 0], layer.w13_suh[:, 1])
+        )
         inners: list[dict[str, Any]] = []
         for e in range(n_exp):
             gate = make_linear_exl3(

--- a/overlay/exl3.py
+++ b/overlay/exl3.py
@@ -66,6 +66,78 @@ _FAT_STATS: dict[str, Any] = {
     "sum_max_rows": 0,
     "hist": [0] * (len(_FAT_BUCKET_EDGES) + 1),
 }
+_FAT_TIERS = ("kernel", "batched", "sorted", "legacy")
+# Machine-checkable E2 (fat-expert) diagnostics. Load-time fields mirror the
+# most recent weight load; counters are monotonic per process and are the
+# ground truth for what actually ran. The key set is contract — extend it only
+# together with a bump of EXL3_FAT_DIAG_SCHEMA.
+EXL3_FAT_DIAG_SCHEMA = 1
+EXL3_FAT_DIAG_KEYS = (
+    "schema",
+    "configured_tier",
+    "effective_tier",
+    "tier_reason",
+    "shared_suh",
+    "shared_suh_layers",
+    "moe_layers_loaded",
+    "sym_exl3_moe",
+    "sym_fat_gemm",
+    "sym_fat_gemm_scatter",
+    "cap_major",
+    "cap_minor",
+    "cap_ok",
+    "tp_rank",
+    "tp_size",
+    "fused_temps_allocs",
+    "fused_temps_bytes",
+    "fat_scratch_allocs",
+    "fat_scratch_bytes",
+    "fat_scratch_peak_bytes",
+    "prefill_layer_calls",
+    "thin_calls",
+    "row_tile_calls",
+    "fallback_calls",
+    "fallback_reasons",
+    "fat_expert_runs",
+    "direct_calls",
+    "scatter_calls",
+    "fat_stat_layers",
+    "fat_layers",
+    "fat_expert_slots",
+    "max_rows",
+)
+_EXL3_FAT_DIAG: dict[str, Any] = {
+    "schema": EXL3_FAT_DIAG_SCHEMA,
+    "configured_tier": "legacy",
+    "effective_tier": "legacy",
+    "tier_reason": "unresolved",
+    "shared_suh": False,
+    "shared_suh_layers": 0,
+    "moe_layers_loaded": 0,
+    "sym_exl3_moe": False,
+    "sym_fat_gemm": False,
+    "sym_fat_gemm_scatter": False,
+    "cap_major": -1,
+    "cap_minor": -1,
+    "cap_ok": False,
+    "tp_rank": -1,
+    "tp_size": 1,
+    "fused_temps_allocs": 0,
+    "fused_temps_bytes": 0,
+    "fat_scratch_allocs": 0,
+    "fat_scratch_bytes": 0,
+    "fat_scratch_peak_bytes": 0,
+    "prefill_layer_calls": 0,
+    "thin_calls": 0,
+    "row_tile_calls": 0,
+    "fallback_calls": {tier: 0 for tier in _FAT_TIERS},
+    "fallback_reasons": {},
+    "fat_expert_runs": 0,
+    "direct_calls": 0,
+    "scatter_calls": 0,
+}
+_FAT_SCRATCH_BYTES: dict[tuple, int] = {}
+_exl3_fat_tier_logged = False
 
 
 def fused_moe_row_tile_enabled() -> bool:
@@ -98,6 +170,236 @@ def fat_kernel_enabled() -> bool:
 
 def fat_expert_log_enabled() -> bool:
     return os.environ.get("EXL3_FAT_EXPERT_LOG", "1") != "0"
+
+def configured_fat_tier() -> str:
+    """Highest fat tier the env requests: kernel > batched > sorted > legacy."""
+    if fat_kernel_enabled():
+        return "kernel"
+    if batched_fat_fallback_enabled():
+        return "batched"
+    if sorted_fat_fallback_enabled():
+        return "sorted"
+    return "legacy"
+
+
+def exl3_fat_symbols() -> tuple[bool, bool, bool]:
+    """(exl3_moe, exl3_fat_gemm, exl3_fat_gemm_scatter) availability."""
+    try:
+        ext = load_exllamav3_ext()
+    except Exception:
+        return False, False, False
+    return (
+        hasattr(ext, "exl3_moe"),
+        hasattr(ext, "exl3_fat_gemm"),
+        hasattr(ext, "exl3_fat_gemm_scatter"),
+    )
+
+
+def exl3_device_capability() -> tuple[int, int]:
+    """CUDA capability of the current device; (-1, -1) without a GPU."""
+    if not torch.cuda.is_available():
+        return -1, -1
+    try:
+        return tuple(int(v) for v in torch.cuda.get_device_capability())
+    except Exception:
+        return -1, -1
+
+
+def _exl3_tp_rank_size() -> tuple[int, int]:
+    """TP identity so each rank's diag line is attributable; -1 outside vLLM."""
+    try:
+        from vllm.distributed import (
+            get_tensor_model_parallel_rank,
+            get_tensor_model_parallel_world_size,
+        )
+
+        return (
+            int(get_tensor_model_parallel_rank()),
+            int(get_tensor_model_parallel_world_size()),
+        )
+    except Exception:
+        return -1, 1
+
+
+def resolve_exl3_fat_tier(
+    shared_suh: bool,
+    symbols: tuple[bool, bool, bool] | None = None,
+) -> tuple[str, str]:
+    """Map the configured fat tier onto what this image + checkpoint can run.
+
+    Order matters: the checkpoint cap comes first. E1 batched and the E2
+    kernel run gate+up as one stacked GEMM behind a single input Hadamard
+    (gate.suh), so a checkpoint without shared SUH caps the tier at sorted —
+    a legitimate lower tier that needs no fat symbols, whatever the image.
+    Only when the kernel would actually run does a missing symbol become an
+    image/flag mismatch, failing closed here at load instead of mid-prefill.
+    """
+    configured = configured_fat_tier()
+    if configured == "legacy":
+        return configured, "none_requested"
+    if not shared_suh and configured in ("kernel", "batched"):
+        return "sorted", "shared_suh_absent"
+    if symbols is None:
+        symbols = exl3_fat_symbols()
+    if configured == "kernel":
+        missing = [
+            name
+            for name, present in zip(
+                ("exl3_fat_gemm", "exl3_fat_gemm_scatter"), symbols[1:]
+            )
+            if not present
+        ]
+        if missing:
+            raise RuntimeError(
+                "EXL3_FAT_KERNEL=1 requires exllamav3_ext."
+                + "/".join(missing)
+                + "; this image was built without the fat kernel — unset "
+                "EXL3_FAT_KERNEL or serve an E2 image"
+            )
+    return configured, f"{configured}_ok"
+
+
+def exl3_fat_diag() -> dict[str, Any]:
+    """Snapshot of the E2 diagnostics; the key set is EXL3_FAT_DIAG_KEYS."""
+    diag = dict(_EXL3_FAT_DIAG)
+    diag["fallback_calls"] = dict(_EXL3_FAT_DIAG["fallback_calls"])
+    diag["fallback_reasons"] = dict(_EXL3_FAT_DIAG["fallback_reasons"])
+    diag.update(
+        fat_stat_layers=_FAT_STATS["layers"],
+        fat_layers=_FAT_STATS["fat_layers"],
+        fat_expert_slots=_FAT_STATS["fat_experts"],
+        max_rows=_FAT_STATS["max_rows"],
+    )
+    return diag
+
+
+def _exl3_fat_diag_line() -> str:
+    d = exl3_fat_diag()
+    parts = [
+        f"schema={d['schema']}",
+        f"configured_tier={d['configured_tier']}",
+        f"effective_tier={d['effective_tier']}",
+        f"tier_reason={d['tier_reason']}",
+        f"shared_suh={int(d['shared_suh'])}",
+        f"shared_suh_layers={d['shared_suh_layers']}/{d['moe_layers_loaded']}",
+        f"sym_exl3_moe={int(d['sym_exl3_moe'])}",
+        f"sym_fat_gemm={int(d['sym_fat_gemm'])}",
+        f"sym_fat_gemm_scatter={int(d['sym_fat_gemm_scatter'])}",
+        f"cap={d['cap_major']}.{d['cap_minor']}",
+        f"cap_ok={int(d['cap_ok'])}",
+        f"tp_rank={d['tp_rank']} tp_size={d['tp_size']}",
+        f"prefill_layer_calls={d['prefill_layer_calls']}",
+        f"thin_calls={d['thin_calls']}",
+        f"row_tile_calls={d['row_tile_calls']}",
+        "fallback_calls="
+        + ",".join(f"{t}={d['fallback_calls'][t]}" for t in _FAT_TIERS),
+        "fallback_reasons="
+        + (
+            ",".join(f"{r}={n}" for r, n in sorted(d["fallback_reasons"].items()))
+            or "none"
+        ),
+        f"fat_expert_runs={d['fat_expert_runs']}",
+        f"direct_calls={d['direct_calls']}",
+        f"scatter_calls={d['scatter_calls']}",
+        f"fat_layers={d['fat_layers']}",
+        f"fat_expert_slots={d['fat_expert_slots']}",
+        f"max_rows={d['max_rows']}",
+        f"fused_temps_allocs={d['fused_temps_allocs']}",
+        f"fused_temps_bytes={d['fused_temps_bytes']}",
+        f"fat_scratch_allocs={d['fat_scratch_allocs']}",
+        f"fat_scratch_bytes={d['fat_scratch_bytes']}",
+        f"fat_scratch_peak_bytes={d['fat_scratch_peak_bytes']}",
+    ]
+    return " ".join(parts)
+
+
+def _record_exl3_fat_reason(reason: str) -> None:
+    reasons = _EXL3_FAT_DIAG["fallback_reasons"]
+    reasons[reason] = reasons.get(reason, 0) + 1
+
+
+def _record_exl3_fat_tier(layer: torch.nn.Module, tier: str, reason: str) -> None:
+    _EXL3_FAT_DIAG["fallback_calls"][tier] += 1
+    _record_exl3_fat_reason(reason)
+    layer._exl3_last_fat_fallback = tier
+    layer._exl3_last_fat_reason = reason
+
+
+def _record_exl3_fat_resolution(layer: torch.nn.Module) -> None:
+    """Resolve the E2 tier once per MoE layer at weight load and log once.
+
+    Per-layer truth lands on layer._exl3_fat_effective_tier; the module state
+    mirrors the most recent load. A resolution that changes between layers of
+    one model is a checkpoint property worth a loud line, not a silent one.
+    """
+    global _exl3_fat_tier_logged
+    shared_suh = bool(getattr(layer, "_exl3_shared_w13_suh", False))
+    effective_tier, tier_reason = resolve_exl3_fat_tier(shared_suh)
+    layer._exl3_fat_effective_tier = effective_tier
+    layer._exl3_fat_tier_reason = tier_reason
+
+    diag = _EXL3_FAT_DIAG
+    sym_moe, sym_gemm, sym_scatter = exl3_fat_symbols()
+    cap_major, cap_minor = exl3_device_capability()
+    diag["moe_layers_loaded"] += 1
+    if shared_suh:
+        diag["shared_suh_layers"] += 1
+    diag["shared_suh"] = diag["shared_suh_layers"] == diag["moe_layers_loaded"]
+    diag["configured_tier"] = configured_fat_tier()
+    diag["sym_exl3_moe"] = sym_moe
+    diag["sym_fat_gemm"] = sym_gemm
+    diag["sym_fat_gemm_scatter"] = sym_scatter
+    diag["cap_major"] = cap_major
+    diag["cap_minor"] = cap_minor
+    # LinearEXL3 (and the fat GEMM built on it) needs >= Ampere; GB10 is SM121.
+    diag["cap_ok"] = (cap_major, cap_minor) >= (8, 0)
+    diag["tp_rank"], diag["tp_size"] = _exl3_tp_rank_size()
+
+    if diag["tier_reason"] == "unresolved":
+        diag["effective_tier"] = effective_tier
+        diag["tier_reason"] = tier_reason
+    elif diag["effective_tier"] != effective_tier:
+        logger.warning(
+            "exl3 e2 diag tier changed %s -> %s (%s): %s",
+            diag["effective_tier"],
+            effective_tier,
+            tier_reason,
+            _exl3_fat_diag_line(),
+        )
+        diag["effective_tier"] = effective_tier
+        diag["tier_reason"] = tier_reason
+    if not _exl3_fat_tier_logged:
+        _exl3_fat_tier_logged = True
+        if (
+            diag["effective_tier"] != diag["configured_tier"]
+            and diag["configured_tier"] != "legacy"
+        ):
+            logger.warning("exl3 e2 diag degraded %s", _exl3_fat_diag_line())
+        else:
+            logger.info("exl3 e2 diag %s", _exl3_fat_diag_line())
+
+
+def reset_exl3_fat_diag_counters() -> None:
+    """Zero the E2 runtime counters; load-time fields and live bytes stay.
+
+    Scratch current/peak restart from the resident cache so a windowed read
+    (e.g. exactly one cold request) still reports honest byte counts.
+    """
+    diag = _EXL3_FAT_DIAG
+    for key in (
+        "prefill_layer_calls",
+        "thin_calls",
+        "row_tile_calls",
+        "fat_expert_runs",
+        "direct_calls",
+        "scatter_calls",
+        "fat_scratch_allocs",
+    ):
+        diag[key] = 0
+    diag["fallback_calls"] = {tier: 0 for tier in _FAT_TIERS}
+    diag["fallback_reasons"] = {}
+    diag["fat_scratch_bytes"] = sum(_FAT_SCRATCH_BYTES.values())
+    diag["fat_scratch_peak_bytes"] = diag["fat_scratch_bytes"]
 
 
 def reset_exl3_fat_expert_stats() -> None:
@@ -159,6 +461,7 @@ def record_exl3_fat_expert_stats(
             gt128,
             st["hist"],
         )
+        logger.info("exl3 e2 diag %s", _exl3_fat_diag_line())
     return {
         "max_rows": max_rows,
         "n_fat": n_fat,
@@ -396,6 +699,7 @@ def apply_exl3_sorted_fat(
         offset += n_rows
         if n_rows <= cap:
             continue
+        _EXL3_FAT_DIAG["fat_expert_runs"] += 1
         token_idx = token_sorted[start:offset]
         h = xh.index_select(0, token_idx)
         pack = inners[e]
@@ -477,6 +781,14 @@ def _fat_scratch(
         ),
     }
     _FAT_SCRATCH_CACHE[key] = scratch
+    _FAT_SCRATCH_BYTES[key] = sum(
+        t.numel() * t.element_size() for t in scratch.values()
+    )
+    diag = _EXL3_FAT_DIAG
+    diag["fat_scratch_allocs"] += 1
+    diag["fat_scratch_bytes"] = sum(_FAT_SCRATCH_BYTES.values())
+    if diag["fat_scratch_bytes"] > diag["fat_scratch_peak_bytes"]:
+        diag["fat_scratch_peak_bytes"] = diag["fat_scratch_bytes"]
     return scratch
 
 
@@ -520,6 +832,7 @@ def apply_exl3_batched_fat(
         offset += n_rows
         if n_rows <= cap:
             continue
+        _EXL3_FAT_DIAG["fat_expert_runs"] += 1
 
         token_idx = token_sorted[start:offset]
         gate = inners[e]["gate"]
@@ -549,6 +862,7 @@ def apply_exl3_batched_fat(
             ext.exl3_fat_gemm(
                 h13, packed13, gate_up, svh13, gate.K, gate.mcg, gate.mul1
             )
+            _EXL3_FAT_DIAG["direct_calls"] += 1
         else:
             w13 = scratch["w13"]
             ext.reconstruct(w13, packed13, gate.K, gate.mcg, gate.mul1)
@@ -584,6 +898,7 @@ def apply_exl3_batched_fat(
                 down.mcg,
                 down.mul1,
             )
+            _EXL3_FAT_DIAG["scatter_calls"] += 1
         else:
             w2 = scratch["w2"]
             ext.reconstruct(w2, down.trellis, down.K, down.mcg, down.mul1)
@@ -637,6 +952,11 @@ def build_exl3_fused_state(layer: torch.nn.Module, inners: list[dict[str, Any]])
             torch.empty((concurrency, rows, intermediate), dtype=torch.float16, device=device),
         )
         _FUSED_TEMP_CACHE[key] = temps
+        _EXL3_FAT_DIAG["fused_temps_allocs"] += 1
+    # Layers share one cache entry, so assign (never accumulate) the bytes.
+    _EXL3_FAT_DIAG["fused_temps_bytes"] = sum(
+        t.numel() * t.element_size() for t in temps
+    )
     layer._exl3_fused_temps = temps
     layer._exl3_fused_concurrency = concurrency
     layer._exl3_k = int(layer._exl3_bits)
@@ -795,6 +1115,11 @@ def apply_exl3_fused_moe(
     # Actual kernel cap is the allocated temp dim1 (env-selected at load).
     cap = int(temps[0].shape[1])
 
+    # Reset per call so a "kernel" label from an earlier prefill cannot
+    # masquerade through later decode/thin/row-tile calls.
+    layer._exl3_last_fat_fallback = "none"
+    layer._exl3_last_fat_reason = "no_fat_experts"
+
     if tokens <= cap:
         _exl3_moe_launch(
             fn, xh, out, expert_count, token_sorted, weight_sorted,
@@ -805,6 +1130,7 @@ def apply_exl3_fused_moe(
     # Prefill larger than temps. E1 copies routing counts on a side stream and
     # launches thin experts immediately, overlapping the D2H synchronization.
     # Decode never reaches here (capture sizes << cap).
+    _EXL3_FAT_DIAG["prefill_layer_calls"] += 1
     want_fat_kernel = fat_kernel_enabled()
     want_batched_fat = batched_fat_fallback_enabled() or want_fat_kernel
     use_sorted_fat = sorted_fat_fallback_enabled() or want_batched_fat
@@ -837,8 +1163,9 @@ def apply_exl3_fused_moe(
         record_exl3_fat_expert_stats(
             counts, max_rows=max_rows, counts_host=counts_host
         )
-
     if max_rows <= cap:
+        _EXL3_FAT_DIAG["thin_calls"] += 1
+        _record_exl3_fat_reason("thin_only")
         if not launched:
             _exl3_moe_launch(
                 fn, xh, out, expert_count, token_sorted, weight_sorted,
@@ -847,6 +1174,10 @@ def apply_exl3_fused_moe(
         return out
 
     if use_row_tiles:
+        _EXL3_FAT_DIAG["row_tile_calls"] += 1
+        layer._exl3_last_fat_fallback = "row_tile"
+        layer._exl3_last_fat_reason = "row_tile_preempts_fat"
+        _record_exl3_fat_reason("row_tile_preempts_fat")
         _exl3_moe_row_tiles(
             fn, xh, out, counts, token_sorted, weight_sorted,
             temps, ptrs, k, limit, n_active_host, max_rows,
@@ -859,9 +1190,10 @@ def apply_exl3_fused_moe(
             temps, ptrs, k, limit, n_active_host,
         )
     if use_batched_fat:
-        layer._exl3_last_fat_fallback = (
-            "kernel" if use_fat_kernel else "batched"
-        )
+        if use_fat_kernel:
+            _record_exl3_fat_tier(layer, "kernel", "kernel_ok")
+        else:
+            _record_exl3_fat_tier(layer, "batched", "batched_ok")
         assert counts_host is not None
         apply_exl3_batched_fat(
             xh,
@@ -875,7 +1207,11 @@ def apply_exl3_fused_moe(
             use_kernel=use_fat_kernel,
         )
     elif use_sorted_fat:
-        layer._exl3_last_fat_fallback = "sorted"
+        _record_exl3_fat_tier(
+            layer,
+            "sorted",
+            "degraded_shared_suh" if want_batched_fat else "sorted_ok",
+        )
         assert counts_host is not None
         apply_exl3_sorted_fat(
             xh,
@@ -888,7 +1224,7 @@ def apply_exl3_fused_moe(
             out,
         )
     else:
-        layer._exl3_last_fat_fallback = "legacy"
+        _record_exl3_fat_tier(layer, "legacy", "legacy_default")
         fat = (counts > cap).nonzero(as_tuple=False).view(-1)
         if fat.numel():
             apply_exl3_python_loop(
@@ -901,6 +1237,7 @@ def apply_exl3_fused_moe(
                 only_experts=set(int(i) for i in fat.tolist()),
                 out=out,
             )
+            _EXL3_FAT_DIAG["fat_expert_runs"] += int(fat.numel())
     return out
 
 
@@ -1206,6 +1543,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         layer._exl3_shared_w13_suh = bool(
             torch.equal(layer.w13_suh[:, 0], layer.w13_suh[:, 1])
         )
+        _record_exl3_fat_resolution(layer)
         inners: list[dict[str, Any]] = []
         for e in range(n_exp):
             gate = make_linear_exl3(

--- a/overlay/exl3_fat_gemm.cu
+++ b/overlay/exl3_fat_gemm.cu
@@ -1,0 +1,295 @@
+#include <cuda_fp16.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <ATen/cuda/CUDAContext.h>
+
+#include "../util.h"
+#include "../util.cuh"
+#include "../ptx.cuh"
+#include "exl3_dq.cuh"
+#include "hadamard_inner.cuh"
+#include "exl3_fat_gemm.cuh"
+
+namespace {
+
+constexpr int FAT_THREADS = 256;
+constexpr int FAT_TILE_M = 128;
+constexpr int FAT_TILE_K = 16;
+constexpr int FAT_TILE_N = 128;
+constexpr int FAT_M_BLOCKS = FAT_TILE_M / 16;
+constexpr int FAT_N_BLOCKS = FAT_TILE_N / 16;
+constexpr int FAT_PACKED_WORDS = 4 * 16;
+constexpr float HAD_SCALE = 0.088388347648f;
+
+__device__ inline void fat_had_ff_128(
+    const float* input_ptr,
+    float* output_ptr,
+    const half* scale)
+{
+    int lane = threadIdx.x & 31;
+    float4 v = reinterpret_cast<const float4*>(input_ptr)[lane];
+
+    float s0 = v.x + v.y;
+    float d0 = v.x - v.y;
+    float s1 = v.z + v.w;
+    float d1 = v.z - v.w;
+    v.x = s0 + s1;
+    v.y = d0 + d1;
+    v.z = s0 - s1;
+    v.w = d0 - d1;
+
+    shuffle_had_f2x32(v.x, v.y, lane);
+    shuffle_had_f2x32(v.z, v.w, lane);
+    v.x *= HAD_SCALE;
+    v.y *= HAD_SCALE;
+    v.z *= HAD_SCALE;
+    v.w *= HAD_SCALE;
+
+    half4 scales = reinterpret_cast<const half4*>(scale)[lane];
+    v.x *= __low2float(scales.x);
+    v.y *= __high2float(scales.x);
+    v.z *= __low2float(scales.y);
+    v.w *= __high2float(scales.y);
+    reinterpret_cast<float4*>(output_ptr)[lane] = v;
+}
+
+template <bool scatter>
+__global__ __launch_bounds__(FAT_THREADS)
+void exl3_fat_gemm_kernel(
+    const half* __restrict__ a,
+    const uint16_t* __restrict__ packed,
+    float* __restrict__ out,
+    const half* __restrict__ svh,
+    const int64_t* __restrict__ token_idx,
+    const half* __restrict__ route_weight,
+    int size_m,
+    int size_k,
+    int size_n)
+{
+    extern __shared__ unsigned char shared_raw[];
+    half* sh_a = reinterpret_cast<half*>(shared_raw);
+    uint16_t* sh_b = reinterpret_cast<uint16_t*>(sh_a + FAT_TILE_M * FAT_TILE_K);
+    float* sh_c = reinterpret_cast<float*>(sh_b + FAT_N_BLOCKS * FAT_PACKED_WORDS);
+
+    int t = threadIdx.x;
+    int warp = t / 32;
+    int lane = t & 31;
+    int m_base = blockIdx.y * FAT_TILE_M;
+    int n_base = blockIdx.x * FAT_TILE_N;
+    int tiles_n = size_n / 16;
+
+    FragC frag_c[FAT_M_BLOCKS][2];
+    #pragma unroll
+    for (int mb = 0; mb < FAT_M_BLOCKS; ++mb)
+    {
+        frag_c[mb][0] = {};
+        frag_c[mb][1] = {};
+    }
+
+    for (int k_block = 0; k_block < size_k / FAT_TILE_K; ++k_block)
+    {
+        int a_row = t / 2;
+        int a_col8 = t & 1;
+        int a_dst_col8 = a_col8 ^ ((a_row >> 2) & 1);
+        int4 a_value = {};
+        if (m_base + a_row < size_m)
+        {
+            const int4* a_src = reinterpret_cast<const int4*>(
+                a + (m_base + a_row) * size_k + k_block * FAT_TILE_K);
+            a_value = a_src[a_col8];
+        }
+        reinterpret_cast<int4*>(sh_a)[a_row * 2 + a_dst_col8] = a_value;
+
+        if (t < 64)
+        {
+            const int4* b_src = reinterpret_cast<const int4*>(
+                packed + (k_block * tiles_n + n_base / 16) * FAT_PACKED_WORDS);
+            reinterpret_cast<int4*>(sh_b)[t] = b_src[t];
+        }
+        __syncthreads();
+
+        FragB frag_b0;
+        FragB frag_b1;
+        const uint32_t* warp_b = reinterpret_cast<const uint32_t*>(
+            sh_b + warp * FAT_PACKED_WORDS);
+        dq_dispatch<4, 1>(warp_b, lane << 3, frag_b0, frag_b1);
+
+        #pragma unroll
+        for (int mb = 0; mb < FAT_M_BLOCKS; ++mb)
+        {
+            FragA frag_a;
+            int row = (lane % 8) + 8 * ((lane / 8) % 2) + mb * 16;
+            int base_col = lane / 16;
+            int swizzled_col = base_col ^ ((row >> 2) & 1);
+            ldsm4(frag_a, reinterpret_cast<int4*>(sh_a) + row * 2 + swizzled_col);
+            ptx_mma_m16n8k16(frag_a, frag_b0, frag_c[mb][0]);
+            ptx_mma_m16n8k16(frag_a, frag_b1, frag_c[mb][1]);
+        }
+        __syncthreads();
+    }
+
+    #pragma unroll
+    for (int mb = 0; mb < FAT_M_BLOCKS; ++mb)
+    {
+        int rows = min(16, size_m - (m_base + mb * 16));
+        if (rows <= 0) break;
+        int row0 = lane / 4;
+        int row1 = row0 + 8;
+        int col = (lane % 4) * 2;
+        int n0 = warp * 16;
+        if (row0 < rows)
+        {
+            float* dst0 = sh_c + row0 * FAT_TILE_N + n0 + col;
+            dst0[0] = frag_c[mb][0][0];
+            dst0[1] = frag_c[mb][0][1];
+            dst0[8] = frag_c[mb][1][0];
+            dst0[9] = frag_c[mb][1][1];
+        }
+        if (row1 < rows)
+        {
+            float* dst1 = sh_c + row1 * FAT_TILE_N + n0 + col;
+            dst1[0] = frag_c[mb][0][2];
+            dst1[1] = frag_c[mb][0][3];
+            dst1[8] = frag_c[mb][1][2];
+            dst1[9] = frag_c[mb][1][3];
+        }
+        __syncthreads();
+
+        for (int row = warp; row < rows; row += 8)
+        {
+            fat_had_ff_128(
+                sh_c + row * FAT_TILE_N,
+                sh_c + row * FAT_TILE_N,
+                svh + n_base);
+        }
+        __syncthreads();
+
+        for (int i = t; i < rows * FAT_TILE_N; i += FAT_THREADS)
+        {
+            int row = i / FAT_TILE_N;
+            int col_out = i % FAT_TILE_N;
+            int source_row = m_base + mb * 16 + row;
+            float value = sh_c[i];
+            if constexpr (scatter)
+            {
+                int64_t destination = token_idx[source_row];
+                value *= __half2float(route_weight[source_row]);
+                // One route per token reaches a given expert, and expert
+                // launches share this stream, so this accumulation is race-free.
+                out[destination * size_n + n_base + col_out] += value;
+            }
+            else
+            {
+                out[source_row * size_n + n_base + col_out] = value;
+            }
+        }
+        __syncthreads();
+    }
+}
+
+void check_common(
+    const at::Tensor& a,
+    const at::Tensor& packed,
+    const at::Tensor& out,
+    const at::Tensor& svh,
+    int64_t K,
+    bool mcg,
+    bool mul1)
+{
+    TORCH_CHECK(a.is_cuda() && packed.is_cuda() && out.is_cuda() && svh.is_cuda(),
+                "exl3_fat_gemm tensors must be CUDA tensors");
+    TORCH_CHECK(a.is_contiguous() && packed.is_contiguous() && out.is_contiguous() && svh.is_contiguous(),
+                "exl3_fat_gemm tensors must be contiguous");
+    TORCH_CHECK(a.scalar_type() == at::kHalf, "a must be float16");
+    TORCH_CHECK(packed.scalar_type() == at::kShort, "packed must be int16");
+    TORCH_CHECK(out.scalar_type() == at::kFloat, "out must be float32");
+    TORCH_CHECK(svh.scalar_type() == at::kHalf, "svh must be float16");
+    TORCH_CHECK(a.dim() == 2 && packed.dim() == 3 && out.dim() == 2 && svh.dim() == 1,
+                "exl3_fat_gemm expects rank-2/rank-3 tensors");
+    TORCH_CHECK(K == 4 && mcg && !mul1,
+                "exl3_fat_gemm currently supports only K4 MCG tensors");
+    TORCH_CHECK(a.size(1) == packed.size(0) * 16,
+                "a K dimension does not match packed tensor");
+    TORCH_CHECK(svh.numel() == packed.size(1) * 16,
+                "svh N dimension does not match packed tensor");
+    TORCH_CHECK(svh.numel() % FAT_TILE_N == 0,
+                "output dimension must be divisible by 128");
+    TORCH_CHECK(packed.size(2) == FAT_PACKED_WORDS,
+                "packed K4 block width must be 64 int16 words");
+    TORCH_CHECK(a.device() == packed.device() && a.device() == out.device() && a.device() == svh.device(),
+                "exl3_fat_gemm tensors must share a device");
+}
+
+template <bool scatter>
+void launch(
+    at::Tensor a,
+    at::Tensor packed,
+    at::Tensor out,
+    at::Tensor svh,
+    at::Tensor token_idx,
+    at::Tensor route_weight)
+{
+    const at::cuda::OptionalCUDAGuard device_guard(a.device());
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+    int size_m = static_cast<int>(a.size(0));
+    int size_k = static_cast<int>(a.size(1));
+    int size_n = static_cast<int>(svh.numel());
+    dim3 block(FAT_THREADS);
+    dim3 grid(size_n / FAT_TILE_N, (size_m + FAT_TILE_M - 1) / FAT_TILE_M);
+    size_t shared = FAT_TILE_M * FAT_TILE_K * sizeof(half)
+                  + FAT_N_BLOCKS * FAT_PACKED_WORDS * sizeof(uint16_t)
+                  + 16 * FAT_TILE_N * sizeof(float);
+    exl3_fat_gemm_kernel<scatter><<<grid, block, shared, stream>>>(
+        reinterpret_cast<const half*>(a.data_ptr()),
+        reinterpret_cast<const uint16_t*>(packed.data_ptr()),
+        reinterpret_cast<float*>(out.data_ptr()),
+        reinterpret_cast<const half*>(svh.data_ptr()),
+        scatter ? reinterpret_cast<const int64_t*>(token_idx.data_ptr()) : nullptr,
+        scatter ? reinterpret_cast<const half*>(route_weight.data_ptr()) : nullptr,
+        size_m,
+        size_k,
+        size_n);
+    cuda_check(cudaPeekAtLastError());
+}
+
+}  // namespace
+
+void exl3_fat_gemm(
+    at::Tensor a,
+    at::Tensor packed,
+    at::Tensor out,
+    at::Tensor svh,
+    int64_t K,
+    bool mcg,
+    bool mul1)
+{
+    check_common(a, packed, out, svh, K, mcg, mul1);
+    TORCH_CHECK(out.size(0) == a.size(0) && out.size(1) == svh.numel(),
+                "out shape must be [M, N]");
+    launch<false>(a, packed, out, svh, at::Tensor(), at::Tensor());
+}
+
+void exl3_fat_gemm_scatter(
+    at::Tensor a,
+    at::Tensor packed,
+    at::Tensor out,
+    at::Tensor svh,
+    at::Tensor token_idx,
+    at::Tensor route_weight,
+    int64_t K,
+    bool mcg,
+    bool mul1)
+{
+    check_common(a, packed, out, svh, K, mcg, mul1);
+    TORCH_CHECK(out.size(1) == svh.numel(), "out N dimension mismatch");
+    TORCH_CHECK(token_idx.is_cuda() && route_weight.is_cuda(),
+                "routing tensors must be CUDA tensors");
+    TORCH_CHECK(token_idx.is_contiguous() && route_weight.is_contiguous(),
+                "routing tensors must be contiguous");
+    TORCH_CHECK(token_idx.scalar_type() == at::kLong, "token_idx must be int64");
+    TORCH_CHECK(route_weight.scalar_type() == at::kHalf, "route_weight must be float16");
+    TORCH_CHECK(token_idx.numel() == a.size(0) && route_weight.numel() == a.size(0),
+                "routing tensors must have M elements");
+    TORCH_CHECK(token_idx.device() == a.device() && route_weight.device() == a.device(),
+                "routing tensors must share a device with a");
+    launch<true>(a, packed, out, svh, token_idx, route_weight);
+}

--- a/overlay/exl3_fat_gemm.cuh
+++ b/overlay/exl3_fat_gemm.cuh
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <torch/extension.h>
+
+void exl3_fat_gemm(
+    at::Tensor a,
+    at::Tensor packed,
+    at::Tensor out,
+    at::Tensor svh,
+    int64_t K,
+    bool mcg,
+    bool mul1);
+
+void exl3_fat_gemm_scatter(
+    at::Tensor a,
+    at::Tensor packed,
+    at::Tensor out,
+    at::Tensor svh,
+    at::Tensor token_idx,
+    at::Tensor route_weight,
+    int64_t K,
+    bool mcg,
+    bool mul1);

--- a/overlay/patch_exl3_fat_kernel.py
+++ b/overlay/patch_exl3_fat_kernel.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Install the additive EXL3 fat-GEMM source and pybind entries."""
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+
+def replace_once(text: str, old: str, new: str) -> str:
+    if text.count(old) != 1:
+        raise RuntimeError(f"expected exactly one binding anchor: {old!r}")
+    return text.replace(old, new, 1)
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: patch_exl3_fat_kernel.py EXLLAMAV3_EXT SOURCE_DIR")
+    ext_root = Path(sys.argv[1]).resolve()
+    source_dir = Path(sys.argv[2]).resolve()
+    quant = ext_root / "quant"
+    bindings = ext_root / "bindings.cpp"
+    if not quant.is_dir() or not bindings.is_file():
+        raise RuntimeError(f"invalid extension root: {ext_root}")
+
+    for name in ("exl3_fat_gemm.cu", "exl3_fat_gemm.cuh"):
+        source = source_dir / name
+        if not source.is_file():
+            raise RuntimeError(f"missing additive source: {source}")
+        shutil.copyfile(source, quant / name)
+
+    text = bindings.read_text()
+    text = replace_once(
+        text,
+        '#include "quant/exl3_moe.cuh"',
+        '#include "quant/exl3_moe.cuh"\n#include "quant/exl3_fat_gemm.cuh"',
+    )
+    text = replace_once(
+        text,
+        '    m.def("exl3_moe", &exl3_moe, "exl3_moe");',
+        '    m.def("exl3_moe", &exl3_moe, "exl3_moe");\n'
+        '    m.def("exl3_fat_gemm", &exl3_fat_gemm, "exl3_fat_gemm");\n'
+        '    m.def("exl3_fat_gemm_scatter", &exl3_fat_gemm_scatter, "exl3_fat_gemm_scatter");',
+    )
+    bindings.write_text(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/start.sh
+++ b/start.sh
@@ -62,6 +62,9 @@ _cli_eager="${ENFORCE_EAGER-}"
 _cli_fused="${EXL3_FUSED_MOE-}"
 _cli_row_tile="${EXL3_MOE_ROW_TILE-}"
 _cli_temp_rows="${EXL3_TEMP_ROWS_FUSED-}"
+_cli_fat_sorted="${EXL3_FAT_SORTED-}"
+_cli_fat_batched="${EXL3_FAT_BATCHED-}"
+_cli_fat_kernel="${EXL3_FAT_KERNEL-}"
 _cli_mnbt="${MAX_NUM_BATCHED_TOKENS-}"
 _cli_image="${IMAGE-}"
 _cli_util="${GPU_MEM_UTIL-}"
@@ -83,6 +86,9 @@ set +a
 [ -n "${_cli_fused}" ] && EXL3_FUSED_MOE="$_cli_fused"
 [ -n "${_cli_row_tile}" ] && EXL3_MOE_ROW_TILE="$_cli_row_tile"
 [ -n "${_cli_temp_rows}" ] && EXL3_TEMP_ROWS_FUSED="$_cli_temp_rows"
+[ -n "${_cli_fat_sorted}" ] && EXL3_FAT_SORTED="$_cli_fat_sorted"
+[ -n "${_cli_fat_batched}" ] && EXL3_FAT_BATCHED="$_cli_fat_batched"
+[ -n "${_cli_fat_kernel}" ] && EXL3_FAT_KERNEL="$_cli_fat_kernel"
 [ -n "${_cli_mnbt}" ] && MAX_NUM_BATCHED_TOKENS="$_cli_mnbt"
 [ -n "${_cli_image}" ] && IMAGE="$_cli_image"
 [ -n "${_cli_util}" ] && GPU_MEM_UTIL="$_cli_util"
@@ -208,6 +214,13 @@ EXL3_FUSED_MOE="${EXL3_FUSED_MOE:-1}"
 EXL3_MOE_ROW_TILE="${EXL3_MOE_ROW_TILE:-0}"
 # Fused exl3_moe temp rows/expert. 1024 was slower than 128+fallback (P2b).
 EXL3_TEMP_ROWS_FUSED="${EXL3_TEMP_ROWS_FUSED:-128}"
+# Sorted routing tier; higher tiers imply it even when this is 0.
+# All three flags default off; set every flag to 0 for instant rollback.
+EXL3_FAT_SORTED="${EXL3_FAT_SORTED:-0}"
+# E1 batched tier: persistent scratch + combined gate/up; implies SORTED=1.
+EXL3_FAT_BATCHED="${EXL3_FAT_BATCHED:-0}"
+# E2 direct trellis kernel; implies BATCHED=1 and SORTED=1.
+EXL3_FAT_KERNEL="${EXL3_FAT_KERNEL:-0}"
 
 # --- abliteration (ablit/) --------------------------------------------------
 # Load-time o_proj orthogonalization (overlay/ablit_runtime.py). Published
@@ -1096,7 +1109,7 @@ launch_cluster() {
              KV_CACHE_DTYPE MTP_TOKENS SPEC_METHOD DFLASH_TOKENS DFLASH_MODEL_DIR \
              DFLASH_DRAFT_TP \
              LANGUAGE_MODEL_ONLY SKIP_MM_PROFILING \
-             LIMIT_MM CHAT_TEMPLATE ENFORCE_EAGER EXL3_FUSED_MOE EXL3_MOE_ROW_TILE EXL3_TEMP_ROWS_FUSED MODEL_DIR EXTRA_ARGS \
+             LIMIT_MM CHAT_TEMPLATE ENFORCE_EAGER EXL3_FUSED_MOE EXL3_MOE_ROW_TILE EXL3_TEMP_ROWS_FUSED EXL3_FAT_SORTED EXL3_FAT_BATCHED EXL3_FAT_KERNEL MODEL_DIR EXTRA_ARGS \
              ABLIT ABLIT_METHOD ABLIT_DIRECTION ABLIT_LAYERS ABLIT_ALPHA ABLIT_INCLUDE_MTP; do
         serve_env+=" -e $v='${!v:-}'"
     done
@@ -1186,6 +1199,9 @@ launch_cluster() {
         -e EXL3_FUSED_MOE="$EXL3_FUSED_MOE" \
         -e EXL3_MOE_ROW_TILE="$EXL3_MOE_ROW_TILE" \
         -e EXL3_TEMP_ROWS_FUSED="$EXL3_TEMP_ROWS_FUSED" \
+        -e EXL3_FAT_SORTED="$EXL3_FAT_SORTED" \
+        -e EXL3_FAT_BATCHED="$EXL3_FAT_BATCHED" \
+        -e EXL3_FAT_KERNEL="$EXL3_FAT_KERNEL" \
         -e ABLIT="$ABLIT" \
         -e ABLIT_METHOD="$ABLIT_METHOD" \
         -e ABLIT_DIRECTION="$ABLIT_DIRECTION" \

--- a/start.sh
+++ b/start.sh
@@ -21,8 +21,10 @@
 #                   worker is missing that digest, try docker pull there,
 #                   then fall back to docker save --platform | ssh docker
 #                   load (issue #8). SKIP_PULL=1 keeps a local copy.
-#                   BUILD=1 rebuilds from this repo instead. Local-only
-#                   tags (no slash) skip pull. SKIP_SHIP=1 never copies.
+#                   BUILD=1 rebuilds from this repo. A git pull that changes
+#                   Dockerfile/overlay also rebuilds once (recipe stamp);
+#                   SKIP_BUILD=1 keeps GHCR. Local-only tags (no slash) skip
+#                   pull. SKIP_SHIP=1 never copies.
 #   3. download   — EXL3/TR3 (+ DFlash2) into the local HF cache if missing
 #   4. sync       — rsync that cache to the worker (each rank loads local disk)
 #   5. launch     — worker --headless, then head + `vllm serve` (both
@@ -41,7 +43,7 @@
 #   ./start.sh logs worker        follow worker container logs
 #
 # Node IPs live in .env (copied from .env.example on first run).
-# Handy overrides: SKIP_DOWNLOAD=1 SKIP_SYNC=1 SKIP_PULL=1 SKIP_SHIP=1 PULL=1 BUILD=1 TAIL=1 HF_TOKEN=...
+# Handy overrides: SKIP_DOWNLOAD=1 SKIP_SYNC=1 SKIP_PULL=1 SKIP_SHIP=1 SKIP_BUILD=1 PULL=1 BUILD=1 TAIL=1 HF_TOKEN=...
 # ============================================================================
 set -euo pipefail
 
@@ -170,8 +172,8 @@ MAX_MODEL_LEN="${MAX_MODEL_LEN:-1000000}"
 GPU_MEM_UTIL="${GPU_MEM_UTIL:-0.87}"
 MAX_NUM_SEQS="${MAX_NUM_SEQS:-4}"
 # 8192 chunk × long history oversubscribes GB10 persistent_topk smem (300k crash).
-# P1 ladder 2026-08-29: 2048 keep; 3584/4096 revert (fat LinearEXL3 tax).
-MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-2048}"
+# E2 one-shot 2026-09-01: 7168 keep (100k ~1148 / 300k ~1107); 2048/3548 similar or slower.
+MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-7168}"
 CHAT_TEMPLATE_HOST="${CHAT_TEMPLATE_HOST:-$SCRIPT_DIR/files/chat_template.jinja}"
 CHAT_TEMPLATE="${CHAT_TEMPLATE:-/opt/glm53/chat_template.jinja}"
 VIDEO_PATCH_HOST="${VIDEO_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm_video_placeholders.py}"
@@ -215,12 +217,13 @@ EXL3_MOE_ROW_TILE="${EXL3_MOE_ROW_TILE:-0}"
 # Fused exl3_moe temp rows/expert. 1024 was slower than 128+fallback (P2b).
 EXL3_TEMP_ROWS_FUSED="${EXL3_TEMP_ROWS_FUSED:-128}"
 # Sorted routing tier; higher tiers imply it even when this is 0.
-# All three flags default off; set every flag to 0 for instant rollback.
 EXL3_FAT_SORTED="${EXL3_FAT_SORTED:-0}"
 # E1 batched tier: persistent scratch + combined gate/up; implies SORTED=1.
 EXL3_FAT_BATCHED="${EXL3_FAT_BATCHED:-0}"
-# E2 direct trellis kernel; implies BATCHED=1 and SORTED=1.
-EXL3_FAT_KERNEL="${EXL3_FAT_KERNEL:-0}"
+# E2 direct trellis kernel (default on). Implies BATCHED=1 and SORTED=1.
+# Needs the patched extension — start.sh rebuilds when the recipe stamp drifts.
+# Set all three flags to 0 for the legacy fat-expert path.
+EXL3_FAT_KERNEL="${EXL3_FAT_KERNEL:-1}"
 
 # --- abliteration (ablit/) --------------------------------------------------
 # Load-time o_proj orthogonalization (overlay/ablit_runtime.py). Published
@@ -527,9 +530,35 @@ image_platform() {
     printf '%s' "${p:-linux/arm64}"
 }
 
+# Hash of Dockerfile + overlay/tests/files/ablit inputs that docker COPY.
+# Compared to LABEL glm53.recipe.stamp so a git pull rebuilds once.
+overlay_recipe_hash() {
+    {
+        printf '%s\n' "$SCRIPT_DIR/Dockerfile"
+        find "$SCRIPT_DIR/overlay" "$SCRIPT_DIR/files" "$SCRIPT_DIR/tests" \
+            "$SCRIPT_DIR/ablit" \
+            -type f \
+            ! -path '*/__pycache__/*' \
+            ! -path '*/ablit/transplant/*' \
+            ! -name '*.pyc' \
+            2>/dev/null
+    } | LC_ALL=C sort | xargs -d '\n' -r sha256sum | sha256sum | awk '{print $1}'
+}
+
+image_recipe_stamp() {
+    local stamp
+    stamp="$(docker image inspect -f '{{ index .Config.Labels "glm53.recipe.stamp" }}' "$IMAGE" 2>/dev/null || true)"
+    case "$stamp" in
+        ""|"<no value>"|"<nil>") printf '' ;;
+        *) printf '%s' "$stamp" ;;
+    esac
+}
+
 build_image() {
-    log "building ${IMAGE} from Dockerfile (log: $LOGDIR/build-sm121.log) ..."
-    docker build -t "$IMAGE" "$SCRIPT_DIR" \
+    local stamp
+    stamp="$(overlay_recipe_hash)"
+    log "building ${IMAGE} from Dockerfile stamp=${stamp:0:12} (log: $LOGDIR/build-sm121.log) ..."
+    docker build --build-arg "GLM53_RECIPE_STAMP=$stamp" -t "$IMAGE" "$SCRIPT_DIR" \
         >"$LOGDIR/build-sm121.log" 2>&1 \
         || { tail -n 40 "$LOGDIR/build-sm121.log" >&2; die "docker build of $IMAGE failed"; }
 }
@@ -541,7 +570,7 @@ pull_image() {
     die "docker pull ${IMAGE} failed.
   :exl3 is a public GHCR package — check network / disk.
   If you still get 401/403: echo YOUR_PAT | docker login ghcr.io -u YOUR_GITHUB_USER --password-stdin
-  Or set GHCR_TOKEN + GHCR_USER in .env. Overlay rebuild: BUILD=1 ./start.sh"
+  Overlay rebuild: BUILD=1 ./start.sh. Recipe-stamp drift also rebuilds; SKIP_BUILD=1 keeps GHCR."
 }
 
 pull_image_on_worker() {
@@ -583,6 +612,18 @@ ensure_image() {
     fi
     local skip_pull="${SKIP_PULL:-0}"
     [ "${PULL:-0}" = "1" ] && skip_pull=0
+    local wanted_stamp have_stamp
+    wanted_stamp="$(overlay_recipe_hash)"
+    have_stamp=""
+    [ "$head_ok" = "1" ] && have_stamp="$(image_recipe_stamp)"
+    if [ "${BUILD:-0}" != "1" ] && [ "${SKIP_BUILD:-0}" != "1" ]; then
+        if [ "$head_ok" = "0" ] || [ "$have_stamp" != "$wanted_stamp" ]; then
+            log "image recipe ${have_stamp:-none} != repo ${wanted_stamp:0:12} — rebuilding (SKIP_BUILD=1 keeps GHCR)"
+            BUILD=1
+        fi
+    elif [ "${SKIP_BUILD:-0}" = "1" ] && [ "$have_stamp" != "$wanted_stamp" ]; then
+        warn "SKIP_BUILD=1 — not rebuilding; stamp ${have_stamp:-none} != repo ${wanted_stamp:0:12}"
+    fi
     if [ "${BUILD:-0}" = "1" ]; then
         build_image
         head_key="$(local_image_key)"

--- a/tests/test_exl3_overlay.py
+++ b/tests/test_exl3_overlay.py
@@ -118,10 +118,103 @@ def _check_gpu_gemm() -> None:
         f"finite mean={float(y.mean()):.4f}",
         flush=True,
     )
+    _check_fat_kernel(device)
     _check_fused_vs_loop(device)
     _check_fused_fat_and_row_tile(device)
+    _check_mixed_thin_fat(device)
     _check_apply_expert_map(device)
     _check_fused_cudagraph(device)
+
+
+
+def _check_fat_kernel(device) -> None:
+    """Compare E2 direct and scatter epilogues with LinearEXL3 reconstruction."""
+    import exllamav3_ext
+    import torch
+    from vllm.model_executor.layers.quantization.exl3 import (
+        MCG_MARKER_SIGNED_INT32,
+        execute_exl3_linear,
+    )
+
+    if not hasattr(exllamav3_ext, "exl3_fat_gemm"):
+        print("exl3 E2 fat kernel absent (E1 image)", flush=True)
+        return
+    assert hasattr(exllamav3_ext, "exl3_fat_gemm_scatter")
+
+    rows = 145
+    in_f = out_f = 256
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(41)
+    trellis = torch.randint(
+        -30000,
+        30000,
+        (in_f // 16, out_f // 16, 4 * 16),
+        dtype=torch.int16,
+        generator=generator,
+    ).to(device)
+    suh = torch.where(
+        torch.rand(in_f, generator=generator) > 0.5,
+        torch.tensor(1.0),
+        torch.tensor(-1.0),
+    ).half().to(device)
+    svh = torch.where(
+        torch.rand(out_f, generator=generator) > 0.5,
+        torch.tensor(1.0),
+        torch.tensor(-1.0),
+    ).half().to(device)
+    mcg = torch.tensor(
+        [MCG_MARKER_SIGNED_INT32], dtype=torch.int32, device=device
+    )
+    x = torch.randn(rows, in_f, dtype=torch.float16, device=device)
+    reference = execute_exl3_linear(
+        x, trellis, suh, svh, mcg, out_dtype=torch.float32
+    )
+    xh = torch.empty_like(x)
+    exllamav3_ext.had_r_128(x, xh, suh, None, 1.0)
+    direct = torch.empty(rows, out_f, dtype=torch.float32, device=device)
+    exllamav3_ext.exl3_fat_gemm(
+        xh, trellis, direct, svh, 4, True, False
+    )
+
+    bound = max(
+        0.15, 0.08 * float(reference.float().abs().max().clamp_min(1.0))
+    )
+    direct_err = float((reference - direct).abs().max())
+    assert torch.isfinite(direct).all()
+    assert direct_err < bound, (
+        f"E2 direct vs reconstruct maxabs={direct_err} bound={bound}"
+    )
+
+    token_idx = torch.randperm(rows + 17, device=device)[:rows].contiguous()
+    route_weight = torch.rand(rows, dtype=torch.float16, device=device)
+    expected = torch.zeros(
+        rows + 17, out_f, dtype=torch.float32, device=device
+    )
+    expected.index_add_(
+        0, token_idx, reference * route_weight.float().unsqueeze(-1)
+    )
+    scattered = torch.zeros_like(expected)
+    exllamav3_ext.exl3_fat_gemm_scatter(
+        xh,
+        trellis,
+        scattered,
+        svh,
+        token_idx,
+        route_weight,
+        4,
+        True,
+        False,
+    )
+    scatter_err = float((expected - scattered).abs().max())
+    assert torch.isfinite(scattered).all()
+    assert scatter_err < bound, (
+        f"E2 scatter vs reconstruct maxabs={scatter_err} bound={bound}"
+    )
+    print(
+        f"exl3 E2 direct/scatter parity OK rows={rows} "
+        f"direct={direct_err:.5f} scatter={scatter_err:.5f} bound={bound:.5f}",
+        flush=True,
+    )
 
 
 def _tiny_layer(device, n_exp: int = 3, hidden: int = 256, inter: int = 256):
@@ -157,6 +250,7 @@ def _tiny_layer(device, n_exp: int = 3, hidden: int = 256, inter: int = 256):
         layer.w13_svh.copy_(torch.randn(tuple(layer.w13_svh.shape), generator=g).half())
         layer.w2_suh.copy_(torch.randn(tuple(layer.w2_suh.shape), generator=g).half())
         layer.w2_svh.copy_(torch.randn(tuple(layer.w2_svh.shape), generator=g).half())
+        layer.w13_suh[:, 1].copy_(layer.w13_suh[:, 0])
         layer.w13_mcg.fill_(MCG_MARKER_SIGNED_INT32)
         layer.w2_mcg.fill_(MCG_MARKER_SIGNED_INT32)
     layer = layer.to(device)
@@ -191,7 +285,7 @@ def _check_fused_vs_loop(device) -> None:
 
 
 def _check_fused_fat_and_row_tile(device) -> None:
-    """T > TEMP_ROWS_FUSED: fallback loop vs GPU row tiles vs unique-expert loop."""
+    """T > temp rows: isolated fat tiers and row tiles match the full loop."""
     import os
 
     import torch
@@ -201,6 +295,9 @@ def _check_fused_fat_and_row_tile(device) -> None:
     )
 
     prev_tile = os.environ.get("EXL3_MOE_ROW_TILE")
+    prev_sorted = os.environ.get("EXL3_FAT_SORTED")
+    prev_batched = os.environ.get("EXL3_FAT_BATCHED")
+    prev_kernel = os.environ.get("EXL3_FAT_KERNEL")
     prev_log = os.environ.get("EXL3_FAT_EXPERT_LOG")
     prev_rows = os.environ.get("EXL3_TEMP_ROWS_FUSED")
     os.environ["EXL3_FAT_EXPERT_LOG"] = "1"
@@ -210,18 +307,64 @@ def _check_fused_fat_and_row_tile(device) -> None:
         del method
         tokens = 128 + 32
         x = torch.randn(tokens, 256, dtype=torch.float16, device=device)
-        # All rows hit expert 0 so count[0] = tokens > 128 (plus expert 1 at tokens).
+        # Both routed experts exceed the 128-row fused cap.
         ids = torch.zeros(tokens, 2, dtype=torch.long, device=device)
         ids[:, 1] = 1
         w = torch.full((tokens, 2), 0.5, dtype=torch.float16, device=device)
         os.environ["EXL3_MOE_ROW_TILE"] = "0"
         reset_exl3_fat_expert_stats()
         y_loop = apply_exl3_experts(x, ids, w, layer, fused=False)
-        y_fb = apply_exl3_experts(x, ids, w, layer, fused=True)
-        assert torch.isfinite(y_loop).all() and torch.isfinite(y_fb).all()
-        err_fb = float((y_loop.float() - y_fb.float()).abs().max())
+
+        os.environ["EXL3_FAT_SORTED"] = "0"
+        os.environ["EXL3_FAT_BATCHED"] = "0"
+        os.environ["EXL3_FAT_KERNEL"] = "0"
+        y_legacy = apply_exl3_experts(x, ids, w, layer, fused=True)
+        assert layer._exl3_last_fat_fallback == "legacy"
+
+        os.environ["EXL3_FAT_SORTED"] = "1"
+        y_sorted = apply_exl3_experts(x, ids, w, layer, fused=True)
+        assert layer._exl3_last_fat_fallback == "sorted"
+
+        os.environ["EXL3_FAT_SORTED"] = "0"
+        os.environ["EXL3_FAT_BATCHED"] = "1"
+        y_batched = apply_exl3_experts(x, ids, w, layer, fused=True)
+        assert layer._exl3_last_fat_fallback == "batched"
+
+        assert (
+            torch.isfinite(y_loop).all()
+            and torch.isfinite(y_legacy).all()
+            and torch.isfinite(y_sorted).all()
+            and torch.isfinite(y_batched).all()
+        )
         bound = max(0.15, 0.08 * float(y_loop.float().abs().max().clamp_min(1.0)))
-        assert err_fb < bound, f"fat fallback vs loop maxabs={err_fb} bound={bound}"
+        err_legacy = float((y_loop.float() - y_legacy.float()).abs().max())
+        err_sorted = float((y_loop.float() - y_sorted.float()).abs().max())
+        err_batched = float((y_loop.float() - y_batched.float()).abs().max())
+        assert err_legacy < bound, (
+            f"legacy fat fallback vs loop maxabs={err_legacy} bound={bound}"
+        )
+        assert err_sorted < bound, (
+            f"sorted fat fallback vs loop maxabs={err_sorted} bound={bound}"
+        )
+        assert err_batched < bound, (
+            f"batched fat fallback vs loop maxabs={err_batched} bound={bound}"
+        )
+        import exllamav3_ext
+
+        err_kernel = None
+        if hasattr(exllamav3_ext, "exl3_fat_gemm"):
+            os.environ["EXL3_FAT_BATCHED"] = "0"
+            os.environ["EXL3_FAT_KERNEL"] = "1"
+            y_kernel = apply_exl3_experts(x, ids, w, layer, fused=True)
+            assert layer._exl3_last_fat_fallback == "kernel"
+            assert torch.isfinite(y_kernel).all()
+            err_kernel = float(
+                (y_loop.float() - y_kernel.float()).abs().max()
+            )
+            assert err_kernel < bound, (
+                f"kernel fat fallback vs loop maxabs={err_kernel} bound={bound}"
+            )
+            os.environ["EXL3_FAT_KERNEL"] = "0"
 
         os.environ["EXL3_MOE_ROW_TILE"] = "1"
         y_tile = apply_exl3_experts(x, ids, w, layer, fused=True)
@@ -233,6 +376,18 @@ def _check_fused_fat_and_row_tile(device) -> None:
             os.environ.pop("EXL3_MOE_ROW_TILE", None)
         else:
             os.environ["EXL3_MOE_ROW_TILE"] = prev_tile
+        if prev_sorted is None:
+            os.environ.pop("EXL3_FAT_SORTED", None)
+        else:
+            os.environ["EXL3_FAT_SORTED"] = prev_sorted
+        if prev_batched is None:
+            os.environ.pop("EXL3_FAT_BATCHED", None)
+        else:
+            os.environ["EXL3_FAT_BATCHED"] = prev_batched
+        if prev_kernel is None:
+            os.environ.pop("EXL3_FAT_KERNEL", None)
+        else:
+            os.environ["EXL3_FAT_KERNEL"] = prev_kernel
         if prev_log is None:
             os.environ.pop("EXL3_FAT_EXPERT_LOG", None)
         else:
@@ -242,8 +397,73 @@ def _check_fused_fat_and_row_tile(device) -> None:
         else:
             os.environ["EXL3_TEMP_ROWS_FUSED"] = prev_rows
     print(
-        f"exl3 fat fallback + row-tile vs loop OK "
-        f"T={tokens} fb={err_fb:.5f} tile={err_tile:.5f} bound={bound:.5f}",
+        "exl3 legacy/sorted/batched/kernel fat fallback + row-tile vs loop OK "
+        f"T={tokens} legacy={err_legacy:.5f} sorted={err_sorted:.5f} "
+        f"batched={err_batched:.5f} kernel={err_kernel} "
+        f"tile={err_tile:.5f} bound={bound:.5f}",
+        flush=True,
+    )
+
+
+def _check_mixed_thin_fat(device) -> None:
+    """One oversized expert plus fused thin experts must compose exactly once."""
+    import torch
+    from vllm.model_executor.layers.quantization.exl3 import apply_exl3_experts
+
+    keys = (
+        "EXL3_MOE_ROW_TILE",
+        "EXL3_FAT_SORTED",
+        "EXL3_FAT_BATCHED",
+        "EXL3_FAT_KERNEL",
+    )
+    previous = {key: os.environ.get(key) for key in keys}
+    try:
+        _method, layer = _tiny_layer(device)
+        tokens = 200
+        x = torch.randn(tokens, 256, dtype=torch.float16, device=device)
+        ids = torch.empty(tokens, 2, dtype=torch.long, device=device)
+        ids[:, 0] = 0
+        ids[:100, 1] = 1
+        ids[100:, 1] = 2
+        weights = torch.full(
+            (tokens, 2), 0.5, dtype=torch.float16, device=device
+        )
+
+        y_loop = apply_exl3_experts(x, ids, weights, layer, fused=False)
+        os.environ["EXL3_MOE_ROW_TILE"] = "0"
+        os.environ["EXL3_FAT_SORTED"] = "1"
+        os.environ["EXL3_FAT_BATCHED"] = "1"
+        os.environ["EXL3_FAT_KERNEL"] = "0"
+        y_batched = apply_exl3_experts(x, ids, weights, layer, fused=True)
+        assert layer._exl3_last_fat_fallback == "batched"
+        assert torch.isfinite(y_loop).all() and torch.isfinite(y_batched).all()
+        bound = max(
+            0.15, 0.08 * float(y_loop.float().abs().max().clamp_min(1.0))
+        )
+        err = float((y_loop.float() - y_batched.float()).abs().max())
+        assert err < bound, (
+            f"mixed thin+fat batched vs loop maxabs={err} bound={bound}"
+        )
+        import exllamav3_ext
+
+        if hasattr(exllamav3_ext, "exl3_fat_gemm"):
+            os.environ["EXL3_FAT_KERNEL"] = "1"
+            y_kernel = apply_exl3_experts(x, ids, weights, layer, fused=True)
+            assert layer._exl3_last_fat_fallback == "kernel"
+            kernel_err = float(
+                (y_loop.float() - y_kernel.float()).abs().max()
+            )
+            assert torch.isfinite(y_kernel).all() and kernel_err < bound, (
+                f"mixed thin+fat kernel vs loop maxabs={kernel_err} bound={bound}"
+            )
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+    print(
+        f"exl3 mixed thin+fat composition OK maxabs={err:.5f} bound={bound:.5f}",
         flush=True,
     )
 

--- a/tests/test_exl3_overlay.py
+++ b/tests/test_exl3_overlay.py
@@ -86,6 +86,87 @@ def _check_ext_arch() -> None:
     print(f"exllamav3_ext arch OK {so} arches={sorted(arches) or 'see cuobjdump'}", flush=True)
 
 
+def _check_e2_diag_static() -> None:
+    """E2 tier resolution and the diag schema are machine-checkable."""
+    from vllm.model_executor.layers.quantization.exl3 import (
+        EXL3_FAT_DIAG_KEYS,
+        EXL3_FAT_DIAG_SCHEMA,
+        configured_fat_tier,
+        exl3_fat_diag,
+        exl3_fat_symbols,
+        resolve_exl3_fat_tier,
+    )
+
+    diag = exl3_fat_diag()
+    assert diag["schema"] == EXL3_FAT_DIAG_SCHEMA == 1, diag["schema"]
+    assert tuple(sorted(diag)) == tuple(sorted(EXL3_FAT_DIAG_KEYS)), (
+        set(diag) ^ set(EXL3_FAT_DIAG_KEYS)
+    )
+
+    keys = ("EXL3_FAT_SORTED", "EXL3_FAT_BATCHED", "EXL3_FAT_KERNEL")
+    previous = {key: os.environ.get(key) for key in keys}
+    try:
+        for key in keys:
+            os.environ.pop(key, None)
+        assert configured_fat_tier() == "legacy"
+        assert resolve_exl3_fat_tier(True) == ("legacy", "none_requested")
+
+        os.environ["EXL3_FAT_SORTED"] = "1"
+        assert configured_fat_tier() == "sorted"
+        assert resolve_exl3_fat_tier(False) == ("sorted", "sorted_ok")
+
+        os.environ["EXL3_FAT_SORTED"] = "0"
+        os.environ["EXL3_FAT_BATCHED"] = "1"
+        assert configured_fat_tier() == "batched"
+        # No shared SUH → the stacked gate+up GEMM would be wrong; sorted is
+        # the legitimate cap, and the reason must say so.
+        assert resolve_exl3_fat_tier(False) == ("sorted", "shared_suh_absent")
+        assert resolve_exl3_fat_tier(True, (True, True, True)) == (
+            "batched",
+            "batched_ok",
+        )
+
+        os.environ["EXL3_FAT_BATCHED"] = "0"
+        os.environ["EXL3_FAT_KERNEL"] = "1"
+        assert configured_fat_tier() == "kernel"
+        assert resolve_exl3_fat_tier(False) == ("sorted", "shared_suh_absent")
+        # The checkpoint cap precedes the image check: without shared SUH the
+        # kernel would not run, so missing fat symbols must not raise.
+        assert resolve_exl3_fat_tier(False, (True, False, False)) == (
+            "sorted",
+            "shared_suh_absent",
+        )
+        # An explicit kernel request fails closed when the symbols are absent
+        # instead of silently running (and reporting) a lower tier.
+        for symbols in ((True, False, True), (True, True, False)):
+            try:
+                resolve_exl3_fat_tier(True, symbols)
+            except RuntimeError:
+                pass
+            else:
+                raise AssertionError(f"kernel tier must fail closed: {symbols}")
+        symbols = exl3_fat_symbols()
+        if symbols[1] and symbols[2]:
+            assert resolve_exl3_fat_tier(True) == ("kernel", "kernel_ok")
+        else:
+            try:
+                resolve_exl3_fat_tier(True)
+            except RuntimeError:
+                pass
+            else:
+                raise AssertionError(
+                    "this image lacks the fat kernel; the live resolve must fail closed"
+                )
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+    print("exl3 E2 diag schema + tier resolution OK", flush=True)
+
+
+
 def _check_gpu_gemm() -> None:
     import torch
     from vllm.model_executor.layers.quantization.exl3 import (
@@ -122,6 +203,7 @@ def _check_gpu_gemm() -> None:
     _check_fused_vs_loop(device)
     _check_fused_fat_and_row_tile(device)
     _check_mixed_thin_fat(device)
+    _check_e2_diag(device)
     _check_apply_expert_map(device)
     _check_fused_cudagraph(device)
 
@@ -468,6 +550,143 @@ def _check_mixed_thin_fat(device) -> None:
     )
 
 
+def _check_e2_diag(device) -> None:
+    """Exact E2 counters for one fat prefill; degradation never poses as kernel."""
+    import torch
+    from vllm.model_executor.layers.quantization.exl3 import (
+        _FAT_SCRATCH_BYTES,
+        _FAT_SCRATCH_CACHE,
+        apply_exl3_experts,
+        exl3_fat_diag,
+        reset_exl3_fat_diag_counters,
+    )
+
+    import exllamav3_ext
+
+    if not hasattr(exllamav3_ext, "exl3_fat_gemm"):
+        print(
+            "exl3 E2 diag counters skipped (E1 image; fail-closed covered statically)",
+            flush=True,
+        )
+        return
+
+    keys = (
+        "EXL3_MOE_ROW_TILE",
+        "EXL3_FAT_SORTED",
+        "EXL3_FAT_BATCHED",
+        "EXL3_FAT_KERNEL",
+        "EXL3_TEMP_ROWS_FUSED",
+    )
+    previous = {key: os.environ.get(key) for key in keys}
+    try:
+        os.environ["EXL3_MOE_ROW_TILE"] = "0"
+        os.environ["EXL3_FAT_SORTED"] = "0"
+        os.environ["EXL3_FAT_BATCHED"] = "0"
+        os.environ["EXL3_FAT_KERNEL"] = "1"
+        os.environ["EXL3_TEMP_ROWS_FUSED"] = "128"
+        _method, layer = _tiny_layer(device, n_exp=3)
+        assert layer._exl3_fat_effective_tier == "kernel", (
+            layer._exl3_fat_effective_tier,
+            layer._exl3_fat_tier_reason,
+        )
+        diag = exl3_fat_diag()
+        assert diag["configured_tier"] == "kernel", diag["configured_tier"]
+        assert diag["effective_tier"] == "kernel", diag["effective_tier"]
+        assert diag["tier_reason"] == "kernel_ok", diag["tier_reason"]
+        assert diag["shared_suh"] is True
+        assert diag["shared_suh_layers"] >= 1
+        assert diag["sym_fat_gemm"] and diag["sym_fat_gemm_scatter"]
+        assert diag["sym_exl3_moe"]
+        assert diag["cap_ok"], (diag["cap_major"], diag["cap_minor"])
+        assert diag["tp_size"] >= 1
+        assert diag["fused_temps_bytes"] > 0
+
+        tokens = 160  # > the 128-row cap, so both routed experts are fat
+        x = torch.randn(tokens, 256, dtype=torch.float16, device=device)
+        ids = torch.zeros(tokens, 2, dtype=torch.long, device=device)
+        ids[:, 1] = 1
+        w = torch.full((tokens, 2), 0.5, dtype=torch.float16, device=device)
+
+        # One accepted E2 call, measured from a clean counter window with an
+        # empty scratch cache: every number below is exact, not a delta.
+        _FAT_SCRATCH_CACHE.clear()
+        _FAT_SCRATCH_BYTES.clear()
+        reset_exl3_fat_diag_counters()
+        y_kernel = apply_exl3_experts(x, ids, w, layer, fused=True)
+        assert torch.isfinite(y_kernel).all()
+        assert layer._exl3_last_fat_fallback == "kernel", layer._exl3_last_fat_fallback
+        assert layer._exl3_last_fat_reason == "kernel_ok"
+        diag = exl3_fat_diag()
+        assert diag["prefill_layer_calls"] == 1, diag["prefill_layer_calls"]
+        assert diag["thin_calls"] == 0 and diag["row_tile_calls"] == 0
+        assert diag["fallback_calls"] == {
+            "kernel": 1,
+            "batched": 0,
+            "sorted": 0,
+            "legacy": 0,
+        }, diag["fallback_calls"]
+        assert diag["fallback_reasons"] == {"kernel_ok": 1}, diag["fallback_reasons"]
+        assert diag["direct_calls"] == 2, diag["direct_calls"]
+        assert diag["scatter_calls"] == 2, diag["scatter_calls"]
+        assert diag["fat_expert_runs"] == 2, diag["fat_expert_runs"]
+        assert diag["fat_scratch_allocs"] == 1, diag["fat_scratch_allocs"]
+        assert diag["fat_scratch_bytes"] == diag["fat_scratch_peak_bytes"] > 0, (
+            diag["fat_scratch_bytes"],
+            diag["fat_scratch_peak_bytes"],
+        )
+
+        # A decode-sized call must not inherit the "kernel" label or counters.
+        xd = torch.randn(2, 256, dtype=torch.float16, device=device)
+        idsd = torch.tensor([[0, 1], [1, 2]], dtype=torch.long, device=device)
+        wd = torch.full((2, 2), 0.5, dtype=torch.float16, device=device)
+        apply_exl3_experts(xd, idsd, wd, layer, fused=True)
+        assert layer._exl3_last_fat_fallback == "none", layer._exl3_last_fat_fallback
+        assert layer._exl3_last_fat_reason == "no_fat_experts"
+        assert exl3_fat_diag()["direct_calls"] == 2
+
+        # Checkpoint without shared SUH: the kernel request visibly degrades.
+        layer._exl3_shared_w13_suh = False
+        before = exl3_fat_diag()
+        y_sorted = apply_exl3_experts(x, ids, w, layer, fused=True)
+        after = exl3_fat_diag()
+        assert torch.isfinite(y_sorted).all()
+        assert layer._exl3_last_fat_fallback == "sorted", layer._exl3_last_fat_fallback
+        assert layer._exl3_last_fat_reason == "degraded_shared_suh"
+        assert after["fallback_calls"]["sorted"] - before["fallback_calls"]["sorted"] == 1
+        assert after["direct_calls"] == before["direct_calls"]
+        assert after["scatter_calls"] == before["scatter_calls"]
+        assert (
+            after["fallback_reasons"].get("degraded_shared_suh", 0)
+            - before["fallback_reasons"].get("degraded_shared_suh", 0)
+            == 1
+        )
+
+        # Row tiles preempt every fat tier even with the kernel requested.
+        layer._exl3_shared_w13_suh = True
+        os.environ["EXL3_MOE_ROW_TILE"] = "1"
+        before = exl3_fat_diag()
+        y_tile = apply_exl3_experts(x, ids, w, layer, fused=True)
+        after = exl3_fat_diag()
+        assert torch.isfinite(y_tile).all()
+        assert layer._exl3_last_fat_fallback == "row_tile"
+        assert after["row_tile_calls"] - before["row_tile_calls"] == 1
+        assert after["fallback_calls"]["kernel"] == before["fallback_calls"]["kernel"]
+        assert after["direct_calls"] == before["direct_calls"]
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+    print(
+        "exl3 E2 diag counters OK: kernel call = prefill_layer_calls 1, "
+        "fallback kernel=1, direct=2, scatter=2, fat_expert_runs=2, "
+        "scratch_allocs=1; shared-SUH loss -> sorted+degraded_shared_suh; "
+        "row tiles preempt",
+        flush=True,
+    )
+
+
 def _check_apply_expert_map(device) -> None:
     import os
 
@@ -607,6 +826,7 @@ def main() -> int:
     _check_quant_registry()
     _check_tp_shard()
     _check_ext_arch()
+    _check_e2_diag_static()
     _check_dflash2()
     if require_gpu:
         _check_gpu_gemm()

--- a/tests/test_image_recipe.py
+++ b/tests/test_image_recipe.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Defaults and overlay recipe-stamp rebuild contract."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+START = ROOT / "start.sh"
+DOCKERFILE = ROOT / "Dockerfile"
+ENV_EXAMPLE = ROOT / ".env.example"
+
+
+def test_documented_defaults() -> None:
+    start = START.read_text()
+    example = ENV_EXAMPLE.read_text()
+    assert 'MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-7168}"' in start
+    assert 'EXL3_FAT_KERNEL="${EXL3_FAT_KERNEL:-1}"' in start
+    assert "MAX_NUM_BATCHED_TOKENS=7168" in example
+    assert re.search(r"^EXL3_FAT_KERNEL=1$", example, re.M)
+
+
+def test_recipe_stamp_wiring() -> None:
+    start = START.read_text()
+    dockerfile = DOCKERFILE.read_text()
+    assert "overlay_recipe_hash() {" in start
+    assert "image_recipe_stamp() {" in start
+    assert 'SKIP_BUILD:-0' in start
+    assert "--build-arg" in start and "GLM53_RECIPE_STAMP" in start
+    assert "ARG GLM53_RECIPE_STAMP=unknown" in dockerfile
+    assert "LABEL glm53.recipe.stamp=${GLM53_RECIPE_STAMP}" in dockerfile
+    assert dockerfile.rstrip().endswith("LABEL glm53.recipe.stamp=${GLM53_RECIPE_STAMP}")
+
+
+def test_overlay_recipe_hash_runs() -> None:
+    source = START.read_text()
+    begin = source.index("overlay_recipe_hash() {")
+    end = source.index("\nimage_recipe_stamp()")
+    script = f"SCRIPT_DIR={str(ROOT)!r}\n" + source[begin:end] + "overlay_recipe_hash\n"
+    result = subprocess.run(
+        ["bash", "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    digest = result.stdout.strip()
+    assert re.fullmatch(r"[0-9a-f]{64}", digest), digest
+
+
+if __name__ == "__main__":
+    test_documented_defaults()
+    test_recipe_stamp_wiring()
+    test_overlay_recipe_hash_runs()
+    print("image recipe tests: PASS")


### PR DESCRIPTION
## Summary

Accelerate EXL3 routed-expert prefill without changing the decode path:

- E1: sort routed rows by expert and process fat experts as contiguous batches.
- E2: add fused direct and scatter CUDA kernels for fat-expert GEMM.
- Keep the existing thin-expert path and legacy fallback.
- Expose tiered `EXL3_FAT_SORTED`, `EXL3_FAT_BATCHED`, and `EXL3_FAT_KERNEL` rollout switches; higher tiers imply their prerequisites.

## Implementation

- Patch the pinned exllamav3 extension during the image build and compile `exl3_fat_gemm` for SM121.
- Add direct-output and scatter-output bindings.
- Cache scratch tensors and staged expert counts to avoid repeated allocations on the hot path.
- Preserve CUDA-graph-safe decode behavior; the new paths apply to fat-expert prefill.
- Cover direct/scatter parity, isolated legacy/sorted/batched/kernel flag selection, mixed thin/fat composition, and CUDA graph capture.

## Verification

Executed from clean PR head `4b8d3c7` based on `origin/main` `493cb88`:

- Python compilation and launcher syntax checks.
- Full Docker build with pinned exllamav3 download, extension compilation, binding assertions, and image self-checks.
- GPU checks for finite EXL3 output, E2 direct/scatter parity, tier isolation, mixed thin/fat composition, and CUDA graph capture.

A local diagnostic follow-up (`86e09e0` + `f1d1d83`, not yet pushed) adds a stable 32-key receipt, both-rank tier/symbol/fallback/call/workspace counters, and fail-closed symbol handling. Its GPU self-check and live on/off/on campaign passed.

## Performance evidence — local promotion sequence complete

The original 64K/100K figures remain withdrawn because they included APC hits. The earlier corrected one-shot table was diagnostic only and is superseded by this repeated sequence.

Protocol:

- 2× DGX Spark GB10, TP=2.
- Same production checkout, weights, DFlash2 revision, runtime patches, ablation, and image lineage in every arm.
- Diagnostic image `glm53-pr77-diag:e7e1286-v3`, derived from proven `glm53-fat-e2:validated-20260901` by replacing only `vllm/.../quantization/exl3.py` and its narrow E2 self-check.
- MNBT 2048; fused MoE on; row tiles off.
- Sequence: E2 on → all three tier flags off → E2 on.
- Five unique-salt cold observations at ~8K, ~100K, and ~300K per boot: 45 accepted cold observations.
- A row was accepted only with API `cached_tokens=0`, prefix-cache hit delta 0, local-cache-hit delta 0, and `local_compute == prompt_tokens`; missing fields fail closed.
- Throughput is `local_compute / TTFT`.

| Rung | On-1 mean (CV) | Off mean (CV) | On-2 mean (CV) | Pooled-on mean | Pooled gain |
|---|---:|---:|---:|---:|---:|
| ~8K | 1125.14 (3.17%) | 941.04 (3.00%) | 1139.51 (2.34%) | 1132.32 | **+20.33%** |
| ~100K | 1238.47 (0.24%) | 1023.20 (0.40%) | 1244.95 (0.09%) | 1241.71 | **+21.36%** |
| ~300K | 1195.33 (0.62%) | 995.05 (0.37%) | 1206.71 (0.08%) | 1201.02 | **+20.70%** |

Boot-specific gains versus the intervening off control were +19.56%/+21.09% at 8K, +21.04%/+21.67% at 100K, and +20.13%/+21.27% at 300K. Every rung has complete separation: the slowest on observation exceeded the fastest off observation.

### Engagement and fallback proof

Final receipts were identical across both TP ranks within each boot:

- On-1: kernel tier active; `direct_calls=scatter_calls=555140`; kernel calls `43569`; batched/sorted/legacy calls `0`; one 130027520-byte scratch allocation.
- Off: legacy tier active; direct/scatter `0`; legacy calls `43568`; kernel/batched/sorted calls `0`; scratch allocations `0`.
- On-2: kernel tier active; `direct_calls=scatter_calls=560536`; kernel calls `43566`; batched/sorted/legacy calls `0`; one 130027520-byte scratch allocation.
- Both on boots reported all E2 symbols present, shared SUH `42/42`, capability 12.1, `max_rows=2048`, zero row-tile calls, and no unintended lower-tier fallback.

All samples, per-arm distributions, exact cache deltas, and diagnostic receipts are in the latest PR comment.

### Scope of the conclusion

On this deployment, E2 is genuinely engaged and yields a repeatable ~20–21% fully uncached prefill gain at 8K–300K. The result is not a silent fallback artifact.

A separate deployment previously did not reproduce the 2048 gain. Rollout therefore remains opt-in pending the maintainer deployment running the same diagnostic image/protocol. If its direct/scatter counters are nonzero but performance is neutral, the effect is geometry-sensitive; zero calls or a fallback reason indicates integration drift.

## Rollout

Flags select the highest enabled tier:

- `EXL3_FAT_SORTED=1` enables sorted routing.
- `EXL3_FAT_BATCHED=1` enables E1 batching and implies sorted routing.
- `EXL3_FAT_KERNEL=1` enables E2 and implies E1 batching and sorted routing.

Setting all three to `0` restores the legacy fat-expert path.
