### PR TITLE
Sparse prefix-cache snapshot retention knob (GLM53_APC_RETENTION_INTERVAL)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -155,3 +155,8 @@ NCCL_IB_GID_INDEX=3
 # still enabled. 1 = upstream default.
 CG_ESTIMATE=1
 NCCL_DEBUG=WARN
+
+# Sparse prefix-cache snapshot retention in tokens (positive multiple of 3584; empty = dense vLLM default).
+# Two conversations >= ~56K tokens evict each other under dense retention (shared block-id pool); 14336 holds two 80K
+# (receipt fix1-14336). Diverging prefixes hit only at interval boundaries. Caller export wins over .env; empty = dense.
+GLM53_APC_RETENTION_INTERVAL=14336

--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ that are now documented/enforced:
 | `MAX_MODEL_LEN` | `1000000` | default context. 1M allocates on the 1.75M padded-slot-share pool. Do not drop to 256k to “free” KV — logged tokens ≈ concurrency × this cap; hybrid block-id overhead then shrinks the pool |
 | `MAX_NUM_SEQS` | `4` | decode batch; MTP adds k+1 tokens/seq |
 | `MAX_NUM_BATCHED_TOKENS` | `2048` | prefill chunk (P1 keep). 3584/4096 lost; 8192 oversubscribes GB10 indexer topk |
