### PR TITLE
launcher: opt-in GLM53_DEFAULT_REASONING_EFFORT (server-side default reasoning effort; empty = unchanged, high recommended)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,6 +140,17 @@ GLM53_SUPPRESS_STOPS_IN_REASONING=1
 # When a decode seq is running, do not mix a peer prefill into that step
 # (issue #6). skip = decode-only steps; N>0 = cap mixed prefill tokens; 0 = off.
 GLM53_MIXED_PREFILL_CHUNK=skip
+# Server-side default reasoning effort ("" | low | high | max), sent as
+# --default-chat-template-kwargs. Empty (the default) sends no flag -- and
+# files/chat_template.jinja then renders "Reasoning Effort: Max" for every
+# client that omits chat_template_kwargs, because it maps the value to itself
+# only for low/high and to max otherwise. Recommended for agentic coding:
+#   GLM53_DEFAULT_REASONING_EFFORT=high
+# Measured 80/80 vs 80/80 against unset(max) at 4.6x less wall time and 4.8x
+# fewer completion tokens (docs/RECEIPTS-default-reasoning-effort.md).
+# Per-request chat_template_kwargs.reasoning_effort still overrides this.
+# 'medium' is rejected: the template does not recognize it (it renders max).
+GLM53_DEFAULT_REASONING_EFFORT=
 # EngineCore execute timeout (seconds). Stock 300 is short for a cold JIT.
 # VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 

--- a/README.md
+++ b/README.md
@@ -412,6 +412,28 @@ curl -s http://127.0.0.1:8888/v1/chat/completions \
 Thinking defaults on. Disable it with the **top-level** JSON field
 `"chat_template_kwargs": {"enable_thinking": false}`. This closes the empty
 thinking block in the generation prompt and omits the reasoning-effort hint.
+
+**Reasoning effort defaults to `max`, not to something cheap.** `files/chat_template.jinja`
+maps `reasoning_effort` to itself only for `low` and `high`, and to `max` for
+everything else — *including when the field is absent*:
+
+```jinja
+{%- set effective_reasoning_effort = reasoning_effort if reasoning_effort is defined and reasoning_effort in ['low', 'high'] else 'max' -%}
+```
+
+So any client that does not send `chat_template_kwargs` (OpenCode, Cline, plain
+`curl`, most SDK defaults) silently gets the most expensive setting. On one
+agentic build task, unset(max) and `high` scored an identical 80/80 while max
+took **4.6×** the wall time and generated **4.8×** the completion tokens
+(`docs/RECEIPTS-default-reasoning-effort.md`).
+
+Set a server-side default with `GLM53_DEFAULT_REASONING_EFFORT` in `.env`
+(recommended `high` for agentic coding); the launcher then passes
+`--default-chat-template-kwargs '{"reasoning_effort":"high"}'` on both ranks.
+The launcher default stays empty, so behaviour is unchanged unless you set it.
+A request that sends `"chat_template_kwargs": {"reasoning_effort": "low"}`
+still overrides the server default — vLLM merges the server defaults first and
+lets request kwargs win.
 Do not send a literal nested `extra_body` object over raw HTTP; `extra_body` is
 an OpenAI Python SDK option that merges its contents into the top-level request.
 The Hub `generation_config.json` stamps `temperature=1.0` / `top_p=0.95` unless
