### PR TITLE
launcher: refuse MAX_NUM_SEQS above the MTP capture list before restart stops anything (#88)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,7 +80,8 @@ SERVED_MODEL_NAME=GLM-5.3-Flash-EXL3
 
 # Winner on this 2× GB10 kit with DFlash2: fused MoE + DFlash2 k=7.
 # Draft KV is auto/bf16; the target still uses KV_CACHE_DTYPE=fp8 (fp8_ds_mla).
-# Rollback: SPEC_METHOD=mtp
+# Rollback: SPEC_METHOD=mtp (needs MAX_NUM_SEQS <= 12 while CUDA graphs are on:
+# the largest MTP capture size; start.sh refuses higher before stopping, #88)
 SPEC_METHOD=dflash
 DFLASH_MODEL=incoai/GLM-5.3-Flash-DFlash2
 DFLASH_TOKENS=7
@@ -89,6 +90,7 @@ DFLASH_TOKENS=7
 DFLASH_DRAFT_TP=2
 MTP_TOKENS=2
 MAX_MODEL_LEN=1000000
+# SPEC_METHOD=mtp (or none) with CUDA graphs: at most 12 on this image (#88).
 MAX_NUM_SEQS=4
 # P1 keep 2048. 3584/4096 lost (fat-expert LinearEXL3). Never 8192 (indexer smem).
 MAX_NUM_BATCHED_TOKENS=2048

--- a/README.md
+++ b/README.md
@@ -365,6 +365,17 @@ is the default. Rollback:
 SPEC_METHOD=mtp ./start.sh restart      # MTP k=2
 ```
 
+Envelope on this image: the MTP rollback is guarded at `MAX_NUM_SEQS` ≤ **12**
+(the largest entry of the launcher's MTP capture list `1 2 3 4 6 8 12`) while
+CUDA graphs are on; the recipe default `4` is the measured MTP boot. Above 12, vLLM's `profile_cudagraph_memory` pass rejects
+the boot in EngineCore init, after weight load (`max_num_seqs (16) exceeds
+available Mamba cache blocks (12)`, #88). The launcher refuses the combination
+up front — before `restart` stops anything — and tells you to lower
+`MAX_NUM_SEQS`, set `ENFORCE_EAGER=1`, or supply a verified larger capture
+list. Only the launcher-generated list is checked: a `--cudagraph-capture-sizes`
+(or `--max-num-seqs`) you put in `EXTRA_ARGS` yourself is passed through
+unvalidated, as before.
+
 `./start.sh` will:
 
 1. Preflight docker/ssh/disk on both nodes
@@ -474,18 +485,18 @@ that are now documented/enforced:
 | `TP` / `NNODES` | `2` / `2` | do not change for this recipe |
 | `QUANTIZATION` | `exl3` | overlay method; never `marlin` |
 | `MTP_TOKENS` | `2` | MTP speculative tokens (`SPEC_METHOD=mtp`) |
-| `SPEC_METHOD` | `dflash` | `dflash` / `mtp` / `none`. Rollback: `SPEC_METHOD=mtp ./start.sh restart` |
+| `SPEC_METHOD` | `dflash` | `dflash` / `mtp` / `none`. Rollback: `SPEC_METHOD=mtp ./start.sh restart` — needs `MAX_NUM_SEQS` ≤ 12 under CUDA graphs on this image (#88); the launcher refuses higher before stopping anything |
 | `DFLASH_MODEL` | `incoai/GLM-5.3-Flash-DFlash2` | DFlash2 draft Hub repo (~2.3 GiB BF16) |
 | `DFLASH_TOKENS` | `7` | DFlash2 speculative tokens (trained block 8) |
 | `DFLASH_DRAFT_TP` | `2` | shard DFlash2 across TP (C4 keep: 8k 938 / decode 65.1). `1` = rank 0 only. Empty = inherit TP |
 | DFlash2 draft KV | `auto` (bf16) | target stays `fp8`/`fp8_ds_mla`; dense draft has no MLA FP8 backend on SM121 |
 | DFlash2 attention | *(unset)* | SM121 picks FLASH_ATTN for non-causal SWA. Do not pin `TRITON_ATTN` |
-| `ENFORCE_EAGER` | `0` | CUDA graphs; MTP capture `1 2 3 4 6 8 12`, DFlash2 `1 2 4 8 16 24 32` |
+| `ENFORCE_EAGER` | `0` | CUDA graphs; MTP capture `1 2 3 4 6 8 12`, DFlash2 `1 2 4 8 16 24 32`. The MTP list caps `MAX_NUM_SEQS` at 12 on this image (#88); `1` = no graphs, no cap |
 | `EXL3_FUSED_MOE` | `1` | `exl3_moe` per layer; `0` = LinearEXL3 loop |
 | `KV_CACHE_DTYPE` | `fp8` | packed `fp8_ds_mla`; not `nvfp4`, not bf16 |
 | `GPU_MEM_UTIL` | `0.87` | GB10 UMA budget (DFlash2 + vision; live pool **1,754,237** tokens / **1.75×** at 1M / 690 blocks / 18.67 GiB) |
 | `MAX_MODEL_LEN` | `1000000` | default context. 1M allocates on the 1.75M padded-slot-share pool. Do not drop to 256k to “free” KV — logged tokens ≈ concurrency × this cap; hybrid block-id overhead then shrinks the pool |
-| `MAX_NUM_SEQS` | `4` | decode batch; MTP adds k+1 tokens/seq |
+| `MAX_NUM_SEQS` | `4` | decode batch; MTP adds k+1 tokens/seq. With `SPEC_METHOD=mtp` (or `none`) and CUDA graphs: ≤ 12 on this image, the largest MTP capture size (#88) |
 | `MAX_NUM_BATCHED_TOKENS` | `2048` | prefill chunk (P1 keep). 3584/4096 lost; 8192 oversubscribes GB10 indexer topk |
 | `GLM53_MIXED_PREFILL_CHUNK` | `skip` | do not mix a peer prefill into a decode step (issue #6). `N>0` = cap tokens; `0` = off. Solo prefill stays MNBT (2048) |
 | `GLM53_SUPPRESS_STOPS_IN_REASONING` | `1` | ignore client `stop` strings until `</think>` (thinking-on default) |
@@ -519,6 +530,8 @@ this Dockerfile instead. After CUDA compile, Python overlay edits
 | `overlay/patch_model_overrides.py` | `"exl3"` in ModelConfig overrides |
 | `tests/test_exl3_overlay.py` | registry, TP shard, `sm_121a` cubin, fused vs loop GEMM, `EXL3_FUSED_MOE=0` |
 | `tests/bench_decode.py` | streaming decode + coherence; `--structured` is the count-1→200 median |
+| `tests/test_numeric_config.py` | launcher numeric guard: `GPU_MEM_UTIL` / `MAX_MODEL_LEN` / `MAX_NUM_SEQS` / `MAX_NUM_BATCHED_TOKENS` type + range matrix, canonical form, `MAX_NUM_SEQS` vs the launcher's MTP capture list (#88), guard runs before `restart` stops anything |
+| `tests/test_mtp_capture_guard.py` | launcher (CPU-only, docker/ssh stubbed): `SPEC_METHOD=mtp MAX_NUM_SEQS=16 ./start.sh restart` exits 2 with zero docker/ssh calls and names the vLLM error; `mtp`/12, `dflash`/16, `ENFORCE_EAGER=1`, a caller-supplied capture list pass the gate and reach `stop` on both ranks |
 | `start.sh` / `stop.sh` / `download.sh` | 2-node launch; Hub fetch on the head only |
 | `files/chat_template.jinja` | GLM-5.3 MM template (`<|image|>` / `<|video|>`); checkpoint jinja is language-only |
 | `overlay/qwen3_dflash2.py` | DFlash2 draft (grouped conv + candidate selector) |

--- a/start.sh
+++ b/start.sh
@@ -189,15 +189,20 @@ FLASHINFER_CUDA_ARCH_LIST="${FLASHINFER_CUDA_ARCH_LIST:-12.1a}"
 # 1..4 seqs × 3 tokens (must include 3). DFlash2 k=7 is 1..4 seqs × 8 tokens
 # (must include 8, 16, 24, 32).
 ENFORCE_EAGER="${ENFORCE_EAGER:-0}"
+# The capture list this launcher generated (empty = eager, or the caller put
+# its own --cudagraph-capture-sizes in EXTRA_ARGS). validate_numeric_config
+# checks MAX_NUM_SEQS against its largest entry for the MTP list (issue #88).
+GLM53_CG_CAPTURE_SIZES=""
 if [ "${ENFORCE_EAGER}" != "1" ]; then
     case " ${EXTRA_ARGS:-} " in
         *" --cudagraph-capture-sizes "*|*" cudagraph-capture-sizes "*) ;;
         *)
             if [ "$SPEC_METHOD" = "dflash" ]; then
-                EXTRA_ARGS="${EXTRA_ARGS:+$EXTRA_ARGS }--cudagraph-capture-sizes 1 2 4 8 16 24 32"
+                GLM53_CG_CAPTURE_SIZES="1 2 4 8 16 24 32"
             else
-                EXTRA_ARGS="${EXTRA_ARGS:+$EXTRA_ARGS }--cudagraph-capture-sizes 1 2 3 4 6 8 12"
+                GLM53_CG_CAPTURE_SIZES="1 2 3 4 6 8 12"
             fi
+            EXTRA_ARGS="${EXTRA_ARGS:+$EXTRA_ARGS }--cudagraph-capture-sizes $GLM53_CG_CAPTURE_SIZES"
             ;;
     esac
 fi
@@ -300,6 +305,36 @@ validate_numeric_config() {
     _glm53_canonical_positive_int MAX_MODEL_LEN "$MAX_MODEL_LEN" 1000000 || return
     _glm53_canonical_positive_int MAX_NUM_SEQS "$MAX_NUM_SEQS" 4096 || return
     _glm53_canonical_positive_int MAX_NUM_BATCHED_TOKENS "$MAX_NUM_BATCHED_TOKENS" 8388608 || return
+    _glm53_validate_cudagraph_capture_envelope || return
+}
+
+# Issue #88: on this image vLLM's profile_cudagraph_memory() builds its
+# throwaway KV config with num_blocks = the largest capture size and calls
+# initialize_kv_cache() without is_profiling=True, so the Mamba guard in
+# compilation.py resolve_cudagraph_mode_and_sizes() raises
+#   max_num_seqs (N) exceeds available Mamba cache blocks (12)
+# in EngineCore init, after weight load. With the launcher's non-DFlash list
+# (1 2 3 4 6 8 12) that rejects every MAX_NUM_SEQS above 12 - and `restart`
+# would already have stopped the running server. Refuse the combination here,
+# before anything is stopped. Only the launcher-generated list is checked: a
+# caller's own --cudagraph-capture-sizes in EXTRA_ARGS is not parsed, and
+# the DFlash list (max 32) is not gated - its limit is unmeasured. Measured
+# for SPEC_METHOD=mtp; `none` and any other non-dflash value get the same
+# list and the same vLLM code path, so they are gated too.
+_glm53_validate_cudagraph_capture_envelope() {
+    local sizes="${GLM53_CG_CAPTURE_SIZES:-}" cap=0 size
+    [ "${SPEC_METHOD:-dflash}" != "dflash" ] || return 0
+    [ -n "$sizes" ] || return 0
+    for size in $sizes; do
+        if ! [[ "$size" =~ ^[0-9]+$ ]]; then
+            echo "internal error: launcher capture list is not numeric (GLM53_CG_CAPTURE_SIZES='$sizes')" >&2
+            return 2
+        fi
+        if [ "$size" -gt "$cap" ]; then cap="$size"; fi
+    done
+    [ "$MAX_NUM_SEQS" -gt "$cap" ] || return 0
+    echo "MAX_NUM_SEQS=$MAX_NUM_SEQS exceeds the largest CUDA-graph capture size ($cap) of the launcher's SPEC_METHOD=$SPEC_METHOD list ($sizes). On this image's vLLM that boot fails in EngineCore init, after weight load: profile_cudagraph_memory() builds a $cap-block throwaway KV config without is_profiling=True and raises 'max_num_seqs ($MAX_NUM_SEQS) exceeds available Mamba cache blocks ($cap)' - a profiling-path false positive, not a measured KV/scheduler limit (issue #88). Lower MAX_NUM_SEQS to at most $cap, set ENFORCE_EAGER=1 (no CUDA graphs), or supply a verified larger --cudagraph-capture-sizes list in EXTRA_ARGS (caller lists are not validated)." >&2
+    return 2
 }
 # GLM53 numeric config guard (end)
 

--- a/tests/test_mtp_capture_guard.py
+++ b/tests/test_mtp_capture_guard.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Stubbed dry runs for the MAX_NUM_SEQS / MTP capture-list guard (issue #88).
+
+On this image vLLM's profile_cudagraph_memory() builds a throwaway KV config
+with num_blocks = the largest CUDA-graph capture size and does not pass
+is_profiling=True, so the Mamba guard raises
+`max_num_seqs (16) exceeds available Mamba cache blocks (12)` in EngineCore
+init, after weight load. The launcher's non-DFlash list is `1 2 3 4 6 8 12`,
+so `SPEC_METHOD=mtp MAX_NUM_SEQS=16 ./start.sh restart` stopped the running
+DFlash server and then failed to replace it.
+
+These tests drive the REAL start.sh under bash from an allow-listed
+environment with docker / ssh / scp / rsync / curl / ip / nvidia-smi stubbed
+first on PATH (each stub records its argv and exits 0; nothing talks to a
+host; PATH is the stubs plus /usr/bin:/bin only) and a .env copied from
+.env.example, then assert:
+
+  1. `restart` (and `start`) with SPEC_METHOD=mtp MAX_NUM_SEQS=16 exits 2
+     with ZERO docker / ssh calls -- before `stop` -- and the message names
+     the vLLM error and the fix. Same for 13, for SPEC_METHOD=none and for
+     CG_ESTIMATE=0 (not the trigger).
+  2. Controls pass the gate and reach `stop` on BOTH ranks (docker rm -f on
+     the head, `docker rm -f` over ssh on the worker): the stock .env, mtp/12,
+     mtp/0012, dflash/16, mtp/16 with ENFORCE_EAGER=1, and mtp/16 with the
+     caller's own --cudagraph-capture-sizes in EXTRA_ARGS (not parsed, not
+     gated). The stubbed preflight then fails, which is fine.
+  3. The generated argv is unchanged: EXTRA_ARGS still ends with
+     `--cudagraph-capture-sizes 1 2 3 4 6 8 12` (mtp) / `1 2 4 8 16 24 32`
+     (dflash), and is untouched under ENFORCE_EAGER=1 or a caller list.
+  4. Static: the guard lives inside the numeric-config sentinels, is called
+     from validate_numeric_config, and main() runs that before
+     `restart) stop; start`.
+
+Run:  python3 tests/test_mtp_capture_guard.py   (or pytest)
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+START = ROOT / "start.sh"
+
+FAILURES: list[str] = []
+SEP = "\x1f"
+HOST_TOOLS = ("docker", "ssh", "scp", "rsync", "curl", "ip", "nvidia-smi")
+MTP_LIST = "1 2 3 4 6 8 12"
+DFLASH_LIST = "1 2 4 8 16 24 32"
+
+STUB = """#!/usr/bin/env bash
+# Records every invocation; never touches a host.
+{ printf '%s\\x1f' "$(basename "$0")" "$@"; printf '\\n'; } >> "$GLM53_STUB_LOG"
+case "$(basename "$0")" in
+    ip) printf 'inet %s/24\\n' "${GLM53_STUB_HEAD_IP:-10.0.0.1}" ;;
+esac
+exit 0
+"""
+
+
+def check(cond: bool, label: str) -> None:
+    print(("  ok   " if cond else "  FAIL ") + label)
+    if not cond:
+        FAILURES.append(label)
+
+
+class Harness:
+    """A throwaway copy of the launcher checkout plus a stub PATH."""
+
+    def __init__(self, tmp: Path) -> None:
+        self.tmp = tmp
+        self.repo = tmp / "repo"
+        self.repo.mkdir()
+        shutil.copy2(START, self.repo / "start.sh")
+        shutil.copy2(ROOT / ".env.example", self.repo / ".env.example")
+        (self.repo / ".env").write_text((ROOT / ".env.example").read_text())
+        for sub in ("overlay", "files", "ablit", "scripts"):
+            if (ROOT / sub).is_dir():
+                shutil.copytree(ROOT / sub, self.repo / sub)
+        self.home = tmp / "home"
+        self.home.mkdir()
+        self.bin = tmp / "bin"
+        self.bin.mkdir()
+        for tool in HOST_TOOLS:
+            p = self.bin / tool
+            p.write_text(STUB)
+            p.chmod(p.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        self.log = tmp / "calls.log"
+        text = (self.repo / "start.sh").read_text()
+        assert text.rstrip().endswith('\nmain "$@"'), 'start.sh must end with main "$@"'
+        (self.repo / "start.fn.sh").write_text(text.rstrip()[: -len('main "$@"')] + '"$@"\n')
+
+    def env(self, **extra: str) -> dict[str, str]:
+        env = {
+            "PATH": f"{self.bin}{os.pathsep}/usr/bin:/bin",
+            "HOME": str(self.home),
+            "USER": "glm53-mtp-guard",
+            "LC_ALL": "C",
+            "TERM": "dumb",
+            "GLM53_STUB_LOG": str(self.log),
+        }
+        env.update(extra)
+        return env
+
+    def calls(self) -> list[list[str]]:
+        if not self.log.exists():
+            return []
+        out = []
+        for line in self.log.read_text().splitlines():
+            argv = line.split(SEP)
+            if argv and argv[-1] == "":
+                argv.pop()
+            out.append(argv)
+        return out
+
+    def host_touching_calls(self) -> list[list[str]]:
+        return [c for c in self.calls() if c and c[0] in ("docker", "ssh", "scp", "rsync")]
+
+    def run(self, *argv: str, entry: str = "start.sh", **extra: str) -> subprocess.CompletedProcess[str]:
+        if self.log.exists():
+            self.log.unlink()
+        return subprocess.run(
+            ["bash", f"./{entry}", *argv],
+            cwd=self.repo,
+            text=True,
+            capture_output=True,
+            check=False,
+            env=self.env(**extra),
+        )
+
+
+def fails_closed(h: Harness, label: str, cmd: str = "restart", **env: str) -> None:
+    r = h.run(cmd, **env)
+    calls = h.host_touching_calls()
+    err = r.stderr.strip()
+    named = (
+        "Mamba cache blocks (12)" in err
+        and "issue #88" in err
+        and "at most 12" in err
+        and "ENFORCE_EAGER=1" in err
+        and f"MAX_NUM_SEQS={int(env['MAX_NUM_SEQS'])} exceeds" in err
+    )
+    check(
+        r.returncode == 2 and not calls and named,
+        f"{label}: rc={r.returncode}, host-touching calls={len(calls)}, message names the vLLM error + fix={named} ({err[-120:]!r})",
+    )
+
+
+def reaches_stop(h: Harness, label: str, **env: str) -> None:
+    r = h.run("restart", **env)
+    calls = h.host_touching_calls()
+    head_rm = any(c[:3] == ["docker", "rm", "-f"] for c in calls)
+    worker_rm = any(c[0] == "ssh" and "docker rm -f" in c[-1] for c in calls)
+    last = (r.stderr.strip().splitlines() or [""])[-1]
+    check(
+        head_rm and worker_rm and "issue #88" not in r.stderr,
+        f"{label} (head rm={head_rm} worker rm={worker_rm}; later rc={r.returncode} is the stubbed preflight: {last[:90]!r})",
+    )
+
+
+def extra_args(h: Harness, **env: str) -> str:
+    r = h.run("eval", 'printf "%s" "${EXTRA_ARGS-}"', entry="start.fn.sh", **env)
+    assert r.returncode == 0, r.stderr[-400:]
+    assert not h.host_touching_calls()
+    return r.stdout
+
+
+def part_static() -> None:
+    print("Static: guard placement")
+    text = START.read_text()
+    begin = text.index("# GLM53 numeric config guard (begin)")
+    end = text.index("# GLM53 numeric config guard (end)")
+    guard = text[begin:end]
+    check(
+        "_glm53_validate_cudagraph_capture_envelope() {" in guard
+        and "_glm53_validate_cudagraph_capture_envelope || return" in guard,
+        "S1 the envelope check is defined inside the numeric-config sentinels and called from validate_numeric_config",
+    )
+    check(
+        guard.index("_glm53_canonical_positive_int MAX_NUM_SEQS") < guard.index("_glm53_validate_cudagraph_capture_envelope || return"),
+        "S1 it runs after MAX_NUM_SEQS is canonicalised (leading zeros stripped, range-checked)",
+    )
+    main_at = text.index("main() {")
+    check(
+        text.index("start|restart) validate_numeric_config", main_at) < text.index("restart)  stop; start", main_at),
+        "S2 main() runs validate_numeric_config before `restart) stop; start`",
+    )
+    check(
+        f'GLM53_CG_CAPTURE_SIZES="{MTP_LIST}"' in text
+        and f'GLM53_CG_CAPTURE_SIZES="{DFLASH_LIST}"' in text
+        and '--cudagraph-capture-sizes $GLM53_CG_CAPTURE_SIZES"' in text,
+        "S3 the list the guard reads is the list appended to EXTRA_ARGS (one variable, no second constant)",
+    )
+
+
+def part_dry_runs(h: Harness) -> None:
+    print("Dry runs: restart fails closed before stop / controls reach stop")
+    reaches_stop(h, "C0 control: stock .env (dflash, MAX_NUM_SEQS=4) passes the gate and reaches stop on both ranks")
+    reaches_stop(h, "C1 control: SPEC_METHOD=mtp MAX_NUM_SEQS=12 (the envelope) reaches stop", SPEC_METHOD="mtp", MAX_NUM_SEQS="12")
+    reaches_stop(h, "C2 control: SPEC_METHOD=mtp MAX_NUM_SEQS=0012 (canonical 12) reaches stop", SPEC_METHOD="mtp", MAX_NUM_SEQS="0012")
+    reaches_stop(h, "C3 control: SPEC_METHOD=dflash MAX_NUM_SEQS=16 is not gated (32-list, unmeasured)", SPEC_METHOD="dflash", MAX_NUM_SEQS="16")
+    reaches_stop(h, "C4 control: SPEC_METHOD=mtp MAX_NUM_SEQS=16 ENFORCE_EAGER=1 (no graphs, no profiling pass)", SPEC_METHOD="mtp", MAX_NUM_SEQS="16", ENFORCE_EAGER="1")
+    reaches_stop(
+        h, "C5 control: SPEC_METHOD=mtp MAX_NUM_SEQS=16 with the caller's own --cudagraph-capture-sizes in EXTRA_ARGS (not parsed, not gated)",
+        SPEC_METHOD="mtp", MAX_NUM_SEQS="16", EXTRA_ARGS="--cudagraph-capture-sizes 1 2 4 8 16",
+    )
+    fails_closed(h, "F1 restart SPEC_METHOD=mtp MAX_NUM_SEQS=16 (issue #88 repro) exits 2 with nothing stopped", SPEC_METHOD="mtp", MAX_NUM_SEQS="16")
+    fails_closed(h, "F2 start   SPEC_METHOD=mtp MAX_NUM_SEQS=16 exits 2 with zero host calls", cmd="start", SPEC_METHOD="mtp", MAX_NUM_SEQS="16")
+    fails_closed(h, "F3 restart SPEC_METHOD=mtp MAX_NUM_SEQS=13 (one above the envelope)", SPEC_METHOD="mtp", MAX_NUM_SEQS="13")
+    fails_closed(h, "F4 restart SPEC_METHOD=mtp MAX_NUM_SEQS=0016 (leading zeros canonicalised first)", SPEC_METHOD="mtp", MAX_NUM_SEQS="0016")
+    fails_closed(h, "F5 restart SPEC_METHOD=none MAX_NUM_SEQS=16 (same launcher list, same vLLM path)", SPEC_METHOD="none", MAX_NUM_SEQS="16")
+    fails_closed(h, "F6 restart SPEC_METHOD=mtp MAX_NUM_SEQS=16 CG_ESTIMATE=0 (CG_ESTIMATE is not the trigger)", SPEC_METHOD="mtp", MAX_NUM_SEQS="16", CG_ESTIMATE="0")
+    fails_closed(h, "F7 restart SPEC_METHOD=mtp MAX_NUM_SEQS=16 ENFORCE_EAGER=0 (explicit graphs)", SPEC_METHOD="mtp", MAX_NUM_SEQS="16", ENFORCE_EAGER="0")
+
+    print("Generated argv unchanged")
+    mtp = extra_args(h, SPEC_METHOD="mtp")
+    dfl = extra_args(h, SPEC_METHOD="dflash")
+    check(mtp.endswith(f"--cudagraph-capture-sizes {MTP_LIST}"), f"G1 mtp EXTRA_ARGS still ends with the MTP list ({mtp!r})")
+    check(dfl.endswith(f"--cudagraph-capture-sizes {DFLASH_LIST}"), f"G2 dflash EXTRA_ARGS still ends with the DFlash list ({dfl!r})")
+    eager = extra_args(h, SPEC_METHOD="mtp", ENFORCE_EAGER="1")
+    check("cudagraph-capture-sizes" not in eager, f"G3 ENFORCE_EAGER=1 generates no list ({eager!r})")
+    own = extra_args(h, SPEC_METHOD="mtp", EXTRA_ARGS="--cudagraph-capture-sizes 1 2 4 8 16 --foo bar")
+    check(own == "--cudagraph-capture-sizes 1 2 4 8 16 --foo bar", f"G4 a caller list is passed through untouched ({own!r})")
+    r = h.run("eval", 'printf "%s|%s" "$GLM53_CG_CAPTURE_SIZES" "$MAX_NUM_SEQS"', entry="start.fn.sh", SPEC_METHOD="mtp", MAX_NUM_SEQS="16")
+    check(r.stdout == f"{MTP_LIST}|16", f"G5 the prologue records the generated list for the guard ({r.stdout!r})")
+
+
+def main() -> int:
+    part_static()
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        part_dry_runs(Harness(Path(raw_tmp)))
+    if FAILURES:
+        print(f"\n{len(FAILURES)} FAILED:")
+        for f in FAILURES:
+            print("  - " + f)
+        return 1
+    print("\nmtp capture guard: PASS")
+    return 0
+
+
+def test_mtp_capture_guard() -> None:
+    assert main() == 0, FAILURES
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_numeric_config.py
+++ b/tests/test_numeric_config.py
@@ -20,7 +20,9 @@ def guard_source() -> str:
     return source[begin:end]
 
 
-def validate(util: str, model: str, seqs: str, batch: str) -> subprocess.CompletedProcess[str]:
+def validate(
+    util: str, model: str, seqs: str, batch: str, **extra: str
+) -> subprocess.CompletedProcess[str]:
     script = (
         guard_source()
         + '\nGPU_MEM_UTIL="$1"; MAX_MODEL_LEN="$2"; MAX_NUM_SEQS="$3"; '
@@ -34,7 +36,7 @@ def validate(util: str, model: str, seqs: str, batch: str) -> subprocess.Complet
         text=True,
         capture_output=True,
         check=False,
-        env={**os.environ, "LC_ALL": "C"},
+        env={**os.environ, "LC_ALL": "C", **extra},
     )
 
 
@@ -64,6 +66,106 @@ def test_decimal_normalization() -> None:
     assert result.stdout.strip() == ".87|1000000|4|1024"
 
 
+MTP_LIST = "1 2 3 4 6 8 12"
+DFLASH_LIST = "1 2 4 8 16 24 32"
+
+
+def test_mtp_capture_envelope() -> None:
+    """Issue #88: with the launcher-generated MTP capture list (max 12) vLLM's
+    profiling pass on this image rejects MAX_NUM_SEQS > 12 in EngineCore init.
+    The guard refuses that combination (rc 2) and names the real error; the
+    DFlash list, eager mode and a caller-supplied list are not gated."""
+    ok = [
+        ("mtp", "12", MTP_LIST),
+        ("mtp", "0012", MTP_LIST),
+        ("mtp", "4", MTP_LIST),
+        ("none", "12", MTP_LIST),
+        ("dflash", "16", DFLASH_LIST),
+        ("dflash", "4096", DFLASH_LIST),
+        ("mtp", "16", ""),          # ENFORCE_EAGER=1 or caller list: nothing generated
+        ("mtp", "4096", ""),
+    ]
+    for spec, seqs, sizes in ok:
+        r = validate("0.87", "1000000", seqs, "2048", SPEC_METHOD=spec, GLM53_CG_CAPTURE_SIZES=sizes)
+        assert r.returncode == 0, (spec, seqs, sizes, r.returncode, r.stderr)
+    # unset SPEC_METHOD in the spliced harness == launcher default dflash: never gated
+    r = validate("0.87", "1000000", "16", "2048", GLM53_CG_CAPTURE_SIZES=MTP_LIST)
+    assert r.returncode == 0, r.stderr
+    bad = [
+        ("mtp", "13", MTP_LIST),
+        ("mtp", "16", MTP_LIST),
+        ("mtp", "0016", MTP_LIST),
+        ("mtp", "4096", MTP_LIST),
+        ("none", "16", MTP_LIST),
+        ("eagle", "16", MTP_LIST),  # any non-dflash value takes the launcher's mtp branch
+    ]
+    for spec, seqs, sizes in bad:
+        r = validate("0.87", "1000000", seqs, "2048", SPEC_METHOD=spec, GLM53_CG_CAPTURE_SIZES=sizes)
+        assert r.returncode == 2, (spec, seqs, sizes, r.returncode, r.stderr)
+        assert "Mamba cache blocks (12)" in r.stderr and "issue #88" in r.stderr, r.stderr
+        assert f"MAX_NUM_SEQS={int(seqs)} exceeds" in r.stderr, r.stderr
+        assert "at most 12" in r.stderr and "ENFORCE_EAGER=1" in r.stderr, r.stderr
+    # the cap follows the list, not a second hard-coded 12
+    r = validate("0.87", "1000000", "16", "2048", SPEC_METHOD="mtp", GLM53_CG_CAPTURE_SIZES="1 2 3 4 6 8 12 16")
+    assert r.returncode == 0, r.stderr
+    r = validate("0.87", "1000000", "17", "2048", SPEC_METHOD="mtp", GLM53_CG_CAPTURE_SIZES="1 2 3 4 6 8 12 16")
+    assert r.returncode == 2 and "Mamba cache blocks (16)" in r.stderr, r.stderr
+    # the range check still runs first: a bad MAX_NUM_SEQS is reported as such
+    r = validate("0.87", "1000000", "O16", "2048", SPEC_METHOD="mtp", GLM53_CG_CAPTURE_SIZES=MTP_LIST)
+    assert r.returncode == 2 and "positive base-10 integer" in r.stderr, r.stderr
+
+
+def prologue_capture_sizes(**env: str) -> str:
+    """Run the REAL start.sh prologue + configuration (trailing `main "$@"`
+    swapped for `"$@"`, then `eval` a printf) from an allow-listed environment
+    and return the GLM53_CG_CAPTURE_SIZES it generated. The prologue makes no
+    host calls; PATH is the system dirs only."""
+    import tempfile
+
+    text = START.read_text()
+    assert text.rstrip().endswith('\nmain "$@"')
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        (tmp / "start.fn.sh").write_text(text.rstrip()[: -len('main "$@"')] + '"$@"\n')
+        (tmp / ".env").write_text((ROOT / ".env.example").read_text())
+        base = {"PATH": "/usr/bin:/bin", "HOME": raw, "USER": "glm53", "LC_ALL": "C"}
+        r = subprocess.run(
+            ["bash", "./start.fn.sh", "eval", 'printf "%s" "${GLM53_CG_CAPTURE_SIZES-<unset>}"'],
+            cwd=tmp, text=True, capture_output=True, check=False, env={**base, **env},
+        )
+    assert r.returncode == 0, r.stderr[-400:]
+    return r.stdout
+
+
+def test_prologue_generated_list_feeds_the_guard() -> None:
+    """The value the guard reads is the one the real prologue generates: set
+    for the launcher-generated lists, empty under ENFORCE_EAGER=1 or when the
+    caller supplies its own --cudagraph-capture-sizes."""
+    cases = {
+        "mtp generated": ({"SPEC_METHOD": "mtp"}, MTP_LIST, 2),
+        "none generated": ({"SPEC_METHOD": "none"}, MTP_LIST, 2),
+        "dflash generated": ({"SPEC_METHOD": "dflash"}, DFLASH_LIST, 0),
+        "mtp eager": ({"SPEC_METHOD": "mtp", "ENFORCE_EAGER": "1"}, "", 0),
+        "mtp caller list": ({"SPEC_METHOD": "mtp", "EXTRA_ARGS": "--cudagraph-capture-sizes 1 2 4 8 16"}, "", 0),
+    }
+    for label, (env, want_sizes, want_rc) in cases.items():
+        sizes = prologue_capture_sizes(**env)
+        assert sizes == want_sizes, (label, sizes)
+        r = validate("0.87", "1000000", "16", "2048", SPEC_METHOD=env["SPEC_METHOD"], GLM53_CG_CAPTURE_SIZES=sizes)
+        assert r.returncode == want_rc, (label, r.returncode, r.stderr)
+
+
+def test_launcher_generates_the_lists_it_validates() -> None:
+    """The capture list the launcher appends to EXTRA_ARGS and the one the
+    guard reads are the same variable (byte-identical lists as before)."""
+    src = START.read_text()
+    assert f'GLM53_CG_CAPTURE_SIZES="{MTP_LIST}"' in src
+    assert f'GLM53_CG_CAPTURE_SIZES="{DFLASH_LIST}"' in src
+    assert '--cudagraph-capture-sizes $GLM53_CG_CAPTURE_SIZES"' in src
+    assert "_glm53_validate_cudagraph_capture_envelope || return" in guard_source()
+    assert "_glm53_validate_cudagraph_capture_envelope() {" in guard_source()
+
+
 def test_restart_validates_before_stop() -> None:
     source = START.read_text()
     main = source.index("main() {")
@@ -75,5 +177,8 @@ def test_restart_validates_before_stop() -> None:
 if __name__ == "__main__":
     test_matrix()
     test_decimal_normalization()
+    test_mtp_capture_envelope()
+    test_prologue_generated_list_feeds_the_guard()
+    test_launcher_generates_the_lists_it_validates()
     test_restart_validates_before_stop()
     print("numeric config tests: PASS")


### PR DESCRIPTION
# launcher: refuse `MAX_NUM_SEQS` above the MTP capture list before `restart` stops anything

## What / why

`SPEC_METHOD=mtp ./start.sh restart` is the documented rollback (`README.md:362-366`, `.env` row at `:477`). On a kit running `MAX_NUM_SEQS=16` it stops the healthy DFlash server and then fails to replace it (#88): both TP ranks raise inside `determine_available_memory → profile_cudagraph_memory`, EngineCore fails, the launcher ends with "server did not become healthy".

Mechanism (read from the vLLM inside the image, `v0.1.dev20051+g487ecf187`): `profile_cudagraph_memory()` builds a throwaway KV config with `num_gpu_blocks_override = max_cudagraph_capture_size` — **12** for the launcher's MTP list `1 2 3 4 6 8 12` (`start.sh:199`) — and calls `initialize_kv_cache(minimal_config)` without `is_profiling=True`, so the Mamba guard in `compilation.py:1499-1515` evaluates `max_num_reqs (16) > num_blocks (12)` against the *profiling* config and raises. A profiling-path false positive, not a KV/scheduler limit; `CG_ESTIMATE` is not the trigger (it only controls whether the estimate is deducted). The recipe default `MAX_NUM_SEQS=4` is unaffected, which is why this stays hidden until someone raises concurrency (#43, #82, #85).

This PR is the launcher-side containment: a fail-fast check in `validate_numeric_config` — which `main()` already runs on `start|restart` **before** `restart` reaches `stop; start` — so a running server is never stopped for a boot that cannot succeed on this image.

- The capture list the launcher generates now lives in one variable, `GLM53_CG_CAPTURE_SIZES`, that feeds `EXTRA_ARGS`. The generated argv is byte-identical (test G1/G2). It stays empty under `ENFORCE_EAGER=1` or when the caller supplies its own `--cudagraph-capture-sizes`.
- `_glm53_validate_cudagraph_capture_envelope` (inside the existing numeric-guard sentinels, after `MAX_NUM_SEQS` is canonicalised): for every non-`dflash` `SPEC_METHOD` with a launcher-generated list, `MAX_NUM_SEQS` above the list maximum exits 2 with a message naming the real error and the fix. The cap is derived from the list, so extending the list moves the guard with it (no second hard-coded 12).
- Scope: `mtp` is the measured case. `none` and any other non-`dflash` value take the same launcher list and the same `else` (= mtp) branch at `start.sh:854-861`, and the vLLM check depends on `has_mamba_layers` and `max_num_reqs`, not on the speculator, so they are gated too. The DFlash list (max 32) is **not** gated — its limit is an untested prediction. A caller's own `--cudagraph-capture-sizes` (or `--max-num-seqs`) in `EXTRA_ARGS` is passed through unvalidated, as before; parsing argv is out of scope, same as the existing numeric guard (#38) validates env knobs only.
- The proper upstream fix is vLLM's `is_profiling=True` plumbing (upstream `main` @ `22df3a3`, `gpu_model_runner.py:6612` + the two `gpu/model_runner.py` call sites). That is an image change and deliberately **not** attempted here; with it in the image this guard becomes redundant and can be dropped.

Pure launcher logic: no live-server receipts apply. The failing boot itself is documented in #88 (head log `launching:` line 10:55:27; worker `Model loading took 82.38 GiB and 370.7 seconds` at 11:02:05; exception 11:02:17, container clock).

## Repro (from #88)

Recipe `main` `493cb88`, image `ghcr.io/miaai-lab/glm-5.3-flash-2x-dgx-sparks:exl3`, 2× DGX Spark, TP=2. `.env`: `MAX_MODEL_LEN=1000000 MAX_NUM_SEQS=16 MAX_NUM_BATCHED_TOKENS=2048 GPU_MEM_UTIL=0.87 KV_CACHE_DTYPE=fp8 ENFORCE_EAGER=0 CG_ESTIMATE=0 DFLASH_DRAFT_TP=2`, vision on.

```bash
SPEC_METHOD=mtp ./start.sh restart
```

Before (Worker_TP0; Worker_TP1 identical), after `stop` had already removed both containers:

```
  File ".../vllm/v1/worker/gpu_worker.py", line 518, in determine_available_memory
    cudagraph_memory_estimate = self.model_runner.profile_cudagraph_memory()
  File ".../vllm/v1/worker/gpu/model_runner.py", line 862, in _init_minimal_kv_cache_for_profiling
    self.initialize_kv_cache(minimal_config)
  File ".../vllm/config/compilation.py", line 1507, in resolve_cudagraph_mode_and_sizes
