### PR TITLE
Indexer prefill-workspace right-sizing: reclaim ~4.5 GiB for KV (+27% capacity, opt-in)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,6 +140,11 @@ GLM53_SUPPRESS_STOPS_IN_REASONING=1
 # When a decode seq is running, do not mix a peer prefill into that step
 # (issue #6). skip = decode-only steps; N>0 = cap mixed prefill tokens; 0 = off.
 GLM53_MIXED_PREFILL_CHUNK=skip
+# Sparse-indexer prefill gather workspace sizing.
+#   stock     = max_model_len * 40 entries (5036.40 MB locked at 1M, measured)
+#   rightsize = the legal per-step maximum, ~+26% KV cache. Opt-in.
+# See docs/DESIGN-indexer-workspace.md. Anything else is rejected at launch.
+GLM53_INDEXER_WORKSPACE=stock
 # EngineCore execute timeout (seconds). Stock 300 is short for a cold JIT.
 # VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -450,6 +450,8 @@ COPY overlay/patch_xgrammar_termination.py /opt/glm53/patch_xgrammar_termination
 COPY tests/test_xgrammar_termination.py /opt/glm53/test_xgrammar_termination.py
 COPY overlay/patch_kpool_tail_slotmap.py /opt/glm53/patch_kpool_tail_slotmap.py
 COPY tests/test_kpool_tail_slotmap.py /opt/glm53/test_kpool_tail_slotmap.py
+COPY overlay/patch_indexer_workspace.py /opt/glm53/patch_indexer_workspace.py
+COPY tests/test_indexer_workspace.py /opt/glm53/test_indexer_workspace.py
 COPY overlay/ablit_runtime.py /opt/glm53/ablit_runtime.py
 COPY overlay/patch_ablit.py /opt/glm53/patch_ablit.py
 COPY tests/test_ablit.py /opt/glm53/test_ablit.py
@@ -463,6 +465,9 @@ RUN python3 /opt/glm53/patch_scheduler_decode_floor.py
 RUN python3 /opt/glm53/patch_hybrid_prefix_hit.py
 RUN python3 /opt/glm53/patch_xgrammar_termination.py
 RUN python3 /opt/glm53/patch_kpool_tail_slotmap.py
+# Applied unconditionally; the injected sizing reads GLM53_INDEXER_WORKSPACE
+# at runtime and returns the stock expression unless it is "rightsize".
+RUN python3 /opt/glm53/patch_indexer_workspace.py
 RUN python3 /opt/glm53/patch_ablit.py
 
 RUN EXL3_SELFCHECK_GPU=0 python3 /opt/glm53/test_exl3_overlay.py \
@@ -471,4 +476,5 @@ RUN EXL3_SELFCHECK_GPU=0 python3 /opt/glm53/test_exl3_overlay.py \
     && python3 /opt/glm53/test_hybrid_prefix_hit.py \
     && python3 /opt/glm53/test_xgrammar_termination.py \
     && python3 /opt/glm53/test_kpool_tail_slotmap.py \
+    && python3 /opt/glm53/test_indexer_workspace.py \
     && python3 /opt/glm53/test_ablit.py