@@ -489,6 +511,7 @@ that are now documented/enforced:
 | `MAX_NUM_BATCHED_TOKENS` | `2048` | prefill chunk (P1 keep). 3584/4096 lost; 8192 oversubscribes GB10 indexer topk |
 | `GLM53_MIXED_PREFILL_CHUNK` | `skip` | do not mix a peer prefill into a decode step (issue #6). `N>0` = cap tokens; `0` = off. Solo prefill stays MNBT (2048) |
 | `GLM53_SUPPRESS_STOPS_IN_REASONING` | `1` | ignore client `stop` strings until `</think>` (thinking-on default) |
+| `GLM53_DEFAULT_REASONING_EFFORT` | *(empty)* | server-side default effort via `--default-chat-template-kwargs`. Empty sends no flag, and the template then renders **Max** for any client that omits `chat_template_kwargs`. `high` is the recommendation for agentic coding: same 80/80 grader score as unset(max) at **4.6×** less wall time and **4.8×** fewer completion tokens ([receipts](docs/RECEIPTS-default-reasoning-effort.md)). `low`/`high`/`max` only — `medium` is rejected at launch because the template does not recognize it |
 | `GLM53_BOOT_SHAPE_WARMUP` | `1` | after `/health`, burn DFlash2 BLOCK / sampler / kpool shapes (nonfatal) |
 | `TRITON_HOST_CACHE` / `TILELANG_HOST_CACHE` | `$CACHE_ROOT/triton` / `tilelang` | persist JIT caches across container recreate |
 | `LANGUAGE_MODEL_ONLY` | `0` | load vision tower (image + video) |
@@ -537,6 +560,7 @@ this Dockerfile instead. After CUDA compile, Python overlay edits
 | `overlay/patch_ablit.py` | install the load_weights hook; bind-mounted and run on both ranks |
 | `ablit/` | direction vectors + `LAYER_MAP.json` from drowzeys' published recipe; `fetch_transplant.py` + `transplant/` for the donor o_proj byte-copy |
 | `tests/test_ablit.py` | recipe integrity, orthogonalization math, TP-shard equivalence, transplant byte-copy + TP slice, hook gating |
+| `tests/test_default_reasoning_effort.sh` | `GLM53_DEFAULT_REASONING_EFFORT` enum guard (`""`/`low`/`high`/`max`; `medium` rejected) and the `--default-chat-template-kwargs` flag at both rank sites, sliced out of `start.sh` and evaluated |
 | `scripts/boot-shape-warmup.sh` | post-`/health` DFlash2 k=7 BLOCK ladder + sampler/kpool arms |
 
 Image-build runs `EXL3_SELFCHECK_GPU=0`. `./start.sh` runs the GPU self-check

--- a/docs/RECEIPTS-default-reasoning-effort.md
+++ b/docs/RECEIPTS-default-reasoning-effort.md
@@ -1,0 +1,133 @@
+# `GLM53_DEFAULT_REASONING_EFFORT` — receipts
+
+Server-side default reasoning effort for the **GLM-5.3-Flash EXL3** 2× DGX Spark serve, via
+vLLM's `--default-chat-template-kwargs`. The launcher default is **empty** — this PR changes
+nothing until an operator sets the knob.
+
+## Why the knob exists
+
+`files/chat_template.jinja` line 7:
+
+```jinja
+{%- set effective_reasoning_effort = reasoning_effort if reasoning_effort is defined and reasoning_effort in ['low', 'high'] else 'max' -%}
+```
+
+The value maps to itself only for `low` and `high`. Everything else — including **undefined** —
+becomes `max`. So every client that omits `chat_template_kwargs` (OpenCode, plain `curl`, most
+SDK defaults) silently gets the most expensive setting, and no serve flag says so.
+
+That also fixes the enum: **`low | high | max` only**. `medium` is rejected at launch, because
+the template does not recognize it and would render `Max` while the operator believed otherwise.
+
+## A/B — unset(max) vs `high` (2026-09-01)
+
+One frozen agentic build brief, run twice per arm on the live serve. Arm A reached the server
+through a proxy injecting `chat_template_kwargs.reasoning_effort=high`; arm B hit the server
+directly, i.e. **the server default, which on this template is `max`**. Server flags were not
+changed and the server was not restarted. Grader is a frozen 80-point rubric.
+
+| Run | Arm | Wall (s) | Grader | Turns | Tool calls | Compactions | Prompt tok | Completion tok |
+|---|---|---:|---:|---:|---:|---:|---:|---:|
+| A-1 | high | 498 | **80/80** | 29 | 30 | 0 | 562,519 | 13,856 |
+| A-2 | high | 438 | **80/80** | 26 | 32 | 0 | 447,190 | 11,621 |
+| B-1 | unset → max | 1,955 | **80/80** | 14 | 21 | 2 | 303,872 | 54,410 |
+| B-2 | unset → max | 2,365 | **80/80** | 20 | 31 | 2 | 399,109 | 66,915 |
+
+Medians (n = 2 per arm):
+
+| Metric | high | unset → max | max ÷ high |
+|---|---:|---:|---:|
+| Grader score | 80.0 / 80 | 80.0 / 80 | 1.00 |
+| Wall time | **468 s** | **2,160 s** | **4.61×** |
+| Completion tokens | **12,739** | **60,663** | **4.76×** |
+| Prompt tokens | 504,855 | 351,491 | 0.70× |
+| Turns | 27.5 | 17 | 0.62× |
+| Tool calls | 31 | 26 | 0.84× |
+| Compactions | 0 | 2 | — |
+
+Effective decode rate was comparable across arms (A-1 ≈ 27.8 completion tok/s, B-2 ≈ 28.3), so
+essentially the whole wall-time gap is **extra generated reasoning**, not slower serving.
+Every run was graded 80/80 and every run's own test suite passed, so tool-calling and structured
+output were exercised at both settings.
+
+**Recommendation: `high` for agentic coding.** Not `low` — a genuine `high`-vs-`low` quality A/B
+has not been run, so `low` is not evidenced here. Arm B was **not** `low`; it was `max`.
+
+## Live receipts to capture on the box
+
+Run these against the target image / running serve and paste the output under each item.
+
+### 1. The flag exists in the target image
+
+```bash
+docker exec glm53-exl3-head vllm serve --help | grep -A2 default-chat-template-kwargs
+```
+
+Expect the option to be listed. Source in this vLLM: `vllm/entrypoints/openai/cli_args.py`
+(:93, :167, :200-201) and `vllm/entrypoints/openai/serving.py` (:131, :146), where server
+defaults are merged first and **request** `chat_template_kwargs` win.
+
+- [ ] captured
+
+### 2. Both ranks carry the flag
+
+```bash
+docker inspect --format '{{.Args}}' glm53-exl3-head
+ssh "$WORKER_SSH" "docker inspect --format '{{.Args}}' glm53-exl3-worker"
+```
+
+Both must show `--default-chat-template-kwargs {"reasoning_effort":"high"}` exactly once, as a
+single argv element. (The launcher builds the JSON space-free precisely so it survives the
+word-split `${worker_nccl}` env path to the worker.)
+
+- [ ] head captured
+- [ ] worker captured
+
+### 3. Render boundary — the default reaches Jinja, and a request overrides it
+
+The claim is about the rendered prompt, not the flag, so probe the renderer. `/tokenize` with
+`return_token_strs` renders the chat template and hands back the text:
+
+```bash
+# A: no chat_template_kwargs -> must render "Reasoning Effort: High" (the server default)
+curl -s localhost:8888/tokenize -H 'Content-Type: application/json' -d '{
+  "model":"GLM-5.3-Flash-EXL3",
+  "messages":[{"role":"user","content":"hi"}],
+  "return_token_strs":true}' | python3 -c 'import json,sys; print("".join(json.load(sys.stdin)["token_strs"])[:200])'
+
+# B: request override -> must render "Reasoning Effort: Low"
+curl -s localhost:8888/tokenize -H 'Content-Type: application/json' -d '{
+  "model":"GLM-5.3-Flash-EXL3",
+  "messages":[{"role":"user","content":"hi"}],
+  "chat_template_kwargs":{"reasoning_effort":"low"},
+  "return_token_strs":true}' | python3 -c 'import json,sys; print("".join(json.load(sys.stdin)["token_strs"])[:200])'
+```
+
+Also record the **before** state (server launched with the knob empty): request A must render
+`Reasoning Effort: Max`. That before/after pair is the whole proof — it shows both that the
+default lands and that it was `max` beforehand.
+
+If `/tokenize` does not surface the rendered text on this build, fall back to a
+logprobs-of-prefix probe: send `max_tokens=1, prompt_logprobs=0` on the chat endpoint and read
+the echoed prompt tokens.
+
+- [ ] before (knob empty): request A renders `Max`
+- [ ] after (knob `high`): request A renders `High`
+- [ ] after (knob `high`): request B renders `Low` — request override wins
+
+### 4. Canaries at the chosen effort
+
+Per the Codex advisory, effort changes template text only, not `<think>` or tool-call grammar —
+but confirm rather than assume, on the running serve with the default in place:
+
+- [ ] reasoning extraction: a normal chat request still returns a populated `reasoning_content`
+- [ ] tool calling: a request with `tools` still emits a well-formed `tool_calls` entry
+- [ ] JSON validity: a `response_format` / guided-JSON request still parses
+
+## Host tests (no hardware)
+
+```
+tests/test_default_reasoning_effort.sh    enum guard + both serve-arg sites
+tests/test_numeric_config.py              unchanged, still green
+tests/test_start_overrides.py             + setness-aware caller override
+```

--- a/docs/RECEIPTS-default-reasoning-effort.md
+++ b/docs/RECEIPTS-default-reasoning-effort.md
@@ -53,81 +53,135 @@ output were exercised at both settings.
 **Recommendation: `high` for agentic coding.** Not `low` — a genuine `high`-vs-`low` quality A/B
 has not been run, so `low` is not evidenced here. Arm B was **not** `low`; it was `max`.
 
-## Live receipts to capture on the box
+## A/B v2 — `high` vs `low` (2026-09-01)
 
-Run these against the target image / running serve and paste the output under each item.
+Same task, grader, harness and vLLM process as above; arm B now went through a `low`-injecting proxy.
+Four runs, alternating A,B,A,B, one at a time, server never reconfigured.
+
+| Run | Arm | Wall (s) | Grader | Turns | Tool calls (errors) | Compactions | Prompt tok | Completion tok |
+|---|---|---:|---:|---:|---:|---:|---:|---:|
+| A-1 | high | 486 | **80/80** | 37 | 36 (0) | 0 | 639,301 | 13,054 |
+| B-1 | low | 297 | **79/80** | 19 | 21 (1, self-recovered) | 0 | 285,585 | 8,478 |
+| A-2 | high | 700 | **80/80** | 27 | 35 (0) | 0 | 733,450 | 20,028 |
+| B-2 | low | 208 | **80/80** | 11 | 15 (0) | 0 | 146,586 | 6,004 |
+
+Medians: wall 593 s vs 252.5 s, completion tokens 16,541 vs 7,241, grader 80.0 vs 79.5 (the lost point was a
+41-line README against a 40-line limit). A tool-call canary (`opencode run` with a `read` tool) passed at both efforts.
+Across v1 + v2 the three levels order monotonically at the grader ceiling: low 252 s < high 468–593 s < max 2,160 s.
+
+Caveats that apply to both A/Bs: n = 2 per arm, one task, and a grader at its ceiling — the benchmark discriminates
+**cost**, not reasoning quality. `low` visibly does less exploration (half the turns and tool calls). That is why the
+recommendation stays `high`, and why `low` is documented as legal but not recommended.
+
+## Live receipts (captured 2026-09-01)
+
+Captured read-only on the live 2× DGX Spark serve — image `ghcr.io/miaai-lab/glm-5.3-flash-2x-dgx-sparks:exl3`
+(`sha256:ad0cdd86…`), vLLM `0.1.dev20051+g487ecf187`, launched with `GLM53_DEFAULT_REASONING_EFFORT=high` in `.env`.
+No restart, no chat completions.
 
 ### 1. The flag exists in the target image
 
-```bash
-docker exec glm53-exl3-head vllm serve --help | grep -A2 default-chat-template-kwargs
+`vllm serve --help` (short page) hides it; `--help=all` lists it:
+
+```
+$ docker exec glm53-exl3-head vllm serve --help=all 2>&1 | grep -n -A2 default-chat-template-kwargs
+80:  --default-chat-template-kwargs DEFAULT_CHAT_TEMPLATE_KWARGS
+81-                        Should either be a valid JSON string or JSON keys
+82-                        passed individually. (default: None)
 ```
 
-Expect the option to be listed. Source in this vLLM: `vllm/entrypoints/openai/cli_args.py`
-(:93, :167, :200-201) and `vllm/entrypoints/openai/serving.py` (:131, :146), where server
+Source in this vLLM: `vllm/entrypoints/openai/cli_args.py` and `vllm/entrypoints/openai/serving.py`, where server
 defaults are merged first and **request** `chat_template_kwargs` win.
 
-- [ ] captured
+- [x] captured
 
 ### 2. Both ranks carry the flag
 
-```bash
-docker inspect --format '{{.Args}}' glm53-exl3-head
-ssh "$WORKER_SSH" "docker inspect --format '{{.Args}}' glm53-exl3-worker"
+The containers' `Cmd` is `bash /start.sh`, so `docker inspect` does not show the serve line; `vllm serve` is pid 1 in
+each container and `/proc/1/cmdline` (NUL-split) is the parsed argv. Element index, next element, occurrence count:
+
+```
+== HEAD ==
+host=spark-deb8 container=glm53-exl3-head image=ghcr.io/miaai-lab/glm-5.3-flash-2x-dgx-sparks:exl3
+vllm serve pid=1
+42:--default-chat-template-kwargs
+43-{"reasoning_effort":"high"}
+occurrences=1
+argc=58
+== WORKER ==
+host=spark-d9d5 container=glm53-exl3-worker image=ghcr.io/miaai-lab/glm-5.3-flash-2x-dgx-sparks:exl3
+vllm serve pid=1
+43:--default-chat-template-kwargs
+44-{"reasoning_effort":"high"}
+occurrences=1
+argc=59
 ```
 
-Both must show `--default-chat-template-kwargs {"reasoning_effort":"high"}` exactly once, as a
-single argv element. (The launcher builds the JSON space-free precisely so it survives the
-word-split `${worker_nccl}` env path to the worker.)
+Head API-server parsed config (the headless rank has no API server and prints no such line):
 
-- [ ] head captured
-- [ ] worker captured
+```
+$ docker logs glm53-exl3-head 2>&1 | grep -i default_chat_template_kwargs
+(APIServer pid=1) INFO 09-01 01:03:44 [api_utils.py:273] non-default args: {… 'chat_template': '/opt/glm53/chat_template.jinja', 'default_chat_template_kwargs': {'reasoning_effort': 'high'}, 'enable_auto_tool_choice': True, 'tool_call_parser': 'glm47', … 'reasoning_parser': 'glm45', … 'nnodes': 2, 'tensor_parallel_size': 2, …}
+```
+
+- [x] head captured
+- [x] worker captured
 
 ### 3. Render boundary — the default reaches Jinja, and a request overrides it
 
-The claim is about the rendered prompt, not the flag, so probe the renderer. `/tokenize` with
-`return_token_strs` renders the chat template and hands back the text:
+`/tokenize` renders the template; because `token_strs` are tokenizer pieces, each id list was passed through
+`/detokenize` for the literal prompt. Served template md5 `37639425…` == `files/chat_template.jinja`.
 
-```bash
-# A: no chat_template_kwargs -> must render "Reasoning Effort: High" (the server default)
-curl -s localhost:8888/tokenize -H 'Content-Type: application/json' -d '{
-  "model":"GLM-5.3-Flash-EXL3",
-  "messages":[{"role":"user","content":"hi"}],
-  "return_token_strs":true}' | python3 -c 'import json,sys; print("".join(json.load(sys.stdin)["token_strs"])[:200])'
+```
+# A: no chat_template_kwargs -> server default
+RESP: {"count":13,…,"token_strs":["[gMASK]","<sop>","<|system|>","Reason","ing","ĠEff","ort",":","ĠHigh","<|user|>","hi","<|assistant|>","<think>"]}
+DETOK: {"prompt":"[gMASK]<sop><|system|>Reasoning Effort: High<|user|>hi<|assistant|><think>"}
 
-# B: request override -> must render "Reasoning Effort: Low"
-curl -s localhost:8888/tokenize -H 'Content-Type: application/json' -d '{
-  "model":"GLM-5.3-Flash-EXL3",
-  "messages":[{"role":"user","content":"hi"}],
-  "chat_template_kwargs":{"reasoning_effort":"low"},
-  "return_token_strs":true}' | python3 -c 'import json,sys; print("".join(json.load(sys.stdin)["token_strs"])[:200])'
+# B: "chat_template_kwargs":{"reasoning_effort":"low"} -> request override wins
+DETOK: {"prompt":"[gMASK]<sop><|system|>Reasoning Effort: Low<|user|>hi<|assistant|><think>"}
+
+# C: "chat_template_kwargs":{"reasoning_effort":"max"} -> request override wins
+DETOK: {"prompt":"[gMASK]<sop><|system|>Reasoning Effort: Max<|user|>hi<|assistant|><think>"}
+
+# D: "chat_template_kwargs":{"reasoning_effort":"medium"} -> no such level in the template, renders Max
+token_strs: [… "ĠMax" …]
 ```
 
-Also record the **before** state (server launched with the knob empty): request A must render
-`Reasoning Effort: Max`. That before/after pair is the whole proof — it shows both that the
-default lands and that it was `max` beforehand.
+Only token position 9 differs between A/B/C: `5124` (`ĠHigh`), `12035` (`ĠLow`), `7487` (`ĠMax`).
 
-If `/tokenize` does not surface the rendered text on this build, fall back to a
-logprobs-of-prefix probe: send `max_tokens=1, prompt_logprobs=0` on the chat endpoint and read
-the echoed prompt tokens.
+**Before state (knob empty).** Not captured live — it needs a serve launched without the knob, i.e. a restart, and the
+box was in use. Substitute: the served template file rendered offline inside the same container with jinja2
+(`jinja2.ext.loopcontrols`, as `tests/test_chat_template.py` does), which is the branch a no-flag serve takes:
 
-- [ ] before (knob empty): request A renders `Max`
-- [ ] after (knob `high`): request A renders `High`
-- [ ] after (knob `high`): request B renders `Low` — request override wins
+```
+ <no kwargs> -> '[gMASK]<sop><|system|>Reasoning Effort: Max<|user|>hi<|assistant|><think>'
+         low -> '[gMASK]<sop><|system|>Reasoning Effort: Low<|user|>hi<|assistant|><think>'
+        high -> '[gMASK]<sop><|system|>Reasoning Effort: High<|user|>hi<|assistant|><think>'
+         max -> '[gMASK]<sop><|system|>Reasoning Effort: Max<|user|>hi<|assistant|><think>'
+      medium -> '[gMASK]<sop><|system|>Reasoning Effort: Max<|user|>hi<|assistant|><think>'
+```
+
+The A/B v1 "direct" arm was measured against this very serve before the knob existed and behaved as `max`.
+
+- [ ] before (knob empty): request A renders `Max` — **not captured live** (offline render above instead)
+- [x] after (knob `high`): request A renders `High`
+- [x] after (knob `high`): request B renders `Low` — request override wins (`max` override also shown)
 
 ### 4. Canaries at the chosen effort
 
-Per the Codex advisory, effort changes template text only, not `<think>` or tool-call grammar —
-but confirm rather than assume, on the running serve with the default in place:
+Effort changes template text only, not `<think>` or tool-call grammar. Evidence from the A/B runs (all through the
+live serve, all with `reasoning_content` streamed before content):
 
-- [ ] reasoning extraction: a normal chat request still returns a populated `reasoning_content`
-- [ ] tool calling: a request with `tools` still emits a well-formed `tool_calls` entry
-- [ ] JSON validity: a `response_format` / guided-JSON request still parses
+- [x] reasoning extraction: every A/B run streamed `reasoning` deltas ahead of content (this is why TTFT-to-content is
+      longer at `high`, see the v2 results' caveat 5)
+- [x] tool calling: 71/71 tool calls succeeded at `high` across v2; canary `read` tool call completed at `high` and `low`
+- [ ] JSON validity under `response_format` / guided-JSON at the chosen effort: **not run** — nothing in the A/B used
+      guided decoding. The effort hint is prompt text and does not touch the grammar path, but this is stated, not shown.
 
 ## Host tests (no hardware)
 
 ```