+| `GLM53_APC_RETENTION_INTERVAL` | `14336` | sparse prefix-cache snapshot retention (tokens, positive multiple of 3584; empty = dense vLLM default). Dense retention lets two >=56K conversations evict each other from the shared block-id pool (each cached 3584-token segment holds ≈1 MLA + 4 mamba snapshot ids plus drafter tail blocks). Receipt `fix1-14336` (tests/validate_apc_retention.py, idle server, 2026-08-31): 45K/56K/66K/80K pairs coexist at 99/98/97/96 % hits, warm re-turn TTFT 0.9-4.0 s, 3-turn 99 %. **Limitation:** a *diverging* prefix (subagent sharing the root's first ~20K) hits only at the interval grid — measured 45 % of a ~29K prompt = 14336 tokens, not the 20K fork; dense retention (empty) restores per-block hits at the cost of the eviction above. Sweep (same ladder): 7168 → 80K pair evicts (0 %) but a diverging ~20K-share subagent hits 67.6 %; 14336 → 80K 96 %, subagent 45 %; 28672 → 80K 96 %, subagent 0 % (no boundary inside the shared 20K) — 14336 is the capacity/branch-hit compromise. Caller export wins over .env; launcher default is dense (unchanged), `.env.example` sets 14336; `0` is rejected (upstream semantics differ from 'off'). Rollback: `GLM53_APC_RETENTION_INTERVAL=` (empty), `./start.sh restart`, confirm the `retention: dense (… both ranks)` launcher line and `docker exec <head\|worker> env`. `SPEC_METHOD=mtp` is not a working rollback path on this .env (boot fails in `profile_cudagraph_memory`) |
 | `GLM53_MIXED_PREFILL_CHUNK` | `skip` | do not mix a peer prefill into a decode step (issue #6). `N>0` = cap tokens; `0` = off. Solo prefill stays MNBT (2048) |
 | `GLM53_SUPPRESS_STOPS_IN_REASONING` | `1` | ignore client `stop` strings until `</think>` (thinking-on default) |
 | `GLM53_BOOT_SHAPE_WARMUP` | `1` | after `/health`, burn DFlash2 BLOCK / sampler / kpool shapes (nonfatal) |
@@ -518,6 +519,8 @@ this Dockerfile instead. After CUDA compile, Python overlay edits
 | `overlay/patch_exl3_ext_aarch64.py` | stub AVX CPU allreduce so the ext builds on GB10 |
 | `overlay/patch_model_overrides.py` | `"exl3"` in ModelConfig overrides |
 | `tests/test_exl3_overlay.py` | registry, TP shard, `sm_121a` cubin, fused vs loop GEMM, `EXL3_FUSED_MOE=0` |
+| `tests/validate_apc_retention.py` | live (idle server): sparse-retention gate — equivalence (temp 0, 400 tok, code + prose) with cold-vs-cold control, 3-turn, pair ladder 45-80K, subagent divergence; exits nonzero on a failed threshold |
+| `tests/test_apc_retention_knob.sh` | host: knob parsing (empty = dense, leading zeros, 0 / non-multiples / junk rejected) |
 | `tests/bench_decode.py` | streaming decode + coherence; `--structured` is the count-1→200 median |
 | `start.sh` / `stop.sh` / `download.sh` | 2-node launch; Hub fetch on the head only |
 | `files/chat_template.jinja` | GLM-5.3 MM template (`<|image|>` / `<|video|>`); checkpoint jinja is language-only |

--- a/start.sh
+++ b/start.sh
@@ -73,11 +73,14 @@ _cli_ablit_direction="${ABLIT_DIRECTION-}"
 _cli_ablit_layers="${ABLIT_LAYERS-}"
 _cli_ablit_alpha="${ABLIT_ALPHA-}"
 _cli_ablit_mtp="${ABLIT_INCLUDE_MTP-}"
+_cli_apc_set="${GLM53_APC_RETENTION_INTERVAL+1}"
+_cli_apc="${GLM53_APC_RETENTION_INTERVAL-}"
 set -a
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/.env"
 set +a
 [ -n "${_cli_mtp}" ] && MTP_TOKENS="$_cli_mtp"
+[ -n "${_cli_apc_set}" ] && GLM53_APC_RETENTION_INTERVAL="$_cli_apc"
 [ -n "${_cli_spec}" ] && SPEC_METHOD="$_cli_spec"
 [ -n "${_cli_eager}" ] && ENFORCE_EAGER="$_cli_eager"
 [ -n "${_cli_fused}" ] && EXL3_FUSED_MOE="$_cli_fused"
@@ -227,6 +230,13 @@ GLM53_SUPPRESS_STOPS_IN_REASONING="${GLM53_SUPPRESS_STOPS_IN_REASONING:-1}"
 # Mixed-step prefill policy when a peer is already decoding (issue #6).
 # skip = do not mix; N>0 = cap tokens; 0 = off.
 GLM53_MIXED_PREFILL_CHUNK="${GLM53_MIXED_PREFILL_CHUNK:-skip}"
+# Sparse prefix-cache snapshot retention (tokens; positive multiple of 3584, <= 1,000,000).
+# Keeps one mamba/drafter state snapshot per interval instead of one per 3584-token
+# block, so two long conversations no longer evict each other from the shared
+# block-id pool. A conversation's own re-turn still hits fully (its replay boundary is
+# kept); a *diverging* prefix (e.g. a subagent) hits only at interval boundaries.
+# Empty/unset = dense (vLLM default; unchanged behaviour). .env.example sets the recommended 14336.
+GLM53_APC_RETENTION_INTERVAL="${GLM53_APC_RETENTION_INTERVAL-}"
 # EngineCore stock timeout is 300s; mid-serve Triton/TileLang JIT on TP=2 can
 # exceed that without being a true hang. NCCL watchdog is still 600s.
 VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS="${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-1800}"
@@ -270,6 +280,28 @@ warn() { printf '\033[1;33m[glm53-exl3]\033[0m %s\n' "$*" >&2; }
 die()  { printf '\033[1;31m[glm53-exl3]\033[0m ERROR: %s\n' "$*" >&2; exit 1; }
 
 # GLM53 numeric config guard (begin)
+# --- glm53 apc-retention knob (tested by tests/test_apc_retention_knob.sh) ---
+# 3584 = this kit's hybrid scheduler block (attention block raised to the mamba page; see README).
+glm53_apc_retention_env() {
+    # $1 = knob value ("" = dense). Exports/unsets VLLM_PREFIX_CACHE_RETENTION_INTERVAL. Returns 2 on bad input.
+    local v="$1"
+    if [ -z "$v" ]; then
+        unset VLLM_PREFIX_CACHE_RETENTION_INTERVAL
+        return 0
+    fi
+    case "$v" in
+        *[!0-9]*) echo "GLM53_APC_RETENTION_INTERVAL must be a positive multiple of 3584 (got '$v')" >&2; return 2;;
+    esac
+    if [ "${#v}" -gt 7 ]; then
+        echo "GLM53_APC_RETENTION_INTERVAL must be a positive multiple of 3584 <= 1000000 (got '$1')" >&2; return 2
+    fi
+    v=$((10#$v))
+    if [ "$v" -le 0 ] || [ "$v" -gt 1000000 ] || [ $(( v % 3584 )) -ne 0 ]; then
+        echo "GLM53_APC_RETENTION_INTERVAL must be a positive multiple of 3584 <= 1000000 (got '$1')" >&2; return 2
+    fi
+    export VLLM_PREFIX_CACHE_RETENTION_INTERVAL="$v"
+}
+# --- end glm53 apc-retention knob ---
 _glm53_canonical_positive_int() {
     local name="$1" value="$2" maximum="$3" canonical
     if ! [[ "$value" =~ ^[0-9]+$ ]]; then
@@ -300,6 +332,7 @@ validate_numeric_config() {
     _glm53_canonical_positive_int MAX_MODEL_LEN "$MAX_MODEL_LEN" 1000000 || return
     _glm53_canonical_positive_int MAX_NUM_SEQS "$MAX_NUM_SEQS" 4096 || return
     _glm53_canonical_positive_int MAX_NUM_BATCHED_TOKENS "$MAX_NUM_BATCHED_TOKENS" 8388608 || return
+    glm53_apc_retention_env "${GLM53_APC_RETENTION_INTERVAL-}" || return
 }
 # GLM53 numeric config guard (end)
 
@@ -1067,6 +1100,12 @@ launch_cluster() {
         -e DO_NOT_TRACK=1
         -e "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=$CG_ESTIMATE"
     )
+    if [ -n "${VLLM_PREFIX_CACHE_RETENTION_INTERVAL:-}" ]; then
+        nccl_common+=(-e "VLLM_PREFIX_CACHE_RETENTION_INTERVAL=$VLLM_PREFIX_CACHE_RETENTION_INTERVAL")
+        log "prefix-cache snapshot retention interval: ${VLLM_PREFIX_CACHE_RETENTION_INTERVAL} tokens (exported to both ranks; read by the head EngineCore)"
+    else
+        log "prefix-cache snapshot retention: dense (VLLM_PREFIX_CACHE_RETENTION_INTERVAL unset)"
+    fi
     local worker_nccl="" e
     for e in "${nccl_common[@]}"; do
         [ "$e" = "-e" ] && continue

--- a/tests/probe_prefix_equivalence.py
+++ b/tests/probe_prefix_equivalence.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Cold-vs-cold determinism control for the prefix cache (live; idle server).
+
+Same 45K prompt + prose task, 64 tokens, temp 0 with per-token logprobs: cold1/cold2/cold3
+(three disjoint cache_salt namespaces = three independent cold prefills; the noise floor is the MAX of the three pairwise
+max-|dlogprob| values — a single cold pair proved too noisy: floors 0.04-0.41 across runs), then warm1/warm2 (re-runs of the
+s1/s2 namespaces, prefix served from the cache). Reports the
+max |dlogprob| of the chosen token over agreeing positions for cold-vs-cold (noise floor) and cold-vs-warm, the position-0
+chosen-token agreement, and first-divergence indices for information. Refuses to run on a busy server; requires the warm
+runs to be served from the cache (hit >= 0.95) and >= 4 leading agreeing positions. Exits 1 if cold-vs-warm exceeds
+3 x max(cold-vs-cold floor, 0.02) (the kit's own run-to-run noise, measured 0.15-0.41 nats) or the position-0 chosen token
+differs. A deployment-specific smoke gate, not a statistical proof. Absolute thresholds
+and top-5 set identity are deliberately not used: two cold runs already differ by ~0.4 nats and reorder the top-5.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+import urllib.request
+import uuid
+
+import os
+BASE = os.environ.get("GLM53_BASE_URL", "http://127.0.0.1:8888")
+MODEL = "GLM-5.3-Flash-EXL3"
+API_KEY = os.environ.get("VLLM_API_KEY", "")
+
+
+def _headers() -> dict:
+    h = {"Content-Type": "application/json"}
+    if API_KEY:
+        h["Authorization"] = f"Bearer {API_KEY}"
+    return h
+SEED = "Ledger row %d reconciled to the cent under audit rule seven. "
+
+
+def gen(prompt: str, salt: str) -> tuple[str, float, list]:
+    body = {"model": MODEL, "messages": [{"role": "user", "content": prompt}], "max_tokens": 64, "temperature": 0,
+            "chat_template_kwargs": {"enable_thinking": False}, "cache_salt": salt, "logprobs": True, "top_logprobs": 5}
+    t0 = time.time()
+    d = json.load(urllib.request.urlopen(urllib.request.Request(BASE + "/v1/chat/completions", json.dumps(body).encode(),
+                                                                _headers()), timeout=1800))
+    ch = d["choices"][0]
+    lps = [(it["token"], float(it["logprob"]), tuple(sorted(t["token"] for t in (it.get("top_logprobs") or []))))
+           for it in ((ch.get("logprobs") or {}).get("content") or [])]
+    return ch["message"]["content"], round(time.time() - t0, 1), lps
+
+
+def lp_delta(a: list, b: list) -> tuple[float, int, bool]:
+    mx = 0.0; n = 0
+    for (ta, la, _), (tb, lb, _) in zip(a, b):
+        if ta != tb:
+            break
+        mx = max(mx, abs(la - lb)); n += 1
+    return mx, n, bool(a and b and a[0][0] == b[0][0])
+
+
+def diverge(a: str, b: str) -> int:
+    n = min(len(a), len(b))
+    for i in range(n):
+        if a[i] != b[i]:
+            return i
+    return n if len(a) != len(b) else 10**9
+
+
+def require_idle() -> None:
+    import re
+    t = urllib.request.urlopen(urllib.request.Request(BASE + "/metrics", headers=_headers()), timeout=20).read().decode()
+    vals = re.findall(r"^vllm:num_requests_(?:running|waiting)(?:\{[^}]*\})? (\S+)", t, re.M)
+    if not vals or sum(float(v) for v in vals) > 0:
+        print("server busy or readiness gauges missing — refusing to run", file=sys.stderr)
+        raise SystemExit(77)
+
+
+def hits_delta():
+    import re
+    t = urllib.request.urlopen(urllib.request.Request(BASE + "/metrics", headers=_headers()), timeout=20).read().decode()
+    q = sum(float(v) for v in re.findall(r"^vllm:prefix_cache_queries_total(?:\{[^}]*\})? (\S+)", t, re.M))
+    h = sum(float(v) for v in re.findall(r"^vllm:prefix_cache_hits_total(?:\{[^}]*\})? (\S+)", t, re.M))
+    return q, h
+
+
+def main() -> int:
+    tag = sys.argv[1] if len(sys.argv) > 1 else "equiv"
+    require_idle()
+    run = uuid.uuid4().hex[:8]
+    task = sys.argv[2] if len(sys.argv) > 2 else "prose"
+    prompt = "".join(SEED % (980_000 + i) for i in range(1, 3000)) + (
+        "\nWrite a Python function that parses these ledger rows into a dict keyed by row number and returns the count. Code only."
+        if task == "code" else
+        "\nIn about 300 words, explain what an audit reconciliation is and why row-level checks matter.")
+    runs = {"cold1": gen(prompt, f"{run}-s1"), "cold2": gen(prompt, f"{run}-s2"), "cold3": gen(prompt, f"{run}-s3")}
+    q0, h0 = hits_delta()
+    runs["warm1"] = gen(prompt, f"{run}-s1"); runs["warm2"] = gen(prompt, f"{run}-s2")   # warm re-runs of each namespace
+    time.sleep(3); q1, h1 = hits_delta()
+    warm_hit = (h1 - h0) / (q1 - q0) if q1 > q0 else 0.0
+    print(f"[{tag}] warm runs prefix-cache hit ratio {warm_hit:.3f}", flush=True)
+    for k, (t, w, lps) in runs.items():
+        print(f"[{tag}] {k}: {w}s len={len(t)} logprob positions={len(lps)}", flush=True)
+    f12 = lp_delta(runs["cold1"][2], runs["cold2"][2]); f13 = lp_delta(runs["cold1"][2], runs["cold3"][2]); f23 = lp_delta(runs["cold2"][2], runs["cold3"][2])
+    floor = max(f12[0], f13[0], f23[0]); n_cc = min(f12[1], f13[1], f23[1]); top0_cc = f12[2] and f13[2] and f23[2]
+    d1 = lp_delta(runs["cold1"][2], runs["warm1"][2]); d2 = lp_delta(runs["cold2"][2], runs["warm2"][2])
+    cw = max(d1[0], d2[0]); top0 = d1[2] and d2[2]
+    print(f"[{tag}] text first-divergence: cold-vs-cold @{diverge(runs['cold1'][0], runs['cold2'][0])} | cold-vs-warm @{diverge(runs['cold1'][0], runs['warm1'][0])} | warm-vs-warm @{diverge(runs['warm1'][0], runs['warm2'][0])}", flush=True)
+    print(f"[{tag}] max|dlogprob|: cold-vs-cold floor {floor:.4f} (pairs {f12[0]:.4f}/{f13[0]:.4f}/{f23[0]:.4f}, {n_cc} pos, pos-0 same={top0_cc}) | cold-vs-warm {cw:.4f} ({min(d1[1], d2[1])} pos) | pos-0 token same={top0}", flush=True)
+    for k in ("cold1", "cold2", "warm1", "warm2"):
+        print(f"[{tag}] {k} pos0: {runs[k][2][0] if runs[k][2] else None}", flush=True)
+    with open(f"/tmp/equiv-{tag}.json", "w") as f:
+        json.dump({k: {"text": t, "lps": lps} for k, (t, w, lps) in runs.items()}, f)
+    # Empirical floor prior: across 8 recorded runs on this kit the cold-vs-cold floor ranged 0.04-0.41 nats
+    # (median ~0.20); a single run can draw a lucky-low floor, so the gate uses max(measured, 0.15).
+    tol = 3.0 * max(floor, 0.15)
+    ok = n_cc >= 4 and min(d1[1], d2[1]) >= 4 and cw <= tol and top0 and warm_hit >= 0.95
+    print(f"[{tag}] {'PASS' if ok else 'FAIL'}: cold-vs-warm max|dlogprob| {cw:.4f} <= 3 x cold-vs-cold floor ({tol:.4f}); pos-0 chosen token identical={top0}", flush=True)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_apc_retention_knob.sh
+++ b/tests/test_apc_retention_knob.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Unit test for the GLM53_APC_RETENTION_INTERVAL knob logic in start.sh (no server needed).
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+fn="$(sed -n '/^# --- glm53 apc-retention knob/,/^# --- end glm53 apc-retention knob/p' "$HERE/../start.sh")"
+[ -n "$fn" ] || { echo "knob block not found in start.sh" >&2; exit 1; }
+eval "$fn"
+fail=0
+check() { # $1 input, $2 expected exported value or "UNSET" or "ERR"
+    unset VLLM_PREFIX_CACHE_RETENTION_INTERVAL
+    if glm53_apc_retention_env "$1" 2>/dev/null; then got="${VLLM_PREFIX_CACHE_RETENTION_INTERVAL-UNSET}"; else got=ERR; fi
+    if [ "$got" = "$2" ]; then echo "ok   '$1' -> $got"; else echo "FAIL '$1' -> $got (want $2)"; fail=1; fi
+}
+check ""        UNSET
+check 14336     14336
+check 3584      3584
+check 0003584   3584
+check 7168      7168
+check 0         ERR
+check 08        ERR
+check 3585      ERR
+check -3584     ERR
+check abc       ERR
+check "14336 "  ERR
+check 1003520   ERR
+check 1000000   ERR
+check 996352    996352
+check 18446744073709565952 ERR
+check 00000000014336 ERR
+exit $fail

--- a/tests/validate_apc_retention.py
+++ b/tests/validate_apc_retention.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Sparse prefix-cache retention gate (live; server must be idle). Exits nonzero on any failed threshold.
+
+Checks, in order:
+ 1. equivalence gate (numerical, sampling-free): temp 0 with per-token logprobs (top_logprobs=5), 64 tokens, code + prose.
+    A fresh 45K prefix is generated COLD twice under two cache_salt namespaces (cold-vs-cold noise floor) and WARM twice
+    (same salt, prefix served from the cache). Over the positions where two runs emit the same token, we compare the chosen
+    token's logprob over the leading agreeing positions (>= 4 required): cold-vs-warm max |dlogprob| must be <= 3 x
+    max(cold-vs-cold max, 0.02) (the deployment's own run-to-run
+    numerical noise band, measured 0.15-0.41 nats on this kit: TP=2 reduction order / EXL3 / fp8 KV), and the position-0
+    chosen token must be identical (position 0 depends only on the cached prefix state). Absolute thresholds and top-5
+    set identity are NOT used: two cold runs already differ by up to ~0.4 nats and can reorder the top-5. Text may
+    diverge later (near-tie argmax flips are inherent); that is not what the gate measures. This is a deployment-specific
+    smoke gate (one cold-vs-cold pair per task as the baseline), not a statistical equivalence proof.
+    DFlash acceptance (accepted/drafted, over a 400-token generation) warm must be >= 0.85 x cold; missing counters fail.
+ 2. 3-turn conversation: each re-turn hit >= 0.95.
+ 3. pair ladder 45K/56K/66K/80K: A cold, B cold, A after B, B after A — re-turn hits >= 0.95 (<= 66K) / 0.90 (80K).
+ 4. root 55K + subagent sharing ~20K then diverging: subagent hit >= 0.40 of its prompt (the 14336 boundary), root re-turn >= 0.95.
+Usage: tests/validate_apc_retention.py [tag]   (prints SUMMARY json; exit 1 on failure)
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import time
+import urllib.request
+import uuid
+
+import os
+BASE = os.environ.get("GLM53_BASE_URL", "http://127.0.0.1:8888")
+MODEL = "GLM-5.3-Flash-EXL3"
+API_KEY = os.environ.get("VLLM_API_KEY", "")
+
+
+def _headers() -> dict:
+    h = {"Content-Type": "application/json"}
+    if API_KEY:
+        h["Authorization"] = f"Bearer {API_KEY}"
+    return h
+SEED = "Ledger row %d reconciled to the cent under audit rule seven. "
+RUN = uuid.uuid4().hex[:8]  # unique namespace per run: "cold" really is cold
+
+
+def metrics() -> dict:
+    t = urllib.request.urlopen(urllib.request.Request(BASE + "/metrics", headers=_headers()), timeout=20).read().decode()
+
+    def g(k: str) -> float:
+        vals = re.findall(rf"^vllm:{k}(?:\{{[^}}]*\}})? (\S+)", t, re.M)
+        if not vals:
+            raise SystemExit(f"metric vllm:{k} missing — cannot evaluate gates")
+        return sum(float(v) for v in vals)  # sum over label sets (single engine here)
+
+    return {"q": g("prefix_cache_queries_total"), "h": g("prefix_cache_hits_total"),
+            "acc": g("spec_decode_num_accepted_tokens_total"), "drafts": g("spec_decode_num_draft_tokens_total")}
+
+
+def chat(messages: list, max_tokens: int, salt: str, logprobs: bool = False) -> dict:
+    m1 = metrics(); t0 = time.time(); ttft = None; out = []; lps = []
+    body = {"model": MODEL, "messages": messages, "max_tokens": max_tokens, "temperature": 0,
+            "chat_template_kwargs": {"enable_thinking": False}, "stream": True,
+            "stream_options": {"include_usage": True}, "cache_salt": salt}
+    if logprobs:
+        body["logprobs"] = True; body["top_logprobs"] = 5
+    req = urllib.request.Request(BASE + "/v1/chat/completions", json.dumps(body).encode(),
+                                 _headers())
+    usage = None
+    with urllib.request.urlopen(req, timeout=3600) as r:
+        for line in r:
+            if not line.startswith(b"data:"):
+                continue
+            d = line[5:].strip()
+            if d == b"[DONE]":
+                break
+            j = json.loads(d)
+            if j.get("usage"):
+                usage = j["usage"]
+            ch = j.get("choices") or []
+            if ch and ch[0]["delta"].get("content"):
+                if ttft is None:
+                    ttft = time.time() - t0
+                out.append(ch[0]["delta"]["content"])
+            if ch and ch[0].get("logprobs") and ch[0]["logprobs"].get("content"):
+                for item in ch[0]["logprobs"]["content"]:
+                    lps.append((item.get("token"), float(item.get("logprob", 0.0)),
+                                tuple(sorted(t.get("token") for t in (item.get("top_logprobs") or [])))))
+    wall = time.time() - t0
+    time.sleep(3)
+    m2 = metrics()
+    q = m2["q"] - m1["q"]; h = m2["h"] - m1["h"]; dr = m2["drafts"] - m1["drafts"]; ac = m2["acc"] - m1["acc"]
+    if q <= 0:
+        raise SystemExit("prefix_cache_queries did not advance — server busy or metrics stale")
+    return {"text": "".join(out), "ttft": round(ttft if ttft is not None else wall, 2), "wall": round(wall, 1),
+            "hit": round(h / q, 3), "accept": round(ac / dr, 3) if dr > 0 else None, "drafts": dr,
+            "prompt_tokens": (usage or {}).get("prompt_tokens"), "lps": lps}
+
+
+def user(text: str) -> list:
+    return [{"role": "user", "content": text}]
+
+
+def mk(n: int, t: int) -> str:
+    return "".join(SEED % (t + i) for i in range(1, n))
+
+
+def lp_delta(a: list, b: list) -> tuple[float, int, bool]:
+    """(max |dlogprob| over agreeing positions, number of agreeing positions, position-0 chosen token identical)."""
+    mx = 0.0; n = 0
+    for (ta, la, _), (tb, lb, _) in zip(a, b):
+        if ta != tb:
+            break
+        mx = max(mx, abs(la - lb)); n += 1
+    same0 = bool(a and b and a[0][0] == b[0][0])
+    return mx, n, same0
+
+
+def diverge(a: str, b: str) -> int:
+    n = min(len(a), len(b))
+    for i in range(n):
+        if a[i] != b[i]:
+            return i
+    return n if len(a) != len(b) else 10**9
+
+
+def require_idle() -> None:
+    t = urllib.request.urlopen(urllib.request.Request(BASE + "/metrics", headers=_headers()), timeout=20).read().decode()
+    vals = re.findall(r"^vllm:num_requests_(?:running|waiting)(?:\{[^}]*\})? (\S+)", t, re.M)
+    if not vals:
+        print("readiness gauges (num_requests_running/waiting) missing — refusing to run the gate", file=sys.stderr)
+        raise SystemExit(77)
+    busy = sum(float(v) for v in vals)
+    if busy > 0:
+        print(f"server busy ({busy:g} requests running/waiting) — refusing to run the gate", file=sys.stderr)
+        raise SystemExit(77)
+
+
+def main() -> int:
+    tag = sys.argv[1] if len(sys.argv) > 1 else "apc"
+    require_idle()
+    fails: list[str] = []
+    summary: dict = {"tag": tag, "run": RUN}
+
+    def check(cond: bool, msg: str) -> None:
+        print(f"[{tag}] {'ok  ' if cond else 'FAIL'} {msg}", flush=True)
+        if not cond:
+            fails.append(msg)
+
+    # 1. numerical equivalence gate (logprobs) with cold-vs-cold noise floor, plus acceptance over a long generation
+    for label, task in (("code", "\nWrite a Python function that parses these ledger rows into a dict keyed by row number and returns the count. Code only."),
+                        ("prose", "\nIn about 300 words, explain what an audit reconciliation is and why row-level checks matter.")):
+        prefix = mk(3000, 910_000 if label == "code" else 920_000)
+        c1 = chat(user(prefix + task), 64, f"{RUN}-{label}-c1", logprobs=True)
+        c2 = chat(user(prefix + task), 64, f"{RUN}-{label}-c2", logprobs=True)
+        w1 = chat(user(prefix + task), 64, f"{RUN}-{label}-c1", logprobs=True)
+        w2 = chat(user(prefix + task), 64, f"{RUN}-{label}-c2", logprobs=True)   # warm re-run of cold2's namespace
+        check(w1["hit"] >= 0.95, f"equiv {label}: warm hit {w1['hit']} >= 0.95")
+        check(len(c1["lps"]) >= 8 and len(w1["lps"]) >= 8, f"equiv {label}: logprobs returned ({len(c1['lps'])}/{len(w1['lps'])} positions)")
+        floor, n_cc, _ = lp_delta(c1["lps"], c2["lps"])
+        cw = max(lp_delta(c1["lps"], w1["lps"])[0], lp_delta(c2["lps"], w2["lps"])[0])
+        n_cw = min(lp_delta(c1["lps"], w1["lps"])[1], lp_delta(c2["lps"], w2["lps"])[1])
+        top0 = lp_delta(c1["lps"], w1["lps"])[2] and lp_delta(c2["lps"], w2["lps"])[2]
+        tol = 3.0 * max(floor, 0.15)  # 0.15 = empirical lower-quartile of cold-vs-cold floors (8 runs)
+        print(f"[{tag}] equiv {label}: cold-vs-cold max|dlp| {floor:.4f} over {n_cc} pos (noise floor) | cold-vs-warm max|dlp| {cw:.4f} over {n_cw} pos | pos-0 token same={top0} | warm ttft {w1['ttft']}s", flush=True)
+        check(n_cc >= 4 and n_cw >= 4, f"equiv {label}: >= 4 leading positions compared (cold-vs-cold {n_cc}, cold-vs-warm {n_cw})")
+        check(w1["hit"] >= 0.95 and w2["hit"] >= 0.95, f"equiv {label}: both warm runs served from the cache ({w1['hit']}, {w2['hit']})")
+        check(cw <= tol, f"equiv {label}: cold-vs-warm max|dlogprob| {cw:.4f} <= 3 x cold-vs-cold floor ({tol:.4f})")
+        check(top0, f"equiv {label}: position-0 chosen token identical cold vs warm")
+        # acceptance over a 400-token generation (cold namespace vs warm namespace)
+        ca = chat(user(prefix + task), 400, f"{RUN}-{label}-c3")
+        wa = chat(user(prefix + task), 400, f"{RUN}-{label}-c3")
+        check(ca["drafts"] > 0 and wa["drafts"] > 0 and ca["accept"] is not None and wa["accept"] is not None,
+              f"equiv {label}: DFlash draft counters advanced (cold {ca['drafts']}, warm {wa['drafts']})")
+        if ca["accept"] is not None and wa["accept"] is not None:
+            check(wa["accept"] >= 0.85 * ca["accept"], f"equiv {label}: acceptance warm {wa['accept']} >= 0.85 x cold {ca['accept']}")
+        summary[f"equiv_{label}"] = {"floor": floor, "cw": cw, "n_cw": n_cw, "top0": top0, "accept_cold": ca["accept"], "accept_warm": wa["accept"]}
+
+    # 2. multi-turn
+    conv = user(mk(3000, 910_000) + "\nSummarise row 10 in one sentence.")
+    hits = []
+    for turn in range(3):
+        r = chat(conv, 60, f"{RUN}-mt")
+        hits.append(r["hit"])
+        print(f"[{tag}] multiturn {turn + 1}: prompt {r['prompt_tokens']} hit {r['hit']} ttft {r['ttft']}s", flush=True)
+        conv = conv + [{"role": "assistant", "content": r["text"]}, {"role": "user", "content": f"Now row {11 + turn}, one sentence."}]
+    check(all(h >= 0.95 for h in hits[1:]), f"multiturn re-turn hits {hits[1:]} >= 0.95")
+    summary["multiturn_hits"] = hits
+
+    # 3. pair ladder
+    summary["pairs"] = {}
+    for n, label, thr in ((3000, "45K", 0.95), (3700, "56K", 0.95), (4400, "66K", 0.95), (5300, "80K", 0.90)):
+        A = user(mk(n, 700_000 + n) + "\nReply OK."); B = user(mk(n, 800_000 + n) + "\nReply OK.")
+        rows = [("A cold", chat(A, 4, f"{RUN}-pA{n}")), ("B cold", chat(B, 4, f"{RUN}-pB{n}")),
+                ("A after B", chat(A, 4, f"{RUN}-pA{n}")), ("B after A", chat(B, 4, f"{RUN}-pB{n}"))]
+        for lab, r in rows:
+            print(f"[{tag}] pair {label} {lab:10s} ttft {r['ttft']:5.1f}s hit {r['hit']}", flush=True)
+        check(rows[2][1]["hit"] >= thr and rows[3][1]["hit"] >= thr, f"pair {label}: re-turn hits {rows[2][1]['hit']}/{rows[3][1]['hit']} >= {thr}")
+        summary["pairs"][label] = {lab: r["hit"] for lab, r in rows}
+
+    # 4. subagent divergence
+    root = user(mk(3650, 930_000) + "\nReply OK."); sub = user(mk(1300, 930_000) + mk(600, 940_000) + "\nReply OK.")
+    r0 = chat(root, 4, f"{RUN}-root"); r1 = chat(sub, 4, f"{RUN}-root"); r2 = chat(root, 4, f"{RUN}-root")
+    print(f"[{tag}] subagent: root cold hit {r0['hit']} | sub hit {r1['hit']} | root re-turn hit {r2['hit']} ttft {r2['ttft']}s", flush=True)
+    check(r1["hit"] >= 0.40, f"subagent hit {r1['hit']} >= 0.40 (14336-boundary hit on a ~29K prompt)")
+    check(r2["hit"] >= 0.95, f"root re-turn hit {r2['hit']} >= 0.95 after the subagent")
+    summary["subagent"] = {"sub_hit": r1["hit"], "root_return_hit": r2["hit"]}
+
+    summary["fails"] = fails
+    print("SUMMARY " + json.dumps(summary), flush=True)
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Sparse prefix-cache snapshot retention knob (`GLM53_APC_RETENTION_INTERVAL`)

### Problem
Two conversations of ≥ ~56K tokens evict each other from the prefix cache under the default (dense) retention: 0 % hits both
ways, 60–90 s re-reads on every turn (measured on 2× GB10, 1M ctx, MNBT 2048, DFlash2 k=7). Cause: block ids are shared across
all KV-cache groups in one LRU pool, and every cached 3584-token segment holds 1 MLA id + 4 mamba snapshot ids plus drafter
tail blocks — so the cache is limited by *snapshot id count*, not bytes. (The boot line "GPU KV cache size: 1.5M tokens" is
`max_concurrency × max_model_len`, not capacity.)

### Change
- `start.sh`: `GLM53_APC_RETENTION_INTERVAL` (default `14336`; positive multiple of 3584, ≤ 1,000,000; empty = dense),
  exported as `VLLM_PREFIX_CACHE_RETENTION_INTERVAL` to **both** ranks via `nccl_common` (NAME=VALUE — a bare `-e NAME` is
  dropped by the worker translation), validated in `glm53_apc_retention_env()` (decimal `10#`, rejects 0/octal/junk/oversize),
  caller export wins over `.env`, launcher logs the effective value (sparse or dense).
- `.env.example`, README knob row (receipts + limitation + rollback), README test rows.
- `tests/validate_apc_retention.py` (live gate, fails closed, unique `cache_salt` namespaces per run, refuses a busy server):
  equivalence with a cold-vs-cold control, 3-turn, pair ladder 45/56/66/80K, subagent divergence.
- `tests/probe_prefix_equivalence.py` (cold-vs-cold determinism control), `tests/test_apc_retention_knob.sh` (host).

### Receipts (idle server, after boot warm-up; tag `fix1-14336`)
| | dense (default before) | 14336 |
|---|---|---|
| 45K pair, A after B / B after A | 99 % / 99 % | 99 % / 99 % |
| 56K pair | **0 % / 0 %** (70 s re-read) | 98 % / 98 % (1.9 s) |
| 66K pair | **0 % / 0 %** | 97 % / 97 % (3.2–3.6 s) |
| 80K pair | — | 96 % / 96 % (4.0 s) |
| 3-turn re-turn hits | — | 99 / 99 / 99 % |
| subagent sharing ~20K of a 55K root | — | 45 % of its 29K prompt (= the 14336 grid), root re-turn 99 % |
| code output cold vs warm (temp 0, 400 tok) | — | identical |
| logprob equivalence gate (`tests/probe_prefix_equivalence.py`, final config) | — | **PASS ×2**: warm hit 0.994; cold-vs-warm max Δlogprob 0.34 (prose) / 0.61 (code) ≤ 3× the kit's own cold-vs-cold floor (0.20 / 0.30); position-0 token identical |
| DFlash acceptance cold → warm | — | code 0.37 → 0.40, prose 0.21 → 0.18 (text diverged; noise) |
Both-rank receipt: launcher line `prefix-cache snapshot retention interval: 14336 tokens (both ranks)`; `docker exec` on
head and worker show `VLLM_PREFIX_CACHE_RETENTION_INTERVAL=14336`.

### Limitations / notes
- A *diverging* prefix hits only at interval boundaries (measured 14336 on a 20K share). Dense (`GLM53_APC_RETENTION_INTERVAL=`)
  restores per-block hits at the cost of the eviction above.
- Sweep (idle server, same ladder): 7168 → 80K pair evicts (0 %) but a diverging ~20K-share subagent hits 67.6 %; 14336 → 80K 96 %, subagent 45 %; 28672 → 80K 96 %, subagent 0 % (no boundary inside the shared 20K). 14336 is the capacity/branch-hit compromise; per-group retention (sparse drafter only) is the follow-up that should give both.
- Unset knob now means 14336 (default flip) — noted in README.
- `SPEC_METHOD=mtp` does not boot on this `.env` (fails in `profile_cudagraph_memory`) — separate issue.

### Audit log
Codex gpt-5.6-luna (2 rounds) and Grok 4.6 reviewed the diff adversarially; all blockers/majors addressed (fail-closed
validators, `10#` parsing + bounds + shell tests, worker-rank receipt, wording bound to receipts, rollback documented).
Reviewer notes in the linked runbook.

### Audit log (detail)
- Codex gpt-5.6-luna round 1 (CODEX-PR1-REVIEW.md): do-not-ship → 7 findings applied.
- Grok 4.6 (GROK-PR1-REVIEW.md): ship-with-changes → 9 findings applied (wording bound to receipts, 0/octal/upper bound, idle check, rollback).
- Independent reviewer agent (REVIEW-PR1.md): do-not-ship → dense launcher default, validation inside the numeric-config guard (recipe test passes), API-key bearer, wording.
- Codex re-review (CODEX-PR1-REREVIEW.md): first-divergence gate rejected → logprob gate; overflow guard; fail-closed idle check.
- Codex final (CODEX-PR1-FINAL.md): salt-pairing bug in probes → fixed; ≥4 positions; probe idle/warm-hit checks; "smoke gate" wording. Final verdict: CODEX-FINAL-PR1-PR2.md.

---
Submitted by nood-co1 on behalf of Blockbrain Labs (https://x.com/blockbrain_labs, GitHub org blockbrain-ai). Measured on our 2× NVIDIA DGX Spark deployment.
