### PR TITLE
Launcher: GLM53_EXTRA_ENV pass-through for diagnostic container env

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ that are now documented/enforced:
 | `MAX_NUM_SEQS` | `4` | decode batch; MTP adds k+1 tokens/seq |
 | `MAX_NUM_BATCHED_TOKENS` | `2048` | prefill chunk (P1 keep). 3584/4096 lost; 8192 oversubscribes GB10 indexer topk |
 | `GLM53_MIXED_PREFILL_CHUNK` | `skip` | do not mix a peer prefill into a decode step (issue #6). `N>0` = cap tokens; `0` = off. Solo prefill stays MNBT (2048) |
+| `GLM53_EXTRA_ENV` | (empty) | space-separated `NAME=VALUE` list of extra container env for both ranks, for diagnostics (e.g. `VLLM_DEBUG_WORKSPACE=1`, `VLLM_LOGGING_LEVEL=DEBUG`). Names validated; caller export wins over `.env` |
 | `GLM53_SUPPRESS_STOPS_IN_REASONING` | `1` | ignore client `stop` strings until `</think>` (thinking-on default) |
 | `GLM53_BOOT_SHAPE_WARMUP` | `1` | after `/health`, burn DFlash2 BLOCK / sampler / kpool shapes (nonfatal) |
 | `TRITON_HOST_CACHE` / `TILELANG_HOST_CACHE` | `$CACHE_ROOT/triton` / `tilelang` | persist JIT caches across container recreate |

--- a/start.sh
+++ b/start.sh
@@ -73,11 +73,14 @@ _cli_ablit_direction="${ABLIT_DIRECTION-}"
 _cli_ablit_layers="${ABLIT_LAYERS-}"
 _cli_ablit_alpha="${ABLIT_ALPHA-}"
 _cli_ablit_mtp="${ABLIT_INCLUDE_MTP-}"
+_cli_extra_env_set="${GLM53_EXTRA_ENV+1}"
+_cli_extra_env="${GLM53_EXTRA_ENV-}"
 set -a
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/.env"
 set +a
 [ -n "${_cli_mtp}" ] && MTP_TOKENS="$_cli_mtp"
+[ -n "${_cli_extra_env_set}" ] && GLM53_EXTRA_ENV="$_cli_extra_env"
 [ -n "${_cli_spec}" ] && SPEC_METHOD="$_cli_spec"
 [ -n "${_cli_eager}" ] && ENFORCE_EAGER="$_cli_eager"
 [ -n "${_cli_fused}" ] && EXL3_FUSED_MOE="$_cli_fused"
@@ -227,6 +230,8 @@ GLM53_SUPPRESS_STOPS_IN_REASONING="${GLM53_SUPPRESS_STOPS_IN_REASONING:-1}"
 # Mixed-step prefill policy when a peer is already decoding (issue #6).
 # skip = do not mix; N>0 = cap tokens; 0 = off.
 GLM53_MIXED_PREFILL_CHUNK="${GLM53_MIXED_PREFILL_CHUNK:-skip}"
+# Space-separated NAME=VALUE list of extra env for both container ranks (diagnostics, e.g. VLLM_DEBUG_WORKSPACE=1).
+GLM53_EXTRA_ENV="${GLM53_EXTRA_ENV:-}"
 # EngineCore stock timeout is 300s; mid-serve Triton/TileLang JIT on TP=2 can
 # exceed that without being a true hang. NCCL watchdog is still 600s.
 VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS="${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-1800}"
@@ -1067,6 +1072,27 @@ launch_cluster() {
         -e DO_NOT_TRACK=1
         -e "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=$CG_ESTIMATE"
     )
+    # Extra container env for diagnostics (space-separated NAME=VALUE list, e.g. GLM53_EXTRA_ENV="VLLM_DEBUG_WORKSPACE=1").
+    # Applied to both ranks. Names: [A-Z_][A-Z0-9_]*, not launcher-owned (NCCL_*, HF_*, GLM53_*, VLLM_API_KEY, cache dirs,
+    # allocator/arch settings). Values: [A-Za-z0-9_./:@,+=-]* only (no spaces, quotes, globs or shell metacharacters — the
+    # worker command line is built as shell text). Only names are logged.
+    if [ -n "${GLM53_EXTRA_ENV:-}" ]; then
+        local _kv _name _value _names=""
+        set -f
+        for _kv in $GLM53_EXTRA_ENV; do
+            case "$_kv" in *=*) ;; *) set +f; die "GLM53_EXTRA_ENV entries must be NAME=VALUE (got '$_kv')";; esac
+            _name="${_kv%%=*}"; _value="${_kv#*=}"
+            [[ "$_name" =~ ^[A-Z_][A-Z0-9_]*$ ]] || { set +f; die "GLM53_EXTRA_ENV: bad name in '$_kv'"; }
+            [[ "$_value" =~ ^[A-Za-z0-9_./:@,+=-]*$ ]] || { set +f; die "GLM53_EXTRA_ENV: unsafe value for $_name (allowed: A-Z a-z 0-9 _ . / : @ , + = -)"; }
+            case "$_name" in
+                NCCL_*|HF_*|GLM53_*|VLLM_API_KEY|VLLM_CACHE_ROOT|TRITON_CACHE_DIR|TILELANG_CACHE_DIR|TORCH_CUDA_ARCH_LIST|FLASHINFER_*|PYTORCH_CUDA_ALLOC_CONF|LD_PRELOAD|PATH|PYTHONPATH|VLLM_ENGINE_READY_TIMEOUT_S|VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS|VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS|VLLM_PREFIX_CACHE_RETENTION_INTERVAL*)
+                    set +f; die "GLM53_EXTRA_ENV: $_name is launcher-owned; set it through its own knob";;
+            esac
+            nccl_common+=(-e "$_kv"); _names="$_names $_name"
+        done
+        set +f
+        log "extra container env (both ranks):${_names}"
+    fi
     local worker_nccl="" e
     for e in "${nccl_common[@]}"; do
         [ "$e" = "-e" ] && continue