-tests/test_default_reasoning_effort.sh    enum guard + both serve-arg sites
+tests/test_default_reasoning_effort.sh    enum guard + both serve-arg sites (27 checks)
 tests/test_numeric_config.py              unchanged, still green
 tests/test_start_overrides.py             + setness-aware caller override
 ```

--- a/docs/RECEIPTS-default-reasoning-effort.md
+++ b/docs/RECEIPTS-default-reasoning-effort.md
@@ -45,10 +45,10 @@ Medians (n = 2 per arm):
 | Tool calls | 31 | 26 | 0.84× |
 | Compactions | 0 | 2 | — |
 
-Effective decode rate was comparable across arms (A-1 ≈ 27.8 completion tok/s, B-2 ≈ 28.3), so
-essentially the whole wall-time gap is **extra generated reasoning**, not slower serving.
-Every run was graded 80/80 and every run's own test suite passed, so tool-calling and structured
-output were exercised at both settings.
+Effective decode rate was comparable across arms (A-1 ≈ 27.8 completion tok/s, B-2 ≈ 28.3). That is
+consistent with most of the wall-time gap being **extra generated reasoning**; it does not isolate
+prompt-processing or tool latency. Every run was graded 80/80 and every run's own test suite passed, so
+the normal tool-calling protocol was exercised at both settings (guided JSON / `response_format` was not).
 
 **Recommendation: `high` for agentic coding.** Not `low` — a genuine `high`-vs-`low` quality A/B
 has not been run, so `low` is not evidenced here. Arm B was **not** `low`; it was `max`.
@@ -67,10 +67,11 @@ Four runs, alternating A,B,A,B, one at a time, server never reconfigured.
 
 Medians: wall 593 s vs 252.5 s, completion tokens 16,541 vs 7,241, grader 80.0 vs 79.5 (the lost point was a
 41-line README against a 40-line limit). A tool-call canary (`opencode run` with a `read` tool) passed at both efforts.
-Across v1 + v2 the three levels order monotonically at the grader ceiling: low 252 s < high 468–593 s < max 2,160 s.
+Across v1 + v2 the observed wall-time medians ordered low 252 s < high 468–593 s < max 2,160 s, with quality
+at or near the grader ceiling in every arm.
 
-Caveats that apply to both A/Bs: n = 2 per arm, one task, and a grader at its ceiling — the benchmark discriminates
-**cost**, not reasoning quality. `low` visibly does less exploration (half the turns and tool calls). That is why the
+Caveats that apply to both A/Bs: n = 2 per arm, one task, and a grader at or near its ceiling — these small runs
+primarily measure **cost**, not reasoning quality. `low` visibly does less exploration (half the turns and tool calls). That is why the
 recommendation stays `high`, and why `low` is documented as legal but not recommended.
 
 ## Live receipts (captured 2026-09-01)

--- a/start.sh
+++ b/start.sh
@@ -73,6 +73,12 @@ _cli_ablit_direction="${ABLIT_DIRECTION-}"
 _cli_ablit_layers="${ABLIT_LAYERS-}"
 _cli_ablit_alpha="${ABLIT_ALPHA-}"
 _cli_ablit_mtp="${ABLIT_INCLUDE_MTP-}"
+# Setness-aware: the recipe default is EMPTY, so "non-empty means the
+# caller set it" cannot distinguish `GLM53_DEFAULT_REASONING_EFFORT= ./start.sh`
+# (deliberately back to the template default) from an unset var. An
+# explicitly empty caller value must win over .env, not be swallowed by it.
+_cli_default_effort_set="${GLM53_DEFAULT_REASONING_EFFORT+1}"
+_cli_default_effort="${GLM53_DEFAULT_REASONING_EFFORT-}"
 set -a
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/.env"
@@ -94,6 +100,7 @@ set +a
 [ -n "${_cli_ablit_layers}" ] && ABLIT_LAYERS="$_cli_ablit_layers"
 [ -n "${_cli_ablit_alpha}" ] && ABLIT_ALPHA="$_cli_ablit_alpha"
 [ -n "${_cli_ablit_mtp}" ] && ABLIT_INCLUDE_MTP="$_cli_ablit_mtp"
+[ -n "${_cli_default_effort_set}" ] && GLM53_DEFAULT_REASONING_EFFORT="$_cli_default_effort"
 
 # ----------------------------- configuration -------------------------------
 MODEL="${MODEL:-Mia-AiLab/GLM-5.3-Flash-EXL3-TR3-4bpw}"
@@ -227,6 +234,19 @@ GLM53_SUPPRESS_STOPS_IN_REASONING="${GLM53_SUPPRESS_STOPS_IN_REASONING:-1}"
 # Mixed-step prefill policy when a peer is already decoding (issue #6).
 # skip = do not mix; N>0 = cap tokens; 0 = off.
 GLM53_MIXED_PREFILL_CHUNK="${GLM53_MIXED_PREFILL_CHUNK:-skip}"
+# Server-side default reasoning effort, injected as
+# `--default-chat-template-kwargs '{"reasoning_effort":"<v>"}'`.
+# EMPTY (the default) changes nothing -- but note what "nothing" means here:
+# files/chat_template.jinja line 7 maps reasoning_effort to itself only for
+# 'low'/'high' and to 'max' for everything else, INCLUDING undefined. So a
+# client that omits chat_template_kwargs gets Reasoning Effort: Max, the most
+# expensive setting. Measured on one agentic build task, unset(max) vs high
+# scored identically (80/80) at 4.6x the wall time and 4.8x the completion
+# tokens, so `high` is the recommendation for agentic coding
+# (docs/RECEIPTS-default-reasoning-effort.md). Set per-request
+# chat_template_kwargs.reasoning_effort to override this default.
+# low | high | max; empty = send no flag. Default applies only when UNSET.
+GLM53_DEFAULT_REASONING_EFFORT="${GLM53_DEFAULT_REASONING_EFFORT-}"
 # EngineCore stock timeout is 300s; mid-serve Triton/TileLang JIT on TP=2 can
 # exceed that without being a true hang. NCCL watchdog is still 600s.
 VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS="${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-1800}"
@@ -291,6 +311,23 @@ _glm53_canonical_positive_int() {
     export "$name"
 }
 
+# Enum knobs are exactly one of a fixed set. Not "non-empty means on": a
+# typo'd knob must not silently pick a serving mode. The match is literal --
+# no trimming, no case folding -- so "High" and " high " are rejected here
+# rather than being handed to vLLM, which would accept the JSON and then
+# silently render Max at the template. That is also why the reasoning-effort
+# enum is low|high|max and NOT medium: files/chat_template.jinja recognizes
+# only low/high and falls back to max, so a 'medium' default would be a lie.
+_glm53_validate_enum() {
+    local name="$1" value="$2" allowed
+    shift 2
+    for allowed in "$@"; do
+        [ "$value" = "$allowed" ] && return 0
+    done
+    echo "$name must be one of: $* (got: $value)" >&2
+    return 2
+}
+
 validate_numeric_config() {
     if ! [[ "$GPU_MEM_UTIL" =~ ^(0([.][0-9]+)?|[.][0-9]+|1([.]0+)?)$ ]] \
        || ! awk -v u="$GPU_MEM_UTIL" 'BEGIN { exit !(u > 0 && u <= 1) }'; then
@@ -300,6 +337,13 @@ validate_numeric_config() {
     _glm53_canonical_positive_int MAX_MODEL_LEN "$MAX_MODEL_LEN" 1000000 || return
     _glm53_canonical_positive_int MAX_NUM_SEQS "$MAX_NUM_SEQS" 4096 || return
     _glm53_canonical_positive_int MAX_NUM_BATCHED_TOKENS "$MAX_NUM_BATCHED_TOKENS" 8388608 || return
+    # Empty/unset is legal and means "send no flag" (the template then renders
+    # Max). Anything non-empty must be exactly one of the three the template
+    # can act on, so the enum stays low|high|max and the error text stays clean.
+    if [ -n "${GLM53_DEFAULT_REASONING_EFFORT-}" ]; then
+        _glm53_validate_enum GLM53_DEFAULT_REASONING_EFFORT \
+            "$GLM53_DEFAULT_REASONING_EFFORT" low high max || return
+    fi
 }
 # GLM53 numeric config guard (end)
 
@@ -851,6 +895,14 @@ ARGS=(
 [ -n "${MAX_NUM_SEQS:-}" ] && ARGS+=(--max-num-seqs "${MAX_NUM_SEQS}")
 [ -n "${MAX_NUM_BATCHED_TOKENS:-}" ] && ARGS+=(--max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}")
 [ -n "${KV_CACHE_DTYPE:-}" ] && ARGS+=(--kv-cache-dtype "${KV_CACHE_DTYPE}")
+# Server-side default reasoning effort. Empty = no flag, and the template then
+# renders Max for any client that omits chat_template_kwargs. The JSON is a
+# single argv element and contains no spaces, so it survives both the array
+# expansion here and the word-split `${worker_nccl}` env path on the worker.
+# Request-level chat_template_kwargs override this default.
+if [ -n "${GLM53_DEFAULT_REASONING_EFFORT:-}" ]; then
+    ARGS+=(--default-chat-template-kwargs "{\"reasoning_effort\":\"${GLM53_DEFAULT_REASONING_EFFORT}\"}")
+fi
 if [ "${SPEC_METHOD:-mtp}" = "dflash" ]; then
     ARGS+=(--speculative-config "$(python3 -S -c 'import json,os
 spec={"method":"dflash","model":os.environ["DFLASH_MODEL_DIR"],"num_speculative_tokens":int(os.environ.get("DFLASH_TOKENS","7")),"kv_cache_dtype":"auto","draft_sample_method":"probabilistic","rejection_sample_method":"standard"}
@@ -943,6 +995,14 @@ ARGS=(
 [ -n "${MAX_NUM_SEQS:-}" ] && ARGS+=(--max-num-seqs "${MAX_NUM_SEQS}")
 [ -n "${MAX_NUM_BATCHED_TOKENS:-}" ] && ARGS+=(--max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}")
 [ -n "${KV_CACHE_DTYPE:-}" ] && ARGS+=(--kv-cache-dtype "${KV_CACHE_DTYPE}")
+# Server-side default reasoning effort. Empty = no flag, and the template then
+# renders Max for any client that omits chat_template_kwargs. The JSON is a
+# single argv element and contains no spaces, so it survives both the array
+# expansion here and the word-split `${worker_nccl}` env path on the worker.
+# Request-level chat_template_kwargs override this default.
+if [ -n "${GLM53_DEFAULT_REASONING_EFFORT:-}" ]; then
+    ARGS+=(--default-chat-template-kwargs "{\"reasoning_effort\":\"${GLM53_DEFAULT_REASONING_EFFORT}\"}")
+fi
 if [ "${SPEC_METHOD:-mtp}" = "dflash" ]; then
     ARGS+=(--speculative-config "$(python3 -S -c 'import json,os
 spec={"method":"dflash","model":os.environ["DFLASH_MODEL_DIR"],"num_speculative_tokens":int(os.environ.get("DFLASH_TOKENS","7")),"kv_cache_dtype":"auto","draft_sample_method":"probabilistic","rejection_sample_method":"standard"}
@@ -1053,6 +1113,7 @@ launch_cluster() {
         -e VLLM_CACHE_ROOT=/root/.cache/vllm
         -e "GLM53_SUPPRESS_STOPS_IN_REASONING=$GLM53_SUPPRESS_STOPS_IN_REASONING"
         -e "GLM53_MIXED_PREFILL_CHUNK=$GLM53_MIXED_PREFILL_CHUNK"
+        -e "GLM53_DEFAULT_REASONING_EFFORT=${GLM53_DEFAULT_REASONING_EFFORT-}"
         -e "TRITON_CACHE_DIR=$TRITON_CACHE_DIR"
         -e "TILELANG_CACHE_DIR=$TILELANG_CACHE_DIR"
         -e "VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=$VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS"

--- a/start.sh
+++ b/start.sh
@@ -245,7 +245,7 @@ GLM53_MIXED_PREFILL_CHUNK="${GLM53_MIXED_PREFILL_CHUNK:-skip}"
 # tokens, so `high` is the recommendation for agentic coding
 # (docs/RECEIPTS-default-reasoning-effort.md). Set per-request
 # chat_template_kwargs.reasoning_effort to override this default.
-# low | high | max; empty = send no flag. Default applies only when UNSET.
+# low | high | max; empty or unset = send no flag.
 GLM53_DEFAULT_REASONING_EFFORT="${GLM53_DEFAULT_REASONING_EFFORT-}"
 # EngineCore stock timeout is 300s; mid-serve Triton/TileLang JIT on TP=2 can
 # exceed that without being a true hang. NCCL watchdog is still 600s.

--- a/tests/test_default_reasoning_effort.sh
+++ b/tests/test_default_reasoning_effort.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# GLM53_DEFAULT_REASONING_EFFORT: launch-time enum guard + the serve-args flag.
+#
+# Two independent claims are checked against start.sh's own text, not a replica:
+#   1. validate_numeric_config accepts exactly "" | low | high | max and rejects
+#      everything else (notably `medium`, which files/chat_template.jinja does
+#      NOT recognize and would silently render as Max).
+#   2. BOTH inner scripts (head rank 0 and headless worker rank 1) append
+#      --default-chat-template-kwargs exactly once, with space-free JSON, when
+#      the knob is set -- and append nothing at all when it is empty.
+# Values are passed through the environment so adversarial strings are
+# exercised safely rather than interpolated into source.
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+START="$HERE/../start.sh"
+[ -f "$START" ] || { echo "start.sh not found" >&2; exit 1; }
+fail=0
+
+# ---------------------------------------------------------------- guard ----
+guard="$(sed -n '/^# GLM53 numeric config guard (begin)$/,/^# GLM53 numeric config guard (end)$/p' "$START")"
+[ -n "$guard" ] || { echo "numeric config guard block not found" >&2; exit 1; }
+printf '%s\n' "$guard" > "/tmp/_effort_guard.$$"
+
+guard_rc() { # reads the value from the environment; echoes validate_numeric_config's rc
+    GLM53_DEFAULT_REASONING_EFFORT="$1" bash -c '
+        source "/tmp/_effort_guard.'$$'"
+        GPU_MEM_UTIL=0.87 MAX_MODEL_LEN=1000000 MAX_NUM_SEQS=4 MAX_NUM_BATCHED_TOKENS=2048
+        validate_numeric_config' >/dev/null 2>&1
+    echo $?
+}
+
+check_guard() {
+    got="$(guard_rc "$1")"
+    if [ "$got" = "$2" ]; then echo "ok   guard [$1] -> rc $got"
+    else echo "FAIL guard [$1] -> rc $got want $2"; fail=1; fi
+}
+
+check_guard ""       0
+check_guard "low"    0
+check_guard "high"   0
+check_guard "max"    0
+check_guard "medium" 2
+check_guard "High"   2
+check_guard "MAX"    2
+check_guard " high"  2
+check_guard "high "  2
+check_guard "junk"   2
+check_guard "1"      2
+check_guard 'high;id' 2
+
+# an UNSET knob must also pass (the guard reads ${VAR-}, not $VAR under set -u)
+if bash -c 'set -u; source "/tmp/_effort_guard.'$$'"
+    GPU_MEM_UTIL=0.87 MAX_MODEL_LEN=1000000 MAX_NUM_SEQS=4 MAX_NUM_BATCHED_TOKENS=2048
+    validate_numeric_config' >/dev/null 2>&1; then
+    echo "ok   guard [<unset>] -> rc 0"
+else
+    echo "FAIL guard [<unset>] must pass with the var unset"; fail=1
+fi
+
+# the rejection message must name the knob and the four legal values
+msg="$(GLM53_DEFAULT_REASONING_EFFORT=medium bash -c '
+    source "/tmp/_effort_guard.'$$'"
+    GPU_MEM_UTIL=0.87 MAX_MODEL_LEN=1000000 MAX_NUM_SEQS=4 MAX_NUM_BATCHED_TOKENS=2048
+    validate_numeric_config' 2>&1 >/dev/null || true)"
+case "$msg" in
+    *GLM53_DEFAULT_REASONING_EFFORT*low*high*max*) echo "ok   guard error names knob and enum" ;;
+    *) echo "FAIL guard error text: [$msg]"; fail=1 ;;
+esac
+
+# ----------------------------------------------------------- serve args ----
+# Slice each inner script out of its quoted heredoc, then keep only the ARGS
+# construction (ARGS=( ... up to the config.json existence check).
+args_block() { # $1 = HEAD_SCRIPT | WORKER_SCRIPT
+    awk -v var="$1" '
+        index($0, "cat > \"$" var "\" <<") { inblk = 1; next }
+        inblk && $0 == "EOF" { exit }
+        inblk { print }
+    ' "$START" | sed -n '/^ARGS=(/,/^\[ -f "${MODEL_DIR}\/config.json"/p' | sed '$d'
+}
+
+for var in HEAD_SCRIPT WORKER_SCRIPT; do
+    args_block "$var" > "/tmp/_effort_args_${var}.$$"
+    if ! [ -s "/tmp/_effort_args_${var}.$$" ]; then
+        echo "FAIL could not slice ARGS block for $var"; fail=1; continue
+    fi
+    if ! grep -q -- '--default-chat-template-kwargs' "/tmp/_effort_args_${var}.$$"; then
+        echo "FAIL $var ARGS block has no --default-chat-template-kwargs"; fail=1
+    fi
+done
+
+emit() { # $1 = HEAD_SCRIPT|WORKER_SCRIPT, $2 = knob value; prints argv one per line
+    GLM53_DEFAULT_REASONING_EFFORT="$2" bash -c '
+        say() { :; }
+        SERVED_MODEL_NAME=m PORT=8888 TP=2 NNODES=2 HEAD_IP=10.0.0.1 MASTER_PORT=29500
+        ENFORCE_EAGER=0 QUANTIZATION=none MAX_MODEL_LEN=1000000 GPU_MEM_UTIL=0.87
+        MAX_NUM_SEQS=4 MAX_NUM_BATCHED_TOKENS=2048 KV_CACHE_DTYPE=fp8
+        SPEC_METHOD=none MTP_TOKENS=0 CHAT_TEMPLATE= LANGUAGE_MODEL_ONLY=0
+        LIMIT_MM= SKIP_MM_PROFILING=0 EXTRA_ARGS=
+        source "/tmp/_effort_args_'"$1"'.'$$'"
+        printf "%s\n" "${ARGS[@]}"' 2>/dev/null
+}
+
+check_emit() { # $1 rank var, $2 value, $3 expected JSON ("" = flag must be absent)
+    local out n json
+    out="$(emit "$1" "$2")"
+    n="$(printf '%s\n' "$out" | grep -c -- '^--default-chat-template-kwargs$' || true)"
+    json="$(printf '%s\n' "$out" | grep -A1 -- '^--default-chat-template-kwargs$' | sed -n '2p')"
+    if [ -z "$3" ]; then
+        if [ "$n" = "0" ]; then echo "ok   $1 [$2] -> no flag"
+        else echo "FAIL $1 [$2] -> emitted $n flag(s): [$json]"; fail=1; fi
+        return
+    fi
+    if [ "$n" != "1" ]; then
+        echo "FAIL $1 [$2] -> flag emitted $n times (want exactly 1)"; fail=1; return
+    fi
+    if [ "$json" != "$3" ]; then
+        echo "FAIL $1 [$2] -> JSON [$json] want [$3]"; fail=1; return
+    fi
+    case "$json" in
+        *" "*) echo "FAIL $1 [$2] -> JSON contains a space: [$json]"; fail=1; return ;;
+    esac
+    echo "ok   $1 [$2] -> $json"
+}
+
+for var in HEAD_SCRIPT WORKER_SCRIPT; do
+    check_emit "$var" ""     ""
+    check_emit "$var" "low"  '{"reasoning_effort":"low"}'
+    check_emit "$var" "high" '{"reasoning_effort":"high"}'
+    check_emit "$var" "max"  '{"reasoning_effort":"max"}'
+done
+
+# the two ranks must build the same flag from the same knob
+h="$(emit HEAD_SCRIPT high | grep -A1 -- '^--default-chat-template-kwargs$' | sed -n '2p')"
+w="$(emit WORKER_SCRIPT high | grep -A1 -- '^--default-chat-template-kwargs$' | sed -n '2p')"
+if [ "$h" = "$w" ] && [ -n "$h" ]; then echo "ok   both ranks build the identical flag"
+else echo "FAIL rank flags differ: head [$h] worker [$w]"; fail=1; fi
+
+# ------------------------------------------------------------- wiring ------
+launcher="$(cat "$START")"
+case "$launcher" in
+    *'_cli_default_effort_set="${GLM53_DEFAULT_REASONING_EFFORT+1}"'*)
+        echo "ok   caller capture is setness-aware" ;;
+    *) echo "FAIL caller capture is not setness-aware"; fail=1 ;;
+esac
+case "$launcher" in
+    *'[ -n "${_cli_default_effort_set}" ] && GLM53_DEFAULT_REASONING_EFFORT="$_cli_default_effort"'*)
+        echo "ok   caller value wins over .env" ;;
+    *) echo "FAIL caller override line missing"; fail=1 ;;
+esac
+case "$launcher" in
+    *'-e "GLM53_DEFAULT_REASONING_EFFORT=${GLM53_DEFAULT_REASONING_EFFORT-}"'*)
+        echo "ok   knob reaches both containers via nccl_common" ;;
+    *) echo "FAIL knob is not exported into the containers"; fail=1 ;;
+esac
+# default must stay empty: this PR changes no behaviour until an operator opts in
+case "$launcher" in
+    *'GLM53_DEFAULT_REASONING_EFFORT="${GLM53_DEFAULT_REASONING_EFFORT-}"'*)
+        echo "ok   launcher default is empty (unchanged behaviour)" ;;
+    *) echo "FAIL launcher default is not empty"; fail=1 ;;
+esac
+
+rm -f "/tmp/_effort_guard.$$" "/tmp/_effort_args_HEAD_SCRIPT.$$" "/tmp/_effort_args_WORKER_SCRIPT.$$"
+[ "$fail" = 0 ] && echo "default reasoning effort tests: PASS"
+exit $fail

--- a/tests/test_start_overrides.py
+++ b/tests/test_start_overrides.py
@@ -41,6 +41,55 @@ def test_max_num_seqs_inline_override_wins() -> None:
     assert result.stdout.strip() == "MAX_NUM_SEQS=4"
 
 
+def _preamble_probe(env: dict[str, str], env_file: str, probe: str) -> str:
+    """Run start.sh's pre-configuration preamble with a synthetic .env."""
+    source = (ROOT / "start.sh").read_text()
+    marker = "# ----------------------------- configuration -------------------------------"
+    preamble, separator, _rest = source.partition(marker)
+    assert separator, "start.sh configuration marker is missing"
+
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        tmp = Path(raw_tmp)
+        script = tmp / "start.sh"
+        script.write_text(preamble + "\n" + probe + "\n")
+        script.chmod(0o755)
+        (tmp / ".env").write_text(env_file)
+        result = subprocess.run(
+            ["bash", str(script)],
+            check=True,
+            capture_output=True,
+            text=True,
+            env={**os.environ, **env},
+        )
+    return result.stdout.strip()
+
+
+def test_default_reasoning_effort_caller_override_is_setness_aware() -> None:
+    """An explicitly EMPTY caller value must beat .env, not be swallowed by it.
+
+    The knob's own default is empty, so ``[ -n "$_cli_x" ]`` cannot tell
+    ``GLM53_DEFAULT_REASONING_EFFORT= ./start.sh`` (deliberately back to the
+    template default) apart from an unset var. Only ``${VAR+1}`` can.
+    """
+    probe = 'printf "EFFORT=[%s]\\n" "${GLM53_DEFAULT_REASONING_EFFORT-unset}"'
+    env_file = "GLM53_DEFAULT_REASONING_EFFORT=high\n"
+
+    # caller unset -> .env wins
+    os.environ.pop("GLM53_DEFAULT_REASONING_EFFORT", None)
+    assert _preamble_probe({}, env_file, probe) == "EFFORT=[high]"
+
+    # caller sets a value -> caller wins
+    assert _preamble_probe(
+        {"GLM53_DEFAULT_REASONING_EFFORT": "low"}, env_file, probe
+    ) == "EFFORT=[low]"
+
+    # caller sets it EMPTY -> caller still wins (the setness-aware case)
+    assert _preamble_probe(
+        {"GLM53_DEFAULT_REASONING_EFFORT": ""}, env_file, probe
+    ) == "EFFORT=[]"
+
+
 if __name__ == "__main__":
     test_max_num_seqs_inline_override_wins()
+    test_default_reasoning_effort_caller_override_is_setness_aware()
     print("start.sh caller override regression OK")


### PR DESCRIPTION
## Launcher knob for the default reasoning effort (`GLM53_DEFAULT_REASONING_EFFORT`)

### Problem
`files/chat_template.jinja` (line 7) maps `reasoning_effort` to itself only for `low`/`high` and to **`max`** for anything
else — including *unset*. The launcher passes no `--default-chat-template-kwargs`, so every client that omits
`chat_template_kwargs.reasoning_effort` silently runs at max, and nothing in the serve args says so.

Measured on one agentic coding task (OpenCode `build`, frozen microagent brief, 2 reps/arm, frozen 80-point grader, same
vLLM process, one run at a time). The grader was at or near its ceiling (median 79.5–80 of 80), so these small runs primarily measure
**cost**, not reasoning quality:

| effort | median wall | median completion tokens | grader (median) |
|---|---|---|---|
| unset (= max) | 2,160 s | 60,663 | 80/80 |
| high | 593 s (v1: 468 s) | 16,541 (v1: 12,739) | 80/80 |
| low | 252.5 s | 7,241 | 79.5/80 |

Decode rate was comparable in all arms (≈28 completion tok/s), consistent with most of the gap being extra generated
reasoning rather than slower serving (it does not isolate prompt-processing or tool latency). `max` also
compacted twice per run (0 compactions at `high`/`low`). Tool calling worked in every run; a dedicated tool-call canary
passed at `high` and at `low`. Caveats (n = 2 per arm, one task, saturated grader — the numbers are a direction, not two
significant figures) are recorded with the raw per-run tables in `docs/RECEIPTS-default-reasoning-effort.md`.

### Change
- `start.sh`: `GLM53_DEFAULT_REASONING_EFFORT` — **default empty = unchanged behaviour** (no flag is sent; the template
  keeps rendering `Max` for clients that omit `chat_template_kwargs`). Enum is exactly `low | high | max`, validated
  **fail-closed** in the numeric-config guard (literal match: `medium`, `High`, `" high"` are rejected at launch with a
  message naming the knob and the three legal values — `medium` deliberately, because the template has no such level and
  would silently render `Max`). Setness-aware caller capture (an explicit `GLM53_DEFAULT_REASONING_EFFORT= ./start.sh`
  wins over `.env`). When set, `--default-chat-template-kwargs '{"reasoning_effort":"<v>"}'` is appended at **both** rank
  serve-args sites (space-free JSON, one argv element, so it survives the worker's word-split env path); the scalar is
  also exported via `nccl_common`. Request-level `chat_template_kwargs` still override (vLLM merges server defaults first,
  request kwargs win).
- `.env.example`: knob present, **empty**, with `high` recommended for agentic coding. **Not silently enabled** — an
  operator has to set it.
- `README.md`: knob row + a note in the effort section that unset = max.
- `tests/test_default_reasoning_effort.sh` (27 checks, mutation-checked), `tests/test_start_overrides.py` (+ setness-aware
  override case), `docs/RECEIPTS-default-reasoning-effort.md` (A/B tables + the receipts below).

### What this PR does and does not do
- Merging it changes **nothing** for anyone who does not set the knob: launcher default empty → no flag → template
  default (`Max`), exactly as today.
- `high` is the **recommendation** for agentic coding, based on the measurements above. It is documented, not enabled.
- Un-proxied clients that need `max` (or `low`) keep it by sending `chat_template_kwargs.reasoning_effort` per request;
  the receipts below show the request override reaching the template on the live serve.

## Receipts

All collected read-only on the live 2× DGX Spark serve (image `ghcr.io/miaai-lab/glm-5.3-flash-2x-dgx-sparks:exl3`,
digest `sha256:ad0cdd86…`, vLLM `0.1.dev20051+g487ecf187`, model `brandonmusic/GLM-5.3-Flash-tr3-4bpw@792d065`), launched
with `GLM53_DEFAULT_REASONING_EFFORT=high` in `.env`. No restart and no chat completions were issued for these receipts.

### 1. The flag exists in the target image (`--help`)

`vllm serve --help` (the short page) does not list it; `--help=all` does:

```
$ docker exec glm53-exl3-head vllm serve --help=all 2>&1 | grep -n -A2 default-chat-template-kwargs
80:  --default-chat-template-kwargs DEFAULT_CHAT_TEMPLATE_KWARGS
81-                        Should either be a valid JSON string or JSON keys
82-                        passed individually. (default: None)
```

### 2. Both ranks carry the flag, once, as one argv element

The containers run `bash /start.sh` (so `docker inspect .Config.Cmd` is not the serve line); the `vllm serve` process is
pid 1 inside each container, so the receipt reads `/proc/1/cmdline` NUL-split — element index, the following element,
occurrence count:

```
== HEAD ==
host=spark-deb8 container=glm53-exl3-head image=ghcr.io/miaai-lab/glm-5.3-flash-2x-dgx-sparks:exl3
vllm serve pid=1
42:--default-chat-template-kwargs
43-{"reasoning_effort":"high"}
occurrences=1
argc=58
== WORKER ==
host=spark-d9d5 container=glm53-exl3-worker image=ghcr.io/miaai-lab/glm-5.3-flash-2x-dgx-sparks:exl3
vllm serve pid=1
43:--default-chat-template-kwargs
44-{"reasoning_effort":"high"}
occurrences=1
argc=59
```

(The worker's index is one higher because of `--headless`; `ps -eo args` in both containers shows the full line:
`… --kv-cache-dtype fp8 --default-chat-template-kwargs {"reasoning_effort":"high"} --speculative-config …`, with
`--node-rank 0` on the head and `--node-rank 1 … --headless` on the worker.)

Parsed config, from the head's API-server log (the headless rank runs no API server and prints no such line — its proof
is the argv above):

```
$ docker logs glm53-exl3-head 2>&1 | grep -i default_chat_template_kwargs
(APIServer pid=1) INFO 09-01 01:03:44 [api_utils.py:273] non-default args: {'model_tag': '…/GLM-5.3-Flash-tr3-4bpw/snapshots/792d065…', 'chat_template': '/opt/glm53/chat_template.jinja', 'default_chat_template_kwargs': {'reasoning_effort': 'high'}, 'enable_auto_tool_choice': True, 'tool_call_parser': 'glm47', … 'reasoning_parser': 'glm45', … 'nnodes': 2, 'tensor_parallel_size': 2, …}
```

### 3. Render boundary — the server default reaches Jinja, and request kwargs override it

`POST /tokenize` renders the chat template through the same path as chat completions. Because `token_strs` are
tokenizer pieces (`Ġ` markers), each result is also passed back through `POST /detokenize` to show the literal prompt.
Served template is byte-identical to `files/chat_template.jinja` (md5 `37639425…` in the container and in the checkout).

```
=== no chat_template_kwargs  -> server default (high) lands
REQ: {"model":"GLM-5.3-Flash-EXL3","messages":[{"role":"user","content":"hi"}],"return_token_strs":true}
RESP: {"count":13,"max_model_len":1000000,"tokens":[154822,154824,154826,25062,287,29905,371,25,5124,154827,6023,154828,154841],"token_strs":["[gMASK]","<sop>","<|system|>","Reason","ing","ĠEff","ort",":","ĠHigh","<|user|>","hi","<|assistant|>","<think>"]}
DETOK: {"prompt":"[gMASK]<sop><|system|>Reasoning Effort: High<|user|>hi<|assistant|><think>"}