ValueError: max_num_seqs (16) exceeds available Mamba cache blocks (12). Each decode sequence requires one Mamba cache block, so CUDA graph capture cannot proceed. Please lower max_num_seqs to at most 12 or increase gpu_memory_utilization.
(EngineCore pid=1366) ERROR 08-31 11:02:17 [core.py:1355] EngineCore failed to start.
```

After (stubbed dry run, identical env; nothing stopped, exit 2 — full receipt below):

```
MAX_NUM_SEQS=16 exceeds the largest CUDA-graph capture size (12) of the launcher's SPEC_METHOD=mtp list (1 2 3 4 6 8 12). On this image's vLLM that boot fails in EngineCore init, after weight load: profile_cudagraph_memory() builds a 12-block throwaway KV config without is_profiling=True and raises 'max_num_seqs (16) exceeds available Mamba cache blocks (12)' - a profiling-path false positive, not a measured KV/scheduler limit (issue #88). Lower MAX_NUM_SEQS to at most 12, set ENFORCE_EAGER=1 (no CUDA graphs), or supply a verified larger --cudagraph-capture-sizes list in EXTRA_ARGS (caller lists are not validated).
```

## Diff summary

- `start.sh`: `GLM53_CG_CAPTURE_SIZES` in the capture-list block; `_glm53_validate_cudagraph_capture_envelope` + its call in `validate_numeric_config` (`+37 / −2` in total).
- `README.md`: envelope paragraph under the rollback block (the guard's envelope is `≤ 12`; the measured MTP boot is the recipe default `4`, so the text says "guarded at", not "boots with"); `SPEC_METHOD` / `MAX_NUM_SEQS` / `ENFORCE_EAGER` rows; test-table rows for `tests/test_numeric_config.py` (was unlisted) and the new test.
- `.env.example`: comments at the rollback line and at `MAX_NUM_SEQS`.
- `tests/test_numeric_config.py`: spliced-guard matrix — pass: `mtp`/12, `mtp`/0012, `none`/12, `dflash`/16, `dflash`/4096, `mtp`/16 with no generated list (eager / caller list), unset `SPEC_METHOD`; fail (rc 2, message names `Mamba cache blocks (12)`, `issue #88`, `at most 12`, `ENFORCE_EAGER=1`): `mtp`/13, 16, 0016, 4096, `none`/16, `eagle`/16; the cap follows the list (`… 12 16` → 16 passes, 17 fails with `(16)`); the range check still runs first (`O16`). `test_prologue_generated_list_feeds_the_guard` runs the **real** prologue + configuration section and feeds the `GLM53_CG_CAPTURE_SIZES` it produced into the guard: generated for `mtp` / `none` (→ 16 refused) and `dflash` (→ passes), empty under `ENFORCE_EAGER=1` and with a caller `--cudagraph-capture-sizes` (→ passes).
- `tests/test_mtp_capture_guard.py` (new): stubbed dry runs of the **real** `start.sh` — `restart` and `start` with the #88 env exit 2 with **zero** docker/ssh calls (also 13, 0016, `none`, `CG_ESTIMATE=0`, `ENFORCE_EAGER=0`); controls (stock `.env`, `mtp`/12, `mtp`/0012, `dflash`/16, `ENFORCE_EAGER=1`, caller list in `EXTRA_ARGS`) pass the gate and reach `stop` on both ranks (`docker rm -f` on the head, `docker rm -f` over ssh on the worker); `EXTRA_ARGS` is unchanged for mtp / dflash / eager / caller list; static guard-placement checks.

Related: #25 (`CG_ESTIMATE`; not the trigger), #28, #38 (the guard this extends), #43, #74, #82, #85.

## Tests (verbatim)

```
# pr/mtp-max-num-seqs-guard @ 7c4c536 (base upstream/main 493cb88) — 2026-09-01 11:04 AWST — macOS 26.4.1, bash 5.3.15(1)-release

$ python3 tests/test_mtp_capture_guard.py
Static: guard placement
  ok   S1 the envelope check is defined inside the numeric-config sentinels and called from validate_numeric_config
  ok   S1 it runs after MAX_NUM_SEQS is canonicalised (leading zeros stripped, range-checked)
  ok   S2 main() runs validate_numeric_config before `restart) stop; start`
  ok   S3 the list the guard reads is the list appended to EXTRA_ARGS (one variable, no second constant)
Dry runs: restart fails closed before stop / controls reach stop
  ok   C0 control: stock .env (dflash, MAX_NUM_SEQS=4) passes the gate and reaches stop on both ranks (head rm=True worker rm=True; later rc=1 is the stubbed preflight: '\x1b[1;31m[glm53-exl3]\x1b[0m ERROR: set NCCL_IB_GID_INDEX (same index both ranks) or HEAD_GID/W')
  ok   C1 control: SPEC_METHOD=mtp MAX_NUM_SEQS=12 (the envelope) reaches stop (head rm=True worker rm=True; later rc=1 is the stubbed preflight: '\x1b[1;31m[glm53-exl3]\x1b[0m ERROR: set NCCL_IB_GID_INDEX (same index both ranks) or HEAD_GID/W')
  ok   C2 control: SPEC_METHOD=mtp MAX_NUM_SEQS=0012 (canonical 12) reaches stop (head rm=True worker rm=True; later rc=1 is the stubbed preflight: '\x1b[1;31m[glm53-exl3]\x1b[0m ERROR: set NCCL_IB_GID_INDEX (same index both ranks) or HEAD_GID/W')
  ok   C3 control: SPEC_METHOD=dflash MAX_NUM_SEQS=16 is not gated (32-list, unmeasured) (head rm=True worker rm=True; later rc=1 is the stubbed preflight: '\x1b[1;31m[glm53-exl3]\x1b[0m ERROR: set NCCL_IB_GID_INDEX (same index both ranks) or HEAD_GID/W')
  ok   C4 control: SPEC_METHOD=mtp MAX_NUM_SEQS=16 ENFORCE_EAGER=1 (no graphs, no profiling pass) (head rm=True worker rm=True; later rc=1 is the stubbed preflight: '\x1b[1;31m[glm53-exl3]\x1b[0m ERROR: set NCCL_IB_GID_INDEX (same index both ranks) or HEAD_GID/W')
  ok   C5 control: SPEC_METHOD=mtp MAX_NUM_SEQS=16 with the caller's own --cudagraph-capture-sizes in EXTRA_ARGS (not parsed, not gated) (head rm=True worker rm=True; later rc=1 is the stubbed preflight: '\x1b[1;31m[glm53-exl3]\x1b[0m ERROR: set NCCL_IB_GID_INDEX (same index both ranks) or HEAD_GID/W')
  ok   F1 restart SPEC_METHOD=mtp MAX_NUM_SEQS=16 (issue #88 repro) exits 2 with nothing stopped: rc=2, host-touching calls=0, message names the vLLM error + fix=True ('CUDA graphs), or supply a verified larger --cudagraph-capture-sizes list in EXTRA_ARGS (caller lists are not validated).')
  ok   F2 start   SPEC_METHOD=mtp MAX_NUM_SEQS=16 exits 2 with zero host calls: rc=2, host-touching calls=0, message names the vLLM error + fix=True ('CUDA graphs), or supply a verified larger --cudagraph-capture-sizes list in EXTRA_ARGS (caller lists are not validated).')
  ok   F3 restart SPEC_METHOD=mtp MAX_NUM_SEQS=13 (one above the envelope): rc=2, host-touching calls=0, message names the vLLM error + fix=True ('CUDA graphs), or supply a verified larger --cudagraph-capture-sizes list in EXTRA_ARGS (caller lists are not validated).')
  ok   F4 restart SPEC_METHOD=mtp MAX_NUM_SEQS=0016 (leading zeros canonicalised first): rc=2, host-touching calls=0, message names the vLLM error + fix=True ('CUDA graphs), or supply a verified larger --cudagraph-capture-sizes list in EXTRA_ARGS (caller lists are not validated).')
  ok   F5 restart SPEC_METHOD=none MAX_NUM_SEQS=16 (same launcher list, same vLLM path): rc=2, host-touching calls=0, message names the vLLM error + fix=True ('CUDA graphs), or supply a verified larger --cudagraph-capture-sizes list in EXTRA_ARGS (caller lists are not validated).')
  ok   F6 restart SPEC_METHOD=mtp MAX_NUM_SEQS=16 CG_ESTIMATE=0 (CG_ESTIMATE is not the trigger): rc=2, host-touching calls=0, message names the vLLM error + fix=True ('CUDA graphs), or supply a verified larger --cudagraph-capture-sizes list in EXTRA_ARGS (caller lists are not validated).')
  ok   F7 restart SPEC_METHOD=mtp MAX_NUM_SEQS=16 ENFORCE_EAGER=0 (explicit graphs): rc=2, host-touching calls=0, message names the vLLM error + fix=True ('CUDA graphs), or supply a verified larger --cudagraph-capture-sizes list in EXTRA_ARGS (caller lists are not validated).')
Generated argv unchanged
  ok   G1 mtp EXTRA_ARGS still ends with the MTP list ('--cudagraph-capture-sizes 1 2 3 4 6 8 12')
  ok   G2 dflash EXTRA_ARGS still ends with the DFlash list ('--cudagraph-capture-sizes 1 2 4 8 16 24 32')
  ok   G3 ENFORCE_EAGER=1 generates no list ('')
  ok   G4 a caller list is passed through untouched ('--cudagraph-capture-sizes 1 2 4 8 16 --foo bar')
  ok   G5 the prologue records the generated list for the guard ('1 2 3 4 6 8 12|16')

mtp capture guard: PASS
rc=0

$ python3 tests/test_numeric_config.py
numeric config tests: PASS
rc=0

$ SPEC_METHOD=mtp MAX_NUM_SEQS=16 ./start.sh restart   (stubbed docker/ssh; the #88 repro)
MAX_NUM_SEQS=16 exceeds the largest CUDA-graph capture size (12) of the launcher's SPEC_METHOD=mtp list (1 2 3 4 6 8 12). On this image's vLLM that boot fails in EngineCore init, after weight load: profile_cudagraph_memory() builds a 12-block throwaway KV config without is_profiling=True and raises 'max_num_seqs (16) exceeds available Mamba cache blocks (12)' - a profiling-path false positive, not a measured KV/scheduler limit (issue #88). Lower MAX_NUM_SEQS to at most 12, set ENFORCE_EAGER=1 (no CUDA graphs), or supply a verified larger --cudagraph-capture-sizes list in EXTRA_ARGS (caller lists are not validated).
rc=2
docker/ssh calls: 0

$ shellcheck -S warning start.sh
rc=0

# other host-runnable suites (unchanged by this PR)
$ python3 tests/test_start_overrides.py -> start.sh caller override regression OK
$ python3 tests/test_bringup_robustness.py -> start.sh bring-up robustness anchors OK
$ python3 tests/test_warm_restart_stdout.py -> warm-restart stdout regression OK
$ python3 tests/test_suppress_stops.py -> test_suppress_stops: ok
$ python3 tests/test_kpool_tail_slotmap.py -> kpool tail slot-map patch OK
$ python3 tests/test_xgrammar_termination.py -> xgrammar speculative patches OK

# need torch/vllm/jinja2 in the image, fail identically on upstream main 493cb88 on this Mac: test_chat_template test_hybrid_prefix_hit test_scheduler_decode_floor test_mixed_prefill_decode test_ablit test_exl3_overlay
```

Closes #88

---
Submitted by nood-co1 on behalf of Blockbrain Labs (https://x.com/blockbrain_labs, GitHub org blockbrain-ai). Measured on our 2× NVIDIA DGX Spark deployment.