--- a/tests/test_launcher_extra_env.sh
+++ b/tests/test_launcher_extra_env.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# GLM53_EXTRA_ENV: NAME=VALUE entries are appended to nccl_common as -e pairs; bad names/values/owned names abort; only names logged.
+# Values are passed through the environment (not interpolated into source) so adversarial strings are exercised safely.
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+blk="$(sed -n '/^    # Extra container env for diagnostics/,/^    fi$/p' "$HERE/../start.sh")"
+[ -n "$blk" ] || { echo "extra-env block not found" >&2; exit 1; }
+printf '%s\n' "$blk" | sed 's/^    //; s/^local _kv _name _value _names=""$/_names=""/' > /tmp/_extra_env_blk.$$
+run() { # reads GLM53_EXTRA_ENV from the environment; prints the joined -e list, the log line, or ERR
+  GLM53_EXTRA_ENV="$1" bash -c 'die() { echo "DIE: $*" >&2; exit 2; }; log() { echo "LOG:$*"; }; nccl_common=(); source /tmp/_extra_env_blk.'$$'; printf "%s " "${nccl_common[@]}"; echo' 2>/dev/null || echo ERR
+}
+fail=0
+check() { got="$(run "$1" | tr '\n' '|' | sed 's/[[:space:]]*|/|/g; s/|$//')"; if [ "$got" = "$2" ]; then echo "ok   [$1]"; else echo "FAIL [$1] -> [$got] want [$2]"; fail=1; fi; }
+check "" ""
+check "VLLM_DEBUG_WORKSPACE=1" "LOG:extra container env (both ranks): VLLM_DEBUG_WORKSPACE|-e VLLM_DEBUG_WORKSPACE=1"
+check "A=1 B_2=x" "LOG:extra container env (both ranks): A B_2|-e A=1 -e B_2=x"
+check "A=a=b" "LOG:extra container env (both ranks): A|-e A=a=b"
+check "A=" "LOG:extra container env (both ranks): A|-e A="
+check "A=/tmp/x.log:1" "LOG:extra container env (both ranks): A|-e A=/tmp/x.log:1"
+check "bad-name=1" "ERR"
+check "novalue" "ERR"
+check "1ABC=2" "ERR"
+check 'A=x;id' "ERR"
+check 'A=$(id)' "ERR"
+check 'A=a b' "ERR"
+check 'A=*' "ERR"
+check 'A="q"' "ERR"
+check "NCCL_DEBUG=INFO" "ERR"
+check "VLLM_API_KEY=leak" "ERR"
+check "GLM53_MIXED_PREFILL_CHUNK=0" "ERR"
+check "VLLM_PREFIX_CACHE_RETENTION_INTERVAL=0" "ERR"
+# secret redaction: the value must not appear in the log line
+out="$(run "VLLM_DEBUG_WORKSPACE=s3cr3t" | head -1)"; case "$out" in *s3cr3t*) echo "FAIL log leaks value"; fail=1;; *) echo "ok   [log redacts values]";; esac
+rm -f /tmp/_extra_env_blk.$$
+exit $fail


### PR DESCRIPTION
## Launcher: `GLM53_EXTRA_ENV` pass-through for diagnostic container env (both ranks)
Space-separated `NAME=VALUE` list, names validated (`[A-Z_][A-Z0-9_]*`), appended to the shared env array so both ranks get it;
caller export wins over `.env`; launcher logs it. Motivation: diagnostics such as `VLLM_DEBUG_WORKSPACE=1` (workspace-size
receipt for the indexer prefill buffer) or `VLLM_LOGGING_LEVEL=DEBUG` without editing `start.sh`. Host test
`tests/test_launcher_extra_env.sh` (valid / invalid entries). Audit: Codex (pending).

---
Submitted by nood-co1 on behalf of Blockbrain Labs (https://x.com/blockbrain_labs, GitHub org blockbrain-ai). Measured on our 2× NVIDIA DGX Spark deployment.