=== "chat_template_kwargs":{"reasoning_effort":"low"}  -> request override wins
RESP: … "token_strs":["[gMASK]","<sop>","<|system|>","Reason","ing","ĠEff","ort",":","ĠLow","<|user|>","hi","<|assistant|>","<think>"]}
DETOK: {"prompt":"[gMASK]<sop><|system|>Reasoning Effort: Low<|user|>hi<|assistant|><think>"}

=== "chat_template_kwargs":{"reasoning_effort":"max"}  -> request override wins
RESP: … "token_strs":["[gMASK]","<sop>","<|system|>","Reason","ing","ĠEff","ort",":","ĠMax","<|user|>","hi","<|assistant|>","<think>"]}
DETOK: {"prompt":"[gMASK]<sop><|system|>Reasoning Effort: Max<|user|>hi<|assistant|><think>"}

=== "chat_template_kwargs":{"reasoning_effort":"medium"}  -> template has no such level, falls back to Max
      (this is why the launcher enum rejects `medium`)
token_strs: ['[gMASK]', '<sop>', '<|system|>', 'Reason', 'ing', 'ĠEff', 'ort', ':', 'ĠMax', '<|user|>', 'hi', '<|assistant|>', '<think>']
```

The token id at position 9 is the only difference between the three renders: `5124` (`ĠHigh`), `12035` (`ĠLow`),
`7487` (`ĠMax`).

**"Before" state (knob empty).** Capturing `/tokenize` on a serve launched *without* the knob would need a restart, which
was not done for these receipts (the box was in use). The template default is instead shown by rendering the served
template file offline inside the same container with jinja2 (`jinja2.ext.loopcontrols`, as `tests/test_chat_template.py`
does), which is exactly the branch a no-flag serve takes:

```
$ docker exec glm53-exl3-head python3 /tmp/render.py      # renders /opt/glm53/chat_template.jinja, messages=[user:"hi"]
 <no kwargs> -> '[gMASK]<sop><|system|>Reasoning Effort: Max<|user|>hi<|assistant|><think>'
         low -> '[gMASK]<sop><|system|>Reasoning Effort: Low<|user|>hi<|assistant|><think>'
        high -> '[gMASK]<sop><|system|>Reasoning Effort: High<|user|>hi<|assistant|><think>'
         max -> '[gMASK]<sop><|system|>Reasoning Effort: Max<|user|>hi<|assistant|><think>'
      medium -> '[gMASK]<sop><|system|>Reasoning Effort: Max<|user|>hi<|assistant|><think>'