--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ that are now documented/enforced:
 | `MAX_NUM_BATCHED_TOKENS` | `2048` | prefill chunk (P1 keep). 3584/4096 lost; 8192 oversubscribes GB10 indexer topk |
 | `GLM53_MIXED_PREFILL_CHUNK` | `skip` | do not mix a peer prefill into a decode step (issue #6). `N>0` = cap tokens; `0` = off. Solo prefill stays MNBT (2048) |
 | `GLM53_SUPPRESS_STOPS_IN_REASONING` | `1` | ignore client `stop` strings until `</think>` (thinking-on default) |
+| `GLM53_INDEXER_WORKSPACE` | `stock` | sparse-indexer prefill gather workspace. `stock` = `max_model_len * 40` entries (**5036.40 MB** locked at 1M — measured, `VLLM_DEBUG_WORKSPACE=1`). `rightsize` = the legal per-step maximum `min(MAX_NUM_SEQS, MNBT) * cdiv(MAX_MODEL_LEN + k, index_kpool)` = 126 MB at `MAX_NUM_SEQS=4` / 504 MB at 16, so **~+26–28% KV**. Opt-in; see [docs/DESIGN-indexer-workspace.md](docs/DESIGN-indexer-workspace.md) |
 | `GLM53_BOOT_SHAPE_WARMUP` | `1` | after `/health`, burn DFlash2 BLOCK / sampler / kpool shapes (nonfatal) |
 | `TRITON_HOST_CACHE` / `TILELANG_HOST_CACHE` | `$CACHE_ROOT/triton` / `tilelang` | persist JIT caches across container recreate |
 | `LANGUAGE_MODEL_ONLY` | `0` | load vision tower (image + video) |
@@ -533,6 +534,8 @@ this Dockerfile instead. After CUDA compile, Python overlay edits
 | `tests/test_xgrammar_termination.py` | exact two-file patch, idempotence, cross-file fail-closed drift, termination/rollback/reset and post-reasoning draft behavior, launcher wiring |
 | `overlay/patch_kpool_tail_slotmap.py` | clamp KpoolTail one-block circular slot mapping; identity for other KV groups |
 | `tests/test_kpool_tail_slotmap.py` | circular addressing math, exact kernel patch, idempotence, fail-closed drift, launcher wiring |
+| `overlay/patch_indexer_workspace.py` | opt-in `GLM53_INDEXER_WORKSPACE=rightsize`: size the sparse-indexer prefill workspace to the legal per-step maximum instead of `max_model_len * 40`; boot-time compress-ratio cross-check |
+| `tests/test_indexer_workspace.py` | sizing formula (MNBT/`max_num_seqs`/spec-token edge cases, stock clamp), chunk-list equivalence vs stock by exhaustion, exact three-site patch, idempotence, fail-closed drift, launcher wiring |
 | `overlay/ablit_runtime.py` | load-time o_proj transplant / projection (`ABLIT=1`); no-op when off |
 | `overlay/patch_ablit.py` | install the load_weights hook; bind-mounted and run on both ranks |
 | `ablit/` | direction vectors + `LAYER_MAP.json` from drowzeys' published recipe; `fetch_transplant.py` + `transplant/` for the donor o_proj byte-copy |

--- a/docs/DESIGN-indexer-workspace.md
+++ b/docs/DESIGN-indexer-workspace.md
@@ -1,0 +1,269 @@
+# Sparse-indexer prefill workspace right-sizing
+
+`GLM53_INDEXER_WORKSPACE=rightsize` · `overlay/patch_indexer_workspace.py` ·
+`tests/test_indexer_workspace.py`
+
+Condensed from the 2026-08-31 read-only inspection of the live fork
+(`0.1.dev20051+g487ecf187` in `glm53-exl3-head`, head Spark 10.0.22.1), with the
+corrections from Codex's review folded in and the 2026-09-01 workspace receipt
+attached. `file:line` citations are against
+`/usr/local/lib/python3.12/dist-packages/vllm/` inside that container.
+
+---
+
+## 1. The receipt
+
+Stage A boot, 2026-09-01, `VLLM_DEBUG_WORKSPACE=1`:
+
+```
+[WORKSPACE DEBUG] Resized workspace from
+  'sparse_attn_indexer_kpool.py:284:sparse_attn_indexer_kpool':
+  0.00 MB -> 5036.40 MB (ubatch 0)
+```
+
+`sparse_attn_indexer_kpool.py:284` is the profiling-run
+`current_workspace_manager().get_simultaneous(values_spec, scales_spec, radix)`
+call, so the line covers the K-gather workspace plus the 1 MiB radix top-k
+scratch. It reconciles to the byte:
+
+```
+values   40,000,000 x 128 B  = 5,120,000,000
+scales   40,000,000 x   4 B  =   160,000,000
+radix                          =     1,048,576
+                                 -------------
+                                 5,281,048,576 B = 5036.40 MiB
+```
+
+That is `get_max_prefill_buffer_size` = `max_model_len * 40` = 40,000,000
+entries at `max_model_len = 1,000,000`
+(`v1/attention/backends/mla/indexer.py:636-646`). The allocation happens during
+the memory profile, so it is **subtracted from the KV pool**, and it is locked
+for the life of the process (`v1/worker/gpu_model_runner.py` ->
+`v1/worker/workspace.py`). It never shrinks.
+
+**This closes UNKNOWN U3 of the research draft: the 4.92 GiB is measured, not
+computed.** It also settles Codex item 6's "132 bytes depends on the active
+FP8/FP4 layout" — the FP8 layout is what this deployment actually locked, and
+the measured total matches 132 B/entry exactly.
+
+## 2. Why it is over-sized
+
+The workspace is sized in **tokens** and indexed in **pools**.
+
+`split_indexer_prefill_chunks` (`indexer.py:81-127`) is the only consumer of
+the size. The metadata builder hands it `seq_lens_cpu // self.compress_ratio`
+(`indexer.py:1100-1104`), and for GLM-5.3-Flash `compress_ratio == index_kpool
+== 4`: `models/glm5next/nvidia/attention.py:137` replaces the indexer kv-cache
+spec with `compress_ratio=index_kpool`. `sparse_attn_indexer_kpool.py:495-496`
+then slices the workspace to `chunk.total_seq_lens`, which is a sum of those
+compressed lengths.
+
+Upstream already knows: `models/deepseek_v4/attention.py:776-778` divides
+`get_max_prefill_buffer_size(vllm_config)` by `compress_ratio` at its call
+site. `models/glm5next/nvidia/attention.py:302` does not — it passes the raw
+token-granular value straight into `SparseAttnIndexerKpool` as
+`total_seq_lens`. The 4x is the whole of the gap between the two call sites.
+
+## 3. What `rightsize` computes
+
+Not a tuned request count — the **legal maximum a single step can present**:
+
+```
+entries = min(max_num_seqs, max_num_batched_tokens)
+          * cdiv(max_model_len + num_speculative_tokens, compress_ratio)
+```
+
+capped at the stock `max_model_len * 40` so the patch can only ever narrow.
+
+| Term | Why |
+|---|---|
+| `min(max_num_seqs, MNBT)` | the scheduler admits at most `max_num_seqs` sequences, and every prefill row costs at least one query token out of the `max_num_batched_tokens` budget — so this bounds the prefill requests in one step |
+| `+ num_speculative_tokens` | the splitter is fed `common_attn_metadata.seq_lens_cpu_upper_bound`, which the builder documents at `indexer.py:1095-1099` as "an upper bound for async-spec extend rows" |
+| `cdiv`, not floor | the consumer floors; cdiv is the safe side |
+| clamp to stock | a config whose legal maximum exceeds stock is one where **stock is already under-sized**. That is an upstream latent risk this overlay does not inherit and does not pretend to fix: it returns stock unchanged and logs a warning |
+
+At the live config (M=1e6, kpool=4, `max_num_seqs=16`, MNBT=2048, k=7):
+`cdiv(1_000_007, 4) = 250,002` per request x 16 = **4,000,032 entries =
+528,004,224 B = 503.5 MiB**, against 5035.4 MiB. At the recipe default
+`MAX_NUM_SEQS=4` it is **1,000,008 entries = 125.9 MiB**.
+
+**The hard floor** is one whole max-length request. `indexer.py:115-119` admits
+a single request that exceeds the budget and sub-chunks it on the query
+dimension M only, never on N, so a workspace below `cdiv(max_model_len, kpool)`
+would overrun. The formula's `max(1, ...)` request count keeps that floor even
+for degenerate configs (`max_num_seqs=0`, `MNBT=0`), and
+`test_prefill_request_count_is_mnbt_bounded` asserts it.
+
+### 3.1 Why the chunk list does not change
+
+Because the size is >= the largest total the splitter can ever be asked to
+pack, the `new_n <= workspace_size` constraint at `indexer.py:109` cannot bind
+anywhere the stock 40x value did not already bind. Every batch the scheduler
+can legally form produces the **same chunk list**, so the same
+`cp_gather_indexer_k_quant_cache` calls, the same `fp8_fp4_mqa_logits` shapes,
+and the same top-k inputs.
+
+This is not asserted, it is checked: `test_chunking_is_identical_to_stock`
+replays a host replica of `split_indexer_prefill_chunks` over 400 randomized
+legal batches plus the extremes and compares chunk lists, and
+`test_chunking_test_has_power` proves the comparison can fail by starving the
+workspace deliberately.
+
+## 4. Decisions on Codex's review
+
+| Codex item | Decision |
+|---|---|
+| **2 — the 128-byte alignment is unsupported by the SM120 paged-MQA kernel** | **Dropped the change entirely.** The draft's Anchor A (decode logits pitch) is not in this PR. The alignment contract is unresolved, so the honest move is to not ship an unproven pitch, not to ship it with a caveat. §6 keeps it as a separate, separately-gated item |
+| **3 — Anchor A's safety proof is incomplete** | Moot: Anchor A is out of scope |
+| **4 — "real need ~33 MB" understates the legal requirement; 264 MB is a throughput tradeoff** | **Accepted, and the draft's `GLM53_INDEXER_WORKSPACE_REQS=8` default is rejected.** There is no request-count knob. The default is the legal maximum derived from `max_num_seqs`/MNBT, which is what Codex asked for, and it also removes the chunking regression surface (§3.1) rather than "accepting and measuring" it. Spec tokens are in the span, per the same item |
+| **5 — "fails closed" needs runtime proof** | **Strengthened from a claim to a check.** The lock's `AssertionError` is still the backstop, but the patch no longer relies on it: the builder raises at `__init__`, on every TP rank, before any step, if the workspace is below the legal maximum. See §5 |
+| **6 — 4.67 GiB is plausible but not demonstrated** | The stock half is now **measured** (§1). The patched half is still an estimate and is gated on the live receipt in §7 |
+| **7 — the capacity projection is approximate** | **Accepted.** The acceptance criterion is the allocator's own `GPU KV cache size` / `Available KV cache memory` startup lines, not GiB arithmetic. §6's percentages are labelled estimates |
+| **11 — Anchor A and Anchor B read different config sources** | **Accepted, with a check.** Sizing runs in `get_max_prefill_buffer_size`, which only receives `vllm_config`, so it reads `hf_text_config.index_kpool`; the runtime divides by `kv_cache_spec.compress_ratio`. They are the same number by construction (`models/glm5next/nvidia/attention.py:137`), but the patch now **refuses to serve** if they disagree |
+| **12 — split the rollout gates; this is a memory patch** | **Accepted, structurally.** This PR is Anchor B only, default off, with memory receipts. Mixed-step latency (research §6, Codex 8-10) is not a success criterion here and is not investigated by this PR |
+| **1 — the refutation of the original top-k hypothesis is too absolute** | Noted; nothing in this PR depends on it. The claim carried forward is only the narrow one the receipt supports |
+
+## 5. Failure modes
+
+* **Wrong compression ratio.** `DeepseekV32IndexerMetadataBuilder.__init__` now
+  raises after `self.compress_ratio` is resolved if
+  `hf_text_config.index_kpool` disagrees with it, naming both values and the
+  knob to unset. Boot fails; no step runs. The comparison is **unconditional**
+  whenever `rightsize` is active and raises in **both** directions. It is not
+  guarded on `self.compress_ratio > 1`: that guard would skip the one
+  combination that actually under-sizes — `index_kpool=4` with
+  `compress_ratio=1` sizes for ~4M compressed entries while the runtime may
+  present ~16M token entries (Codex PR-8 blocker). The mirror direction sizes
+  at stock and cannot under-run, but it still means the two config sources
+  disagree about the model, which is not a state to serve `rightsize` from.
+  Both directions are covered by
+  `tests/test_indexer_workspace.py::test_builder_ratio_mismatch_raises_both_directions`,
+  and `::test_builder_guard_is_inert_in_stock_mode` pins that stock mode runs
+  no cross-check at all.
+* **Workspace below the legal maximum.** Same site, same raise. This can only
+  fire if the formula and the clamp disagree, which is exactly the condition
+  worth crashing on.
+* **Anything else.** The workspace is still locked after warmup, so
+  `_ensure_workspace_size` still raises an `AssertionError` naming the calling
+  site and the requested size (`v1/worker/workspace.py`) rather than
+  overrunning. That is the backstop, not the plan.
+* **Bad knob value.** `_glm53_workspace_mode()` raises on anything but exactly
+  `stock`/`rightsize`, and `start.sh`'s numeric guard rejects it earlier still,
+  turning a container boot failure into a launcher error. The two enums are
+  literally identical: the default applies **only** to an unset var, and the
+  value is then compared as-is, so `""`, `" rightsize "` and `RIGHTSIZE` are
+  errors on both sides. The launcher's caller capture uses the
+  `${GLM53_INDEXER_WORKSPACE+1}` setness probe, so an explicitly empty caller
+  value reaches the guard instead of being replaced by a `.env` value.
+  `tests/test_indexer_workspace.py::test_mode_enum_matches_launcher_enum` runs
+  both implementations over the same values and requires the verdicts to match.
+* **TP-rank divergence.** Both quantities derive from `model_config`,
+  `scheduler_config` and `speculative_config` plus one env var, all shipped
+  identically to head and worker by `start.sh`. No device tensor, no scheduler
+  state, no `.item()`. Each rank logs its computed sizing at boot, so a
+  mismatch is visible in the receipts rather than inferred.
+* **Default off.** With the knob unset or `stock`,
+  `get_max_prefill_buffer_size` returns `max_model_len * 40` and logs nothing.
+  The image can carry the overlay and serve exactly stock.
+
+## 6. Expected gain — and what this PR does not claim
+
+**Memory (the claim).** At `MAX_NUM_SEQS=16`, 4,751,995,776 B = **4.43 GiB**
+returns to the KV pool; at the recipe default `MAX_NUM_SEQS=4`, **4.79 GiB**.
+Against the 16.93 GiB available-KV figure from the inspected boot that is an
+estimated **+26%** and **+28%** respectively. Per Codex item 7 these are
+estimates: the acceptance number is whatever the allocator prints (§7).
+
+(The research draft's +27.6% assumed the rejected `REQS=8` sizing. The
+difference between 4.43 and 4.67 GiB is the price of removing the chunking
+regression, and it is worth paying.)
+
+**Latency (not a claim).** The research train's arithmetic put the indexer's
+entire context-proportional decode cost at ~1 ms/step at 100K KV, ~0.5% of the
+measured 200 ms long-context delta. Codex item 8 correctly notes that roofline
+arithmetic cannot *prove* the indexer is not a contributor — so this PR simply
+does not make a latency claim in either direction. The pass bar is **no receipt
+worse than -3%**. The plan's original "+10% on 100K-KV decode or mixed-step"
+gate does not apply to this PR and would fail a correct memory change.
+
+**Out of scope, deliberately:**
+
+* *The decode logits pitch.* `sparse_attn_indexer_kpool.py:788-797` passes
+  `max_model_len` as the paged-MQA logits row pitch
+  (`utils/deep_gemm.py:620,625-626`: output is `[B*next_n, max_model_len]`
+  float32) while `decode_metadata.seq_lens` is pool-granular — a flat 4x
+  over-stride on a transient allocation. It is a genuine bug and an
+  upstreamable one, but the required pitch alignment is not documented in the
+  shipped SM120 headers (Codex item 2) and the op is captured inside the FULL
+  cudagraph, so it needs its own kernel-ABI and bitwise-equivalence gate. Not
+  here.
+* *The mixed-step tax.* Codex items 8-10. Separate investigation.
+
+**Upstreamability.** The magic 40 has a stated rationale (`indexer.py:638-645`)
+tied to the flashmla_sparse workspace, which is not the backend here
+(`FLASHINFER_MLA_SPARSE_SM120`). An upstream fix should make the factor
+backend- and compression-aware rather than env-gated — most simply, by dividing
+at the glm5next call site the way `deepseek_v4/attention.py:776-778` already
+does. Keep this as a recipe overlay; file the upstream issue separately.
+
+## 7. Test plan
+
+**Host (green before merge — `tests/test_indexer_workspace.py`, 16 tests):**
+
+* the sizing formula across Codex's edge cases: MNBT-bounded request count,
+  `max_num_seqs`-bounded request count, `k=7` spec tokens (and monotonicity in
+  k), the true per-step maximum, the one-request floor at degenerate configs,
+  `index_kpool <= 1` / missing / junk => stock, and the never-exceeds-stock
+  clamp over a `M x kpool x max_num_seqs x MNBT` sweep;
+* the stock sizing reproducing the 5036.40 MB receipt to the byte;
+* chunk-list equivalence against stock by exhaustion, plus a power check;
+* the knob enum, including that a typo raises rather than selecting a mode;
+* apply / idempotence / `--preflight`-writes-nothing / three-way anchor drift /
+  half-patched refusal, against a fixture assembled from verbatim excerpts of
+  the live container's `indexer.py`, and against the live file itself
+  (`GLM53_INDEXER_BACKEND_PY_SRC=…`, or `GLM53_INDEXER_LIVE_SSH=1` to pull it
+  read-only from the running head container);
+* the shipped dispatch, exec'd out of the patched file text by AST, so the
+  mode dispatch and the stock-clamp warning are covered and not just the
+  formula;
+* launcher / Dockerfile / README wiring.
+
+**Live (the gate on the memory claim).** Boot A stock, boot B
+`GLM53_INDEXER_WORKSPACE=rightsize`, everything else identical:
+
+1. **Workspace receipt.** `VLLM_DEBUG_WORKSPACE=1` on both. Expect
+   `5036.40 MB` -> `~504.5 MB` at `MAX_NUM_SEQS=16` (`~126.9 MB` at 4), and the
+   `[glm53-indexer-workspace] rightsize:` / `builder:` lines on **both** TP
+   ranks with equal values.
+2. **Capacity receipt — the headline.** `Available KV cache memory` and
+   `GPU KV cache size: N tokens` / `Maximum concurrency` from both startup
+   logs. This is the acceptance number, per Codex item 7; the GiB arithmetic in
+   §6 is only the prediction.
+3. **Temp-0 logprob equivalence.** Same prompts at 8K / 50K / 100K,
+   `temperature=0`, top-5 logprobs compared token-by-token against the stock
+   boot. §3.1 says the chunk list is identical, so this must be **exactly**
+   equal; any drift is a bug, not a tolerance.
+4. **100K-prompt prefill smoke.** One cold 100K prefill to completion, then a
+   concurrent long-context prefill at the configured `MAX_NUM_SEQS` — the case
+   the rejected `REQS=8` sizing would have re-chunked. Expect no
+   `_ensure_workspace_size` assertion, no extra chunk count, and prefill
+   timings within the -3% bar.
+
+Only after 1 and 2 land as receipts does the +26% become a claim rather than a
+prediction. The default stays `stock` until then, and flipping it is a separate
+change.
+
+## 8. Anchors
+
+Three pinned sites in `v1/attention/backends/mla/indexer.py`, all preflighted
+before any is written:
+
+| Site | Location | Change |
+|---|---|---|
+| `os import` | module header | `import os` (stock has none at module scope) |
+| `workspace sizing` | `get_max_prefill_buffer_size` | helper functions + mode dispatch; stock path returns the unchanged expression |
+| `builder cross-check` | `DeepseekV32IndexerMetadataBuilder.__init__`, after `compress_ratio` resolution | fail-closed ratio/size check + per-rank boot log |
+
+Drift in any anchor exits nonzero and leaves the file untouched.
+`--preflight` validates without writing, so CI catches drift while the knob is
+off.

--- a/overlay/patch_indexer_workspace.py
+++ b/overlay/patch_indexer_workspace.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""Right-size the sparse-indexer prefill gather workspace (opt-in).
+
+``get_max_prefill_buffer_size`` returns ``max_model_len * 40`` entries
+(``v1/attention/backends/mla/indexer.py``). Each entry is 128 fp8 bytes plus a
+4-byte scale = 132 bytes, so at ``max_model_len=1_000_000`` that is 40,000,000
+entries = 5,280,000,000 B. The kpool indexer requests it (plus the 1 MiB radix
+top-k scratch) during the *memory profile* — so it is subtracted from the KV
+pool — and then it is locked for the life of the process
+(``v1/worker/gpu_model_runner.py`` -> ``v1/worker/workspace.py``).
+
+Live receipt, head Spark, Stage A boot 2026-09-01 with ``VLLM_DEBUG_WORKSPACE=1``::
+
+    [WORKSPACE DEBUG] Resized workspace from
+      'sparse_attn_indexer_kpool.py:284:sparse_attn_indexer_kpool':
+      0.00 MB -> 5036.40 MB (ubatch 0)
+
+5036.40 MiB is 5,281,048,576 B == 40,000,000*132 + 1 MiB radix scratch, to the
+byte. The over-allocation is measured, not inferred.
+
+Why it is over-sized
+--------------------
+The splitter that consumes the workspace (``split_indexer_prefill_chunks``) is
+fed COMPRESSED seq lens: the metadata builder divides by ``compress_ratio``
+before calling it, and for GLM-5.3-Flash ``compress_ratio == index_kpool == 4``
+(``models/glm5next/nvidia/attention.py`` sets ``compress_ratio=index_kpool`` on
+the indexer kv-cache spec). The workspace is therefore sized in TOKENS while it
+is indexed in POOLS. Upstream already knows this: ``models/deepseek_v4/
+attention.py`` divides ``get_max_prefill_buffer_size(vllm_config)`` by
+``compress_ratio`` at its call site; ``models/glm5next/nvidia/attention.py``
+does not.
+
+What ``rightsize`` computes
+---------------------------
+The LEGAL MAXIMUM a single step can ask for, not a tuned guess:
+
+    entries = min(max_num_seqs, max_num_batched_tokens)
+              * cdiv(max_model_len + num_speculative_tokens, compress_ratio)
+
+* ``min(max_num_seqs, max_num_batched_tokens)`` bounds the prefill requests in
+  one step: the scheduler admits at most ``max_num_seqs`` sequences, and every
+  prefill row contributes at least one query token to the ``max_num_batched_
+  tokens`` budget.
+* ``+ num_speculative_tokens`` covers ``seq_lens_cpu_upper_bound``, which the
+  builder documents as "an upper bound for async-spec extend rows" and which is
+  the tensor actually handed to the splitter.
+* ``cdiv`` (not floor) because the consumer floors; cdiv is the upper bound.
+
+Because the result is >= the largest total the splitter can ever be asked to
+pack, the ``new_n <= workspace_size`` constraint inside
+``split_indexer_prefill_chunks`` can never bind that the stock 40x value did not
+already bind. The chunk list is therefore IDENTICAL to stock for every batch the
+scheduler can legally form -- see ``split_prefill_chunks`` below and
+``tests/test_indexer_workspace.py::test_chunking_is_identical_to_stock``, which
+proves it by exhaustion over randomized legal batches rather than asserting it.
+
+The result is also clamped to the stock value, so this patch can only ever
+narrow. If a config's legal maximum exceeds ``max_model_len * 40`` the stock
+value is returned unchanged and a warning is logged: stock is already under the
+legal maximum there, which is an upstream latent risk this overlay does not
+inherit and does not fix.
+
+At the live config (M=1e6, kpool=4, max_num_seqs=16, MNBT=2048, k=7):
+4,000,032 entries = 528,004,224 B = 503.5 MiB, against 5035.4 MiB. ~4.43 GiB
+returns to the KV pool.
+
+Fail-closed, at boot, at the authoritative source
+-------------------------------------------------
+The sizing runs in ``get_max_prefill_buffer_size``, which only has
+``vllm_config``, so it reads ``hf_text_config.index_kpool``. The value the
+runtime actually uses is ``self.kv_cache_spec.compress_ratio``, resolved later
+in ``DeepseekV32IndexerMetadataBuilder.__init__``. Those are the same number by
+construction, but "by construction" is not a check, so the patch installs one:
+the builder raises at init if the two disagree, and logs the computed sizing on
+every TP rank so a rank mismatch is visible in the boot receipts.
+
+That comparison is unconditional whenever ``rightsize`` is active, and raises in
+BOTH directions. It is not guarded on ``self.compress_ratio > 1``: the direction
+that actually under-sizes is ``index_kpool=4`` with ``compress_ratio=1``, which
+sizes for ~4M compressed entries while the runtime may present ~16M token
+entries, and that direction is precisely the one such a guard would skip.
+
+Activation
+----------
+``GLM53_INDEXER_WORKSPACE=stock``      (default, and the value of an UNSET var)
+    ``get_max_prefill_buffer_size`` returns ``max_model_len * 40``, byte-for-byte
+    the stock expression. The image may be built with this patch applied and
+    still serve exactly stock.
+``GLM53_INDEXER_WORKSPACE=rightsize``  opt in.
+Any other value raises at boot rather than picking a serving mode from a typo.
+The match is literal, so ``""``, ``" rightsize "`` and ``RIGHTSIZE`` all raise:
+identical semantics to ``start.sh``'s ``_glm53_validate_enum``, which defaults
+only on an unset var and then compares the value as-is.
+
+Conventions follow ``overlay/patch_kpool_tail_slotmap.py``: pinned ANCHOR, MARK
+sentinel, ``verified_state``, ``prepare``, idempotent, atomic replace, pyc
+clear, drift => nonzero exit. All three sites are preflighted before any is
+written.
+
+Usage::
+
+    python3 patch_indexer_workspace.py              # apply
+    python3 patch_indexer_workspace.py --preflight  # validate anchors only
+"""
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+
+TARGET = Path(
+    os.environ.get(
+        "GLM53_INDEXER_BACKEND_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/v1/attention/backends/mla/indexer.py",
+    )
+)
+
+ENV_NAME = "GLM53_INDEXER_WORKSPACE"
+STOCK_MULTIPLIER = 40
+BYTES_PER_ENTRY = 132  # 128 fp8 value bytes + 4 scale bytes (FP8 indexer cache)
+
+
+# ---------------------------------------------------------------------------
+# The injected sizing helpers, as source.
+#
+# This string is BOTH what gets written into indexer.py AND what the host tests
+# exercise: it is exec'd below to produce module-level callables. There is one
+# implementation of the formula, so a test can never pass against a replica that
+# has drifted from the shipped code.
+# ---------------------------------------------------------------------------
+HELPERS_SRC = '''
+
+# [glm53-indexer-workspace] Opt-in right-sizing of the prefill gather
+# workspace. See overlay/patch_indexer_workspace.py and
+# docs/DESIGN-indexer-workspace.md in the recipe. Default is stock.
+_GLM53_WORKSPACE_ENV = "GLM53_INDEXER_WORKSPACE"
+
+
+def _glm53_workspace_mode() -> str:
+    """Exactly "stock" or "rightsize"; an UNSET var means "stock".
+
+    Same contract as the launcher: start.sh runs
+    ``_glm53_validate_enum GLM53_INDEXER_WORKSPACE "${GLM53_INDEXER_WORKSPACE-stock}"
+    stock rightsize``, which substitutes the default only when the var is
+    unset and then compares the value literally. So no normalisation here
+    either -- no strip, no lower, and "" is a value, not an absence.
+    "RIGHTSIZE", " rightsize " and "" are operator errors on both sides of the
+    container boundary, and must not silently select a serving mode.
+    """
+    raw = os.environ.get(_GLM53_WORKSPACE_ENV)
+    if raw is None:
+        return "stock"
+    if raw not in ("stock", "rightsize"):
+        raise ValueError(
+            f"{_GLM53_WORKSPACE_ENV} must be exactly one of: stock rightsize "
+            f"(got: {raw!r})"
+        )
+    return raw
+
+
+def _glm53_stock_workspace_entries(max_model_len: int) -> int:
+    return max_model_len * 40
+
+
+def _glm53_indexer_compress_ratio(vllm_config) -> int:
+    """Indexer pool width from config only. 1 == no compression == no-op."""
+    hf = getattr(vllm_config.model_config, "hf_text_config", None)
+    raw = getattr(hf, "index_kpool", None) if hf is not None else None
+    try:
+        ratio = int(raw or 1)
+    except (TypeError, ValueError):
+        return 1
+    return ratio if ratio > 1 else 1
+
+
+def _glm53_rightsized_workspace_entries(vllm_config) -> int:
+    """Legal maximum compressed N a single prefill step can require.
+
+    Never larger than the stock value: this is a narrowing only.
+    """
+    max_model_len = int(vllm_config.model_config.max_model_len)
+    stock = _glm53_stock_workspace_entries(max_model_len)
+    ratio = _glm53_indexer_compress_ratio(vllm_config)
+    if ratio <= 1:
+        return stock
+    sched = vllm_config.scheduler_config
+    spec_cfg = getattr(vllm_config, "speculative_config", None)
+    num_spec = int(getattr(spec_cfg, "num_speculative_tokens", 0) or 0)
+    # Every prefill row costs at least one query token, so a step can carry at
+    # most this many prefill requests.
+    max_prefill_reqs = max(
+        1, min(int(sched.max_num_seqs), int(sched.max_num_batched_tokens))
+    )
+    # seq_lens_cpu_upper_bound may run ahead of max_model_len by the draft
+    # length on async-spec extend rows; cdiv because the consumer floors.
+    span = max_model_len + max(0, num_spec)
+    per_req = -(-span // ratio)
+    return min(per_req * max_prefill_reqs, stock)
+'''
+
+_HELPER_NS: dict = {"os": os}
+exec(compile(HELPERS_SRC, "<glm53-indexer-workspace helpers>", "exec"), _HELPER_NS)
+
+workspace_mode = _HELPER_NS["_glm53_workspace_mode"]
+stock_workspace_entries = _HELPER_NS["_glm53_stock_workspace_entries"]
+indexer_compress_ratio = _HELPER_NS["_glm53_indexer_compress_ratio"]
+rightsized_workspace_entries = _HELPER_NS["_glm53_rightsized_workspace_entries"]
+
+
+def split_prefill_chunks(
+    compressed_seq_lens: list[int],
+    query_lens: list[int],
+    workspace_size: int,
+    max_logits_bytes: int,
+) -> list[tuple[tuple[int, int], tuple[int, int]]]:
+    """Host replica of ``split_indexer_prefill_chunks`` (indexer.py).
+
+    Used only by the tests, to prove that a right-sized workspace produces the
+    same chunk list as the stock 40x one for every batch the scheduler can
+    legally form. Slices are returned as ``(start, stop)`` pairs so the result
+    compares by value.
+    """
+    chunks: list[tuple[tuple[int, int], tuple[int, int]]] = []
+    n = len(compressed_seq_lens)
+    max_logits_elems = max_logits_bytes // 4
+    end = 0
+    while end < n:
+        start, chunk_m, chunk_n = end, 0, 0
+        while end < n:
+            q, s = query_lens[end], compressed_seq_lens[end]
+            new_m, new_n = chunk_m + q, chunk_n + s
+            if new_n <= workspace_size and new_m * new_n <= max_logits_elems:
+                chunk_m, chunk_n = new_m, new_n
+                end += 1
+            else:
+                break
+        if end == start:
+            chunk_m, chunk_n = query_lens[end], compressed_seq_lens[end]
+            end += 1
+        req_slice = (start, end)
+        max_q = max(1, max_logits_elems // chunk_n) if chunk_n > 0 else max(1, chunk_m)
+        for q_off in range(0, chunk_m, max_q):
+            sub_m = min(max_q, chunk_m - q_off)
+            chunks.append((req_slice, (q_off, q_off + sub_m)))
+    return chunks
+
+
+# ---------------------------------------------------------------------------
+# Site 1 -- module-scope ``import os``
+# ---------------------------------------------------------------------------
+MARK_IMPORT = "import os  # [glm53-indexer-workspace] workspace mode env\n"
+
+ANCHOR_IMPORT = """# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from dataclasses import dataclass
+"""
+
+PATCHED_IMPORT = """# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os  # [glm53-indexer-workspace] workspace mode env
+from dataclasses import dataclass
+"""
+
+
+# ---------------------------------------------------------------------------
+# Site 2 -- the sizing function itself
+# ---------------------------------------------------------------------------
+MARK_SIZE = (
+    "    # [glm53-indexer-workspace] The workspace is sized in TOKENS "
+    "but indexed in\n"
+)
+
+ANCHOR_SIZE = """def get_max_prefill_buffer_size(vllm_config: VllmConfig):
+    max_model_len = vllm_config.model_config.max_model_len
+    # NOTE(Chen): 40 is a magic number for controlling the prefill buffer size.
+    # Each entry is 128 fp8 bytes and 4 scale bytes for a total of 132 bytes.
+    # The flashmla_sparse backend uses a workspace size of 5 * max_model_len.
+    # The memory usage of the workspace there is 576 * 2 bytes; so we size this as
+    # (576 * 2 // 132) * 5 = 40 to maximize this workspace size while still fitting
+    # within the flashmla_sparse workspace.
+    # For DeepSeek-V3.2, the max_model_len is 163840.
+    #   40 * 163840 * 132 = 865075200 bytes = 825 MB
+    return max_model_len * 40
+"""
+
+PATCHED_SIZE = (
+    HELPERS_SRC.lstrip("\n")
+    + """
+
+def get_max_prefill_buffer_size(vllm_config: VllmConfig):
+    max_model_len = vllm_config.model_config.max_model_len
+    # NOTE(Chen): 40 is a magic number for controlling the prefill buffer size.
+    # Each entry is 128 fp8 bytes and 4 scale bytes for a total of 132 bytes.
+    # The flashmla_sparse backend uses a workspace size of 5 * max_model_len.
+    # The memory usage of the workspace there is 576 * 2 bytes; so we size this as
+    # (576 * 2 // 132) * 5 = 40 to maximize this workspace size while still fitting
+    # within the flashmla_sparse workspace.
+    # For DeepSeek-V3.2, the max_model_len is 163840.
+    #   40 * 163840 * 132 = 865075200 bytes = 825 MB
+    # [glm53-indexer-workspace] The workspace is sized in TOKENS but indexed in
+    # POOLS: split_indexer_prefill_chunks above is fed seq_lens // compress_ratio
+    # by the metadata builder, and models/deepseek_v4/attention.py already
+    # divides this return value by compress_ratio at its call site --
+    # models/glm5next/nvidia/attention.py does not. At max_model_len=1e6 the
+    # stock value is 40,000,000 entries; a 2026-09-01 VLLM_DEBUG_WORKSPACE boot
+    # measured the resulting lock at 5036.40 MB, inside the memory profile and
+    # therefore straight out of the KV pool.
+    #
+    # "rightsize" returns the LEGAL MAXIMUM a single step can need, so the
+    # workspace constraint in the splitter binds exactly where it already did
+    # and the chunk list is unchanged. It never exceeds the stock value.
+    # Default is stock: an unset env var is byte-for-byte the expression below.
+    _glm53_stock = _glm53_stock_workspace_entries(max_model_len)
+    if _glm53_workspace_mode() != "rightsize":
+        return _glm53_stock
+    _glm53_entries = _glm53_rightsized_workspace_entries(vllm_config)
+    if _glm53_entries >= _glm53_stock:
+        # The legal maximum is already above stock: stock is under-sized here
+        # to begin with. Return it unchanged rather than growing the profile.
+        logger.warning(
+            "[glm53-indexer-workspace] legal max %d entries >= stock %d; "
+            "keeping stock sizing",
+            _glm53_entries,
+            _glm53_stock,
+        )
+        return _glm53_stock
+    logger.info(
+        "[glm53-indexer-workspace] rightsize: compress_ratio=%d "
+        "max_num_seqs=%d max_num_batched_tokens=%d -> %d entries "
+        "(stock %d, ~%.1f MiB reclaimed at 132 B/entry)",
+        _glm53_indexer_compress_ratio(vllm_config),
+        vllm_config.scheduler_config.max_num_seqs,
+        vllm_config.scheduler_config.max_num_batched_tokens,
+        _glm53_entries,
+        _glm53_stock,
+        (_glm53_stock - _glm53_entries) * 132 / (1024 * 1024),
+    )
+    return _glm53_entries
+"""
+)
+
+
+# ---------------------------------------------------------------------------
+# Site 3 -- fail-closed cross-check at the authoritative runtime source
+# ---------------------------------------------------------------------------
+MARK_GUARD = "        # [glm53-indexer-workspace] The sizing above ran against\n"
+
+ANCHOR_GUARD = """        # KV compression. Default to 1 for no compression.
+        self.compress_ratio = 1
+        # Get compress_ratio for DeepseekV4 support
+        if isinstance(self.kv_cache_spec, MLAAttentionSpec):
+            self.compress_ratio = self.kv_cache_spec.compress_ratio
+        if self.dcp_world_size > 1 and self.compress_ratio > 1:
+            raise NotImplementedError(
+                "DCP is not supported with sparse indexer KV compression "
+                f"(compress_ratio={self.compress_ratio})."
+            )
+"""
+
+PATCHED_GUARD = """        # KV compression. Default to 1 for no compression.
+        self.compress_ratio = 1
+        # Get compress_ratio for DeepseekV4 support
+        if isinstance(self.kv_cache_spec, MLAAttentionSpec):
+            self.compress_ratio = self.kv_cache_spec.compress_ratio
+        if self.dcp_world_size > 1 and self.compress_ratio > 1:
+            raise NotImplementedError(
+                "DCP is not supported with sparse indexer KV compression "
+                f"(compress_ratio={self.compress_ratio})."
+            )
+        # [glm53-indexer-workspace] The sizing above ran against
+        # hf_text_config.index_kpool, because get_max_prefill_buffer_size only
+        # receives vllm_config. THIS is the authoritative ratio: the runtime
+        # divides seq_lens by self.compress_ratio before handing them to the
+        # splitter. They are the same number by construction
+        # (models/glm5next/nvidia/attention.py replaces the indexer spec with
+        # compress_ratio=index_kpool), but construction is not a check. Fail at
+        # init, on every TP rank, rather than at the first oversized step.
+        #
+        # The comparison is UNCONDITIONAL in rightsize mode, in both
+        # directions. Guarding it on self.compress_ratio > 1 would skip the one
+        # case that actually under-sizes: index_kpool=4 with
+        # kv_cache_spec.compress_ratio=1 sizes the workspace for ~4M compressed
+        # entries while the runtime hands the splitter up to ~16M token
+        # entries. The mirror case (index_kpool absent/1 with compress_ratio>1)
+        # sizes at stock and so cannot under-run, but it still means the two
+        # config sources disagree about the model being served, which is not a
+        # state to serve rightsize from.
+        if _glm53_workspace_mode() == "rightsize":
+            _glm53_cfg_ratio = _glm53_indexer_compress_ratio(self.vllm_config)
+            if _glm53_cfg_ratio != self.compress_ratio:
+                raise ValueError(
+                    "[glm53-indexer-workspace] compress-ratio disagreement: "
+                    f"hf_text_config.index_kpool={_glm53_cfg_ratio} but "
+                    f"kv_cache_spec.compress_ratio={self.compress_ratio}. "
+                    "Refusing to serve on a workspace sized from the wrong "
+                    f"ratio; unset {_GLM53_WORKSPACE_ENV} to use stock sizing."
+                )
+            _glm53_need = _glm53_rightsized_workspace_entries(self.vllm_config)
+            _glm53_stock = _glm53_stock_workspace_entries(
+                self.vllm_config.model_config.max_model_len
+            )
+            if self.max_prefill_buffer_size < min(_glm53_need, _glm53_stock):
+                raise ValueError(
+                    "[glm53-indexer-workspace] workspace "
+                    f"{self.max_prefill_buffer_size} entries is below the legal "
+                    f"per-step maximum {_glm53_need} (compress_ratio="
+                    f"{self.compress_ratio}, max_num_seqs="
+                    f"{self.vllm_config.scheduler_config.max_num_seqs})."
+                )
+            logger.info(
+                "[glm53-indexer-workspace] builder: compress_ratio=%d "
+                "workspace=%d entries (legal max %d, stock %d)",
+                self.compress_ratio,
+                self.max_prefill_buffer_size,
+                _glm53_need,
+                _glm53_stock,
+            )
+"""
+
+
+SITES = (
+    ("os import", MARK_IMPORT, ANCHOR_IMPORT, PATCHED_IMPORT),
+    ("workspace sizing", MARK_SIZE, ANCHOR_SIZE, PATCHED_SIZE),
+    ("builder cross-check", MARK_GUARD, ANCHOR_GUARD, PATCHED_GUARD),
+)
+
+
+def verified_state(text: str) -> bool:
+    """Exact post-state check.
+
+    Two of the three replacements are insertions that legitimately keep their
+    anchor, so ``anchor == 0`` would reject them and ignoring the anchor would
+    stop catching a half-applied site. Expect exactly as many surviving anchors
+    as the replacement itself contains.
+    """
+    return all(
+        text.count(mark) == 1
+        and text.count(patched) == 1
+        and text.count(anchor) == patched.count(anchor)
+        for _name, mark, anchor, patched in SITES
+    )
+
+
+def prepare(source: str) -> tuple[str, str]:
+    """Idempotent, fail-closed. Returns ``(text, action)``."""
+    marks = sum(source.count(mark) for _n, mark, _a, _p in SITES)
+    if marks:
+        if marks != len(SITES) or not verified_state(source):
+            raise ValueError(
+                "partial/inconsistent indexer workspace patch "
+                f"(marks={marks}, expected {len(SITES)}) -- refusing to touch "
+                "a half-patched file"
+            )
+        return source, "already present"
+
+    out = source
+    for name, _mark, anchor, patched in SITES:
+        n = out.count(anchor)
+        if n != 1:
+            raise ValueError(
+                f"pinned indexer anchor '{name}' drifted (found {n}, expected 1)"
+            )
+        out = out.replace(anchor, patched, 1)
+
+    if not verified_state(out):
+        raise ValueError("indexer workspace post-patch verification failed")
+    return out, "patched"
+
+
+def replace_file(target: Path, source: str) -> None:
+    tmp = target.with_name(f".{target.name}.glm53-indexer-workspace.tmp")
+    try:
+        tmp.write_text(source)
+        os.chmod(tmp, stat.S_IMODE(target.stat().st_mode))
+        os.replace(tmp, target)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def clear_pyc(target: Path) -> None:
+    cache = target.parent / "__pycache__"
+    if not cache.is_dir():
+        return
+    for pyc in cache.glob(f"{target.stem}*.pyc"):
+        pyc.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv if argv is None else argv
+    preflight_only = "--preflight" in argv[1:]
+
+    if not TARGET.is_file():
+        raise SystemExit(f"missing {TARGET}")
+    source = TARGET.read_text()
+    try:
+        patched, action = prepare(source)
+    except ValueError as exc:
+        raise SystemExit(f"indexer workspace preflight failed: {exc}") from exc
+    compile(patched, str(TARGET), "exec")
+
+    if preflight_only:
+        print(f"{TARGET.name}: indexer workspace preflight OK ({action})")
+        return 0
+
+    if patched != source:
+        replace_file(TARGET, patched)
+        clear_pyc(TARGET)
+    # Report the value as set, not as normalised: this script runs at image
+    # build time where the knob is usually unset, and printing "stock" for an
+    # explicitly empty value would hide the error the runtime will raise.
+    mode = os.environ.get(ENV_NAME, "stock (unset)")
+    print(f"{TARGET.name}: indexer workspace {action} ({ENV_NAME}={mode!r})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/start.sh
+++ b/start.sh
@@ -73,6 +73,10 @@ _cli_ablit_direction="${ABLIT_DIRECTION-}"
 _cli_ablit_layers="${ABLIT_LAYERS-}"
 _cli_ablit_alpha="${ABLIT_ALPHA-}"
 _cli_ablit_mtp="${ABLIT_INCLUDE_MTP-}"
+# Setness-aware: an explicitly empty caller value is an operator error and
+# must reach validate_numeric_config, not be swallowed by a .env value.
+_cli_indexer_workspace_set="${GLM53_INDEXER_WORKSPACE+1}"
+_cli_indexer_workspace="${GLM53_INDEXER_WORKSPACE-}"
 set -a
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/.env"
@@ -94,6 +98,7 @@ set +a
 [ -n "${_cli_ablit_layers}" ] && ABLIT_LAYERS="$_cli_ablit_layers"
 [ -n "${_cli_ablit_alpha}" ] && ABLIT_ALPHA="$_cli_ablit_alpha"
 [ -n "${_cli_ablit_mtp}" ] && ABLIT_INCLUDE_MTP="$_cli_ablit_mtp"
+[ -n "${_cli_indexer_workspace_set}" ] && GLM53_INDEXER_WORKSPACE="$_cli_indexer_workspace"
 
 # ----------------------------- configuration -------------------------------
 MODEL="${MODEL:-Mia-AiLab/GLM-5.3-Flash-EXL3-TR3-4bpw}"
@@ -227,6 +232,12 @@ GLM53_SUPPRESS_STOPS_IN_REASONING="${GLM53_SUPPRESS_STOPS_IN_REASONING:-1}"
 # Mixed-step prefill policy when a peer is already decoding (issue #6).
 # skip = do not mix; N>0 = cap tokens; 0 = off.
 GLM53_MIXED_PREFILL_CHUNK="${GLM53_MIXED_PREFILL_CHUNK:-skip}"
+# Sparse-indexer prefill gather workspace (overlay/patch_indexer_workspace.py).
+# stock = max_model_len * 40 entries (5036.40 MB locked at 1M, measured);
+# rightsize = the legal per-step maximum, ~+26% KV. Default applies only
+# when UNSET: an explicitly empty value is an operator error and
+# validate_numeric_config rejects it rather than guessing a serving mode.
+GLM53_INDEXER_WORKSPACE="${GLM53_INDEXER_WORKSPACE-stock}"
 # EngineCore stock timeout is 300s; mid-serve Triton/TileLang JIT on TP=2 can
 # exceed that without being a true hang. NCCL watchdog is still 600s.
 VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS="${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-1800}"
@@ -291,6 +302,24 @@ _glm53_canonical_positive_int() {
     export "$name"
 }
 
+# Enum knobs are exactly one of a fixed set. Not "non-empty means on": a
+# typo'd knob must not silently pick a serving mode. GLM53_INDEXER_WORKSPACE
+# sizes the sparse-indexer prefill workspace, and the patched
+# get_max_prefill_buffer_size itself raises on anything but stock/rightsize
+# (overlay/patch_indexer_workspace.py, _glm53_workspace_mode), so catching it
+# here turns a container boot failure into a launcher error. The match is
+# literal on both sides -- the "-stock" default applies only to an UNSET var,
+# so "", " rightsize " and "RIGHTSIZE" all fail here and would fail there.
+_glm53_validate_enum() {
+    local name="$1" value="$2" allowed
+    shift 2
+    for allowed in "$@"; do
+        [ "$value" = "$allowed" ] && return 0
+    done
+    echo "$name must be one of: $* (got: $value)" >&2
+    return 2
+}
+
 validate_numeric_config() {
     if ! [[ "$GPU_MEM_UTIL" =~ ^(0([.][0-9]+)?|[.][0-9]+|1([.]0+)?)$ ]] \
        || ! awk -v u="$GPU_MEM_UTIL" 'BEGIN { exit !(u > 0 && u <= 1) }'; then
@@ -300,6 +329,8 @@ validate_numeric_config() {
     _glm53_canonical_positive_int MAX_MODEL_LEN "$MAX_MODEL_LEN" 1000000 || return
     _glm53_canonical_positive_int MAX_NUM_SEQS "$MAX_NUM_SEQS" 4096 || return
     _glm53_canonical_positive_int MAX_NUM_BATCHED_TOKENS "$MAX_NUM_BATCHED_TOKENS" 8388608 || return
+    _glm53_validate_enum GLM53_INDEXER_WORKSPACE "${GLM53_INDEXER_WORKSPACE-stock}" \
+        stock rightsize || return
 }
 # GLM53 numeric config guard (end)
 
@@ -902,6 +933,9 @@ fi
 if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
     python3 /opt/glm53/patch_kpool_tail_slotmap.py
 fi
+if [ -f /opt/glm53/patch_indexer_workspace.py ]; then
+    python3 /opt/glm53/patch_indexer_workspace.py
+fi
 if [ -f /opt/glm53/patch_ablit.py ]; then
     python3 /opt/glm53/patch_ablit.py
 fi
@@ -992,6 +1026,9 @@ fi
 if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
     python3 /opt/glm53/patch_kpool_tail_slotmap.py
 fi
+if [ -f /opt/glm53/patch_indexer_workspace.py ]; then
+    python3 /opt/glm53/patch_indexer_workspace.py
+fi
 if [ -f /opt/glm53/patch_ablit.py ]; then
     python3 /opt/glm53/patch_ablit.py
 fi
@@ -1053,6 +1090,7 @@ launch_cluster() {
         -e VLLM_CACHE_ROOT=/root/.cache/vllm
         -e "GLM53_SUPPRESS_STOPS_IN_REASONING=$GLM53_SUPPRESS_STOPS_IN_REASONING"
         -e "GLM53_MIXED_PREFILL_CHUNK=$GLM53_MIXED_PREFILL_CHUNK"
+        -e "GLM53_INDEXER_WORKSPACE=$GLM53_INDEXER_WORKSPACE"
         -e "TRITON_CACHE_DIR=$TRITON_CACHE_DIR"
         -e "TILELANG_CACHE_DIR=$TILELANG_CACHE_DIR"
         -e "VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=$VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS"

--- a/tests/test_indexer_workspace.py
+++ b/tests/test_indexer_workspace.py
@@ -1,0 +1,819 @@
+#!/usr/bin/env python3
+"""Tests for the opt-in sparse-indexer prefill workspace right-sizing.
+
+Host-only, no GPU, no torch. Three groups:
+
+* the sizing formula, against the edge cases raised in Codex's review of the
+  research draft (MNBT-bounded chunk count, max_num_seqs, k=7 spec tokens, the
+  true per-step maximum, and the stock clamp);
+* a proof by exhaustion that the right-sized workspace produces the SAME chunk
+  list as the stock ``max_model_len * 40`` one for every batch the scheduler can
+  legally form -- the equivalence claim, checked rather than asserted;
+* apply / idempotence / fail-closed drift against a fixture built from the live
+  container's ``indexer.py`` (and, opt-in, against the live file itself).
+"""
+from __future__ import annotations
+
+import os
+import random
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+PATCH = next(
+    p
+    for p in (
+        HERE / "patch_indexer_workspace.py",
+        ROOT / "overlay" / "patch_indexer_workspace.py",
+    )
+    if p.is_file()
+)
+sys.path.insert(0, str(PATCH.parent))
+from patch_indexer_workspace import (  # noqa: E402
+    ANCHOR_GUARD,
+    ANCHOR_IMPORT,
+    ANCHOR_SIZE,
+    BYTES_PER_ENTRY,
+    ENV_NAME,
+    MARK_SIZE,
+    STOCK_MULTIPLIER,
+    indexer_compress_ratio,
+    prepare,
+    rightsized_workspace_entries,
+    split_prefill_chunks,
+    stock_workspace_entries,
+    verified_state,
+    workspace_mode,
+)
+
+INSTALLED = Path(
+    "/usr/local/lib/python3.12/dist-packages/vllm/v1/attention/backends/mla/indexer.py"
+)
+
+# Live deployment (head Spark, glm53-exl3-head, build 0.1.dev20051+g487ecf187).
+LIVE_MAX_MODEL_LEN = 1_000_000
+LIVE_KPOOL = 4
+LIVE_MAX_NUM_SEQS = 16
+LIVE_MNBT = 2048
+LIVE_SPEC = 7
+RADIX_TOPK_WORKSPACE_BYTES = 1024 * 1024
+
+# vLLM's own default for VLLM_SPARSE_INDEXER_MAX_LOGITS_MB.
+MAX_LOGITS_BYTES = 512 * 1024 * 1024
+
+# Fixture assembled from verbatim excerpts of the live container file, pulled
+# read-only. All three pinned anchors, in file order, in a module that compiles.
+PINNED_FIXTURE = (
+    ANCHOR_IMPORT
+    + '''
+import torch
+
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.v1.kv_cache_interface import MLAAttentionSpec
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class DeepseekV32IndexerPrefillChunkMetadata:
+    total_seq_lens: int
+
+
+'''
+    + ANCHOR_SIZE
+    + '''
+
+class DeepseekV32IndexerMetadataBuilder:
+    def __init__(self, kv_cache_spec, vllm_config, device):
+        self.kv_cache_spec = kv_cache_spec
+        self.vllm_config = vllm_config
+        self.device = device
+        self.dcp_world_size = 1
+        # NOTE(Chen):an estimated max size of flattened_kv. Need to double check.
+        self.max_prefill_buffer_size = get_max_prefill_buffer_size(self.vllm_config)
+
+'''
+    + ANCHOR_GUARD
+)
+
+
+# --------------------------------------------------------------------------
+# config stubs (duck-typed exactly as the injected helpers traverse them)
+# --------------------------------------------------------------------------
+class _Ns:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+def cfg(
+    max_model_len=LIVE_MAX_MODEL_LEN,
+    kpool=LIVE_KPOOL,
+    max_num_seqs=LIVE_MAX_NUM_SEQS,
+    mnbt=LIVE_MNBT,
+    spec=LIVE_SPEC,
+    with_kpool_attr=True,
+):
+    hf = _Ns(index_kpool=kpool) if with_kpool_attr else _Ns()
+    return _Ns(
+        model_config=_Ns(max_model_len=max_model_len, hf_text_config=hf),
+        scheduler_config=_Ns(max_num_seqs=max_num_seqs, max_num_batched_tokens=mnbt),
+        speculative_config=_Ns(num_speculative_tokens=spec) if spec is not None else None,
+    )
+
+
+def cdiv(a: int, b: int) -> int:
+    return -(-a // b)
+
+
+def _set_mode(value):
+    if value is None:
+        os.environ.pop(ENV_NAME, None)
+    else:
+        os.environ[ENV_NAME] = value
+
+
+# --------------------------------------------------------------------------
+# 1. mode enum
+# --------------------------------------------------------------------------
+def test_mode_enum() -> None:
+    """Literal match, exactly like start.sh's ``_glm53_validate_enum``.
+
+    The launcher expands ``${GLM53_INDEXER_WORKSPACE-stock}`` -- default on
+    UNSET only -- and then compares the value as-is against ``stock rightsize``.
+    The python side must agree character for character, or a value the launcher
+    rejects (or accepts) changes meaning across the container boundary.
+    """
+    saved = os.environ.get(ENV_NAME)
+    try:
+        # Only an absent var defaults.
+        _set_mode(None)
+        assert workspace_mode() == "stock"
+        for good in ("stock", "rightsize"):
+            _set_mode(good)
+            assert workspace_mode() == good
+        # A typo, a case variant, padding, or an explicitly empty value must
+        # not select a serving mode -- all four are launcher errors too.
+        for bad in (
+            "", " ", "  ", "\t", "\n",
+            "Stock", "STOCK", "RIGHTSIZE", "Rightsize",
+            " rightsize ", "rightsize ", " stock", "stock\n",
+            "1", "0", "on", "yes", "right-size", "rightsized", "true",
+        ):
+            _set_mode(bad)
+            try:
+                workspace_mode()
+            except ValueError as exc:
+                assert ENV_NAME in str(exc), bad
+                assert repr(bad) in str(exc), bad
+            else:
+                raise AssertionError(f"{bad!r} must be rejected")
+    finally:
+        _set_mode(saved)
+
+
+def test_mode_enum_matches_launcher_enum() -> None:
+    """Cross-check the two implementations against one another, by value.
+
+    Runs start.sh's own ``_glm53_validate_enum`` (lifted out of the guard
+    block) over the same values and requires the accept/reject verdicts to
+    match ``_glm53_workspace_mode`` exactly.
+    """
+    start = ROOT / "start.sh"
+    if not start.is_file():
+        return
+    source = start.read_text()
+    begin = source.index("# GLM53 numeric config guard (begin)")
+    end = source.index("# GLM53 numeric config guard (end)")
+    guard = source[begin:end]
+
+    script = (
+        guard
+        + '\n_glm53_validate_enum GLM53_INDEXER_WORKSPACE '
+        + '"${GLM53_INDEXER_WORKSPACE-stock}" stock rightsize\n'
+    )
+    saved = os.environ.get(ENV_NAME)
+    try:
+        for value in (
+            None, "stock", "rightsize",
+            "", " ", "Stock", "RIGHTSIZE", " rightsize ", "1", "on", "true",
+        ):
+            env = {k: v for k, v in os.environ.items() if k != ENV_NAME}
+            if value is not None:
+                env[ENV_NAME] = value
+            shell_ok = subprocess.run(
+                ["bash", "-c", script],
+                check=False, capture_output=True, text=True, env=env,
+            ).returncode == 0
+            _set_mode(value)
+            try:
+                workspace_mode()
+                py_ok = True
+            except ValueError:
+                py_ok = False
+            assert py_ok == shell_ok, (value, py_ok, shell_ok)
+    finally:
+        _set_mode(saved)
+
+
+# --------------------------------------------------------------------------
+# 2. the sizing formula
+# --------------------------------------------------------------------------
+def test_stock_matches_live_workspace_receipt() -> None:
+    """The stock sizing reproduces the measured lock, to the byte.
+
+    Head Spark, Stage A boot 2026-09-01, VLLM_DEBUG_WORKSPACE=1:
+
+        [WORKSPACE DEBUG] Resized workspace from
+          'sparse_attn_indexer_kpool.py:284:sparse_attn_indexer_kpool':
+          0.00 MB -> 5036.40 MB (ubatch 0)
+
+    sparse_attn_indexer_kpool.py:284 is the profiling-run
+    ``get_simultaneous(values_spec, scales_spec, radix)`` call, so the receipt
+    covers the gather workspace plus the 1 MiB radix top-k scratch.
+    """
+    entries = stock_workspace_entries(LIVE_MAX_MODEL_LEN)
+    assert entries == LIVE_MAX_MODEL_LEN * STOCK_MULTIPLIER == 40_000_000
+    total = entries * BYTES_PER_ENTRY + RADIX_TOPK_WORKSPACE_BYTES
+    assert total == 5_281_048_576
+    assert f"{total / (1024 * 1024):.2f}" == "5036.40"
+
+
+def test_no_op_when_uncompressed() -> None:
+    stock = stock_workspace_entries(LIVE_MAX_MODEL_LEN)
+    # compress_ratio 1 => the workspace really is token-granular; leave it.
+    assert rightsized_workspace_entries(cfg(kpool=1)) == stock
+    assert rightsized_workspace_entries(cfg(kpool=0)) == stock
+    assert rightsized_workspace_entries(cfg(kpool=None)) == stock
+    # A config that has no index_kpool at all (DeepSeek-V3.2 dense indexer).
+    assert rightsized_workspace_entries(cfg(with_kpool_attr=False)) == stock
+    assert indexer_compress_ratio(cfg(with_kpool_attr=False)) == 1
+    # A junk value must not size a workspace.
+    assert rightsized_workspace_entries(cfg(kpool="four")) == stock
+
+
+def test_true_per_step_maximum() -> None:
+    """The default is the legal maximum, not a tuned request count.
+
+    Codex's review rejected the draft's ``REQS=8``: 264 MB is a throughput
+    tradeoff, not the required workspace. This sizes the largest total
+    compressed N a single step can legally present.
+    """
+    got = rightsized_workspace_entries(cfg())
+    per_req = cdiv(LIVE_MAX_MODEL_LEN + LIVE_SPEC, LIVE_KPOOL)
+    assert per_req == 250_002
+    assert got == per_req * LIVE_MAX_NUM_SEQS == 4_000_032
+    assert got * BYTES_PER_ENTRY == 528_004_224
+    # Recovered against stock: ~4.43 GiB at max_num_seqs=16.
+    reclaimed = (stock_workspace_entries(LIVE_MAX_MODEL_LEN) - got) * BYTES_PER_ENTRY
+    assert 4.40 < reclaimed / 1024**3 < 4.45
+    # The recipe default max_num_seqs=4 reclaims more.
+    got4 = rightsized_workspace_entries(cfg(max_num_seqs=4))
+    assert got4 == per_req * 4 == 1_000_008
+    reclaimed4 = (stock_workspace_entries(LIVE_MAX_MODEL_LEN) - got4) * BYTES_PER_ENTRY
+    assert 4.75 < reclaimed4 / 1024**3 < 4.85
+
+
+def test_spec_tokens_are_headroom() -> None:
+    """k=7 draft tokens can push seq_lens_cpu_upper_bound past max_model_len.
+
+    The builder feeds the splitter ``seq_lens_cpu_upper_bound``, documented as
+    "an upper bound for async-spec extend rows", so the per-request span must
+    carry the draft length.
+    """
+    no_spec = rightsized_workspace_entries(cfg(spec=0))
+    with_spec = rightsized_workspace_entries(cfg(spec=LIVE_SPEC))
+    none_cfg = rightsized_workspace_entries(cfg(spec=None))
+    assert no_spec == cdiv(LIVE_MAX_MODEL_LEN, LIVE_KPOOL) * LIVE_MAX_NUM_SEQS
+    assert with_spec > no_spec
+    assert with_spec - no_spec == 2 * LIVE_MAX_NUM_SEQS  # cdiv rolls over by 2
+    assert none_cfg == no_spec
+    # Monotone in the draft length.
+    prev = 0
+    for k in range(0, 32):
+        cur = rightsized_workspace_entries(cfg(spec=k))
+        assert cur >= prev
+        prev = cur
+
+
+def test_prefill_request_count_is_mnbt_bounded() -> None:
+    """A prefill row costs >= 1 query token, so MNBT caps the request count."""
+    per_req = cdiv(LIVE_MAX_MODEL_LEN + LIVE_SPEC, LIVE_KPOOL)
+    # MNBT below max_num_seqs: MNBT binds.
+    assert rightsized_workspace_entries(cfg(max_num_seqs=64, mnbt=8)) == per_req * 8
+    # max_num_seqs below MNBT: max_num_seqs binds.
+    assert rightsized_workspace_entries(cfg(max_num_seqs=8, mnbt=2048)) == per_req * 8
+    # Equal: either.
+    assert rightsized_workspace_entries(cfg(max_num_seqs=8, mnbt=8)) == per_req * 8
+    # Degenerate configs still leave room for one whole request (the hard
+    # floor: the splitter sub-chunks an oversized single request on the query
+    # dimension only, never on N).
+    for seqs, mnbt in ((1, 1), (0, 2048), (16, 0)):
+        got = rightsized_workspace_entries(cfg(max_num_seqs=seqs, mnbt=mnbt))
+        assert got >= per_req, (seqs, mnbt, got)
+
+
+def test_never_exceeds_stock() -> None:
+    """Narrowing only. A config whose legal max is above stock keeps stock."""
+    stock = stock_workspace_entries(LIVE_MAX_MODEL_LEN)
+    # 256 seqs x 250,002 = 64,000,512 > 40,000,000.
+    assert rightsized_workspace_entries(cfg(max_num_seqs=256)) == stock
+    for M in (8192, 65_536, 163_840, 262_144, 1_000_000):
+        for kpool in (2, 4, 8, 16):
+            for seqs in (1, 4, 16, 64, 256):
+                for mnbt in (1, 2048, 8192):
+                    c = cfg(max_model_len=M, kpool=kpool, max_num_seqs=seqs, mnbt=mnbt)
+                    got = rightsized_workspace_entries(c)
+                    assert got <= M * STOCK_MULTIPLIER
+                    assert got >= min(
+                        cdiv(M + LIVE_SPEC, kpool), M * STOCK_MULTIPLIER
+                    )
+
+
+# --------------------------------------------------------------------------
+# 3. chunking equivalence -- the "no behaviour change" claim, checked
+# --------------------------------------------------------------------------
+def _legal_batches(rng, count=400):
+    """Batches the scheduler can actually form at the live config."""
+    for _ in range(count):
+        n = rng.randint(1, LIVE_MAX_NUM_SEQS)
+        # Query tokens: >= 1 each, total <= MNBT.
+        qlens = [1] * n
+        for _ in range(rng.randint(0, LIVE_MNBT - n)):
+            qlens[rng.randrange(n)] += 1
+        seqs = [rng.randint(q, LIVE_MAX_MODEL_LEN) for q in qlens]
+        yield [s // LIVE_KPOOL for s in seqs], qlens
+    # The extremes, deterministically.
+    yield [LIVE_MAX_MODEL_LEN // LIVE_KPOOL] * LIVE_MAX_NUM_SEQS, [
+        LIVE_MNBT // LIVE_MAX_NUM_SEQS
+    ] * LIVE_MAX_NUM_SEQS
+    yield [LIVE_MAX_MODEL_LEN // LIVE_KPOOL], [LIVE_MNBT]
+    yield [1] * LIVE_MAX_NUM_SEQS, [1] * LIVE_MAX_NUM_SEQS
+
+
+def test_chunking_is_identical_to_stock() -> None:
+    stock_ws = stock_workspace_entries(LIVE_MAX_MODEL_LEN)
+    right_ws = rightsized_workspace_entries(cfg())
+    assert right_ws < stock_ws
+    rng = random.Random(20260901)
+    seen_multi_chunk = False
+    for compressed, qlens in _legal_batches(rng):
+        a = split_prefill_chunks(compressed, qlens, stock_ws, MAX_LOGITS_BYTES)
+        b = split_prefill_chunks(compressed, qlens, right_ws, MAX_LOGITS_BYTES)
+        assert a == b, (compressed[:4], qlens[:4], len(a), len(b))
+        seen_multi_chunk = seen_multi_chunk or len(a) > 1
+    # The comparison has to have exercised the splitter's other constraint,
+    # or it proves nothing about chunking at all.
+    assert seen_multi_chunk
+
+
+def test_chunking_test_has_power() -> None:
+    """An under-sized workspace must visibly change the chunk list.
+
+    Without this the equivalence test above could pass on a splitter replica
+    that ignores the workspace argument.
+    """
+    stock_ws = stock_workspace_entries(LIVE_MAX_MODEL_LEN)
+    per_req = LIVE_MAX_MODEL_LEN // LIVE_KPOOL
+    compressed = [per_req] * 4
+    qlens = [8] * 4
+    full = split_prefill_chunks(compressed, qlens, stock_ws, MAX_LOGITS_BYTES)
+    starved = split_prefill_chunks(compressed, qlens, per_req, MAX_LOGITS_BYTES)
+    assert len(starved) > len(full)
+    # The draft's rejected REQS=8 sizing starves a 16-way 1M-context prefill:
+    # at one query token per row the logits budget still admits all 16, but a
+    # 2,000,000-entry workspace splits them into two chunks and re-runs
+    # cp_gather_indexer_k_quant_cache. The legal-maximum sizing does not.
+    wide, thin = [per_req] * 16, [1] * 16
+    stock_chunks = split_prefill_chunks(wide, thin, stock_ws, MAX_LOGITS_BYTES)
+    assert len(stock_chunks) == 1
+    assert (
+        split_prefill_chunks(wide, thin, per_req * 8, MAX_LOGITS_BYTES)
+        != stock_chunks
+    )
+    assert (
+        split_prefill_chunks(
+            wide, thin, rightsized_workspace_entries(cfg()), MAX_LOGITS_BYTES
+        )
+        == stock_chunks
+    )
+
+
+# --------------------------------------------------------------------------
+# 4. patch apply / idempotence / drift
+# --------------------------------------------------------------------------
+def _run_patch(target: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["GLM53_INDEXER_BACKEND_PY"] = str(target)
+    return subprocess.run(
+        [sys.executable, str(PATCH), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_fixture_apply_and_idempotence() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        target = Path(raw) / "indexer.py"
+        target.write_text(PINNED_FIXTURE)
+
+        pre = _run_patch(target, "--preflight")
+        assert pre.returncode == 0, pre.stderr
+        assert "preflight OK" in pre.stdout
+        assert target.read_text() == PINNED_FIXTURE  # preflight writes nothing
+
+        first = _run_patch(target)
+        assert first.returncode == 0, first.stderr
+        text = target.read_text()
+        assert verified_state(text)
+        assert MARK_SIZE in text
+        assert "_glm53_rightsized_workspace_entries" in text
+        assert "already present" not in first.stdout
+        compile(text, str(target), "exec")
+
+        second = _run_patch(target)
+        assert second.returncode == 0, second.stderr
+        assert "already present" in second.stdout
+        assert target.read_text() == text
+
+        again, action = prepare(text)
+        assert action == "already present"
+        assert again == text
+
+        post = _run_patch(target, "--preflight")
+        assert post.returncode == 0, post.stderr
+
+
+class _MLAAttentionSpec:
+    """Stand-in for vllm.v1.kv_cache_interface.MLAAttentionSpec.
+
+    Only ``compress_ratio`` and the isinstance check matter to the guard.
+    """
+
+    def __init__(self, compress_ratio: int):
+        self.compress_ratio = compress_ratio
+
+
+class _NonMLASpec:
+    """A kv-cache spec that is NOT an MLAAttentionSpec.
+
+    Stock leaves ``self.compress_ratio = 1`` for these, which is the same
+    under-sizing shape as an MLA spec that reports 1.
+    """
+
+
+def _patched_sizing_namespace() -> dict:
+    """Exec the patched sizing AND the patched builder OUT OF THE FILE TEXT.
+
+    HELPERS_SRC is shared between the overlay and the injected code, but the
+    body of ``get_max_prefill_buffer_size`` itself -- the mode dispatch, the
+    stock clamp and its warning -- and the whole builder cross-check exist only
+    in the patched file. Pull them out by AST and run them, so the shipped
+    dispatch and the shipped guard are covered and not just the formula.
+    """
+    import ast
+
+    with tempfile.TemporaryDirectory() as raw:
+        target = Path(raw) / "indexer.py"
+        target.write_text(PINNED_FIXTURE)
+        assert _run_patch(target).returncode == 0
+        tree = ast.parse(target.read_text())
+
+    def _wanted(node) -> bool:
+        if isinstance(node, ast.FunctionDef):
+            return (
+                node.name.startswith("_glm53_")
+                or node.name == "get_max_prefill_buffer_size"
+            )
+        if isinstance(node, ast.ClassDef):
+            return node.name == "DeepseekV32IndexerMetadataBuilder"
+        if isinstance(node, ast.Assign):
+            return getattr(node.targets[0], "id", "") == "_GLM53_WORKSPACE_ENV"
+        return False
+
+    wanted = [node for node in tree.body if _wanted(node)]
+    for name in ("get_max_prefill_buffer_size", "DeepseekV32IndexerMetadataBuilder"):
+        assert any(getattr(n, "name", None) == name for n in wanted), name
+    calls: list[tuple[str, tuple]] = []
+
+    class _Logger:
+        def info(self, *a):
+            calls.append(("info", a))
+
+        def warning(self, *a):
+            calls.append(("warning", a))
+
+    ns = {
+        "os": os,
+        "logger": _Logger(),
+        "VllmConfig": object,
+        "MLAAttentionSpec": _MLAAttentionSpec,
+        "_calls": calls,
+    }
+    exec(compile(ast.Module(body=wanted, type_ignores=[]), "<patched>", "exec"), ns)
+    return ns
+
+
+def test_patched_sizing_dispatch() -> None:
+    ns = _patched_sizing_namespace()
+    get_size = ns["get_max_prefill_buffer_size"]
+    calls = ns["_calls"]
+    stock = stock_workspace_entries(LIVE_MAX_MODEL_LEN)
+    saved = os.environ.get(ENV_NAME)
+    try:
+        # Default and explicit stock are the stock expression, exactly.
+        for value in (None, "stock"):
+            _set_mode(value)
+            calls.clear()
+            assert get_size(cfg()) == stock == LIVE_MAX_MODEL_LEN * 40
+            assert calls == []  # stock is silent: no new boot-log noise
+
+        _set_mode("rightsize")
+        calls.clear()
+        assert get_size(cfg()) == 4_000_032
+        assert [k for k, _ in calls] == ["info"]
+
+        # Legal max above stock -> stock, loudly.
+        calls.clear()
+        assert get_size(cfg(max_num_seqs=256)) == stock
+        assert [k for k, _ in calls] == ["warning"]
+
+        # Non-kpool config is a no-op even when the knob is on.
+        calls.clear()
+        assert get_size(cfg(kpool=1)) == stock
+        assert [k for k, _ in calls] == ["warning"]
+
+        _set_mode("bogus")
+        try:
+            get_size(cfg())
+        except ValueError as exc:
+            assert ENV_NAME in str(exc)
+        else:
+            raise AssertionError("bad mode must raise from the patched module")
+    finally:
+        _set_mode(saved)
+
+
+def _build(ns, spec, config):
+    return ns["DeepseekV32IndexerMetadataBuilder"](spec, config, "cpu")
+
+
+def test_builder_ratio_mismatch_raises_both_directions() -> None:
+    """The cross-check is unconditional in rightsize mode, in both directions.
+
+    Regression for the blocker Codex found in the first PR-8 draft: the guard
+    read ``if mode == "rightsize" and self.compress_ratio > 1``, so the ONE
+    combination that actually under-sizes -- ``hf_text_config.index_kpool=4``
+    with ``kv_cache_spec.compress_ratio=1`` -- skipped the check entirely. The
+    workspace is then sized for compressed pools while the runtime hands the
+    splitter raw token counts, roughly 4x too many.
+    """
+    ns = _patched_sizing_namespace()
+    calls = ns["_calls"]
+    saved = os.environ.get(ENV_NAME)
+    try:
+        _set_mode("rightsize")
+
+        # Direction A -- the under-sizing one, and the one the old guard skipped.
+        # Sizing believes ratio 4; the runtime divides by 1.
+        sized_for = ns["get_max_prefill_buffer_size"](cfg(kpool=4))
+        assert sized_for == 4_000_032
+        runtime_worst_case = LIVE_MAX_NUM_SEQS * (LIVE_MAX_MODEL_LEN + LIVE_SPEC)
+        assert runtime_worst_case > 3.9 * sized_for  # ~4x under-sized, uncaught
+        for spec in (_MLAAttentionSpec(1), _NonMLASpec()):
+            calls.clear()
+            try:
+                _build(ns, spec, cfg(kpool=4))
+            except ValueError as exc:
+                msg = str(exc)
+                assert "index_kpool=4" in msg, msg
+                assert "compress_ratio=1" in msg, msg
+                assert ENV_NAME in msg, msg
+            else:
+                raise AssertionError(f"index_kpool=4 vs compress_ratio=1 ({spec}) "
+                                     "must raise")
+
+        # Direction B -- config says no compression, the runtime compresses.
+        # Sizing returns stock here, so it cannot under-run, but the two config
+        # sources disagree about the model and rightsize must not serve on that.
+        for kpool in (1, 0, None):
+            calls.clear()
+            try:
+                _build(ns, _MLAAttentionSpec(4), cfg(kpool=kpool))
+            except ValueError as exc:
+                msg = str(exc)
+                assert "index_kpool=1" in msg, msg
+                assert "compress_ratio=4" in msg, msg
+            else:
+                raise AssertionError(f"index_kpool={kpool} vs compress_ratio=4 "
+                                     "must raise")
+        # ... including the config that has no index_kpool attribute at all.
+        try:
+            _build(ns, _MLAAttentionSpec(4), cfg(with_kpool_attr=False))
+        except ValueError as exc:
+            assert "compress_ratio=4" in str(exc)
+        else:
+            raise AssertionError("missing index_kpool vs compress_ratio=4 must raise")
+    finally:
+        _set_mode(saved)
+
+
+def test_builder_agreeing_ratios_pass() -> None:
+    """Agreement builds, at the compressed AND the uncompressed ratio."""
+    ns = _patched_sizing_namespace()
+    calls = ns["_calls"]
+    stock = stock_workspace_entries(LIVE_MAX_MODEL_LEN)
+    saved = os.environ.get(ENV_NAME)
+    try:
+        _set_mode("rightsize")
+
+        calls.clear()
+        builder = _build(ns, _MLAAttentionSpec(4), cfg(kpool=4))
+        assert builder.max_prefill_buffer_size == 4_000_032
+        # One sizing info + one builder info, no warning.
+        assert [k for k, _ in calls] == ["info", "info"]
+
+        # ratio 1 on both sides: a dense indexer. Sized at stock, and the guard
+        # now runs (it used to be skipped) and finds agreement.
+        calls.clear()
+        builder = _build(ns, _MLAAttentionSpec(1), cfg(kpool=1))
+        assert builder.max_prefill_buffer_size == stock
+        assert [k for k, _ in calls] == ["warning", "info"]
+
+        calls.clear()
+        builder = _build(ns, _NonMLASpec(), cfg(with_kpool_attr=False))
+        assert builder.max_prefill_buffer_size == stock
+    finally:
+        _set_mode(saved)
+
+
+def test_builder_guard_is_inert_in_stock_mode() -> None:
+    """Stock mode is untouched: no cross-check, no logs, stock sizing."""
+    ns = _patched_sizing_namespace()
+    calls = ns["_calls"]
+    stock = stock_workspace_entries(LIVE_MAX_MODEL_LEN)
+    saved = os.environ.get(ENV_NAME)
+    try:
+        for mode in (None, "stock"):
+            _set_mode(mode)
+            for spec, config in (
+                (_MLAAttentionSpec(1), cfg(kpool=4)),   # direction A
+                (_MLAAttentionSpec(4), cfg(kpool=1)),   # direction B
+                (_MLAAttentionSpec(4), cfg(kpool=4)),   # agreement
+                (_NonMLASpec(), cfg(kpool=4)),
+            ):
+                calls.clear()
+                builder = _build(ns, spec, config)
+                assert builder.max_prefill_buffer_size == stock, mode
+                assert calls == [], (mode, calls)
+    finally:
+        _set_mode(saved)
+
+
+def test_builder_guard_has_no_ratio_condition() -> None:
+    """The shipped guard must not reintroduce a ``compress_ratio > 1`` gate.
+
+    The behavioural tests above would still pass against a guard that was
+    merely reordered; this pins the source form that made the blocker possible.
+    """
+    from patch_indexer_workspace import PATCHED_GUARD
+
+    dispatch = PATCHED_GUARD.split("[glm53-indexer-workspace]", 1)[1]
+    assert 'if _glm53_workspace_mode() == "rightsize":' in dispatch
+    old_form = 'if _glm53_workspace_mode() == "rightsize" and self.compress_ratio'
+    assert old_form not in dispatch
+
+
+def test_fail_closed_on_drift() -> None:
+    for old, new in (
+        ("return max_model_len * 40", "return max_model_len * 48"),
+        ("from dataclasses import dataclass", "from dataclasses import dataclass, field"),
+        ("self.compress_ratio = self.kv_cache_spec.compress_ratio",
+         "self.compress_ratio = self.kv_cache_spec.kv_compress_ratio"),
+    ):
+        drifted = PINNED_FIXTURE.replace(old, new, 1)
+        assert drifted != PINNED_FIXTURE, old
+        with tempfile.TemporaryDirectory() as raw:
+            target = Path(raw) / "indexer.py"
+            target.write_text(drifted)
+            result = _run_patch(target)
+            assert result.returncode != 0, old
+            assert "preflight failed" in result.stderr
+            assert "drifted" in result.stderr
+            # A drifted anchor leaves the file untouched.
+            assert target.read_text() == drifted
+            # ... and --preflight fails the same way, so CI catches drift while
+            # the knob is still off.
+            pre = _run_patch(target, "--preflight")
+            assert pre.returncode != 0
+
+
+def test_fail_closed_on_half_patched() -> None:
+    partial = PINNED_FIXTURE.replace(ANCHOR_SIZE, MARK_SIZE + ANCHOR_SIZE, 1)
+    with tempfile.TemporaryDirectory() as raw:
+        target = Path(raw) / "indexer.py"
+        target.write_text(partial)
+        result = _run_patch(target)
+        assert result.returncode != 0
+        assert "partial/inconsistent" in result.stderr
+        assert target.read_text() == partial
+
+
+def test_live_copy_if_present() -> None:
+    """Apply to a copy of the installed/live file when one is reachable."""
+    src = Path(os.environ.get("GLM53_INDEXER_BACKEND_PY_SRC", INSTALLED))
+    if not src.is_file():
+        return
+    with tempfile.TemporaryDirectory() as raw:
+        target = Path(raw) / "indexer.py"
+        target.write_text(src.read_text())
+        result = _run_patch(target)
+        assert result.returncode == 0, result.stderr
+        text = target.read_text()
+        assert verified_state(text)
+        compile(text, str(target), "exec")
+
+
+def test_live_container_copy_if_enabled() -> None:
+    """Opt-in: pull indexer.py read-only from the running head container.
+
+    Off by default -- the image build and CI have no route to the Sparks.
+    Enable with GLM53_INDEXER_LIVE_SSH=1.
+    """
+    if os.environ.get("GLM53_INDEXER_LIVE_SSH") != "1":
+        return
+    jump = os.environ.get("GLM53_LIVE_SSH_JUMP", "blockbrain@192.168.1.116")
+    head = os.environ.get("GLM53_LIVE_SSH_HEAD", "10.0.22.1")
+    container = os.environ.get("GLM53_LIVE_CONTAINER", "glm53-exl3-head")
+    remote = (
+        "/usr/local/lib/python3.12/dist-packages/vllm/"
+        "v1/attention/backends/mla/indexer.py"
+    )
+    fetched = subprocess.run(
+        [
+            "ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=20", jump,
+            f'ssh {head} "docker exec {container} cat {remote}"',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert fetched.returncode == 0, fetched.stderr
+    assert "def get_max_prefill_buffer_size" in fetched.stdout
+    with tempfile.TemporaryDirectory() as raw:
+        target = Path(raw) / "indexer.py"
+        target.write_text(fetched.stdout)
+        result = _run_patch(target)
+        assert result.returncode == 0, result.stderr
+        assert verified_state(target.read_text())
+
+
+# --------------------------------------------------------------------------
+# 5. recipe wiring
+# --------------------------------------------------------------------------
+def test_recipe_wiring_if_present() -> None:
+    start = ROOT / "start.sh"
+    dockerfile = ROOT / "Dockerfile"
+    readme = ROOT / "README.md"
+    if not start.is_file() or not dockerfile.is_file():
+        return
+    launcher = start.read_text()
+    image = dockerfile.read_text()
+    assert 'GLM53_INDEXER_WORKSPACE="${GLM53_INDEXER_WORKSPACE-stock}"' in launcher
+    assert '_cli_indexer_workspace="${GLM53_INDEXER_WORKSPACE-}"' in launcher
+    # Setness-aware capture: an explicitly empty caller value must survive the
+    # .env source and reach the enum guard, not be swallowed by a .env value.
+    assert '_cli_indexer_workspace_set="${GLM53_INDEXER_WORKSPACE+1}"' in launcher
+    assert (
+        '[ -n "${_cli_indexer_workspace_set}" ] '
+        '&& GLM53_INDEXER_WORKSPACE="$_cli_indexer_workspace"'
+    ) in launcher
+    assert '_glm53_validate_enum GLM53_INDEXER_WORKSPACE' in launcher
+    assert '-e "GLM53_INDEXER_WORKSPACE=$GLM53_INDEXER_WORKSPACE"' in launcher
+    assert launcher.count("python3 /opt/glm53/patch_indexer_workspace.py") == 2
+    assert "COPY overlay/patch_indexer_workspace.py" in image
+    assert "COPY tests/test_indexer_workspace.py" in image
+    assert "RUN python3 /opt/glm53/patch_indexer_workspace.py" in image
+    assert "python3 /opt/glm53/test_indexer_workspace.py" in image
+    if readme.is_file():
+        text = readme.read_text()
+        assert "`GLM53_INDEXER_WORKSPACE`" in text
+        assert "tests/test_indexer_workspace.py" in text
+
+
+def main() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for fn in tests:
+        fn()
+    print(f"indexer workspace right-sizing OK ({len(tests)} tests)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_numeric_config.py
+++ b/tests/test_numeric_config.py
@@ -64,6 +64,41 @@ def test_decimal_normalization() -> None:
     assert result.stdout.strip() == ".87|1000000|4|1024"
 
 
+def validate_enum(value: str | None) -> subprocess.CompletedProcess[str]:
+    """Run validate_numeric_config with only GLM53_INDEXER_WORKSPACE varying."""
+    script = (
+        guard_source()
+        + '\nGPU_MEM_UTIL=0.87; MAX_MODEL_LEN=1000000; MAX_NUM_SEQS=4; '
+        + 'MAX_NUM_BATCHED_TOKENS=1024\n'
+        + 'validate_numeric_config || exit $?\n'
+        + 'printf "%s\\n" "${GLM53_INDEXER_WORKSPACE-unset}"\n'
+    )
+    env = {k: v for k, v in os.environ.items() if k != "GLM53_INDEXER_WORKSPACE"}
+    env["LC_ALL"] = "C"
+    if value is not None:
+        env["GLM53_INDEXER_WORKSPACE"] = value
+    return subprocess.run(
+        ["bash", "-c", script], text=True, capture_output=True, check=False, env=env
+    )
+
+
+def test_indexer_workspace_enum() -> None:
+    """Strict enum: default on UNSET only, then a literal match.
+
+    ``overlay/patch_indexer_workspace.py``'s ``_glm53_workspace_mode`` applies
+    the same rule inside the container, so an empty or case-variant value must
+    fail here rather than change meaning across the boundary.
+    """
+    for good in (None, "stock", "rightsize"):
+        result = validate_enum(good)
+        assert result.returncode == 0, (good, result.stderr)
+    for bad in ("", " ", "Stock", "RIGHTSIZE", " rightsize ", "1", "on", "true",
+                "rightsize\n"):
+        result = validate_enum(bad)
+        assert result.returncode == 2, (bad, result.returncode, result.stdout)
+        assert "GLM53_INDEXER_WORKSPACE must be one of" in result.stderr, bad
+
+
 def test_restart_validates_before_stop() -> None:
     source = START.read_text()
     main = source.index("main() {")
@@ -75,5 +110,6 @@ def test_restart_validates_before_stop() -> None:
 if __name__ == "__main__":
     test_matrix()
     test_decimal_normalization()
+    test_indexer_workspace_enum()
     test_restart_validates_before_stop()
     print("numeric config tests: PASS")

--- a/tests/test_start_overrides.py
+++ b/tests/test_start_overrides.py
@@ -41,6 +41,55 @@ def test_max_num_seqs_inline_override_wins() -> None:
     assert result.stdout.strip() == "MAX_NUM_SEQS=4"
 
 
+def _run_preamble(env_file: str, caller: dict[str, str], probe: str) -> str:
+    source = (ROOT / "start.sh").read_text()
+    marker = "# ----------------------------- configuration -------------------------------"
+    preamble, separator, _rest = source.partition(marker)
+    assert separator, "start.sh configuration marker is missing"
+
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        tmp = Path(raw_tmp)
+        script = tmp / "start.sh"
+        script.write_text(preamble + probe)
+        script.chmod(0o755)
+        (tmp / ".env").write_text(env_file)
+
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("GLM53_INDEXER_WORKSPACE",)}
+        env.update(caller)
+        result = subprocess.run(
+            ["bash", str(script)], check=True, capture_output=True, text=True, env=env
+        )
+    return result.stdout.strip()
+
+
+def test_indexer_workspace_caller_capture_is_setness_aware() -> None:
+    """An explicitly EMPTY caller value must not be swallowed by ``.env``.
+
+    ``GLM53_INDEXER_WORKSPACE=`` is an operator error; the enum guard has to see
+    it. A ``[ -n "$_cli_..." ]`` restore would silently hand back the ``.env``
+    value instead, so the capture uses the ``${VAR+1}`` setness probe.
+    """
+    probe = '\nprintf "V=[%s]\\n" "${GLM53_INDEXER_WORKSPACE-UNSET}"\n'
+    env_file = "GLM53_INDEXER_WORKSPACE=rightsize\n"
+
+    # Caller silent: .env wins.
+    assert _run_preamble(env_file, {}, probe) == "V=[rightsize]"
+    # Caller sets a real value: caller wins (the pre-existing contract).
+    assert _run_preamble(
+        env_file, {"GLM53_INDEXER_WORKSPACE": "stock"}, probe
+    ) == "V=[stock]"
+    # Caller sets it EMPTY: the empty value survives to the guard.
+    assert _run_preamble(
+        env_file, {"GLM53_INDEXER_WORKSPACE": ""}, probe
+    ) == "V=[]"
+    # ... and with no .env value either.
+    assert _run_preamble("", {"GLM53_INDEXER_WORKSPACE": ""}, probe) == "V=[]"
+    # Unset on both sides stays unset until the configuration default.
+    assert _run_preamble("", {}, probe) == "V=[UNSET]"
+
+
 if __name__ == "__main__":
     test_max_num_seqs_inline_override_wins()
+    test_indexer_workspace_caller_capture_is_setness_aware()
     print("start.sh caller override regression OK")


### PR DESCRIPTION
## Indexer prefill-workspace right-sizing (`GLM53_INDEXER_WORKSPACE=rightsize`, default `stock`)

### Problem
`get_max_prefill_buffer_size` sizes the sparse-MLA indexer's prefill workspace at `max_model_len × 40` entries. At 1M context
that is 40,000,000 × 132 B + 1 MiB = **5,281,048,576 B = 5036.40 MiB**, requested during the memory profile and locked —
reconciled to the byte with the live boot receipt (`[WORKSPACE DEBUG] Resized workspace … 0.00 MB -> 5036.40 MB`,
`sparse_attn_indexer_kpool.py:284`). The legal per-step need is orders of magnitude smaller. (The related `deepseek_v4`
call site already divides by `compress_ratio`; the `glm5next` one does not — that asymmetry is the cleaner upstream fix.)

### Change
Overlay `patch_indexer_workspace.py` (fail-closed, transactional, opt-in): `rightsize` sizes the workspace at the **legal
per-step maximum** `min(max_num_seqs, MNBT) × cdiv(max_model_len + k_spec, index_kpool)`, clamped to stock so it can only
narrow; chunking behaviour proven byte-identical to stock over 400 randomized legal batches (+ a test-power test). An
unconditional cross-check of `hf_text_config.index_kpool` vs `kv_cache_spec.compress_ratio` raises at init on any mismatch,
both directions. Strict enum parsing parity-tested against the launcher's validator; setness-aware caller capture. Default
`stock` = byte-identical behaviour. 21-check host test; Dockerfile test-before-patch.

### Expected gain (estimates until the allocator receipt below)
Reclaims ~4.4–4.8 GiB of the 17 GiB KV budget → **~+26–28 % KV capacity** at `MAX_NUM_SEQS` 16/4. No latency claims.

### Live receipts (2026-09-01, both boots on the same deployed config)
| | stock | rightsize |
|---|---|---|
| workspace (boot log) | 40,000,000 entries / **5036.40 MB** | **4,000,032 entries** (`legal max 4000032`; ~4531.9 MiB reclaimed) |
| Available KV cache memory | 16.98 GiB | **21.5 GiB (+26.6 %)** |
| GPU KV cache size / max concurrency | 1,555,555 tokens / 1.56× | **1,929,951 tokens / 1.93×** |
| prefill smoke 8K / 50K / 100K | — | 9.7 s / 57.2 s / 115.1 s, clean outputs |
| temp-0 logprob equivalence (3-cold-pair floor + 0.15 empirical prior) | prose PASS | prose PASS (re-run; one initial FAIL was a lucky-low single-run floor), code PASS |
| stock-vs-rightsize cold outputs (cross-boot) | — | diverge @42–52 chars = the same position the within-boot cold-vs-cold pairs diverge (inherent run-to-run noise, not a workspace effect) |

### Audit log
Codex gpt-5.6-luna design review of the research (build-with-changes: hypothesis refutation accepted, anchor L dropped,
REQS knob rejected in favour of the legal maximum) → applied; final pass (fix-first: unconditional cross-check both
directions, strict enum parity, setness capture) → applied; confirm: deploy-for-live-test.

---
Submitted by nood-co1 on behalf of Blockbrain Labs (https://x.com/blockbrain_labs, GitHub org blockbrain-ai). Measured on our 2× NVIDIA DGX Spark deployment.
