### PR TITLE
launcher: caller exports win over .env for every key .env defines (#91)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # GLM-5.3-Flash EXL3 — 2× DGX Spark (GB10 / SM121)
 # Copy to .env and edit. ./start.sh does this for you on first run.
+# Any key set here can be overridden per invocation (KEY=value ./start.sh
+# restart): a non-empty caller export wins over this file (#91).
 
 # --- nodes (edit these) ------------------------------------------------
 HEAD_IP=10.0.0.1

--- a/README.md
+++ b/README.md
@@ -347,7 +347,17 @@ cp .env.example .env          # edit HEAD_IP / WORKER_IP / WORKER_USER if needed
 ```
 
 First run of `./start.sh` copies `.env.example` → `.env` if missing. Prefix env
-wins over `.env` (`SPEC_METHOD=dflash SKIP_DOWNLOAD=1 ./start.sh restart`).
+wins over `.env` (`SPEC_METHOD=dflash SKIP_DOWNLOAD=1 ./start.sh restart`) for
+every key `.env` assigns — not just an allowlist (#91): a non-empty caller
+export replaces the matching `.env` value before the launcher configures
+itself; variables the rank scripts use reach the containers through the
+existing `-e` / argv wiring, host-only controls stay host-side. An
+explicitly empty export (`KEY= ./start.sh`) is ignored; edit `.env` when an
+empty value is required. The scanner is lexical: any line of the form
+`[export ]NAME[+]=VALUE` counts as an assignment, including such text inside
+a heredoc or conditional; other shell constructs in `.env` (`unset`,
+`declare`, …) are sourced as before but their effect is not tracked. Keys
+`.env` does not set follow the launcher defaults in `start.sh`.
 
 `./start.sh` downloads weights automatically when the HF cache is incomplete
 (120 shards of `Mia-AiLab/GLM-5.3-Flash-EXL3-TR3-4bpw`, falling back to
@@ -519,6 +529,7 @@ this Dockerfile instead. After CUDA compile, Python overlay edits
 | `overlay/patch_model_overrides.py` | `"exl3"` in ModelConfig overrides |
 | `tests/test_exl3_overlay.py` | registry, TP shard, `sm_121a` cubin, fused vs loop GEMM, `EXL3_FUSED_MOE=0` |
 | `tests/bench_decode.py` | streaming decode + coherence; `--structured` is the count-1→200 median |
+| `tests/test_start_overrides.py` | launcher (CPU-only, docker/ssh stubbed): every key `.env.example` defines survives a caller export through the real prologue, `.env` still beats the script defaults with no exports, empty exports do not override, readonly shell exports (`SHELLOPTS`) and CRLF / `export KEY=` / quoted-JSON `.env` lines are handled; runs under every bash on the host (3.2 and 5.x) |
 | `start.sh` / `stop.sh` / `download.sh` | 2-node launch; Hub fetch on the head only |
 | `files/chat_template.jinja` | GLM-5.3 MM template (`<|image|>` / `<|video|>`); checkpoint jinja is language-only |
 | `overlay/qwen3_dflash2.py` | DFlash2 draft (grouped conv + candidate selector) |

--- a/start.sh
+++ b/start.sh
@@ -55,45 +55,35 @@ if [ ! -f "$SCRIPT_DIR/.env" ]; then
     cp "$SCRIPT_DIR/.env.example" "$SCRIPT_DIR/.env"
     printf '\033[1;36m[glm53-exl3]\033[0m wrote .env from .env.example — edit HEAD_IP / WORKER_IP if needed\n'
 fi
-# Caller exports (MTP_TOKENS=2 ./start.sh restart) must win over .env.
-_cli_mtp="${MTP_TOKENS-}"
-_cli_spec="${SPEC_METHOD-}"
-_cli_eager="${ENFORCE_EAGER-}"
-_cli_fused="${EXL3_FUSED_MOE-}"
-_cli_row_tile="${EXL3_MOE_ROW_TILE-}"
-_cli_temp_rows="${EXL3_TEMP_ROWS_FUSED-}"
-_cli_mnbt="${MAX_NUM_BATCHED_TOKENS-}"
-_cli_image="${IMAGE-}"
-_cli_util="${GPU_MEM_UTIL-}"
-_cli_lm="${LANGUAGE_MODEL_ONLY-}"
-_cli_max_num_seqs="${MAX_NUM_SEQS-}"
-_cli_ablit="${ABLIT-}"
-_cli_ablit_method="${ABLIT_METHOD-}"
-_cli_ablit_direction="${ABLIT_DIRECTION-}"
-_cli_ablit_layers="${ABLIT_LAYERS-}"
-_cli_ablit_alpha="${ABLIT_ALPHA-}"
-_cli_ablit_mtp="${ABLIT_INCLUDE_MTP-}"
+# Caller exports (MTP_TOKENS=2 ./start.sh restart) must win over .env for
+# every key .env defines (#28, #44, #91): remember the caller's non-empty
+# exported value of each such key, source .env, then re-apply them. Same
+# [ -n ] semantics as the per-knob capture this replaces (an explicitly empty
+# caller export does not override .env; edit .env for an empty value). The
+# scanner is lexical: any line of the form `[export ]NAME[+]=VALUE` counts,
+# even inside a heredoc or conditional; shell constructs in .env (unset,
+# declare, ...) are sourced but not tracked. Only exported, non-readonly
+# names are captured, so a launcher-internal variable named in .env
+# (SCRIPT_DIR) is never replayed and readonly `declare -rx` shell state
+# (SHELLOPTS) is never touched - unlike an `eval "$(export -p)"` replay,
+# which dies on it under set -e. Works on bash 3.2 (macOS) and 5.x.
+_env_keys="$(sed -nE 's/^[[:space:]]*(export[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*)\+?=.*/\2/p' "$SCRIPT_DIR/.env")"
+_caller_overrides=()
+while IFS= read -r _k; do
+    [ -n "$_k" ] || continue
+    _flags="$(declare -p "$_k" 2>/dev/null || true)"
+    _flags="${_flags#declare -}"; _flags="${_flags%% *}"
+    case "$_flags" in *r*) continue ;; *x*) ;; *) continue ;; esac
+    if [ -n "${!_k:+x}" ]; then _caller_overrides+=("$_k=${!_k}"); fi
+done <<< "$_env_keys"
 set -a
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/.env"
 set +a
-[ -n "${_cli_mtp}" ] && MTP_TOKENS="$_cli_mtp"
-[ -n "${_cli_spec}" ] && SPEC_METHOD="$_cli_spec"
-[ -n "${_cli_eager}" ] && ENFORCE_EAGER="$_cli_eager"
-[ -n "${_cli_fused}" ] && EXL3_FUSED_MOE="$_cli_fused"
-[ -n "${_cli_row_tile}" ] && EXL3_MOE_ROW_TILE="$_cli_row_tile"
-[ -n "${_cli_temp_rows}" ] && EXL3_TEMP_ROWS_FUSED="$_cli_temp_rows"
-[ -n "${_cli_mnbt}" ] && MAX_NUM_BATCHED_TOKENS="$_cli_mnbt"
-[ -n "${_cli_image}" ] && IMAGE="$_cli_image"
-[ -n "${_cli_util}" ] && GPU_MEM_UTIL="$_cli_util"
-[ -n "${_cli_lm}" ] && LANGUAGE_MODEL_ONLY="$_cli_lm"
-[ -n "${_cli_max_num_seqs}" ] && MAX_NUM_SEQS="$_cli_max_num_seqs"
-[ -n "${_cli_ablit}" ] && ABLIT="$_cli_ablit"
-[ -n "${_cli_ablit_method}" ] && ABLIT_METHOD="$_cli_ablit_method"
-[ -n "${_cli_ablit_direction}" ] && ABLIT_DIRECTION="$_cli_ablit_direction"
-[ -n "${_cli_ablit_layers}" ] && ABLIT_LAYERS="$_cli_ablit_layers"
-[ -n "${_cli_ablit_alpha}" ] && ABLIT_ALPHA="$_cli_ablit_alpha"
-[ -n "${_cli_ablit_mtp}" ] && ABLIT_INCLUDE_MTP="$_cli_ablit_mtp"
+# Each entry is NAME=value (SC2163 misreads the indirection).
+# shellcheck disable=SC2163
+for _kv in ${_caller_overrides[@]+"${_caller_overrides[@]}"}; do export "$_kv"; done
+unset _k _kv _flags _env_keys _caller_overrides
 
 # ----------------------------- configuration -------------------------------
 MODEL="${MODEL:-Mia-AiLab/GLM-5.3-Flash-EXL3-TR3-4bpw}"

--- a/tests/test_start_overrides.py
+++ b/tests/test_start_overrides.py
@@ -1,21 +1,191 @@
 #!/usr/bin/env python3
-"""Regression test for caller overrides that must win over ``.env``."""
+"""Regression tests for caller overrides that must win over ``.env`` (#28, #44, #91).
+
+The README rule is "prefix env wins over .env". start.sh implements it in the
+prologue (before the configuration section): remember the caller's non-empty
+value of every key .env assigns, source .env, re-apply them. These tests drive
+that prologue two ways:
+
+  1. The spliced preamble (everything before the configuration marker) with a
+     one-key .env -- the original #28 regression, unchanged.
+  2. The REAL start.sh, with its trailing ``main "$@"`` swapped for ``"$@"`` so
+     the full prologue + configuration section runs and a printf can then read
+     the resolved values, from an allow-listed environment with docker / ssh /
+     scp / rsync / curl / ip / nvidia-smi stubbed first on PATH (nothing
+     touches a host; the stubs record every call and the tests assert none).
+     Every key .env.example defines (45 at the time of writing) is exported by
+     the caller and must survive; a child process must inherit the override
+     (the ``set -a`` contract); with no caller export .env must still beat the
+     script defaults; an explicitly empty export must NOT override (the
+     ``[ -n ]`` semantics the per-knob allowlist had); a readonly exported
+     shell variable (SHELLOPTS) must not break the prologue, even when a
+     heredoc line in .env looks like `SHELLOPTS=...`; a .env naming a
+     launcher-internal variable (SCRIPT_DIR) must not replay it; a .env with
+     comments, blank lines, indentation, ``export KEY=``, ``KEY+=``, a CRLF
+     line (sourced with the carriage return kept, as before) and a quoted
+     JSON value must parse. The matrix runs under every bash found on
+     the host (``bash`` on PATH, /bin/bash -- 3.2 on macOS -- and Homebrew's
+     5.x when present).
+
+Run:  python3 tests/test_start_overrides.py   (or pytest)
+"""
 
 from __future__ import annotations
 
 import os
+import re
+import shutil
+import stat
 import subprocess
 import tempfile
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+START = ROOT / "start.sh"
+ENV_EXAMPLE = ROOT / ".env.example"
+CONFIG_MARKER = "# ----------------------------- configuration -------------------------------"
+
+# Same shape as the sed in start.sh: an assignment at line start, optional
+# `export`, optional leading whitespace. Comments (`# KEY=`) do not count.
+KEY_RE = re.compile(r"^[ \t]*(?:export[ \t]+)?([A-Za-z_][A-Za-z0-9_]*)\+?=", re.M)
+HOST_TOOLS = ("docker", "ssh", "scp", "rsync", "curl", "ip", "nvidia-smi")
+SEP = "\x1f"
+
+STUB = """#!/usr/bin/env bash
+# Records every invocation; never touches a host.
+{ printf '%s\\x1f' "$(basename "$0")" "$@"; printf '\\n'; } >> "$GLM53_STUB_LOG"
+exit 0
+"""
+
+
+def env_keys(text: str) -> list[str]:
+    seen: list[str] = []
+    for key in KEY_RE.findall(text):
+        if key not in seen:
+            seen.append(key)
+    return seen
+
+
+def bashes() -> list[str]:
+    """Every distinct bash on this host: PATH's, /bin/bash (macOS 3.2), Homebrew 5.x."""
+    found: list[str] = []
+    seen: set[str] = set()
+    for cand in (shutil.which("bash"), "/bin/bash", "/opt/homebrew/bin/bash", "/usr/local/bin/bash"):
+        if not cand or not Path(cand).is_file() or not os.access(cand, os.X_OK):
+            continue
+        real = os.path.realpath(cand)
+        if real in seen:
+            continue
+        seen.add(real)
+        found.append(cand)
+    assert found, "no bash found"
+    return found
+
+
+def bash_version(bash: str) -> str:
+    out = subprocess.run([bash, "-c", 'printf "%s" "$BASH_VERSION"'], capture_output=True, text=True, check=True)
+    return out.stdout.strip()
+
+
+class Harness:
+    """Throwaway copy of the launcher plus a stub PATH (no real docker / ssh)."""
+
+    def __init__(self, tmp: Path) -> None:
+        self.tmp = tmp
+        self.repo = tmp / "repo"
+        self.repo.mkdir()
+        shutil.copy2(START, self.repo / "start.sh")
+        shutil.copy2(ENV_EXAMPLE, self.repo / ".env.example")
+        text = (self.repo / "start.sh").read_text()
+        assert text.rstrip().endswith('\nmain "$@"'), 'start.sh must end with main "$@"'
+        (self.repo / "start.fn.sh").write_text(text.rstrip()[: -len('main "$@"')] + '"$@"\n')
+        self.home = tmp / "home"
+        self.home.mkdir()
+        self.bin = tmp / "bin"
+        self.bin.mkdir()
+        for tool in HOST_TOOLS:
+            p = self.bin / tool
+            p.write_text(STUB)
+            p.chmod(p.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        self.log = tmp / "calls.log"
+
+    def env(self, extra: dict[str, str]) -> dict[str, str]:
+        # Allow-listed: nothing from the developer shell leaks in (no BASH_ENV,
+        # HF_*, GLM53_*, SKIP_* ...); PATH is the stubs plus the system dirs only.
+        env = {
+            "PATH": f"{self.bin}{os.pathsep}/usr/bin:/bin",
+            "HOME": str(self.home),
+            "USER": "glm53-overrides",
+            "LC_ALL": "C",
+            "TERM": "dumb",
+            "GLM53_STUB_LOG": str(self.log),
+        }
+        env.update(extra)
+        return env
+
+    def host_calls(self) -> list[str]:
+        if not self.log.exists():
+            return []
+        return [line.split(SEP)[0] for line in self.log.read_text().splitlines() if line]
+
+    def resolve(self, bash: str, dotenv: str, keys: list[str], caller: dict[str, str]) -> tuple[dict[str, str], dict[str, str]]:
+        """Run the full prologue + configuration under `bash`; return the
+        resolved value of every key in the launcher and in a child process."""
+        (self.repo / ".env").write_text(dotenv)
+        if self.log.exists():
+            self.log.unlink()
+        names = " ".join(keys)
+        # `eval` runs in the launcher's own context after the whole prologue.
+        body = (
+            f'for _n in {names}; do printf "P\\x1f%s\\x1f%s\\n" "$_n" "${{!_n-<unset>}}"; done; '
+            f'"$BASH" -c \'for _n in {names}; do printf "C\\x1f%s\\x1f%s\\n" "$_n" "${{!_n-<unset>}}"; done\''
+        )
+        # bytes, not text=True: universal newlines would turn a CRLF value's
+        # carriage return into a newline before we can see it.
+        r = subprocess.run(
+            [bash, "./start.fn.sh", "eval", body],
+            cwd=self.repo,
+            capture_output=True,
+            check=False,
+            env=self.env(caller),
+        )
+        assert r.returncode == 0, (bash, r.returncode, r.stderr[-800:].decode(errors="replace"))
+        parent: dict[str, str] = {}
+        child: dict[str, str] = {}
+        for line in r.stdout.decode(errors="replace").split("\n"):
+            if SEP not in line:
+                continue
+            scope, name, value = line.split(SEP, 2)
+            (parent if scope == "P" else child)[name] = value
+        assert not self.host_calls(), f"prologue must not touch a host: {self.host_calls()}"
+        return parent, child
+
+
+def caller_value(key: str) -> str:
+    if key == "LIMIT_MM":
+        return '{"image":9,"video":2}'
+    if key == "SERVED_MODEL_NAME":
+        return 'caller "quoted" value with spaces = and equals'
+    return f"caller-{key}"
+
+
+def test_no_per_knob_allowlist_remains() -> None:
+    src = START.read_text()
+    assert "_cli_" not in src, "the per-knob _cli_* allowlist must be gone (generic rule, #91)"
+    code = "\n".join(l for l in src.splitlines() if not l.lstrip().startswith("#"))
+    assert "export -p" not in code, "never replay every export (readonly declare -rx fails under set -e)"
+    prologue = src.partition(CONFIG_MARKER)[0]
+    assert 'source "$SCRIPT_DIR/.env"' in prologue
+    assert "_caller_overrides" in prologue and "${!_k:+x}" in prologue
+    assert 'declare -p "$_k"' in prologue, "only exported names are captured"
+    assert "*r*) continue" in prologue, "readonly (declare -rx) names are never replayed"
 
 
 def test_max_num_seqs_inline_override_wins() -> None:
-    source = (ROOT / "start.sh").read_text()
-    marker = "# ----------------------------- configuration -------------------------------"
-    preamble, separator, _rest = source.partition(marker)
+    """The original #28 regression: spliced preamble, one-key .env."""
+    source = START.read_text()
+    preamble, separator, _rest = source.partition(CONFIG_MARKER)
     assert separator, "start.sh configuration marker is missing"
 
     with tempfile.TemporaryDirectory() as raw_tmp:
@@ -28,8 +198,8 @@ def test_max_num_seqs_inline_override_wins() -> None:
         script.chmod(0o755)
         (tmp / ".env").write_text("MAX_NUM_SEQS=2\n")
 
-        env = os.environ.copy()
-        env["MAX_NUM_SEQS"] = "4"
+        # isolated: no BASH_ENV / PATH surprises from the developer shell
+        env = {"PATH": "/usr/bin:/bin", "HOME": str(tmp), "USER": "glm53", "MAX_NUM_SEQS": "4"}
         result = subprocess.run(
             ["bash", str(script)],
             check=True,
@@ -41,6 +211,120 @@ def test_max_num_seqs_inline_override_wins() -> None:
     assert result.stdout.strip() == "MAX_NUM_SEQS=4"
 
 
+def test_every_env_example_key_survives_a_caller_export() -> None:
+    example = ENV_EXAMPLE.read_text()
+    keys = env_keys(example)
+    assert len(keys) >= 40, keys
+    for key in ("MAX_NUM_SEQS", "GLM53_MIXED_PREFILL_CHUNK", "CG_ESTIMATE", "MAX_MODEL_LEN", "LIMIT_MM", "SPEC_METHOD"):
+        assert key in keys, key
+    caller = {k: caller_value(k) for k in keys}
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        h = Harness(Path(raw_tmp))
+        for bash in bashes():
+            ver = bash_version(bash)
+            parent, child = h.resolve(bash, example, keys, caller)
+            lost = {k: parent.get(k) for k in keys if parent.get(k) != caller[k]}
+            assert not lost, f"{bash} ({ver}): .env clobbered caller exports: {lost}"
+            not_inherited = {k: child.get(k) for k in keys if child.get(k) != caller[k]}
+            assert not not_inherited, f"{bash} ({ver}): child did not inherit: {not_inherited}"
+            print(f"  ok   {len(keys)} .env.example keys survive a caller export under {bash} ({ver})")
+
+
+def test_env_still_beats_script_defaults_without_caller_exports() -> None:
+    """No caller export: the .env value wins over the start.sh default and is
+    exported to children (unchanged behaviour)."""
+    keys = ["MAX_NUM_SEQS", "MAX_MODEL_LEN", "GLM53_MIXED_PREFILL_CHUNK", "CG_ESTIMATE", "DFLASH_TOKENS", "SPEC_METHOD", "LIMIT_MM"]
+    dotenv = (
+        "MAX_NUM_SEQS=2\nMAX_MODEL_LEN=200000\nGLM53_MIXED_PREFILL_CHUNK=512\n"
+        "CG_ESTIMATE=0\nDFLASH_TOKENS=5\nSPEC_METHOD=mtp\nLIMIT_MM='{\"image\":1,\"video\":0}'\n"
+    )
+    expect = {
+        "MAX_NUM_SEQS": "2", "MAX_MODEL_LEN": "200000", "GLM53_MIXED_PREFILL_CHUNK": "512",
+        "CG_ESTIMATE": "0", "DFLASH_TOKENS": "5", "SPEC_METHOD": "mtp", "LIMIT_MM": '{"image":1,"video":0}',
+    }
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        h = Harness(Path(raw_tmp))
+        for bash in bashes():
+            parent, child = h.resolve(bash, dotenv, keys, {})
+            assert parent == expect, (bash, parent)
+            assert child == expect, (bash, child)
+            print(f"  ok   .env beats script defaults with no caller export under {bash}")
+
+
+def test_empty_caller_export_does_not_override() -> None:
+    """`MAX_NUM_SEQS= ./start.sh` keeps the .env value: same [ -n ] rule as the
+    allowlist this replaces (DFLASH_DRAFT_TP treats empty as meaningful, and
+    an empty export is the usual accident of `VAR= cmd` typos)."""
+    keys = ["MAX_NUM_SEQS", "DFLASH_DRAFT_TP", "CG_ESTIMATE"]
+    dotenv = "MAX_NUM_SEQS=2\nDFLASH_DRAFT_TP=2\nCG_ESTIMATE=0\n"
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        h = Harness(Path(raw_tmp))
+        for bash in bashes():
+            parent, _child = h.resolve(bash, dotenv, keys, {"MAX_NUM_SEQS": "", "DFLASH_DRAFT_TP": "", "CG_ESTIMATE": "1"})
+            assert parent == {"MAX_NUM_SEQS": "2", "DFLASH_DRAFT_TP": "2", "CG_ESTIMATE": "1"}, (bash, parent)
+            print(f"  ok   empty caller export does not override .env under {bash}")
+
+
+def test_readonly_exports_and_odd_env_lines() -> None:
+    """SHELLOPTS in the environment is imported readonly+exported by bash
+    (`declare -rx`); an `eval "$(export -p)"` replay dies on it under set -e.
+    The .env-key rule never replays it. The .env itself carries every line
+    shape the parser must accept."""
+    dotenv = (
+        "# GLM-5.3-Flash EXL3 -- comment lines are not keys\n"
+        "\n"
+        "   \n"
+        "# MAX_NUM_SEQS=99\n"
+        "MAX_NUM_SEQS=2\n"
+        "export SPEC_METHOD=mtp\n"
+        "  CG_ESTIMATE=0\n"
+        "DFLASH_TOKENS=5\r\n"
+        "GLM53_MIXED_PREFILL_CHUNK=512 # trailing comment\n"
+        "LIMIT_MM='{\"image\":4,\"video\":1}'\n"
+        "MAX_MODEL_LEN=\n"
+        "MODEL_REVISION+=-suffix\n"
+        "SCRIPT_DIR=/nowhere\n"
+        # assignment-looking text inside a heredoc: the lexical scanner picks
+        # SHELLOPTS up, and the readonly filter must then refuse to replay it
+        # (export "SHELLOPTS=..." would abort the launcher under set -e).
+        "cat >/dev/null <<'NOTES'\n"
+        "SHELLOPTS=ignored\n"
+        "NOTES\n"
+    )
+    keys = ["MAX_NUM_SEQS", "SPEC_METHOD", "CG_ESTIMATE", "DFLASH_TOKENS", "GLM53_MIXED_PREFILL_CHUNK", "LIMIT_MM", "MAX_MODEL_LEN", "MODEL_REVISION", "SCRIPT_DIR"]
+    caller = {
+        "MAX_NUM_SEQS": "4", "SPEC_METHOD": "dflash", "CG_ESTIMATE": "1", "DFLASH_TOKENS": "7",
+        "GLM53_MIXED_PREFILL_CHUNK": "skip", "LIMIT_MM": '{"image":9,"video":2}', "MAX_MODEL_LEN": "300000",
+        "MODEL_REVISION": "abc123",
+        "SHELLOPTS": "braceexpand:hashall:interactive-comments",
+    }
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        h = Harness(Path(raw_tmp))
+        for bash in bashes():
+            parent, child = h.resolve(bash, dotenv, keys, caller)
+            want = {k: caller[k] for k in keys if k != "SCRIPT_DIR"}
+            # SCRIPT_DIR is a launcher-internal (non-exported) variable: a .env
+            # that assigns it is sourced as before, but the launcher's own
+            # pre-source value must never be captured and replayed over it.
+            want["SCRIPT_DIR"] = "/nowhere"
+            assert parent == want, (bash, parent)
+            assert {k: child[k] for k in want if k != "SCRIPT_DIR"} == {k: want[k] for k in want if k != "SCRIPT_DIR"}, (bash, child)
+            # and with no caller export the odd lines source as bash sources them
+            parent, _ = h.resolve(bash, dotenv, keys, {"SHELLOPTS": "braceexpand:hashall"})
+            assert parent["MAX_NUM_SEQS"] == "2" and parent["SPEC_METHOD"] == "mtp" and parent["CG_ESTIMATE"] == "0"
+            assert parent["DFLASH_TOKENS"] == "5\r", "CRLF line: carriage return stays in the value (unchanged; no normalisation)"
+            assert parent["LIMIT_MM"] == '{"image":4,"video":1}'
+            assert parent["MAX_MODEL_LEN"] == "1000000", "empty .env value falls through to the launcher default"
+            assert parent["MODEL_REVISION"].endswith("-suffix"), "KEY+= line is sourced as an append"
+            assert parent["SCRIPT_DIR"] == "/nowhere"
+            print(f"  ok   readonly SHELLOPTS export, internal SCRIPT_DIR not replayed, comment/blank/indented/export/+=/CRLF/JSON .env lines under {bash}")
+
+
 if __name__ == "__main__":
+    test_no_per_knob_allowlist_remains()
     test_max_num_seqs_inline_override_wins()
+    test_every_env_example_key_survives_a_caller_export()
+    test_env_still_beats_script_defaults_without_caller_exports()
+    test_empty_caller_export_does_not_override()
+    test_readonly_exports_and_odd_env_lines()
     print("start.sh caller override regression OK")


### PR DESCRIPTION
# launcher: caller exports win over `.env` for every key `.env` defines

## What / why

`README.md` promises "Prefix env wins over `.env`". `start.sh` implemented that with a hand-maintained allowlist of 17 `_cli_*` names (`start.sh:58-96`). `.env.example` defined 45 keys at the tested base (48 on current main — #77/#86/#96 added `EXL3_FAT_KERNEL`, `GLM53_INDEXER_WORKSPACE`, `GLM53_SPINWAIT_MS`); 30 of them were not on the list, so a caller export of any of those — `GLM53_MIXED_PREFILL_CHUNK`, `CG_ESTIMATE`, `MAX_MODEL_LEN`, `DFLASH_TOKENS`, `KV_CACHE_DTYPE`, `MODEL`, `PORT`, `LIMIT_MM`, … — silently lost to whatever `.env` said. #28 (merged) and #44 (open) each add knobs one at a time after they bite someone; this PR replaces the list with the rule the README states.

Before sourcing `.env`, the prologue now remembers the caller's non-empty **exported, non-readonly** value of every key `.env` assigns (`[export ]NAME[+]=VALUE` lines), sources `.env` with `set -a` as before, then re-applies those values. Nothing is `eval`'d.

- Same `[ -n ]` semantics as the allowlist it replaces, for every key except the two setness-aware exceptions below: an explicitly empty caller export (`KEY= ./start.sh`) does not override `.env`; edit `.env` for an empty value. Exceptions (from current main, kept with their own `${VAR+1}` capture because their contract is "an explicitly empty caller value is an operator error that must reach the guard"): `GLM53_INDEXER_WORKSPACE`, `GLM53_SPINWAIT_MS` — for these an empty caller export survives to `validate_numeric_config` and is rejected there. With no caller exports behaviour is byte-identical: `.env` still beats the script defaults and is exported via `set -a`; the variables the rank scripts use reach the containers through the unchanged `-e` / argv wiring, host-only controls stay host-side.
- Only exported, non-readonly names are captured (`declare -p` attribute check: `x` required, `r` refused). A `.env` that happens to assign a launcher-internal variable (`SCRIPT_DIR`) is sourced as before but the launcher's own pre-source value is never replayed over it; readonly `declare -rx` shell state (`SHELLOPTS`) is never replayed even when an assignment-looking `SHELLOPTS=` line sits inside a heredoc in `.env` (test fixture; without the `r` filter that `export` aborts the launcher under `set -e`). That is why the generic `eval "$(export -p)"` replay floated in #91 was rejected: it dies on `declare -rx SHELLOPTS`.
- bash 3.2 (macOS `/bin/bash`) and 5.x: indirect `${!k:+x}` under `set -u`, `+=` on an empty array, the `${a[@]+"${a[@]}"}` guard, here-string (bash 3.2 backs it with a temp file, as it does for every here-string in the launcher's environment).
- The scanner is lexical and documented as such in the README: any `[export ]NAME[+]=VALUE` line counts, including such text inside a heredoc or conditional; other shell constructs in `.env` (`unset`, `declare`, …) are sourced but their effect is not tracked — same as the allowlist never tracked them.

Pure launcher logic: no live-server receipts apply (the change ends before the configuration section; the two containers receive the resolved values through the unchanged `-e` lines).

## Repro (from #91, no Sparks needed)

Upstream `main` `493cb88`, `.env` with `MAX_NUM_SEQS=4 GLM53_MIXED_PREFILL_CHUNK=skip CG_ESTIMATE=0 MAX_MODEL_LEN=1000000 DFLASH_TOKENS=7 GLM53_BOOT_SHAPE_WARMUP=1 KV_CACHE_DTYPE=fp8 SPEC_METHOD=dflash`, prologue + a `printf` of the resolved values:

```
$ env MAX_NUM_SEQS=8 GLM53_MIXED_PREFILL_CHUNK=512 CG_ESTIMATE=1 MAX_MODEL_LEN=200000 DFLASH_TOKENS=5 \
      GLM53_BOOT_SHAPE_WARMUP=0 KV_CACHE_DTYPE=auto SPEC_METHOD=mtp bash ./start-stub.sh
RESOLVED MAX_NUM_SEQS=8 GLM53_MIXED_PREFILL_CHUNK=skip CG_ESTIMATE=0 MAX_MODEL_LEN=1000000 DFLASH_TOKENS=7 GLM53_BOOT_SHAPE_WARMUP=1 KV_CACHE_DTYPE=fp8 SPEC_METHOD=mtp
```

Two of eight caller values survive (the two on the allowlist). With this PR all eight do — and so do the other 37 keys `.env.example` defines (test below).

How it bit us: `GLM53_MIXED_PREFILL_CHUNK=skip ./start.sh restart` against a `.env` that still said `512` came up as cap-512 with nothing unusual printed; a 15-minute mixed-prefill measurement was booked against the wrong policy before `docker exec … env` on the head showed it.

## Diff summary

- `start.sh` (prologue, before `# --- configuration ---`): the 17 `_cli_*` captures and 17 restores become one scan of `.env` keys + one export-attribute-filtered capture loop + one replay loop (`+25 / −35`).
- `README.md`: the precedence sentence states the rule precisely (every key `.env` assigns; empty export ignored; scanner grammar); test-table row.
- `.env.example`: two-line header note that any key here can be overridden per invocation.
- `tests/test_start_overrides.py`: keeps the #28 regression (spliced preamble, one-key `.env`) and adds runs of the **real** `start.sh` (`main "$@"` swapped for `"$@"`, `eval` a `printf` after the full prologue + configuration section; `docker`/`ssh`/`scp`/`rsync`/`curl`/`ip`/`nvidia-smi` stubbed first on an allow-listed `PATH`; zero host-touching calls asserted): all `.env.example` keys (45 at the tested base; 48 on current main, the three new names pinned explicitly) survive a caller export and are inherited by a child process; `.env` beats the script defaults with no exports; empty exports do not override (all keys except the two setness-aware exceptions, which are covered by main's own setness tests kept in the file); `SHELLOPTS` readonly export in the environment (plus a heredoc `SHELLOPTS=` line in `.env`); `SCRIPT_DIR` in `.env` not replayed; comment / blank / indented / `export KEY=` / `KEY+=` / CRLF (carriage return kept in the value, unchanged) / quoted-JSON lines. The matrix runs under every bash found on the host (`bash` on `PATH`, `/bin/bash`, Homebrew's).

Supersedes #44's narrower additions (`DFLASH_TOKENS`, `MAX_MODEL_LEN`, `CG_ESTIMATE`); #44 stays open while this is reviewed and can be closed as superseded if this merges. Related: #28 (merged `MAX_NUM_SEQS`).

## Tests (verbatim)

```
# pr/env-caller-precedence @ 0da8451 (base upstream/main 493cb88) — 2026-09-01 10:53 AWST — macOS 26.4.1, /bin/bash 3.2.57(1)-release, /opt/homebrew/bin/bash 5.3.15(1)-release

$ python3 tests/test_start_overrides.py
  ok   45 .env.example keys survive a caller export under /opt/homebrew/bin/bash (5.3.15(1)-release)
  ok   45 .env.example keys survive a caller export under /bin/bash (3.2.57(1)-release)
  ok   .env beats script defaults with no caller export under /opt/homebrew/bin/bash
  ok   .env beats script defaults with no caller export under /bin/bash
  ok   empty caller export does not override .env under /opt/homebrew/bin/bash
  ok   empty caller export does not override .env under /bin/bash
  ok   readonly SHELLOPTS export, internal SCRIPT_DIR not replayed, comment/blank/indented/export/+=/CRLF/JSON .env lines under /opt/homebrew/bin/bash
  ok   readonly SHELLOPTS export, internal SCRIPT_DIR not replayed, comment/blank/indented/export/+=/CRLF/JSON .env lines under /bin/bash
start.sh caller override regression OK
rc=0

$ shellcheck -S warning start.sh
rc=0

# other host-runnable suites (unchanged by this PR)
$ python3 tests/test_numeric_config.py -> numeric config tests: PASS
$ python3 tests/test_bringup_robustness.py -> start.sh bring-up robustness anchors OK
$ python3 tests/test_warm_restart_stdout.py -> warm-restart stdout regression OK
$ python3 tests/test_suppress_stops.py -> test_suppress_stops: ok
$ python3 tests/test_kpool_tail_slotmap.py -> kpool tail slot-map patch OK
$ python3 tests/test_xgrammar_termination.py -> xgrammar speculative patches OK

# need torch/vllm/jinja2 in the image, fail identically on upstream main 493cb88 on this Mac (ModuleNotFoundError / missing vllm source): test_chat_template test_hybrid_prefix_hit test_scheduler_decode_floor test_mixed_prefill_decode test_ablit test_exl3_overlay
```

Closes #91

---
Submitted by nood-co1 on behalf of Blockbrain Labs (https://x.com/blockbrain_labs, GitHub org blockbrain-ai). Measured on our 2× NVIDIA DGX Spark deployment.

**Update 2026-09-02 (merge to main e25aa70):** the receipt block above is verbatim from the tested SHA. Post-merge re-run on the same host, both bashes: `ok 48 .env.example keys survive a caller export under /opt/homebrew/bin/bash (5.3.15(1)-release)` / `ok 48 ... under /bin/bash (3.2.57(1)-release)`; all other suite lines unchanged. Main's setness-aware `GLM53_INDEXER_WORKSPACE`/`GLM53_SPINWAIT_MS` captures are kept as the two documented exceptions to the generic rule (an explicitly empty caller export of those must reach the guard); see the update comment.