```

It is also the state every prior measurement was taken in: the A/B v1 "direct" arm hit this serve before the knob
existed and behaved as `max` (60,663 median completion tokens, 2 compactions/run).

### 4. A/B measurements

Two runs, both on the same live serve, same task, same grader, one run at a time, server never reconfigured mid-run:

- **v1 — high vs unset(max)** (`AB-EFFORT-RESULTS-2026-09-01.md`): high 498/438 s vs max 1,955/2,365 s; all four 80/80.
  Medians: 468 s vs 2,160 s (4.61×), completion tokens 12,739 vs 60,663 (4.76×), compactions 0 vs 2.
- **v2 — high vs low** (`AB-EFFORT-V2-RESULTS-2026-09-01.md`): high 486/700 s (80/80, 80/80) vs low 297/208 s (79/80, 80/80).
  Medians: 593 s vs 252.5 s, completion tokens 16,541 vs 7,241, tool errors 0/71 vs 1/36 (self-recovered), compactions
  0/0. Tool-call canary (`opencode run` with a `read` tool) passed at both efforts. The single lost point at `low` was a
  41-line README against a 40-line limit.

Per-run tables and all caveats are in `docs/RECEIPTS-default-reasoning-effort.md`. What is **not** evidenced: a
`high`-vs-`low` quality difference on a task that is not at the grader ceiling — hence the recommendation is `high`, not
`low`.

### 5. Host tests (this Mac, no hardware)

```
$ bash tests/test_default_reasoning_effort.sh
ok   guard [] -> rc 0 … ok   guard [medium] -> rc 2 … ok   guard [<unset>] -> rc 0
ok   HEAD_SCRIPT [] -> no flag … ok   HEAD_SCRIPT [max] -> {"reasoning_effort":"max"}
ok   WORKER_SCRIPT [] -> no flag … ok   WORKER_SCRIPT [max] -> {"reasoning_effort":"max"}
ok   both ranks build the identical flag
ok   caller capture is setness-aware
ok   caller value wins over .env
ok   knob reaches both containers via nccl_common
ok   launcher default is empty (unchanged behaviour)
default reasoning effort tests: PASS            (27 checks)

$ python3 -m pytest tests -q
26 passed in 1.02s
```

Applies cleanly on `main` @ 493cb88 (`git merge-tree` clean).

### Audit log
Codex gpt-5.6-luna advisory (build-with-changes: keep launcher default empty, recommend `high`, enum `low|high|max` —
drop `medium`, receipts: target-image `--help`, both-rank argv/config, render-boundary, A/B metrics + tool canaries) →
applied. Final pre-deploy pass: deploy-for-live-test, with the note that `/tokenize` `token_strs` are tokenizer pieces
and the receipt should detokenize → done above. Pre-open pass on the final diff + body: OPEN-WITH-EDITS, no code blockers; four
wording fixes adopted (grader "at or near" its ceiling — v2-low scored 79/80 once; the wall-time gap is *consistent
with* extra reasoning, not isolated proof; guided-JSON was not tested; `start.sh` comment now reads "empty or unset =
send no flag").

---
Submitted by nood-co1 on behalf of Blockbrain Labs (https://x.com/blockbrain_labs, GitHub org blockbrain-ai). Measured on our 2× NVIDIA DGX Spark deployment.
