### PR TITLE
Honest KV-capacity boot log for the hybrid model (GLM53_KV_CAPACITY_LOG)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,6 +140,12 @@ GLM53_SUPPRESS_STOPS_IN_REASONING=1
 # When a decode seq is running, do not mix a peer prefill into that step
 # (issue #6). skip = decode-only steps; N>0 = cap mixed prefill tokens; 0 = off.
 GLM53_MIXED_PREFILL_CHUNK=skip
+# Boot-time KV capacity breakdown (overlay patch_kv_capacity_log.py): after
+# vLLM's "GPU KV cache size: N tokens" line (N = max_concurrency x max_model_len,
+# not a pool size) log one line per KV-cache group plus the usable block ids,
+# the ids one aligned cached segment costs across groups and the resulting
+# cached-conversation capacity. 1 = log (default), 0 = off. Log-only; exactly 0 or 1.
+GLM53_KV_CAPACITY_LOG=1
 # EngineCore execute timeout (seconds). Stock 300 is short for a cold JIT.
 # VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -448,6 +448,8 @@ COPY overlay/patch_hybrid_prefix_hit.py /opt/glm53/patch_hybrid_prefix_hit.py
 COPY tests/test_hybrid_prefix_hit.py /opt/glm53/test_hybrid_prefix_hit.py
 COPY overlay/patch_xgrammar_termination.py /opt/glm53/patch_xgrammar_termination.py
 COPY tests/test_xgrammar_termination.py /opt/glm53/test_xgrammar_termination.py
+COPY overlay/patch_kv_capacity_log.py /opt/glm53/patch_kv_capacity_log.py
+COPY tests/test_kv_capacity_log.py /opt/glm53/test_kv_capacity_log.py
 COPY overlay/patch_kpool_tail_slotmap.py /opt/glm53/patch_kpool_tail_slotmap.py
 COPY tests/test_kpool_tail_slotmap.py /opt/glm53/test_kpool_tail_slotmap.py
 COPY overlay/ablit_runtime.py /opt/glm53/ablit_runtime.py
@@ -461,6 +463,12 @@ RUN python3 /opt/glm53/patch_glm5_drafter_group.py
 RUN python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
 RUN python3 /opt/glm53/patch_scheduler_decode_floor.py
 RUN python3 /opt/glm53/patch_hybrid_prefix_hit.py
+# Runs AFTER patch_glm5_drafter_group.py (same file) and BEFORE its own patch:
+# the host test preflights the real kv_cache_utils.py (both anchors present,
+# stock 'GPU KV cache size' line untouched) and replays the derivation against
+# the deployment's synthetic hybrid layout (642 usable ids / 38 ids per segment).
+RUN GLM53_KV_CACHE_UTILS_PY=/usr/local/lib/python3.12/dist-packages/vllm/v1/core/kv_cache_utils.py GLM53_REQUIRE_TARGET=1 python3 /opt/glm53/test_kv_capacity_log.py
+RUN python3 /opt/glm53/patch_kv_capacity_log.py
 RUN python3 /opt/glm53/patch_xgrammar_termination.py
 RUN python3 /opt/glm53/patch_kpool_tail_slotmap.py
 RUN python3 /opt/glm53/patch_ablit.py

--- a/README.md
+++ b/README.md
@@ -531,13 +531,21 @@ from the same config objects, one line per group and one summary — on the 643-
 
 `blocks/request` is the same `cdiv` expression the stock line is built from (its column sum, 414, is the stock
 denominator). "Ids per cached segment" is the dense-retention cost with block-aligned hits — what each manager's
-`reachable_block_mask` hashes with no retention interval: every block for full/MLA attention and mamba (`align`),
-`min(cdiv(window − 1, 64) + 1 (EAGLE), 3584 / 64)` = 33 for the drafter, 0 for the kpool tail (opts out of prefix
-caching). The alignment is the lcm of the group block sizes (the coordinator's scheduler block). The figure is an
-upper bound: a running request holds its own blocks, and PR #83's per-group retention lowers the drafter's cost
-to boundary tails only (not modelled here — the summary states its assumption). Spec kinds the derivation does
-not model are reported as such and the capacity is withheld rather than guessed. The current rightsized boot
-(820 ids) reads `usable block ids: 819 … ≈ 75,264 tokens = 21 segments`.
+`reachable_block_mask` hashes with no retention interval: every block for `FullAttentionSpec` / `MLAAttentionSpec`
+and for `MambaSpec` in `align`/`all` mode (read from the spec the manager acts on),
+`min(cdiv(window − 1, 64) + 1 (EAGLE), 3584 / 64)` = 33 for the drafter (`SlidingWindowSpec` /
+`SlidingWindowMLASpec`), 0 for the kpool tail (opts out of prefix caching). Exact class names only: any other
+spec — subclasses such as `SinkFullAttentionSpec` included, since they come with their own manager rule — is
+reported as unmodelled and the capacity is withheld rather than guessed, as it is under DCP/PCP > 1 (block sizes
+are rescaled per rank there). The alignment is the lcm of the group block sizes (the coordinator's scheduler
+block). The figure is an upper bound: a running request holds its own blocks, and PR #83's per-group retention
+lowers the drafter's cost to boundary tails only (not modelled here — the summary states its assumption).
+
+The numbers move with the boot, the arithmetic does not: the figures elsewhere in this README (690 blocks /
+1,754,237 tokens / 1.75× at 1M) are the same quantity on the reference kit's boot (690 / 1.75 ≈ 394 ids per
+1M-token request under that config); our 2026-08-31 boot had 643 ids at 414 per request, and the current
+rightsized-workspace boot 820 (`usable block ids: 819 … ≈ 75,264 tokens = 21 segments`). Read your own boot's
+summary line rather than any number in this section.
 
 ## Image / overlay
 
@@ -575,7 +583,7 @@ this Dockerfile instead. After CUDA compile, Python overlay edits
 | `overlay/patch_kpool_tail_slotmap.py` | clamp KpoolTail one-block circular slot mapping; identity for other KV groups |
 | `tests/test_kpool_tail_slotmap.py` | circular addressing math, exact kernel patch, idempotence, fail-closed drift, launcher wiring |
 | `overlay/patch_kv_capacity_log.py` | log-only: after the stock `GPU KV cache size` line (kept byte-identical) log per-group `blocks/request` (the stock line's own denominator) and the usable-block-ids / ids-per-aligned-segment / cached-conversation-capacity summary; unmodelled spec kinds withhold the figure; knob `GLM53_KV_CAPACITY_LOG` (0/1); two pinned anchors, preflighted before either is written, atomic, idempotent |
-| `tests/test_kv_capacity_log.py` | host: pure-python replica of the derivation against the deployment's hybrid layout (blocks/request `[280,1,9,9,9,9,97]` = 414, 643 ids → the logged `1,553,140` / `1.55x`, 642 usable, alignment 3584, ids per segment `[1,0,1,1,1,1,33]` = 38, ≈ 57,344 tokens; the 820-id boot → 75,264), single-group / uniform-type / non-EAGLE / unmodelled / null-block edge cases, knob matrix, the exec'd helpers are the shipped text; apply on a vendored fixture of the in-image `kv_cache_utils.py` (and the real file when present): stock line untouched, idempotent, per-anchor drift refuses with nothing written, partial marker refused; launcher 0/1 guard and wiring |
+| `tests/test_kv_capacity_log.py` | host: pure-python replica of the derivation against the deployment's hybrid layout (blocks/request `[280,1,9,9,9,9,97]` = 414, 643 ids → the logged `1,553,140` / `1.55x`, 642 usable, alignment 3584, ids per segment `[1,0,1,1,1,1,33]` = 38, ≈ 57,344 tokens; the 820-id boot → 75,264), single-group / uniform-type / non-EAGLE / subclass-unmodelled / mamba-mode-from-spec / DCP-withheld / null-block edge cases, knob matrix, the exec'd helpers are the shipped text; apply on a vendored fixture of the in-image `kv_cache_utils.py` (and the real file when present): stock line untouched, idempotent, per-anchor drift refuses with nothing written, partial marker refused; launcher 0/1 guard and wiring |
 | `tests/test_launcher_rank_parity.py` | launcher (CPU-only, docker/ssh stubbed): `restart` fails closed on a bad knob or a missing / mis-pointed / broken overlay (every artifact) before anything is stopped, overlay order pinned in one list emitted into both rank scripts (kv-capacity-log after the drafter-group patch it shares a file with), both ranks mount the same host artifacts (head mount = scp source = worker mount) and receive identical `GLM53_KV_CAPACITY_LOG` values |
 | `overlay/ablit_runtime.py` | load-time o_proj transplant / projection (`ABLIT=1`); no-op when off |
 | `overlay/patch_ablit.py` | install the load_weights hook; bind-mounted and run on both ranks |

--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ The Hub `generation_config.json` stamps `temperature=1.0` / `top_p=0.95` unless
 the request overrides. The launcher sets
 `--chat-template /opt/glm53/chat_template.jinja` (checkpoint jinja is language-only).
 
-Needs: Docker (no sudo) on both nodes, passwordless SSH head → worker,
+Needs: Docker (no sudo) on both nodes, python3 on the head (verifies the overlay artifacts before `restart` stops anything), passwordless SSH head → worker,
 `hf` / `huggingface-cli` + `curl` + `rsync` on the head, ~180 GiB free per
 node for the first download. The GHCR image is public; login is only needed
 if you hit anonymous pull rate limits (`GHCR_TOKEN` + `GHCR_USER`).
@@ -488,6 +488,7 @@ that are now documented/enforced:
 | `MAX_NUM_SEQS` | `4` | decode batch; MTP adds k+1 tokens/seq |
 | `MAX_NUM_BATCHED_TOKENS` | `2048` | prefill chunk (P1 keep). 3584/4096 lost; 8192 oversubscribes GB10 indexer topk |
 | `GLM53_MIXED_PREFILL_CHUNK` | `skip` | do not mix a peer prefill into a decode step (issue #6). `N>0` = cap tokens; `0` = off. Solo prefill stays MNBT (2048) |
+| `GLM53_KV_CAPACITY_LOG` | `1` | after vLLM's `GPU KV cache size: N tokens` boot line (N = max_concurrency × max_model_len, **not** a pool size) log one line per KV-cache group and a summary with the usable block ids, the ids one aligned cached segment costs across groups and the resulting cached-conversation capacity (overlay `patch_kv_capacity_log.py`; see [What the KV cache boot line means](#what-the-kv-cache-boot-line-means)). `0` = off (one line saying so). Log-only, no serving change either way. Exactly `0` or `1`; the launcher refuses anything else before `restart` stops the pair |
 | `GLM53_SUPPRESS_STOPS_IN_REASONING` | `1` | ignore client `stop` strings until `</think>` (thinking-on default) |
 | `GLM53_BOOT_SHAPE_WARMUP` | `1` | after `/health`, burn DFlash2 BLOCK / sampler / kpool shapes (nonfatal) |
 | `TRITON_HOST_CACHE` / `TILELANG_HOST_CACHE` | `$CACHE_ROOT/triton` / `tilelang` | persist JIT caches across container recreate |
@@ -497,6 +498,46 @@ that are now documented/enforced:
 | `HEAD_CX7_IF` / `WORKER_CX7_IF` | `enp1s0f1np1` / `enp1s0f0np0` | NCCL sockets |
 | `HEAD_CX7_IB` / `WORKER_CX7_IB` | `rocep1s0f1` / `rocep1s0f0` | NCCL HCAs |
 | `USE_HOST_NCCL` | `0` | image nvidia-nccl; host preload duplicates DeepEP |
+
+## What the KV cache boot line means
+
+vLLM logs once per boot (`v1/core/kv_cache_utils.py`, `update_kv_cache_capacity`):
+
+```
+GPU KV cache size: 1,553,140 tokens, Maximum concurrency for 1,000,000 tokens per request: 1.55x
+```
+
+The first number is `int(max_concurrency × max_model_len)`, with `max_concurrency = num_blocks /
+num_blocks_per_request` and `num_blocks_per_request` a **sum over KV-cache groups** of
+`cdiv(spec.max_memory_usage_bytes, spec.page_size_bytes)`. It is a concurrency figure in token units, not the
+size of a prefix cache. On this hybrid model (MLA + kpool tail + 4 mamba + DFlash2 drafter SWA, one shared
+`BlockPool` with globally unique block ids) the pool behind that line was **643 block ids** (642 usable; id 0 is
+the null block) and one cached 3584-token segment costs **38** of them (1 MLA + 4 mamba + 33 drafter), so
+about **57K tokens** of cached conversation fit with nothing running — not 1.5M. Neither `num_blocks` nor
+`num_blocks_per_request` is logged by stock vLLM (feature request
+[vllm-project/vllm#54662](https://github.com/vllm-project/vllm/issues/54662)).
+
+Overlay `patch_kv_capacity_log.py` (`GLM53_KV_CAPACITY_LOG=1`, default) keeps that line byte-identical and adds,
+from the same config objects, one line per group and one summary — on the 643-id boot:
+
+```
+[glm53-kv-capacity-log] group 0: MLAAttentionSpec layers=11 block_size=3584 page_size=… B blocks/request@1,000,000=280 prefix_caching=yes
+[glm53-kv-capacity-log] group 1: KpoolTailSpec layers=11 block_size=4 page_size=… B blocks/request@1,000,000=1 prefix_caching=no (scratch) window=4 eagle=no
+[glm53-kv-capacity-log] group 2: MambaSpec layers=9 block_size=3584 page_size=… B blocks/request@1,000,000=9 prefix_caching=yes mamba_cache_mode=align
+… groups 3-5 identical to group 2 …
+[glm53-kv-capacity-log] group 6: SlidingWindowSpec layers=1 block_size=64 page_size=… B blocks/request@1,000,000=97 prefix_caching=yes window=2048 eagle=yes
+[glm53-kv-capacity-log] usable block ids: 642 (num_blocks=643 incl. the null block; 414 ids per 1,000,000-token request => 1.55x); ids per 3584-token cached segment across groups: 38 (per group: [1, 0, 1, 1, 1, 1, 33]); cached-conversation capacity at this alignment ≈ 57,344 tokens = 16 segments (aligned dense-retention prefix-cache upper bound: nothing running, every reachable block hashed, block-aligned hits). The 'GPU KV cache size' line above is max_concurrency x max_model_len, not this figure.
+```
+
+`blocks/request` is the same `cdiv` expression the stock line is built from (its column sum, 414, is the stock
+denominator). "Ids per cached segment" is the dense-retention cost with block-aligned hits — what each manager's
+`reachable_block_mask` hashes with no retention interval: every block for full/MLA attention and mamba (`align`),
+`min(cdiv(window − 1, 64) + 1 (EAGLE), 3584 / 64)` = 33 for the drafter, 0 for the kpool tail (opts out of prefix
+caching). The alignment is the lcm of the group block sizes (the coordinator's scheduler block). The figure is an
+upper bound: a running request holds its own blocks, and PR #83's per-group retention lowers the drafter's cost
+to boundary tails only (not modelled here — the summary states its assumption). Spec kinds the derivation does
+not model are reported as such and the capacity is withheld rather than guessed. The current rightsized boot
+(820 ids) reads `usable block ids: 819 … ≈ 75,264 tokens = 21 segments`.
 
 ## Image / overlay
 
@@ -533,6 +574,9 @@ this Dockerfile instead. After CUDA compile, Python overlay edits
 | `tests/test_xgrammar_termination.py` | exact two-file patch, idempotence, cross-file fail-closed drift, termination/rollback/reset and post-reasoning draft behavior, launcher wiring |
 | `overlay/patch_kpool_tail_slotmap.py` | clamp KpoolTail one-block circular slot mapping; identity for other KV groups |
 | `tests/test_kpool_tail_slotmap.py` | circular addressing math, exact kernel patch, idempotence, fail-closed drift, launcher wiring |
+| `overlay/patch_kv_capacity_log.py` | log-only: after the stock `GPU KV cache size` line (kept byte-identical) log per-group `blocks/request` (the stock line's own denominator) and the usable-block-ids / ids-per-aligned-segment / cached-conversation-capacity summary; unmodelled spec kinds withhold the figure; knob `GLM53_KV_CAPACITY_LOG` (0/1); two pinned anchors, preflighted before either is written, atomic, idempotent |
+| `tests/test_kv_capacity_log.py` | host: pure-python replica of the derivation against the deployment's hybrid layout (blocks/request `[280,1,9,9,9,9,97]` = 414, 643 ids → the logged `1,553,140` / `1.55x`, 642 usable, alignment 3584, ids per segment `[1,0,1,1,1,1,33]` = 38, ≈ 57,344 tokens; the 820-id boot → 75,264), single-group / uniform-type / non-EAGLE / unmodelled / null-block edge cases, knob matrix, the exec'd helpers are the shipped text; apply on a vendored fixture of the in-image `kv_cache_utils.py` (and the real file when present): stock line untouched, idempotent, per-anchor drift refuses with nothing written, partial marker refused; launcher 0/1 guard and wiring |
+| `tests/test_launcher_rank_parity.py` | launcher (CPU-only, docker/ssh stubbed): `restart` fails closed on a bad knob or a missing / mis-pointed / broken overlay (every artifact) before anything is stopped, overlay order pinned in one list emitted into both rank scripts (kv-capacity-log after the drafter-group patch it shares a file with), both ranks mount the same host artifacts (head mount = scp source = worker mount) and receive identical `GLM53_KV_CAPACITY_LOG` values |
 | `overlay/ablit_runtime.py` | load-time o_proj transplant / projection (`ABLIT=1`); no-op when off |
 | `overlay/patch_ablit.py` | install the load_weights hook; bind-mounted and run on both ranks |
 | `ablit/` | direction vectors + `LAYER_MAP.json` from drowzeys' published recipe; `fetch_transplant.py` + `transplant/` for the donor o_proj byte-copy |

--- a/docs/DESIGN-kv-capacity-log.md
+++ b/docs/DESIGN-kv-capacity-log.md
@@ -1,0 +1,120 @@
+# DESIGN — honest KV-capacity boot log (`patch_kv_capacity_log.py`)
+
+Overlay: `overlay/patch_kv_capacity_log.py`. Test: `tests/test_kv_capacity_log.py`. Knob: `GLM53_KV_CAPACITY_LOG`.
+`file:line` references are to the live fork inside `glm53-exl3-head` (vLLM `0.1.dev20051+g487ecf187`,
+`/usr/local/lib/python3.12/dist-packages/vllm/`), read read-only on 2026-09-01. `U:` = `v1/core/kv_cache_utils.py`,
+`I:` = `v1/kv_cache_interface.py`, `S:` = `v1/core/single_type_kv_cache_manager.py`, `C:` = `v1/core/kv_cache_coordinator.py`,
+`B:` = `v1/core/block_pool.py`. Upstream feature request: [vllm-project/vllm#54662](https://github.com/vllm-project/vllm/issues/54662).
+
+## 1. Problem
+
+`update_kv_cache_capacity` (`U:2289-2303`, called once from `v1/engine/core.py:334` with the scheduler's
+`KVCacheConfig`) logs:
+
+```
+GPU KV cache size: 1,553,140 tokens, Maximum concurrency for 1,000,000 tokens per request: 1.55x
+```
+
+`num_tokens = int(max_concurrency * max_model_len)` (`U:2276-2286`) with
+`max_concurrency = num_blocks / num_blocks_per_request` and
+
+```python
+num_blocks_per_request = sum(                      # U:948-954
+    cdiv(group.kv_cache_spec.max_memory_usage_bytes(vllm_config),
+         group.kv_cache_spec.page_size_bytes)
+    for group in kv_cache_config.kv_cache_groups)
+```
+
+For one group that is the pool's token capacity up to rounding. For this model it is a *sum over seven groups*
+drawing ids from **one** `BlockPool`, so the figure is "how many 1M-token requests fit" in token units. Neither
+`num_blocks` nor `num_blocks_per_request` is logged; `max_concurrency` is printed at `%.2f`. From the line alone a
+reader can pin the ratio to an interval and nothing more (the runbook recovered 643/414 by hand from the physical
+bound). Two independent reviews read the line as a ~1.5M-token prefix cache before the arithmetic was redone; the
+coexisting-conversation capacity was ~50–100K.
+
+## 2. Deployment arithmetic (the numbers the test pins)
+
+Group layout at boot (`C:1331` log line, plus the kpool tail group the coordinator lists separately):
+
+| gid | spec (`I:`) | block | `max_memory_usage_bytes` | blocks / 1M-token request |
+|---|---|---:|---|---:|
+| 0 | `MLAAttentionSpec` (`I:295-300`) | 3584 | `cdiv(L, bs) * page` | 280 |
+| 1 | `KpoolTailSpec` (`I:760-766`, opts out `I:779-786`) | 4 | `1 * page` | 1 |
+| 2–5 | `MambaSpec`, `mamba_cache_mode=align` (`I:818-819`) | 3584 | `(2 + num_speculative_blocks) * page`, `num_speculative_blocks = num_speculative_tokens = 7` (`layers/mamba/abstract.py:74`) | 9 each = 36 |
+| 6 | `SlidingWindowSpec` drafter, window 2048 (`I:616-647`) | 64 | `(cdiv(min(2047 + max_in_flight_tokens, L), 64) + 1) * page`, `max_in_flight_tokens = max_concurrent_batches(2, async) * 2048 = 4096` (`config/vllm.py:565-586`) | 97 |
+| | | | **sum** | **414** |
+
+`643 / 414 = 1.553140…` → `1,553,140 tokens`, `1.55x` — the logged line, reproduced. The current rightsized boot:
+`820 / 414 = 1.98x`, `1,980,676 tokens` (boot log 2026-09-01 01:09:54).
+
+`BlockPool.__init__` pops one block as the permanent null block (`B:188-191`), so **usable ids = num_blocks − 1**
+= 642 (819). `num_gpu_blocks_override` sets the actual pool size, so the same subtraction applies there.
+
+Ids one cached 3584-token segment costs, dense retention (what each manager's `reachable_block_mask` hashes with
+no retention interval, hits ending on scheduler-block boundaries):
+
+| gid | rule | ids |
+|---|---|---:|
+| 0 | `FullAttentionManager` keeps the base mask (`None` = every block, `S:482-500`) → `3584 / 3584` | 1 |
+| 1 | opted out; `KpoolTailManager.cache_blocks` is a hard return | 0 |
+| 2–5 | `MambaManager.reachable_block_mask`, `retention_interval is None` → dense (`S:1509-1511`) → one state per block position | 1 each = 4 |
+| 6 | `need = _contiguous_blocks_for_hit(2048, 64, use_eagle=True) = cdiv(2047, 64) + 1 = 33` (`S:886-895`); `per_segment = 3584 / 64 = 56`; mask hashes `min(need, per_segment)` blocks per segment (`S:1032-1046`) | 33 |
+| | **total** | **38** |
+
+Capacity at this alignment = `642 // 38 * 3584 = 16 segments = 57,344 tokens` (819 → 21 segments = 75,264).
+The design train measured the knee at 14 segments OK / 17 fail with a running request holding its own blocks
+(`research-2026-08-31/DESIGN-drafter-retention.md` §4), consistent with a 16-segment idle bound.
+
+## 3. What the overlay logs, and from where
+
+Two sites in `kv_cache_utils.py`, both preflighted before either is written (`prepare()`), atomic replace,
+idempotent, one `MARK` per site, `verified_state` exact post-state, drift ⇒ non-zero exit:
+
+1. helpers inserted above `def get_max_concurrency_for_kv_cache_config(` (signature line is identical in-image and
+   on upstream `22df3a3`; `patch_glm5_drafter_group.py` edits this file elsewhere and must run first);
+2. one call appended after the stock `logger.info_once("GPU KV cache size: …")` block, which stays byte-identical
+   (the test asserts the whole of `update_kv_cache_capacity` up to and including that block is unchanged and that
+   `kv_cache_size_tokens` / `kv_cache_max_concurrency` are stored exactly as stock).
+
+Per group: `index, spec type (UniformTypeKVCacheSpecs unwrapped), layers, block_size, page_size_bytes,
+blocks/request@max_model_len, prefix_caching (fork participates_in_prefix_caching → upstream prefix_cacheable →
+True), window + eagle for sliding-window kinds, mamba_cache_mode for mamba`. `blocks/request` is the same
+`cdiv` expression as `U:948-954`; its column sum is the stock denominator.
+
+Summary: `usable block ids: X (num_blocks=N incl. the null block; D ids per L-token request => R x); ids per
+A-token cached segment across groups: Y (per group: […]); cached-conversation capacity at this alignment ≈ Z
+tokens = S segments (aligned dense-retention prefix-cache upper bound: nothing running, every reachable block
+hashed, block-aligned hits). The 'GPU KV cache size' line above is max_concurrency x max_model_len, not this
+figure.` with `A = lcm(block sizes of all groups)` — what the coordinator asserts its scheduler block size to be
+(`C:621-626`).
+
+Per-spec policy (`_glm53_ids_per_segment`), by class name in the MRO so subclasses inherit their base's rule:
+opted-out → 0; `MambaSpec` in `align`/`all` → `A / bs`; `SlidingWindowSpec` family → `min(cdiv(window − 1, bs) +
+eagle, A / bs)`; `FullAttentionSpec` family → `A / bs`; `ChunkedLocalAttentionSpec`, `CrossAttentionSpec`,
+`EncoderOnlyAttentionSpec`, mamba mode `none`, a window-less sliding-window spec, an unknown kind → **unmodelled**:
+the summary names the group and withholds the capacity figure instead of guessing.
+
+EAGLE detection mirrors `C:637-651` with `patch_hybrid_prefix_hit.py` applied: `group.is_eagle_group` when any
+group carries it; else, when `speculative_config.use_eagle()`, the groups whose unwrapped spec is an exact
+`SlidingWindowSpec` (`_glm53_is_draft_swa_spec`); else every group (the upstream fallback).
+
+## 4. Failure modes and the knob
+
+`GLM53_KV_CAPACITY_LOG`: unset or `1` → log; `0` → one line `[glm53-kv-capacity-log] disabled
+(GLM53_KV_CAPACITY_LOG=0)`; anything else → `ValueError` at the log site (outside the derivation's `try`: a typo'd
+knob must not silently pick a mode). The launcher rejects the same set first (`_glm53_validate_bool_flag`,
+inside the numeric guard, before `restart` stops anything), so the container only ever sees `0`/`1`.
+Any exception inside the derivation → one `warning_once` naming it (`… could not derive the block-level KV capacity
+(log-only; serving unaffected): <Type>: <msg>`), no info lines, boot proceeds. All log arguments are preformatted
+strings (`info_once` caches on its arguments and needs them hashable).
+
+## 5. Scope
+
+Log-only: no control flow, allocation or config mutation; runs once per engine boot. Not modelled, on purpose:
+- per-group retention (#83, `VLLM_PREFIX_CACHE_RETENTION_INTERVAL[_SWA]`) lowers the drafter's cost to boundary
+  tails only; fine-grained hits (#84) let a hit end on a 64-token boundary. Both are resolved later, in the
+  coordinator, from env and manager capabilities; the summary states the policy it assumes (dense, block-aligned).
+- a running request's own blocks (the figure is an idle upper bound; `414` ids per 1M-token request is the
+  per-request peak, a different quantity).
+- per-step accounting / gauges (the research train's Part B, do-not-build).
+- KV connectors / CPU offload (none on this kit).

--- a/docs/DESIGN-kv-capacity-log.md
+++ b/docs/DESIGN-kv-capacity-log.md
@@ -88,11 +88,17 @@ hashed, block-aligned hits). The 'GPU KV cache size' line above is max_concurren
 figure.` with `A = lcm(block sizes of all groups)` — what the coordinator asserts its scheduler block size to be
 (`C:621-626`).
 
-Per-spec policy (`_glm53_ids_per_segment`), by class name in the MRO so subclasses inherit their base's rule:
-opted-out → 0; `MambaSpec` in `align`/`all` → `A / bs`; `SlidingWindowSpec` family → `min(cdiv(window − 1, bs) +
-eagle, A / bs)`; `FullAttentionSpec` family → `A / bs`; `ChunkedLocalAttentionSpec`, `CrossAttentionSpec`,
-`EncoderOnlyAttentionSpec`, mamba mode `none`, a window-less sliding-window spec, an unknown kind → **unmodelled**:
-the summary names the group and withholds the capacity figure instead of guessing.
+Per-spec policy (`_glm53_ids_per_segment`), by **exact** class name of the unwrapped spec — a subclass may come
+with its own manager and reservation rule (`SinkFullAttentionSpec` keeps permanent sink blocks, `KpoolTailSpec` is
+scratch, `TQFullAttentionSpec` / `RSWASpec` / `HiddenStateCacheSpec` carry other semantics), so nothing is costed
+by its base class: opted-out → 0; `MambaSpec` in `align`/`all` → `A / bs`, the mode read from the spec the manager
+acts on (`I:795`; a uniform group whose members disagree is "mixed"); `SlidingWindowSpec` / `SlidingWindowMLASpec`
+→ `min(cdiv(window − 1, bs) + eagle, A / bs)`; `FullAttentionSpec` / `MLAAttentionSpec` → `A / bs`; everything
+else (chunked-local, cross/encoder, sink, mamba mode `none`/mixed, a window-less SWA spec, unknown kinds) →
+**unmodelled**: the summary names the group and withholds the capacity figure. The figure is also withheld
+under `decode_context_parallel_size > 1` or `prefill_context_parallel_size > 1`, where the resolver rescales
+block sizes per rank and the raw lcm is no longer the scheduler alignment (not this kit: both are 1, and the
+SWA spec asserts DCP == 1).
 
 EAGLE detection mirrors `C:637-651` with `patch_hybrid_prefix_hit.py` applied: `group.is_eagle_group` when any
 group carries it; else, when `speculative_config.use_eagle()`, the groups whose unwrapped spec is an exact

--- a/overlay/patch_kv_capacity_log.py
+++ b/overlay/patch_kv_capacity_log.py
@@ -52,11 +52,13 @@ What the summary models (and what it does not)
 i.e. what the managers' ``reachable_block_mask`` hashes when no retention
 interval is set and hits end on scheduler-block boundaries:
 
-* ``FullAttentionSpec`` family (incl. MLA): every block is hashed ->
-  ``alignment / block_size`` ids (1 here);
-* ``MambaSpec`` in ``align`` / ``all`` cache mode: one state per block ->
-  ``alignment / block_size`` ids per group (1 each here);
-* ``SlidingWindowSpec`` family: ``min(need, alignment / block_size)`` with
+* exactly ``FullAttentionSpec`` / ``MLAAttentionSpec``: every block is hashed
+  -> ``alignment / block_size`` ids (1 here);
+* exactly ``MambaSpec`` in ``align`` / ``all`` cache mode (read from the spec
+  the manager acts on): one state per block -> ``alignment / block_size`` ids
+  per group (1 each here);
+* exactly ``SlidingWindowSpec`` / ``SlidingWindowMLASpec``:
+  ``min(need, alignment / block_size)`` with
   ``need = cdiv(window - 1, block_size) + (1 if EAGLE group)`` -- the
   contiguous run a hit needs (``SlidingWindowManager._contiguous_blocks_for_hit``;
   33 of 56 here);
@@ -64,9 +66,12 @@ interval is set and hits end on scheduler-block boundaries:
   per request, never a cached one.
 
 Alignment is the lcm of every group's block size, which is what the
-coordinator asserts its scheduler block size to be (3584 here). Anything else
-(chunked-local, cross/encoder attention, mamba cache mode ``none``, a block
-size that does not divide the alignment) is reported as UNMODELLED and the
+coordinator asserts its scheduler block size to be (3584 here) when no
+context parallelism rescales block sizes; under DCP/PCP > 1 the figure is
+withheld. Any other spec class -- subclasses included, because a subclass
+may come with its own manager and reservation rule (``SinkFullAttentionSpec``
+keeps permanent sink blocks; ``KpoolTailSpec`` is scratch) -- and mamba cache
+mode ``none`` / a mixed uniform group are reported as UNMODELLED and the
 capacity figure is withheld rather than guessed. Not modelled on purpose: the
 per-group retention overlay (#83) makes the drafter cost boundary tails only,
 and fine-grained hits (#84) change where a segment may end; both are decided
@@ -198,7 +203,6 @@ def _glm53_kv_capacity_rows(vllm_config, kv_cache_config) -> list:
     this column IS that function's denominator.
     """
     eagle = _glm53_eagle_group_ids(vllm_config, kv_cache_config)
-    mamba_mode = getattr(getattr(vllm_config, "cache_config", None), "mamba_cache_mode", None)
     rows = []
     for index, group in enumerate(kv_cache_config.kv_cache_groups):
         spec = group.kv_cache_spec
@@ -224,9 +228,23 @@ def _glm53_kv_capacity_rows(vllm_config, kv_cache_config) -> list:
             window = getattr(inner, "sliding_window", None)
             row["sliding_window"] = int(window) if window is not None else None
         if "MambaSpec" in kinds:
-            row["mamba_cache_mode"] = mamba_mode
+            row["mamba_cache_mode"] = _glm53_mamba_cache_mode(spec)
         rows.append(row)
     return rows
+
+
+def _glm53_mamba_cache_mode(spec):
+    """The mode the managers act on: each resolved MambaSpec's own field
+    (set from cache_config at spec creation, but the spec is what the manager
+    reads). A uniform group whose members disagree is reported as "mixed" and
+    left unmodelled.
+    """
+    members = getattr(spec, "kv_cache_specs", None)
+    specs = list(members.values()) if isinstance(members, dict) and members else [spec]
+    modes = {getattr(s, "mamba_cache_mode", None) for s in specs}
+    if len(modes) != 1:
+        return "mixed"
+    return modes.pop()
 
 
 def _glm53_ids_per_segment(row: dict, alignment: int):
@@ -241,15 +259,16 @@ def _glm53_ids_per_segment(row: dict, alignment: int):
     if block_size <= 0 or alignment % block_size:
         return None
     per_segment = alignment // block_size
-    kinds = row["kinds"]
-    if "MambaSpec" in kinds:
+    # EXACT class names only. A subclass may come with its own manager and its
+    # own reservation rule (SinkFullAttentionSpec keeps permanent sink blocks,
+    # KpoolTailSpec is a scratch buffer, TQ/RSWA/HiddenState carry other
+    # semantics), so anything not listed is unmodelled, never costed by its
+    # base class.
+    kind = row["spec"]
+    if kind == "MambaSpec":
         # align: one state snapshot per block position; all: every block.
         return per_segment if row["mamba_cache_mode"] in ("align", "all") else None
-    if "ChunkedLocalAttentionSpec" in kinds:
-        return None
-    if "CrossAttentionSpec" in kinds or "EncoderOnlyAttentionSpec" in kinds:
-        return None
-    if "SlidingWindowSpec" in kinds:
+    if kind in ("SlidingWindowSpec", "SlidingWindowMLASpec"):
         window = row["sliding_window"]
         if not window:
             return None
@@ -258,26 +277,39 @@ def _glm53_ids_per_segment(row: dict, alignment: int):
         # caches every block once need >= per_segment.
         need = cdiv(window - 1, block_size) + (1 if row["eagle"] else 0)
         return min(need, per_segment)
-    if "FullAttentionSpec" in kinds:
+    if kind in ("FullAttentionSpec", "MLAAttentionSpec"):
         # FullAttentionManager keeps the base reachable_block_mask (None):
         # every block is hashed.
         return per_segment
     return None
 
 
-def _glm53_kv_capacity_summary(rows: list, num_blocks: int) -> dict:
+def _glm53_context_parallel_sizes(vllm_config) -> tuple:
+    pc = getattr(vllm_config, "parallel_config", None)
+    dcp = int(getattr(pc, "decode_context_parallel_size", 1) or 1)
+    pcp = int(getattr(pc, "prefill_context_parallel_size", 1) or 1)
+    return dcp, pcp
+
+
+def _glm53_kv_capacity_summary(rows: list, num_blocks: int, vllm_config=None) -> dict:
     num_blocks = int(num_blocks)
     usable = max(num_blocks - 1, 0)  # block id 0 is BlockPool's null block
     blocks_per_request = sum(int(r["blocks_per_request"]) for r in rows)
+    # lcm of the raw group block sizes == the coordinator's scheduler block
+    # size when no context parallelism scales the per-rank block sizes.
     alignment = 1
     for r in rows:
         alignment = math.lcm(alignment, max(int(r["block_size"]), 1))
     per_group = [_glm53_ids_per_segment(r, alignment) for r in rows]
     unmodelled = [r["index"] for r, v in zip(rows, per_group) if v is None]
+    withheld = None
+    dcp, pcp = _glm53_context_parallel_sizes(vllm_config) if vllm_config is not None else (1, 1)
+    if dcp > 1 or pcp > 1:
+        withheld = f"context parallelism (dcp={dcp}, pcp={pcp}) rescales block sizes; alignment not derived here"
     total = sum(v for v in per_group if v)
     capacity = None
     segments = None
-    if rows and not unmodelled and total > 0:
+    if rows and not unmodelled and withheld is None and total > 0:
         segments = usable // total
         capacity = segments * alignment
     return {
@@ -287,6 +319,7 @@ def _glm53_kv_capacity_summary(rows: list, num_blocks: int) -> dict:
         "alignment": alignment,
         "per_group": per_group,
         "unmodelled": unmodelled,
+        "withheld": withheld,
         "total": total,
         "segments": segments,
         "capacity_tokens": capacity,
@@ -322,6 +355,8 @@ def _glm53_kv_capacity_lines(rows: list, summary: dict, max_model_len: int) -> l
             why = "unmodelled: " + ", ".join(
                 f"group {r['index']} {r['spec']}" for r in rows if r["index"] in summary["unmodelled"]
             )
+        elif summary.get("withheld"):
+            why = summary["withheld"]
         else:
             why = "no prefix-cacheable group costs ids"
         lines.append(
@@ -351,7 +386,7 @@ def _glm53_log_kv_capacity(vllm_config, kv_cache_config, max_model_len) -> None:
         return
     try:
         rows = _glm53_kv_capacity_rows(vllm_config, kv_cache_config)
-        summary = _glm53_kv_capacity_summary(rows, kv_cache_config.num_blocks)
+        summary = _glm53_kv_capacity_summary(rows, kv_cache_config.num_blocks, vllm_config)
         lines = _glm53_kv_capacity_lines(rows, summary, max_model_len)
     except Exception as exc:  # diagnostic only: never take the server down
         logger.warning_once(

--- a/overlay/patch_kv_capacity_log.py
+++ b/overlay/patch_kv_capacity_log.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+"""Honest KV-capacity boot log for the hybrid model (log-only overlay).
+
+The problem
+-----------
+``update_kv_cache_capacity`` (``v1/core/kv_cache_utils.py``) logs, once per
+boot::
+
+    GPU KV cache size: 1,553,140 tokens, Maximum concurrency for 1,000,000 tokens per request: 1.55x
+
+The first number is ``int(max_concurrency * max_model_len)`` where
+``max_concurrency = num_blocks / num_blocks_per_request`` and
+``num_blocks_per_request`` is a SUM OVER KV-CACHE GROUPS of
+``cdiv(spec.max_memory_usage_bytes(cfg), spec.page_size_bytes)``
+(``get_max_concurrency_for_kv_cache_config``). For a single-group model that
+is the pool's token capacity up to rounding, which is what the label suggests.
+For this hybrid model (MLA + kpool tail + 4 mamba + DFlash2 drafter SWA, one
+shared BlockPool with globally unique block ids) it is a concurrency figure in
+token units: neither ``num_blocks`` nor ``num_blocks_per_request`` is logged,
+``max_concurrency`` is printed to two decimals, and only their ratio can be
+recovered. On this kit the line read 1.5M tokens while the pool was 643 block
+ids (642 usable) and one cached 3584-token segment cost 38 of them
+(1 MLA + 4 mamba + 33 drafter) -- about 57K tokens of cached conversation with
+nothing running. Two reviewers independently read the line as a 1.5M-token
+prefix cache. Upstream feature request: vllm-project/vllm#54662.
+
+What this overlay does
+----------------------
+Immediately after the existing line (kept byte-identical) it logs, from the
+SAME config objects the existing line is computed from:
+
+* one line per KV-cache group: index, spec type, block_size, page size, blocks
+  per ``max_model_len`` request (the same ``cdiv`` expression as
+  ``get_max_concurrency_for_kv_cache_config``, so the two cannot drift), and
+  whether the group takes part in prefix caching;
+* one summary line: usable block ids (``num_blocks - 1``: ``BlockPool``
+  permanently holds back block id 0 as the null block), the ids one aligned
+  cached segment costs across groups (per group), and the resulting
+  cached-conversation capacity at that alignment.
+
+Log-only. No control flow, no allocation, no config mutation, runs once in the
+engine core at boot. Knob ``GLM53_KV_CAPACITY_LOG``: unset or ``1`` = log,
+``0`` = one line saying it is disabled, anything else = ``ValueError`` (a
+typo'd knob must not silently pick a mode; the launcher rejects it first).
+Any failure inside the derivation itself is a ``warning_once`` naming the
+exception, and boot proceeds: the feature is diagnostic and must never take
+the server down.
+
+What the summary models (and what it does not)
+----------------------------------------------
+"Ids per cached segment" is the DENSE-retention cost with block-aligned hits,
+i.e. what the managers' ``reachable_block_mask`` hashes when no retention
+interval is set and hits end on scheduler-block boundaries:
+
+* ``FullAttentionSpec`` family (incl. MLA): every block is hashed ->
+  ``alignment / block_size`` ids (1 here);
+* ``MambaSpec`` in ``align`` / ``all`` cache mode: one state per block ->
+  ``alignment / block_size`` ids per group (1 each here);
+* ``SlidingWindowSpec`` family: ``min(need, alignment / block_size)`` with
+  ``need = cdiv(window - 1, block_size) + (1 if EAGLE group)`` -- the
+  contiguous run a hit needs (``SlidingWindowManager._contiguous_blocks_for_hit``;
+  33 of 56 here);
+* groups that opt out of prefix caching (``KpoolTailSpec``): 0 -- a live block
+  per request, never a cached one.
+
+Alignment is the lcm of every group's block size, which is what the
+coordinator asserts its scheduler block size to be (3584 here). Anything else
+(chunked-local, cross/encoder attention, mamba cache mode ``none``, a block
+size that does not divide the alignment) is reported as UNMODELLED and the
+capacity figure is withheld rather than guessed. Not modelled on purpose: the
+per-group retention overlay (#83) makes the drafter cost boundary tails only,
+and fine-grained hits (#84) change where a segment may end; both are decided
+later, in the coordinator, and the summary says which policy it assumes.
+
+EAGLE detection mirrors the coordinator exactly: ``group.is_eagle_group`` when
+any group carries it, else -- when ``speculative_config.use_eagle()`` -- the
+groups whose unwrapped spec is an exact ``SlidingWindowSpec``
+(``patch_hybrid_prefix_hit.py``'s ``_glm53_is_draft_swa_spec``), else every
+group (the upstream fallback).
+
+Conventions follow ``overlay/patch_indexer_workspace.py`` /
+``patch_kpool_tail_slotmap.py``: pinned ANCHOR, MARK sentinel,
+``verified_state``, ``prepare``, idempotent, atomic replace, pyc clear, drift
+=> nonzero exit. Both sites are preflighted before either is written. Must be
+applied AFTER ``patch_glm5_drafter_group.py`` (same file); it has no anchors
+in common with any other overlay.
+
+Usage::
+
+    python3 patch_kv_capacity_log.py              # apply
+    python3 patch_kv_capacity_log.py --preflight  # validate anchors only
+"""
+from __future__ import annotations
+
+import math
+import os
+import stat
+import sys
+from pathlib import Path
+
+
+TARGET = Path(
+    os.environ.get(
+        "GLM53_KV_CACHE_UTILS_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/kv_cache_utils.py",
+    )
+)
+
+ENV_NAME = "GLM53_KV_CAPACITY_LOG"
+TAG = "[glm53-kv-capacity-log]"
+
+
+# ---------------------------------------------------------------------------
+# The injected helpers, as source.
+#
+# This string is BOTH what gets written into kv_cache_utils.py AND what the
+# host tests exercise: it is exec'd below to produce module-level callables.
+# One implementation of the derivation, so a test can never pass against a
+# replica that has drifted from the shipped code. Inside kv_cache_utils.py the
+# names it relies on (``cdiv``, ``math``, ``os``, ``logger``) are all bound
+# above the insert point; ``prepare`` checks that.
+# ---------------------------------------------------------------------------
+HELPERS_SRC = '''# [glm53-kv-capacity-log] helpers -- log-only; see overlay/patch_kv_capacity_log.py
+_GLM53_KV_CAPACITY_ENV = "GLM53_KV_CAPACITY_LOG"
+_GLM53_KV_CAPACITY_TAG = "[glm53-kv-capacity-log]"
+
+
+def _glm53_kv_capacity_log_enabled() -> bool:
+    """Exactly "0" or "1"; an UNSET var means "1" (log).
+
+    Same contract as the launcher's ``_glm53_validate_bool_flag``: no strip,
+    no lower, "" is a value and not an absence. A typo'd knob raises rather
+    than silently choosing.
+    """
+    raw = os.environ.get(_GLM53_KV_CAPACITY_ENV)
+    if raw is None or raw == "1":
+        return True
+    if raw == "0":
+        return False
+    raise ValueError(
+        f"{_GLM53_KV_CAPACITY_ENV} must be exactly 0 or 1 (got: {raw!r})"
+    )
+
+
+def _glm53_inner_kv_spec(spec):
+    """Unwrap a UniformTypeKVCacheSpecs so the group's real spec class is named."""
+    specs = getattr(spec, "kv_cache_specs", None)
+    if isinstance(specs, dict) and specs:
+        return next(iter(specs.values()))
+    return spec
+
+
+def _glm53_spec_kind_names(spec) -> tuple:
+    return tuple(c.__name__ for c in type(spec).__mro__)
+
+
+def _glm53_spec_prefix_cacheable(spec) -> bool:
+    """Fork flag first, then upstream's, else True (legacy specs cache)."""
+    for name in ("participates_in_prefix_caching", "prefix_cacheable"):
+        value = getattr(spec, name, None)
+        if callable(value):
+            value = value()
+        if isinstance(value, bool):
+            return value
+    return True
+
+
+def _glm53_eagle_group_ids(vllm_config, kv_cache_config) -> set:
+    """Mirror of KVCacheCoordinator.__init__ (with patch_hybrid_prefix_hit.py).
+
+    ``is_eagle_group`` is authoritative when any group carries it. Otherwise,
+    when the speculative config is EAGLE-like, the exact-``SlidingWindowSpec``
+    groups are flagged (the DFlash2 drafter), else every group.
+    """
+    groups = list(kv_cache_config.kv_cache_groups)
+    ids = {i for i, g in enumerate(groups) if bool(getattr(g, "is_eagle_group", False))}
+    if ids:
+        return ids
+    spec_cfg = getattr(vllm_config, "speculative_config", None)
+    use_eagle = getattr(spec_cfg, "use_eagle", None) if spec_cfg is not None else None
+    if callable(use_eagle):
+        use_eagle = use_eagle()
+    if not use_eagle:
+        return set()
+    swa = {
+        i
+        for i, g in enumerate(groups)
+        if type(_glm53_inner_kv_spec(g.kv_cache_spec)).__name__ == "SlidingWindowSpec"
+    }
+    return swa or set(range(len(groups)))
+
+
+def _glm53_kv_capacity_rows(vllm_config, kv_cache_config) -> list:
+    """One dict per KV-cache group, from the same objects the stock line uses.
+
+    ``blocks_per_request`` is deliberately the same expression as the
+    comprehension in ``get_max_concurrency_for_kv_cache_config``: the sum of
+    this column IS that function's denominator.
+    """
+    eagle = _glm53_eagle_group_ids(vllm_config, kv_cache_config)
+    mamba_mode = getattr(getattr(vllm_config, "cache_config", None), "mamba_cache_mode", None)
+    rows = []
+    for index, group in enumerate(kv_cache_config.kv_cache_groups):
+        spec = group.kv_cache_spec
+        inner = _glm53_inner_kv_spec(spec)
+        kinds = _glm53_spec_kind_names(inner)
+        row = {
+            "index": index,
+            "spec": kinds[0],
+            "kinds": kinds,
+            "layers": len(getattr(group, "layer_names", ()) or ()),
+            "block_size": int(spec.block_size),
+            "page_size_bytes": int(spec.page_size_bytes),
+            "blocks_per_request": cdiv(
+                spec.max_memory_usage_bytes(vllm_config),
+                spec.page_size_bytes,
+            ),
+            "prefix_cacheable": _glm53_spec_prefix_cacheable(spec),
+            "eagle": index in eagle,
+            "sliding_window": None,
+            "mamba_cache_mode": None,
+        }
+        if "SlidingWindowSpec" in kinds:
+            window = getattr(inner, "sliding_window", None)
+            row["sliding_window"] = int(window) if window is not None else None
+        if "MambaSpec" in kinds:
+            row["mamba_cache_mode"] = mamba_mode
+        rows.append(row)
+    return rows
+
+
+def _glm53_ids_per_segment(row: dict, alignment: int):
+    """Block ids one aligned cached segment costs in this group under DENSE
+    retention with block-aligned hits (what ``reachable_block_mask`` hashes
+    when no retention interval is set). ``None`` = not modelled: the summary
+    then withholds the capacity figure instead of guessing.
+    """
+    if not row["prefix_cacheable"]:
+        return 0
+    block_size = row["block_size"]
+    if block_size <= 0 or alignment % block_size:
+        return None
+    per_segment = alignment // block_size
+    kinds = row["kinds"]
+    if "MambaSpec" in kinds:
+        # align: one state snapshot per block position; all: every block.
+        return per_segment if row["mamba_cache_mode"] in ("align", "all") else None
+    if "ChunkedLocalAttentionSpec" in kinds:
+        return None
+    if "CrossAttentionSpec" in kinds or "EncoderOnlyAttentionSpec" in kinds:
+        return None
+    if "SlidingWindowSpec" in kinds:
+        window = row["sliding_window"]
+        if not window:
+            return None
+        # SlidingWindowManager._contiguous_blocks_for_hit: the run a hit needs,
+        # +1 when the EAGLE last-block drop applies. reachable_block_mask
+        # caches every block once need >= per_segment.
+        need = cdiv(window - 1, block_size) + (1 if row["eagle"] else 0)
+        return min(need, per_segment)
+    if "FullAttentionSpec" in kinds:
+        # FullAttentionManager keeps the base reachable_block_mask (None):
+        # every block is hashed.
+        return per_segment
+    return None
+
+
+def _glm53_kv_capacity_summary(rows: list, num_blocks: int) -> dict:
+    num_blocks = int(num_blocks)
+    usable = max(num_blocks - 1, 0)  # block id 0 is BlockPool's null block
+    blocks_per_request = sum(int(r["blocks_per_request"]) for r in rows)
+    alignment = 1
+    for r in rows:
+        alignment = math.lcm(alignment, max(int(r["block_size"]), 1))
+    per_group = [_glm53_ids_per_segment(r, alignment) for r in rows]
+    unmodelled = [r["index"] for r, v in zip(rows, per_group) if v is None]
+    total = sum(v for v in per_group if v)
+    capacity = None
+    segments = None
+    if rows and not unmodelled and total > 0:
+        segments = usable // total
+        capacity = segments * alignment
+    return {
+        "num_blocks": num_blocks,
+        "usable": usable,
+        "blocks_per_request": blocks_per_request,
+        "alignment": alignment,
+        "per_group": per_group,
+        "unmodelled": unmodelled,
+        "total": total,
+        "segments": segments,
+        "capacity_tokens": capacity,
+    }
+
+
+def _glm53_kv_capacity_lines(rows: list, summary: dict, max_model_len: int) -> list:
+    """Preformatted lines (info_once caches on its arguments: pass strings)."""
+    tag = _GLM53_KV_CAPACITY_TAG
+    lines = []
+    for r in rows:
+        extra = ""
+        if r["sliding_window"] is not None:
+            extra += f" window={r['sliding_window']} eagle={'yes' if r['eagle'] else 'no'}"
+        if r["mamba_cache_mode"] is not None:
+            extra += f" mamba_cache_mode={r['mamba_cache_mode']}"
+        cacheable = "yes" if r["prefix_cacheable"] else "no (scratch)"
+        lines.append(
+            f"{tag} group {r['index']}: {r['spec']} layers={r['layers']} "
+            f"block_size={r['block_size']} page_size={r['page_size_bytes']:,} B "
+            f"blocks/request@{int(max_model_len):,}={r['blocks_per_request']} "
+            f"prefix_caching={cacheable}{extra}"
+        )
+    bpr = summary["blocks_per_request"]
+    ratio = f"{summary['num_blocks'] / bpr:.2f}x" if bpr else "n/a"
+    head = (
+        f"{tag} usable block ids: {summary['usable']} "
+        f"(num_blocks={summary['num_blocks']} incl. the null block; "
+        f"{bpr} ids per {int(max_model_len):,}-token request => {ratio})"
+    )
+    if summary["capacity_tokens"] is None:
+        if summary["unmodelled"]:
+            why = "unmodelled: " + ", ".join(
+                f"group {r['index']} {r['spec']}" for r in rows if r["index"] in summary["unmodelled"]
+            )
+        else:
+            why = "no prefix-cacheable group costs ids"
+        lines.append(
+            f"{head}; ids per {summary['alignment']}-token cached segment across groups: "
+            f"not derived ({why}; per group: {summary['per_group']}); "
+            "cached-conversation capacity at this alignment: not derived"
+        )
+    else:
+        lines.append(
+            f"{head}; ids per {summary['alignment']}-token cached segment across groups: "
+            f"{summary['total']} (per group: {summary['per_group']}); "
+            f"cached-conversation capacity at this alignment ≈ {summary['capacity_tokens']:,} tokens "
+            f"= {summary['segments']} segments (aligned dense-retention prefix-cache upper bound: "
+            "nothing running, every reachable block hashed, block-aligned hits). "
+            "The 'GPU KV cache size' line above is max_concurrency x max_model_len, not this figure."
+        )
+    return lines
+
+
+def _glm53_log_kv_capacity(vllm_config, kv_cache_config, max_model_len) -> None:
+    """Called right after the stock 'GPU KV cache size' line. Log-only."""
+    # The knob is validated OUTSIDE the try: a malformed value must raise.
+    if not _glm53_kv_capacity_log_enabled():
+        logger.info_once(
+            f"{_GLM53_KV_CAPACITY_TAG} disabled ({_GLM53_KV_CAPACITY_ENV}=0)"
+        )
+        return
+    try:
+        rows = _glm53_kv_capacity_rows(vllm_config, kv_cache_config)
+        summary = _glm53_kv_capacity_summary(rows, kv_cache_config.num_blocks)
+        lines = _glm53_kv_capacity_lines(rows, summary, max_model_len)
+    except Exception as exc:  # diagnostic only: never take the server down
+        logger.warning_once(
+            f"{_GLM53_KV_CAPACITY_TAG} could not derive the block-level KV "
+            f"capacity (log-only; serving unaffected): {type(exc).__name__}: {exc}"
+        )
+        return
+    for line in lines:
+        logger.info_once(line)
+
+
+'''
+
+
+class _RecordingLogger:
+    """Host stand-in for vLLM's logger: keeps what would have been logged."""
+
+    def __init__(self) -> None:
+        self.info: list[str] = []
+        self.warnings: list[str] = []
+
+    def info_once(self, msg, *args, **kwargs) -> None:
+        self.info.append(msg % args if args else msg)
+
+    def warning_once(self, msg, *args, **kwargs) -> None:
+        self.warnings.append(msg % args if args else msg)
+
+
+def cdiv(a: int, b: int) -> int:
+    return -(-a // b)
+
+
+def load_helpers(logger: _RecordingLogger | None = None) -> dict:
+    """Exec HELPERS_SRC into a fresh namespace (what the tests drive)."""
+    ns: dict = {"os": os, "math": math, "cdiv": cdiv, "logger": logger or _RecordingLogger()}
+    exec(compile(HELPERS_SRC, "<glm53-kv-capacity-log helpers>", "exec"), ns)
+    return ns
+
+
+_HELPERS = load_helpers()
+kv_capacity_log_enabled = _HELPERS["_glm53_kv_capacity_log_enabled"]
+inner_kv_spec = _HELPERS["_glm53_inner_kv_spec"]
+spec_prefix_cacheable = _HELPERS["_glm53_spec_prefix_cacheable"]
+eagle_group_ids = _HELPERS["_glm53_eagle_group_ids"]
+kv_capacity_rows = _HELPERS["_glm53_kv_capacity_rows"]
+ids_per_segment = _HELPERS["_glm53_ids_per_segment"]
+kv_capacity_summary = _HELPERS["_glm53_kv_capacity_summary"]
+kv_capacity_lines = _HELPERS["_glm53_kv_capacity_lines"]
+
+
+# ---------------------------------------------------------------------------
+# Site 1 -- helpers, inserted above the function whose denominator they mirror
+# ---------------------------------------------------------------------------
+MARK_HELPERS = "# [glm53-kv-capacity-log] helpers -- log-only; see overlay/patch_kv_capacity_log.py\n"
+
+ANCHOR_HELPERS = """def get_max_concurrency_for_kv_cache_config(
+    vllm_config: VllmConfig, kv_cache_config: KVCacheConfig
+) -> float:
+"""
+
+PATCHED_HELPERS = HELPERS_SRC + ANCHOR_HELPERS
+
+
+# ---------------------------------------------------------------------------
+# Site 2 -- the call, appended after the stock line (which stays byte-identical)
+# ---------------------------------------------------------------------------
+MARK_CALL = "    _glm53_log_kv_capacity(vllm_config, kv_cache_config, max_model_len)  # [glm53-kv-capacity-log]\n"
+
+ANCHOR_CALL = """    logger.info_once(
+        "GPU KV cache size: %s tokens, "
+        "Maximum concurrency for %s tokens per request: %.2fx",
+        f"{num_tokens:,}",
+        f"{max_model_len:,}",
+        max_concurrency,
+    )
+"""
+
+PATCHED_CALL = ANCHOR_CALL + MARK_CALL
+
+
+SITES = (
+    ("capacity helpers", MARK_HELPERS, ANCHOR_HELPERS, PATCHED_HELPERS),
+    ("capacity log call", MARK_CALL, ANCHOR_CALL, PATCHED_CALL),
+)
+
+# Names the injected helpers rely on; each must be bound above the insert point.
+REQUIRED_BINDINGS = (
+    "from vllm.utils.math_utils import cdiv",
+    "import math\n",
+    "import os\n",
+    "logger = init_logger(__name__)\n",
+)
+
+
+def verified_state(text: str) -> bool:
+    """Exact post-state check.
+
+    Both replacements keep their anchor (they are insertions), so expect exactly
+    as many surviving anchors as the replacement itself contains, one mark per
+    site, and the helper block above the function it mirrors.
+    """
+    ok = all(
+        text.count(mark) == 1
+        and text.count(patched) == 1
+        and text.count(anchor) == patched.count(anchor)
+        for _name, mark, anchor, patched in SITES
+    )
+    return ok and text.index(MARK_HELPERS) < text.index(ANCHOR_HELPERS) < text.index(MARK_CALL)
+
+
+def prepare(source: str) -> tuple[str, str]:
+    """Idempotent, fail-closed. Returns ``(text, action)``. Nothing is written here."""
+    marks = sum(source.count(mark) for _n, mark, _a, _p in SITES)
+    if marks:
+        if marks != len(SITES) or not verified_state(source):
+            raise ValueError(
+                "partial/inconsistent kv-capacity-log patch "
+                f"(marks={marks}, expected {len(SITES)}) -- refusing to touch "
+                "a half-patched file"
+            )
+        return source, "already present"
+
+    for binding in REQUIRED_BINDINGS:
+        head = source[: source.find(ANCHOR_HELPERS)] if ANCHOR_HELPERS in source else source
+        if binding not in head:
+            raise ValueError(
+                f"kv_cache_utils.py does not bind {binding.strip()!r} above the "
+                "insert point; the injected helpers would NameError"
+            )
+
+    out = source
+    for name, _mark, anchor, patched in SITES:
+        n = out.count(anchor)
+        if n != 1:
+            raise ValueError(
+                f"pinned kv-capacity-log anchor '{name}' drifted (found {n}, expected 1)"
+            )
+    for name, _mark, anchor, patched in SITES:
+        out = out.replace(anchor, patched, 1)
+
+    if not verified_state(out):
+        raise ValueError("kv-capacity-log post-patch verification failed")
+    return out, "patched"
+
+
+def replace_file(target: Path, source: str) -> None:
+    tmp = target.with_name(f".{target.name}.glm53-kv-capacity-log.tmp")
+    try:
+        tmp.write_text(source)
+        os.chmod(tmp, stat.S_IMODE(target.stat().st_mode))
+        os.replace(tmp, target)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def clear_pyc(target: Path) -> None:
+    cache = target.parent / "__pycache__"
+    if not cache.is_dir():
+        return
+    for pyc in cache.glob(f"{target.stem}*.pyc"):
+        pyc.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv if argv is None else argv
+    preflight_only = "--preflight" in argv[1:]
+
+    if not TARGET.is_file():
+        raise SystemExit(f"missing {TARGET}")
+    source = TARGET.read_text()
+    try:
+        patched, action = prepare(source)
+    except ValueError as exc:
+        raise SystemExit(f"kv-capacity-log preflight failed: {exc}") from exc
+    compile(patched, str(TARGET), "exec")
+
+    if preflight_only:
+        print(f"{TARGET.name}: kv-capacity-log preflight OK ({action})")
+        return 0
+
+    if patched != source:
+        replace_file(TARGET, patched)
+        clear_pyc(TARGET)
+    # Report the value as set, not as normalised: at image build time the knob
+    # is usually unset, and printing "1" for an explicitly empty value would
+    # hide the error the runtime will raise.
+    mode = os.environ.get(ENV_NAME, "1 (unset)")
+    print(f"{TARGET.name}: kv-capacity-log {action} ({ENV_NAME}={mode!r})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/start.sh
+++ b/start.sh
@@ -73,11 +73,14 @@ _cli_ablit_direction="${ABLIT_DIRECTION-}"
 _cli_ablit_layers="${ABLIT_LAYERS-}"
 _cli_ablit_alpha="${ABLIT_ALPHA-}"
 _cli_ablit_mtp="${ABLIT_INCLUDE_MTP-}"
+_cli_kvcap_set="${GLM53_KV_CAPACITY_LOG+1}"
+_cli_kvcap="${GLM53_KV_CAPACITY_LOG-}"
 set -a
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/.env"
 set +a
 [ -n "${_cli_mtp}" ] && MTP_TOKENS="$_cli_mtp"
+[ -n "${_cli_kvcap_set}" ] && GLM53_KV_CAPACITY_LOG="$_cli_kvcap"
 [ -n "${_cli_spec}" ] && SPEC_METHOD="$_cli_spec"
 [ -n "${_cli_eager}" ] && ENFORCE_EAGER="$_cli_eager"
 [ -n "${_cli_fused}" ] && EXL3_FUSED_MOE="$_cli_fused"
@@ -173,6 +176,7 @@ STOP_PATCH_HOST="${STOP_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_suppress_stops_in_
 SCHED_PATCH_HOST="${SCHED_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_scheduler_decode_floor.py}"
 DRAFTER_PATCH_HOST="${DRAFTER_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm5_drafter_group.py}"
 APC_PATCH_HOST="${APC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_hybrid_prefix_hit.py}"
+KVCAP_PATCH_HOST="${KVCAP_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kv_capacity_log.py}"
 XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_xgrammar_termination.py}"
 KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kpool_tail_slotmap.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
@@ -227,6 +231,16 @@ GLM53_SUPPRESS_STOPS_IN_REASONING="${GLM53_SUPPRESS_STOPS_IN_REASONING:-1}"
 # Mixed-step prefill policy when a peer is already decoding (issue #6).
 # skip = do not mix; N>0 = cap tokens; 0 = off.
 GLM53_MIXED_PREFILL_CHUNK="${GLM53_MIXED_PREFILL_CHUNK:-skip}"
+# 1 = at boot, after vLLM's "GPU KV cache size: N tokens" line (which is
+# max_concurrency x max_model_len, not a pool size), log one line per KV-cache
+# group (spec, block_size, blocks per max_model_len request) and a summary with
+# the usable block ids, the ids one aligned cached segment costs across groups
+# and the resulting cached-conversation capacity (overlay
+# patch_kv_capacity_log.py). 0 = do not log (one line saying so). Log-only:
+# no serving behaviour changes either way. Default applies only when UNSET: an
+# explicitly empty value is an operator error and validate_numeric_config
+# rejects it.
+GLM53_KV_CAPACITY_LOG="${GLM53_KV_CAPACITY_LOG-1}"
 # EngineCore stock timeout is 300s; mid-serve Triton/TileLang JIT on TP=2 can
 # exceed that without being a true hang. NCCL watchdog is still 600s.
 VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS="${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-1800}"
@@ -291,6 +305,21 @@ _glm53_canonical_positive_int() {
     export "$name"
 }
 
+# Kill switches are exactly 0 or 1. Not "non-empty means on", not `[ "$v" = 0 ]`
+# with everything else treated as on: a typo'd knob must not silently pick a
+# serving mode. GLM53_KV_CAPACITY_LOG decides whether the boot-time KV
+# capacity breakdown is logged, and the overlay itself refuses at the log site
+# on anything but 0/1 (overlay/patch_kv_capacity_log.py,
+# _glm53_kv_capacity_log_enabled), so catching it here turns a container boot
+# failure into a launcher error.
+_glm53_validate_bool_flag() {
+    local name="$1" value="$2"
+    if [ "$value" != 0 ] && [ "$value" != 1 ]; then
+        echo "$name must be exactly 0 or 1 (got: $value)" >&2
+        return 2
+    fi
+}
+
 validate_numeric_config() {
     if ! [[ "$GPU_MEM_UTIL" =~ ^(0([.][0-9]+)?|[.][0-9]+|1([.]0+)?)$ ]] \
        || ! awk -v u="$GPU_MEM_UTIL" 'BEGIN { exit !(u > 0 && u <= 1) }'; then
@@ -300,8 +329,88 @@ validate_numeric_config() {
     _glm53_canonical_positive_int MAX_MODEL_LEN "$MAX_MODEL_LEN" 1000000 || return
     _glm53_canonical_positive_int MAX_NUM_SEQS "$MAX_NUM_SEQS" 4096 || return
     _glm53_canonical_positive_int MAX_NUM_BATCHED_TOKENS "$MAX_NUM_BATCHED_TOKENS" 8388608 || return
+    _glm53_validate_bool_flag GLM53_KV_CAPACITY_LOG "${GLM53_KV_CAPACITY_LOG-1}" || return
 }
 # GLM53 numeric config guard (end)
+
+# GLM53 overlay artifact guard (begin)
+# Every file both rank containers mount. main() runs validate_overlay_artifacts
+# on start|restart BEFORE `restart` stops anything: a missing, empty,
+# mis-pointed, truncated or syntactically broken input is a launcher error
+# with the healthy pair left serving, not a container that dies at boot after
+# the old one is gone. Python overlays: path|identity string|last line -
+# the identity string (MARK / target path / hook marker) is distinct per file
+# so a *_PATCH_HOST pointed at a different overlay is caught, and the last
+# non-blank line must match exactly so a copy truncated anywhere before EOF
+# (even one that still parses) is caught too. This guards against operator
+# error (wrong path, stale checkout, truncated copy); it is not a
+# tamper-proof manifest. Needs python3 on the head (DGX OS ships it).
+# preflight() re-checks existence later; this is the fail-closed early gate.
+validate_overlay_artifacts() {
+    # Sentinels that contain quotes live in single-quoted locals.
+    local main_guard='    sys.exit(main())'
+    local video_end='    print("glm53: overlay install ok aligned=True", file=sys.stderr)'
+    local ablit_marker='MARKER = "ABLIT-HOOK"'
+    local -a artifacts=(
+        "$VIDEO_PATCH_HOST|vllm/model_executor/layers/|$video_end"
+        "$STOP_PATCH_HOST|[suppress-stops-in-reasoning]|    raise SystemExit(main(sys.argv))"
+        "$SCHED_PATCH_HOST|[glm53-decode-floor]|$main_guard"
+        "$DRAFTER_PATCH_HOST|vllm/v1/core/kv_cache_utils.py|$main_guard"
+        "$APC_PATCH_HOST|[glm53-hybrid-apc]|$main_guard"
+        "$KVCAP_PATCH_HOST|[glm53-kv-capacity-log]|$main_guard"
+        "$XGRAMMAR_PATCH_HOST|vllm/v1/structured_output/|$main_guard"
+        "$KPOOL_TAIL_PATCH_HOST|[glm53-kpool-tail-slotmap]|$main_guard"
+        "$SCRIPT_DIR/overlay/patch_ablit.py|$ablit_marker|    main()"
+        "$SCRIPT_DIR/overlay/ablit_runtime.py|o_proj abliteration (ABLIT)|    return report"
+    )
+    local entry path rest tag tail last
+    if [ "${#artifacts[@]}" -eq 0 ]; then
+        echo "overlay artifact list is empty - refusing to launch" >&2
+        return 2
+    fi
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "python3 is required on the head to verify overlay artifacts before launch" >&2
+        return 2
+    fi
+    for entry in "${artifacts[@]}"; do
+        path="${entry%%|*}"
+        rest="${entry#*|}"
+        tag="${rest%%|*}"
+        tail="${rest#*|}"
+        if [ ! -f "$path" ] || [ ! -r "$path" ] || [ ! -s "$path" ]; then
+            echo "overlay artifact missing, unreadable or empty: $path" >&2
+            return 2
+        fi
+        if ! grep -qF -- "$tag" "$path"; then
+            echo "overlay artifact $path does not carry its identity string '$tag' (wrong file?)" >&2
+            return 2
+        fi
+        # `|| true`: under pipefail a whitespace-only file makes grep exit 1,
+        # which must surface as the rc=2 diagnostic below, not a bare exit 1.
+        last="$(grep -v '^[[:space:]]*$' "$path" | tail -n 1 || true)"
+        if [ "$last" != "$tail" ]; then
+            echo "overlay artifact $path does not end with '$tail' (truncated copy? last line: '$last')" >&2
+            return 2
+        fi
+        # Parse-only: proves the file is importable Python without executing it
+        # or leaving __pycache__ litter in the checkout.
+        if ! python3 -c 'import ast, sys; ast.parse(open(sys.argv[1], encoding="utf-8").read(), sys.argv[1])' "$path" 2>/dev/null; then
+            echo "overlay artifact does not parse as Python: $path" >&2
+            return 2
+        fi
+    done
+    # Non-Python inputs both ranks mount: the chat template and the ablit
+    # layer map (the .pt payloads are ABLIT's own concern at hook time).
+    if [ ! -f "$CHAT_TEMPLATE_HOST" ] || [ ! -r "$CHAT_TEMPLATE_HOST" ] || [ ! -s "$CHAT_TEMPLATE_HOST" ]; then
+        echo "chat template missing, unreadable, empty or not a regular file: $CHAT_TEMPLATE_HOST" >&2
+        return 2
+    fi
+    if ! python3 -c 'import json, sys; json.load(open(sys.argv[1], encoding="utf-8"))' "$SCRIPT_DIR/ablit/LAYER_MAP.json" 2>/dev/null; then
+        echo "ablit layer map missing or not JSON: $SCRIPT_DIR/ablit/LAYER_MAP.json" >&2
+        return 2
+    fi
+}
+# GLM53 overlay artifact guard (end)
 
 banner() {
     local label="${1:-start.sh}"
@@ -435,6 +544,7 @@ preflight() {
     [ -f "$SCHED_PATCH_HOST" ] || die "$SCHED_PATCH_HOST missing"
     [ -f "$DRAFTER_PATCH_HOST" ] || die "$DRAFTER_PATCH_HOST missing"
     [ -f "$APC_PATCH_HOST" ] || die "$APC_PATCH_HOST missing"
+    [ -f "$KVCAP_PATCH_HOST" ] || die "$KVCAP_PATCH_HOST missing"
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "$XGRAMMAR_PATCH_HOST missing"
     [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "$KPOOL_TAIL_PATCH_HOST missing"
     [ -f "$SCRIPT_DIR/overlay/patch_ablit.py" ] || die "$SCRIPT_DIR/overlay/patch_ablit.py missing"
@@ -822,6 +932,40 @@ sync_weights() {
 }
 
 # ------------------------ inner container scripts --------------------------
+# Overlay application order inside BOTH rank containers. write_inner_scripts
+# emits this one list verbatim into the head and the worker inner script, so
+# the two ranks cannot drift apart. Pinned for the prefix-cache overlays,
+# which share the kv_cache_coordinator.py helper insert point:
+#   patch_hybrid_prefix_hit -> patch_apc_per_group_retention -> patch_apc_fine_grained_hits
+# (hybrid = Mia's partial-hit base, per-group = PR #83, fine-grained = PR #84),
+# then patch_kv_capacity_log (kv_cache_utils.py only, log-only; it must follow
+# patch_glm5_drafter_group, which edits the same file, and has no shared
+# anchors with the coordinator overlays).
+# Entries that are not mounted are skipped in-container (`[ -f ]`); which ones
+# MUST exist is decided by the overlay artifact guard above, not here.
+GLM53_OVERLAY_ORDER=(
+    patch_glm_video_placeholders.py
+    patch_suppress_stops_in_reasoning.py
+    patch_scheduler_decode_floor.py
+    patch_glm5_drafter_group.py
+    patch_hybrid_prefix_hit.py
+    patch_apc_per_group_retention.py
+    patch_apc_fine_grained_hits.py
+    patch_kv_capacity_log.py
+    patch_xgrammar_termination.py
+    patch_kpool_tail_slotmap.py
+    patch_ablit.py
+)
+
+# Emits the in-container apply block for GLM53_OVERLAY_ORDER (same bytes for
+# both ranks).
+emit_overlay_block() {
+    local p
+    for p in "${GLM53_OVERLAY_ORDER[@]}"; do
+        printf 'if [ -f /opt/glm53/%s ]; then\n    python3 /opt/glm53/%s\nfi\n' "$p" "$p"
+    done
+}
+
 write_inner_scripts() {
     cat > "$HEAD_SCRIPT" <<'EOF'
 #!/bin/bash
@@ -881,30 +1025,9 @@ if [ -n "${EXTRA_ARGS:-}" ]; then
 fi
 
 [ -f "${MODEL_DIR}/config.json" ] || { say "FATAL: ${MODEL_DIR}/config.json missing"; ls -la "${MODEL_DIR}" | head; exit 1; }
-if [ -f /opt/glm53/patch_glm_video_placeholders.py ]; then
-    python3 /opt/glm53/patch_glm_video_placeholders.py
-fi
-if [ -f /opt/glm53/patch_suppress_stops_in_reasoning.py ]; then
-    python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
-fi
-if [ -f /opt/glm53/patch_scheduler_decode_floor.py ]; then
-    python3 /opt/glm53/patch_scheduler_decode_floor.py
-fi
-if [ -f /opt/glm53/patch_glm5_drafter_group.py ]; then
-    python3 /opt/glm53/patch_glm5_drafter_group.py
-fi
-if [ -f /opt/glm53/patch_hybrid_prefix_hit.py ]; then
-    python3 /opt/glm53/patch_hybrid_prefix_hit.py
-fi
-if [ -f /opt/glm53/patch_xgrammar_termination.py ]; then
-    python3 /opt/glm53/patch_xgrammar_termination.py
-fi
-if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
-    python3 /opt/glm53/patch_kpool_tail_slotmap.py
-fi
-if [ -f /opt/glm53/patch_ablit.py ]; then
-    python3 /opt/glm53/patch_ablit.py
-fi
+EOF
+    emit_overlay_block >> "$HEAD_SCRIPT"
+    cat >> "$HEAD_SCRIPT" <<'EOF'
 if [ "${ABLIT:-0}" = "1" ]; then
     say "ablit: o_proj orthogonalization ON (method=${ABLIT_METHOD:-auto} direction=${ABLIT_DIRECTION:-dealign} layers=${ABLIT_LAYERS:-15-45} alpha=${ABLIT_ALPHA:-3.0})"
 else
@@ -971,30 +1094,9 @@ if [ -n "${EXTRA_ARGS:-}" ]; then
 fi
 
 [ -f "${MODEL_DIR}/config.json" ] || { say "FATAL: ${MODEL_DIR}/config.json missing"; ls -la "${MODEL_DIR}" | head; exit 1; }
-if [ -f /opt/glm53/patch_glm_video_placeholders.py ]; then
-    python3 /opt/glm53/patch_glm_video_placeholders.py
-fi
-if [ -f /opt/glm53/patch_suppress_stops_in_reasoning.py ]; then
-    python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
-fi
-if [ -f /opt/glm53/patch_scheduler_decode_floor.py ]; then
-    python3 /opt/glm53/patch_scheduler_decode_floor.py
-fi
-if [ -f /opt/glm53/patch_glm5_drafter_group.py ]; then
-    python3 /opt/glm53/patch_glm5_drafter_group.py
-fi
-if [ -f /opt/glm53/patch_hybrid_prefix_hit.py ]; then
-    python3 /opt/glm53/patch_hybrid_prefix_hit.py
-fi
-if [ -f /opt/glm53/patch_xgrammar_termination.py ]; then
-    python3 /opt/glm53/patch_xgrammar_termination.py
-fi
-if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
-    python3 /opt/glm53/patch_kpool_tail_slotmap.py
-fi
-if [ -f /opt/glm53/patch_ablit.py ]; then
-    python3 /opt/glm53/patch_ablit.py
-fi
+EOF
+    emit_overlay_block >> "$WORKER_SCRIPT"
+    cat >> "$WORKER_SCRIPT" <<'EOF'
 if [ "${ABLIT:-0}" = "1" ]; then
     say "ablit: o_proj orthogonalization ON (method=${ABLIT_METHOD:-auto} direction=${ABLIT_DIRECTION:-dealign} layers=${ABLIT_LAYERS:-15-45} alpha=${ABLIT_ALPHA:-3.0})"
 else
@@ -1025,7 +1127,9 @@ launch_cluster() {
     [ -f "$DRAFTER_PATCH_HOST" ] || die "missing $DRAFTER_PATCH_HOST"
     scp -q -o BatchMode=yes "$DRAFTER_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_glm5_drafter_group.py"
     [ -f "$APC_PATCH_HOST" ] || die "missing $APC_PATCH_HOST"
+    [ -f "$KVCAP_PATCH_HOST" ] || die "missing $KVCAP_PATCH_HOST"
     scp -q -o BatchMode=yes "$APC_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_hybrid_prefix_hit.py"
+    scp -q -o BatchMode=yes "$KVCAP_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kv_capacity_log.py"
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "missing $XGRAMMAR_PATCH_HOST"
     scp -q -o BatchMode=yes "$XGRAMMAR_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_xgrammar_termination.py"
     [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "missing $KPOOL_TAIL_PATCH_HOST"
@@ -1053,6 +1157,7 @@ launch_cluster() {
         -e VLLM_CACHE_ROOT=/root/.cache/vllm
         -e "GLM53_SUPPRESS_STOPS_IN_REASONING=$GLM53_SUPPRESS_STOPS_IN_REASONING"
         -e "GLM53_MIXED_PREFILL_CHUNK=$GLM53_MIXED_PREFILL_CHUNK"
+        -e "GLM53_KV_CAPACITY_LOG=$GLM53_KV_CAPACITY_LOG"
         -e "TRITON_CACHE_DIR=$TRITON_CACHE_DIR"
         -e "TILELANG_CACHE_DIR=$TILELANG_CACHE_DIR"
         -e "VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=$VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS"
@@ -1067,6 +1172,7 @@ launch_cluster() {
         -e DO_NOT_TRACK=1
         -e "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=$CG_ESTIMATE"
     )
+    log "boot KV-capacity breakdown log: GLM53_KV_CAPACITY_LOG=${GLM53_KV_CAPACITY_LOG} (both ranks)"
     local worker_nccl="" e
     for e in "${nccl_common[@]}"; do
         [ "$e" = "-e" ] && continue
@@ -1123,6 +1229,7 @@ launch_cluster() {
         -v '/tmp/patch_scheduler_decode_floor.py:/opt/glm53/patch_scheduler_decode_floor.py:ro' \
         -v '/tmp/patch_glm5_drafter_group.py:/opt/glm53/patch_glm5_drafter_group.py:ro' \
         -v '/tmp/patch_hybrid_prefix_hit.py:/opt/glm53/patch_hybrid_prefix_hit.py:ro' \
+        -v '/tmp/patch_kv_capacity_log.py:/opt/glm53/patch_kv_capacity_log.py:ro' \
         -v '/tmp/patch_xgrammar_termination.py:/opt/glm53/patch_xgrammar_termination.py:ro' \
         -v '/tmp/patch_kpool_tail_slotmap.py:/opt/glm53/patch_kpool_tail_slotmap.py:ro' \
         -v '/tmp/glm53-ablit:/opt/glm53/ablit:ro' \
@@ -1154,6 +1261,7 @@ launch_cluster() {
         -v "$SCHED_PATCH_HOST:/opt/glm53/patch_scheduler_decode_floor.py:ro" \
         -v "$DRAFTER_PATCH_HOST:/opt/glm53/patch_glm5_drafter_group.py:ro" \
         -v "$APC_PATCH_HOST:/opt/glm53/patch_hybrid_prefix_hit.py:ro" \
+        -v "$KVCAP_PATCH_HOST:/opt/glm53/patch_kv_capacity_log.py:ro" \
         -v "$XGRAMMAR_PATCH_HOST:/opt/glm53/patch_xgrammar_termination.py:ro" \
         -v "$KPOOL_TAIL_PATCH_HOST:/opt/glm53/patch_kpool_tail_slotmap.py:ro" \
         -v "$SCRIPT_DIR/ablit:/opt/glm53/ablit:ro" \
@@ -1391,7 +1499,7 @@ logs() {
 main() {
     local cmd="${1:-start}"
     case "$cmd" in
-        start|restart) validate_numeric_config ;;
+        start|restart) validate_numeric_config; validate_overlay_artifacts ;;
     esac
     case "$cmd" in
         stop)     banner stop.sh ;;

--- a/start.sh
+++ b/start.sh
@@ -424,7 +424,7 @@ validate_overlay_artifacts() {
         "$KVCAP_PATCH_HOST|[glm53-kv-capacity-log]|$main_guard"
         "$XGRAMMAR_PATCH_HOST|vllm/v1/structured_output/|$main_guard"
         "$KPOOL_TAIL_PATCH_HOST|[glm53-kpool-tail-slotmap]|$main_guard"
-        "$SPINWAIT_PATCH_HOST|glm53-spinwait|$main_guard"
+        "$SPINWAIT_PATCH_HOST|device_communicators/shm_broadcast.py|$main_guard"
         "$SCRIPT_DIR/overlay/patch_ablit.py|$ablit_marker|    main()"
         "$SCRIPT_DIR/overlay/ablit_runtime.py|o_proj abliteration (ABLIT)|    return report"
     )

--- a/tests/test_kpool_tail_slotmap.py
+++ b/tests/test_kpool_tail_slotmap.py
@@ -182,7 +182,12 @@ def test_recipe_wiring_if_present() -> None:
     launcher = start.read_text()
     image = dockerfile.read_text()
     assert 'KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-' in launcher
-    assert launcher.count("python3 /opt/glm53/patch_kpool_tail_slotmap.py") == 2
+    # Both ranks apply the one pinned list (GLM53_OVERLAY_ORDER) that
+    # write_inner_scripts emits into the head and worker inner scripts.
+    order = launcher[launcher.index("GLM53_OVERLAY_ORDER=(") : launcher.index(")", launcher.index("GLM53_OVERLAY_ORDER=("))]
+    assert "\n    patch_kpool_tail_slotmap.py\n" in order
+    assert 'emit_overlay_block >> "$HEAD_SCRIPT"' in launcher
+    assert 'emit_overlay_block >> "$WORKER_SCRIPT"' in launcher
     assert (
         "-v '/tmp/patch_kpool_tail_slotmap.py:"
         "/opt/glm53/patch_kpool_tail_slotmap.py:ro'" in launcher

--- a/tests/test_kv_capacity_log.py
+++ b/tests/test_kv_capacity_log.py
@@ -120,12 +120,13 @@ class KpoolTailSpec(SlidingWindowSpec):  # I:739-786
 
 
 class MambaSpec(KVCacheSpec):  # I:790-821
-    def __init__(self, block_size: int, page: int, num_speculative_blocks: int):
+    def __init__(self, block_size: int, page: int, num_speculative_blocks: int, mamba_cache_mode: str = "align"):
         super().__init__(block_size, page)
         self.num_speculative_blocks = num_speculative_blocks
+        self.mamba_cache_mode = mamba_cache_mode  # set from cache_config at spec creation (abstract.py:74)
 
     def max_memory_usage_bytes(self, cfg) -> int:
-        mode = cfg.cache_config.mamba_cache_mode
+        mode = cfg.cache_config.mamba_cache_mode  # the fork reads cache_config here (I:813-818)
         if mode == "all":
             return (P.cdiv(cfg.model_config.max_model_len, self.block_size) + self.num_speculative_blocks) * self.page_size_bytes
         if mode == "align":
@@ -141,6 +142,18 @@ class ChunkedLocalAttentionSpec(AttentionSpec):
 class CrossAttentionSpec(AttentionSpec):
     def max_memory_usage_bytes(self, cfg) -> int:
         return 2 * self.page_size_bytes
+
+
+class SinkFullAttentionSpec(FullAttentionSpec):  # I:866: its manager keeps permanent sink blocks
+    pass
+
+
+class TQFullAttentionSpec(FullAttentionSpec):  # I:392
+    pass
+
+
+class RSWASpec(FullAttentionSpec):  # I:508
+    pass
 
 
 class UniformTypeKVCacheSpecs(KVCacheSpec):  # I:920-948
@@ -174,26 +187,27 @@ LIVE_SPEC_TOKENS = 7
 MLA_PAGE = 2_351_104 * 11  # 3584 x 656 B x 11 layers (fp8_ds_mla), uniform group
 
 
-def live_cfg(max_model_len=LIVE_MAX_MODEL_LEN, mamba_mode="align", use_eagle=True, in_flight=LIVE_IN_FLIGHT):
+def live_cfg(max_model_len=LIVE_MAX_MODEL_LEN, mamba_mode="align", use_eagle=True, in_flight=LIVE_IN_FLIGHT, dcp=1, pcp=1):
     spec_cfg = _Ns(use_eagle=(lambda: use_eagle)) if use_eagle is not None else None
     return _Ns(
         model_config=_Ns(max_model_len=max_model_len),
         cache_config=_Ns(mamba_cache_mode=mamba_mode),
+        parallel_config=_Ns(decode_context_parallel_size=dcp, prefill_context_parallel_size=pcp),
         speculative_config=spec_cfg,
         max_in_flight_tokens=in_flight,
     )
 
 
-def live_groups():
+def live_groups(mamba_mode="align"):
     return (
         [group(MLAAttentionSpec(3584, MLA_PAGE), 11), group(KpoolTailSpec(4, 1024, 4), 11)]
-        + [group(MambaSpec(3584, 4096, LIVE_SPEC_TOKENS), 9) for _ in range(4)]
+        + [group(MambaSpec(3584, 4096, LIVE_SPEC_TOKENS, mamba_mode), 9) for _ in range(4)]
         + [group(SlidingWindowSpec(64, 8192, 2048), 1)]
     )
 
 
-def kv_config(num_blocks: int, groups=None):
-    return _Ns(num_blocks=num_blocks, kv_cache_groups=live_groups() if groups is None else groups)
+def kv_config(num_blocks: int, groups=None, mamba_mode="align"):
+    return _Ns(num_blocks=num_blocks, kv_cache_groups=live_groups(mamba_mode) if groups is None else groups)
 
 
 def stock_line(num_blocks: int, bpr: int, max_model_len: int) -> tuple[str, str]:
@@ -329,20 +343,37 @@ def part_a() -> None:
     check(sw["per_group"] == [1, 56], "A9 window wider than the segment: need 65 >= 56 -> every block of the segment (reachable_block_mask returns None)")
 
     # Unmodelled kinds withhold the capacity instead of guessing.
-    for label, mode in (("mamba_cache_mode=none", "none"),):
-        rr = P.kv_capacity_rows(live_cfg(mamba_mode=mode), kv_config(643))
-        ss = P.kv_capacity_summary(rr, 643)
-        check(ss["unmodelled"] == [2, 3, 4, 5] and ss["capacity_tokens"] is None and ss["segments"] is None, f"A10 {label}: mamba groups unmodelled, capacity withheld")
-        ll = P.kv_capacity_lines(rr, ss, LIVE_MAX_MODEL_LEN)[-1]
-        check("not derived (unmodelled: group 2 MambaSpec" in ll and "cached-conversation capacity at this alignment: not derived" in ll and "≈" not in ll, "A10 ... and the summary line says so")
-    rr = P.kv_capacity_rows(live_cfg(mamba_mode="all"), kv_config(643))
+    rr = P.kv_capacity_rows(live_cfg(mamba_mode="none"), kv_config(643, mamba_mode="none"))
+    ss = P.kv_capacity_summary(rr, 643)
+    check(ss["unmodelled"] == [2, 3, 4, 5] and ss["capacity_tokens"] is None and ss["segments"] is None, "A10 mamba_cache_mode=none: mamba groups unmodelled, capacity withheld")
+    ll = P.kv_capacity_lines(rr, ss, LIVE_MAX_MODEL_LEN)[-1]
+    check("not derived (unmodelled: group 2 MambaSpec" in ll and "cached-conversation capacity at this alignment: not derived" in ll and "≈" not in ll, "A10 ... and the summary line says so")
+    rr = P.kv_capacity_rows(live_cfg(mamba_mode="align"), kv_config(643, mamba_mode="none"))
+    ss = P.kv_capacity_summary(rr, 643)
+    check(rr[2]["mamba_cache_mode"] == "none" and ss["unmodelled"] == [2, 3, 4, 5], "A10 the mode is read from the MambaSpec the manager acts on, not cache_config (spec none / config align -> unmodelled)")
+    mixed_mamba = UniformTypeKVCacheSpecs({"a": MambaSpec(3584, 8, 7, "align"), "b": MambaSpec(3584, 8, 7, "none")})
+    rr = P.kv_capacity_rows(cfg, kv_config(10, [group(mixed_mamba, 2)]))
+    check(rr[0]["mamba_cache_mode"] == "mixed" and P.kv_capacity_summary(rr, 10)["per_group"] == [None], "A10 a uniform mamba group with disagreeing member modes is 'mixed' and unmodelled")
+    rr = P.kv_capacity_rows(live_cfg(mamba_mode="all"), kv_config(643, mamba_mode="all"))
     ss = P.kv_capacity_summary(rr, 643)
     check([r["blocks_per_request"] for r in rr][2] == 287 and ss["per_group"][2] == 1 and ss["total"] == 38, "A10 mamba all-mode: 280+7 blocks/request, still one state per block position")
+    for cls in (SinkFullAttentionSpec, TQFullAttentionSpec, RSWASpec):
+        rr = P.kv_capacity_rows(c1, kv_config(100, [group(cls(16, 1), 1)]))
+        check(P.kv_capacity_summary(rr, 100)["per_group"] == [None], f"A10 {cls.__name__} (a FullAttentionSpec subclass with its own manager rule) is unmodelled, never costed as dense")
+    rr = P.kv_capacity_rows(live_cfg(use_eagle=None), kv_config(10, [group(MLAAttentionSpec(3584, 1), 1), group(SlidingWindowMLASpec(64, 1, 2048), 1)]))
+    check(P.kv_capacity_summary(rr, 10)["per_group"] == [1, 32], "A10 SlidingWindowMLASpec is costed by the window rule (exact-name allowlist), no EAGLE without a speculative config")
+    for label, kw in (("dcp=2", {"dcp": 2}), ("pcp=2", {"pcp": 2})):
+        rr = P.kv_capacity_rows(live_cfg(**kw), kv_config(643))
+        ss = P.kv_capacity_summary(rr, 643, live_cfg(**kw))
+        ll = P.kv_capacity_lines(rr, ss, LIVE_MAX_MODEL_LEN)[-1]
+        check(ss["capacity_tokens"] is None and ss["withheld"] and "context parallelism" in ll and "not derived" in ll, f"A10 {label}: the figure is withheld (block sizes are rescaled per rank; alignment not derived here)")
+    ss = P.kv_capacity_summary(rows, 643, cfg)
+    check(ss["withheld"] is None and ss["capacity_tokens"] == 57_344, "A10 dcp=pcp=1 (this kit): nothing withheld")
     mixed = [group(FullAttentionSpec(16, 1), 1), group(ChunkedLocalAttentionSpec(16, 1), 1), group(CrossAttentionSpec(16, 1), 1)]
     sm = P.kv_capacity_summary(P.kv_capacity_rows(c1, kv_config(100, mixed)), 100)
     check(sm["per_group"] == [1, None, None] and sm["unmodelled"] == [1, 2] and sm["capacity_tokens"] is None, "A10 chunked-local / cross attention are unmodelled")
-    check(P.ids_per_segment({"prefix_cacheable": True, "block_size": 16, "kinds": ("WeirdSpec", "KVCacheSpec", "object"), "eagle": False, "sliding_window": None, "mamba_cache_mode": None}, 16) is None, "A10 an unknown spec kind is unmodelled (never silently costed)")
-    check(P.ids_per_segment({"prefix_cacheable": True, "block_size": 64, "kinds": ("SlidingWindowSpec", "AttentionSpec", "KVCacheSpec", "object"), "eagle": True, "sliding_window": None, "mamba_cache_mode": None}, 3584) is None, "A10 a sliding-window spec without a window is unmodelled")
+    check(P.ids_per_segment({"prefix_cacheable": True, "block_size": 16, "spec": "WeirdSpec", "kinds": ("WeirdSpec", "KVCacheSpec", "object"), "eagle": False, "sliding_window": None, "mamba_cache_mode": None}, 16) is None, "A10 an unknown spec kind is unmodelled (never silently costed)")
+    check(P.ids_per_segment({"prefix_cacheable": True, "block_size": 64, "spec": "SlidingWindowSpec", "kinds": ("SlidingWindowSpec", "AttentionSpec", "KVCacheSpec", "object"), "eagle": True, "sliding_window": None, "mamba_cache_mode": None}, 3584) is None, "A10 a sliding-window spec without a window is unmodelled")
 
     # Null block / tiny pools / max_model_len below the alignment.
     for nb, usable, cap in ((1, 0, 0), (0, 0, 0), (38, 37, 0), (39, 38, 3584)):

--- a/tests/test_kv_capacity_log.py
+++ b/tests/test_kv_capacity_log.py
@@ -1,0 +1,770 @@
+#!/usr/bin/env python3
+"""Tests for the honest KV-capacity boot log overlay (host-only, no GPU, no torch).
+
+Part A  the derivation, driven through the SAME helper text the overlay writes
+        into kv_cache_utils.py (exec'd, not re-implemented): the deployment's
+        hybrid layout reproduces the logged stock line (643 ids / 414 per
+        request -> 1,553,140 tokens, 1.55x) and the runbook numbers (642 usable
+        ids, 38 ids per 3584-token segment, 57,344 tokens); the 820-id boot;
+        single-group / uniform-type / EAGLE / unmodelled / null-block edges;
+        the knob matrix; failure modes (malformed knob raises, derivation
+        error -> warning, no config mutation, hashable log arguments).
+Part B  patch mechanics on a fixture built from verbatim excerpts of the live
+        container's kv_cache_utils.py (both pinned anchors in file order, in a
+        module that compiles): stock line byte-identical after patching,
+        end-to-end call through the patched update_kv_cache_capacity with
+        vllm stubbed, idempotent re-apply, per-anchor drift -> non-zero exit
+        with NOTHING written, partial / altered markers refused, missing
+        binding refused, --preflight, pyc clear; the real installed file when
+        present (mandatory with GLM53_REQUIRE_TARGET=1, i.e. in the image).
+Part C  launcher wiring: the numeric-config guard accepts exactly 0/1 for
+        GLM53_KV_CAPACITY_LOG (unset -> 1), caller capture is set-ness aware,
+        artifact guard entry, scp + both mounts + `-e` forward, overlay order
+        after patch_glm5_drafter_group.py, Dockerfile test-before-patch,
+        .env.example and README rows.
+"""
+from __future__ import annotations
+
+import copy
+import os
+import subprocess
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+PATCH = next(
+    p
+    for p in (HERE / "patch_kv_capacity_log.py", ROOT / "overlay" / "patch_kv_capacity_log.py")
+    if p.is_file()
+)
+sys.path.insert(0, str(PATCH.parent))
+import patch_kv_capacity_log as P  # noqa: E402
+
+START = ROOT / "start.sh"
+DOCKERFILE = ROOT / "Dockerfile"
+ENV_EXAMPLE = ROOT / ".env.example"
+README = ROOT / "README.md"
+
+CHECKS = 0
+FAILURES: list[str] = []
+
+
+def check(cond: bool, label: str) -> None:
+    global CHECKS
+    CHECKS += 1
+    print(("  ok   " if cond else "  FAIL ") + label)
+    if not cond:
+        FAILURES.append(label)
+
+
+# --------------------------------------------------------------------------
+# synthetic specs, duck-typed exactly as the fork's kv_cache_interface.py
+# (class NAMES and MRO matter: the helpers classify by them)
+# --------------------------------------------------------------------------
+class _Ns:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+class KVCacheSpec:
+    def __init__(self, block_size: int, page: int):
+        self.block_size = block_size
+        self._page = page
+
+    @property
+    def page_size_bytes(self) -> int:
+        return self._page
+
+
+class AttentionSpec(KVCacheSpec):
+    pass
+
+
+class FullAttentionSpec(AttentionSpec):
+    def max_memory_usage_bytes(self, cfg) -> int:  # I:295-300
+        return P.cdiv(cfg.model_config.max_model_len, self.block_size) * self.page_size_bytes
+
+
+class MLAAttentionSpec(FullAttentionSpec):
+    pass
+
+
+class SlidingWindowSpec(AttentionSpec):
+    def __init__(self, block_size: int, page: int, window: int):
+        super().__init__(block_size, page)
+        self.sliding_window = window
+
+    def max_admission_blocks_per_request(self, max_in_flight_tokens: int, max_model_len: int) -> int:  # I:616-637
+        num_tokens = min(self.sliding_window - 1 + max_in_flight_tokens, max_model_len)
+        return P.cdiv(num_tokens, self.block_size) + 1
+
+    def max_memory_usage_bytes(self, cfg) -> int:  # I:639-647
+        return self.max_admission_blocks_per_request(cfg.max_in_flight_tokens, cfg.model_config.max_model_len) * self.page_size_bytes
+
+
+class SlidingWindowMLASpec(SlidingWindowSpec):
+    pass
+
+
+class KpoolTailSpec(SlidingWindowSpec):  # I:739-786
+    def max_admission_blocks_per_request(self, max_in_flight_tokens: int, max_model_len: int) -> int:
+        return 1
+
+    @property
+    def participates_in_prefix_caching(self) -> bool:
+        return False
+
+
+class MambaSpec(KVCacheSpec):  # I:790-821
+    def __init__(self, block_size: int, page: int, num_speculative_blocks: int):
+        super().__init__(block_size, page)
+        self.num_speculative_blocks = num_speculative_blocks
+
+    def max_memory_usage_bytes(self, cfg) -> int:
+        mode = cfg.cache_config.mamba_cache_mode
+        if mode == "all":
+            return (P.cdiv(cfg.model_config.max_model_len, self.block_size) + self.num_speculative_blocks) * self.page_size_bytes
+        if mode == "align":
+            return self.page_size_bytes * (2 + self.num_speculative_blocks)
+        return self.page_size_bytes * (1 + self.num_speculative_blocks)
+
+
+class ChunkedLocalAttentionSpec(AttentionSpec):
+    def max_memory_usage_bytes(self, cfg) -> int:
+        return 3 * self.page_size_bytes
+
+
+class CrossAttentionSpec(AttentionSpec):
+    def max_memory_usage_bytes(self, cfg) -> int:
+        return 2 * self.page_size_bytes
+
+
+class UniformTypeKVCacheSpecs(KVCacheSpec):  # I:920-948
+    def __init__(self, kv_cache_specs: dict):
+        self.kv_cache_specs = kv_cache_specs
+        self.block_size = next(iter(kv_cache_specs.values())).block_size
+
+    @property
+    def participates_in_prefix_caching(self) -> bool:
+        return all(getattr(s, "participates_in_prefix_caching", True) for s in self.kv_cache_specs.values())
+
+    @property
+    def page_size_bytes(self) -> int:
+        return sum(s.page_size_bytes for s in self.kv_cache_specs.values())
+
+    def max_memory_usage_bytes(self, cfg) -> int:
+        pages = max(P.cdiv(s.max_memory_usage_bytes(cfg), s.page_size_bytes) for s in self.kv_cache_specs.values())
+        return pages * self.page_size_bytes
+
+
+def group(spec, layers: int, eagle: bool = False):
+    return _Ns(layer_names=[f"layer.{i}" for i in range(layers)], kv_cache_spec=spec, is_eagle_group=eagle)
+
+
+# Live deployment (head Spark): MAX_MODEL_LEN 1e6, MNBT 2048, async scheduling
+# (max_concurrent_batches 2 -> max_in_flight_tokens 4096), k=7 DFlash2 tokens,
+# mamba block 3584 in align mode, drafter SWA window 2048 block 64, kpool 4.
+LIVE_MAX_MODEL_LEN = 1_000_000
+LIVE_IN_FLIGHT = 2 * 2048
+LIVE_SPEC_TOKENS = 7
+MLA_PAGE = 2_351_104 * 11  # 3584 x 656 B x 11 layers (fp8_ds_mla), uniform group
+
+
+def live_cfg(max_model_len=LIVE_MAX_MODEL_LEN, mamba_mode="align", use_eagle=True, in_flight=LIVE_IN_FLIGHT):
+    spec_cfg = _Ns(use_eagle=(lambda: use_eagle)) if use_eagle is not None else None
+    return _Ns(
+        model_config=_Ns(max_model_len=max_model_len),
+        cache_config=_Ns(mamba_cache_mode=mamba_mode),
+        speculative_config=spec_cfg,
+        max_in_flight_tokens=in_flight,
+    )
+
+
+def live_groups():
+    return (
+        [group(MLAAttentionSpec(3584, MLA_PAGE), 11), group(KpoolTailSpec(4, 1024, 4), 11)]
+        + [group(MambaSpec(3584, 4096, LIVE_SPEC_TOKENS), 9) for _ in range(4)]
+        + [group(SlidingWindowSpec(64, 8192, 2048), 1)]
+    )
+
+
+def kv_config(num_blocks: int, groups=None):
+    return _Ns(num_blocks=num_blocks, kv_cache_groups=live_groups() if groups is None else groups)
+
+
+def stock_line(num_blocks: int, bpr: int, max_model_len: int) -> tuple[str, str]:
+    """What update_kv_cache_capacity prints: int(mc * L) and %.2fx."""
+    mc = num_blocks / bpr
+    return f"{int(mc * max_model_len):,}", f"{mc:.2f}x"
+
+
+def drive(cfg, kc, max_model_len=None, env=None):
+    """Run the shipped _glm53_log_kv_capacity with a recording logger."""
+    log = P._RecordingLogger()
+    ns = P.load_helpers(log)
+    saved = os.environ.get(P.ENV_NAME)
+    try:
+        if env is None:
+            os.environ.pop(P.ENV_NAME, None)
+        else:
+            os.environ[P.ENV_NAME] = env
+        ns["_glm53_log_kv_capacity"](cfg, kc, cfg.model_config.max_model_len if max_model_len is None else max_model_len)
+    finally:
+        if saved is None:
+            os.environ.pop(P.ENV_NAME, None)
+        else:
+            os.environ[P.ENV_NAME] = saved
+    return log
+
+
+# --------------------------------------------------------------------------
+# Part A -- derivation
+# --------------------------------------------------------------------------
+def part_a() -> None:
+    print("Part A: derivation (shipped helper text, exec'd)")
+    check(P.HELPERS_SRC in P.PATCHED_HELPERS and P.PATCHED_HELPERS.endswith(P.ANCHOR_HELPERS), "A0 the exec'd helper text is the text written above the anchor, verbatim")
+
+    cfg, kc = live_cfg(), kv_config(643)
+    rows = P.kv_capacity_rows(cfg, kc)
+    bpr = [r["blocks_per_request"] for r in rows]
+    check(bpr == [280, 1, 9, 9, 9, 9, 97], f"A1 blocks/request per group = {bpr} (MLA cdiv(1e6,3584); kpool 1; mamba align 2+7; drafter cdiv(min(2047+4096,1e6),64)+1)")
+    check(sum(bpr) == 414, "A1 sum = 414 = the stock denominator (DESIGN-drafter-retention §3)")
+    tokens, ratio = stock_line(643, 414, LIVE_MAX_MODEL_LEN)
+    check(tokens == "1,553,140" and ratio == "1.55x", f"A1 stock line reproduced from 643 ids: {tokens} tokens, {ratio} (runbook 08-31)")
+    check([r["spec"] for r in rows] == ["MLAAttentionSpec", "KpoolTailSpec"] + ["MambaSpec"] * 4 + ["SlidingWindowSpec"], "A1 spec names by group")
+    check([r["prefix_cacheable"] for r in rows] == [True, False, True, True, True, True, True], "A1 only the kpool tail opts out of prefix caching")
+    check([r["eagle"] for r in rows] == [False] * 6 + [True], "A1 EAGLE flag: the exact-SlidingWindowSpec drafter group only (coordinator fallback mirrored)")
+    check(rows[6]["sliding_window"] == 2048 and rows[2]["mamba_cache_mode"] == "align", "A1 window / mamba mode carried on the rows")
+
+    s = P.kv_capacity_summary(rows, 643)
+    check(s["usable"] == 642 and s["num_blocks"] == 643, "A2 usable block ids = 642 (643 minus the null block)")
+    check(s["alignment"] == 3584, "A2 alignment = lcm(3584, 4, 64) = 3584 (the coordinator's scheduler block)")
+    check(s["per_group"] == [1, 0, 1, 1, 1, 1, 33], f"A2 ids per 3584-token segment per group = {s['per_group']}")
+    check(s["total"] == 38, "A2 ids per segment across groups = 38 (1 MLA + 4 mamba + 33 drafter)")
+    check(s["segments"] == 16 and s["capacity_tokens"] == 57_344, "A2 capacity = 642 // 38 * 3584 = 57,344 tokens (partial final segment floored: 642 = 16*38 + 34)")
+    check(s["unmodelled"] == [] and s["blocks_per_request"] == 414, "A2 nothing unmodelled; denominator carried")
+
+    lines = P.kv_capacity_lines(rows, s, LIVE_MAX_MODEL_LEN)
+    check(len(lines) == 8 and all(isinstance(x, str) and "%" not in x for x in lines), "A3 8 preformatted lines (7 groups + summary), hashable strings, no printf directives (info_once caches on its args)")
+    check(lines[0] == "[glm53-kv-capacity-log] group 0: MLAAttentionSpec layers=11 block_size=3584 page_size=25,862,144 B blocks/request@1,000,000=280 prefix_caching=yes", "A3 group 0 line verbatim")
+    check(lines[1].endswith("blocks/request@1,000,000=1 prefix_caching=no (scratch) window=4 eagle=no") and "KpoolTailSpec" in lines[1], "A3 kpool tail line: scratch, 1 block/request")
+    check(lines[6] == "[glm53-kv-capacity-log] group 6: SlidingWindowSpec layers=1 block_size=64 page_size=8,192 B blocks/request@1,000,000=97 prefix_caching=yes window=2048 eagle=yes", "A3 drafter line verbatim")
+    summary = lines[7]
+    for frag in (
+        "usable block ids: 642 (num_blocks=643 incl. the null block; 414 ids per 1,000,000-token request => 1.55x)",
+        "ids per 3584-token cached segment across groups: 38 (per group: [1, 0, 1, 1, 1, 1, 33])",
+        "cached-conversation capacity at this alignment ≈ 57,344 tokens = 16 segments",
+        "dense-retention",
+        "'GPU KV cache size' line above is max_concurrency x max_model_len, not this figure",
+    ):
+        check(frag in summary, f"A3 summary carries {frag[:60]!r}")
+
+    log = drive(cfg, kc)
+    check(log.info == lines and not log.warnings, "A4 _glm53_log_kv_capacity emits exactly those lines through logger.info_once, no warning")
+
+    # The current rightsized boot (deploy/dogfood-next 2026-09-01 08:0x): 820 ids.
+    rows820 = P.kv_capacity_rows(cfg, kv_config(820))
+    s820 = P.kv_capacity_summary(rows820, 820)
+    tokens, ratio = stock_line(820, 414, LIVE_MAX_MODEL_LEN)
+    check(tokens == "1,980,676" and ratio == "1.98x", f"A5 820 ids -> stock line {tokens} / {ratio} (boot log 09-01 01:09:54)")
+    check(s820["usable"] == 819 and s820["segments"] == 21 and s820["capacity_tokens"] == 75_264, "A5 820 ids -> 819 usable, 21 segments, 75,264 tokens")
+    line = P.kv_capacity_lines(rows820, s820, LIVE_MAX_MODEL_LEN)[-1]
+    check("usable block ids: 819 (num_blocks=820" in line and "≈ 75,264 tokens = 21 segments" in line, "A5 820-id summary line")
+
+    # Single-group full-attention model: the stock figure and the summary agree
+    # up to the null block, which is the whole point of the label upstream.
+    one = [group(FullAttentionSpec(16, 4096), 32)]
+    c1 = live_cfg(max_model_len=4096, use_eagle=None)
+    r1 = P.kv_capacity_rows(c1, kv_config(1000, one))
+    s1 = P.kv_capacity_summary(r1, 1000)
+    check(r1[0]["blocks_per_request"] == 256 and s1["alignment"] == 16 and s1["per_group"] == [1] and s1["capacity_tokens"] == 999 * 16, "A6 single full-attention group: capacity = usable * block_size = 15,984")
+    check(stock_line(1000, 256, 4096)[0] == "16,000" and 16_000 - s1["capacity_tokens"] == 16, "A6 ... one block (the null block) below the stock 16,000 figure")
+
+    # UniformTypeKVCacheSpecs wrapper: name the inner class, page = sum, opt-out propagates.
+    uni = UniformTypeKVCacheSpecs({"a": MLAAttentionSpec(3584, 100), "b": MLAAttentionSpec(3584, 200)})
+    ru = P.kv_capacity_rows(cfg, kv_config(10, [group(uni, 2)]))
+    check(ru[0]["spec"] == "MLAAttentionSpec" and ru[0]["page_size_bytes"] == 300 and ru[0]["blocks_per_request"] == 280 and ru[0]["prefix_cacheable"], "A7 uniform-type wrapper unwrapped for the name; page/blocks from the wrapper")
+    uni_scratch = UniformTypeKVCacheSpecs({"a": KpoolTailSpec(4, 8, 4)})
+    check(P.spec_prefix_cacheable(uni_scratch) is False and P.spec_prefix_cacheable(uni) is True, "A7 wrapper participation aggregates its members")
+
+    # Participation flags: fork's first, upstream's second, default True.
+    class _Up(FullAttentionSpec):
+        @property
+        def prefix_cacheable(self):
+            return False
+
+    class _Both(FullAttentionSpec):
+        @property
+        def participates_in_prefix_caching(self):
+            return True
+
+        @property
+        def prefix_cacheable(self):
+            return False
+
+    check(P.spec_prefix_cacheable(_Up(16, 1)) is False, "A8 upstream `prefix_cacheable` False is honoured when the fork flag is absent")
+    check(P.spec_prefix_cacheable(_Both(16, 1)) is True, "A8 the fork flag wins when both exist")
+    check(P.spec_prefix_cacheable(FullAttentionSpec(16, 1)) is True, "A8 neither flag -> participates (legacy specs cache)")
+    ru2 = P.kv_capacity_rows(cfg, kv_config(10, [group(_Up(16, 1), 1)]))
+    check(P.kv_capacity_summary(ru2, 10)["per_group"] == [0], "A8 an opted-out group costs 0 ids per segment")
+
+    # EAGLE detection.
+    ids = P.eagle_group_ids(live_cfg(use_eagle=None), kv_config(10))
+    check(ids == set(), "A9 no speculative config -> no EAGLE group")
+    ids = P.eagle_group_ids(live_cfg(use_eagle=False), kv_config(10))
+    check(ids == set(), "A9 use_eagle() False -> no EAGLE group")
+    gs = live_groups()
+    gs[0].is_eagle_group = True
+    check(P.eagle_group_ids(cfg, kv_config(10, gs)) == {0}, "A9 is_eagle_group is authoritative when any group carries it (fallback not consulted)")
+    gs = [group(MLAAttentionSpec(3584, 1), 1), group(SlidingWindowMLASpec(64, 1, 2048), 1)]
+    check(P.eagle_group_ids(cfg, kv_config(10, gs)) == {0, 1}, "A9 use_eagle() with no exact SlidingWindowSpec group -> every group (upstream fallback; SlidingWindowMLASpec subclass is NOT the drafter predicate, same as the coordinator overlay)")
+    rn = P.kv_capacity_rows(live_cfg(use_eagle=None), kv_config(10))
+    check(P.kv_capacity_summary(rn, 643)["per_group"][6] == 32, "A9 drafter without EAGLE: cdiv(2047, 64) = 32 ids per segment")
+    wide = [group(MLAAttentionSpec(3584, 1), 1), group(SlidingWindowSpec(64, 1, 4096), 1)]
+    sw = P.kv_capacity_summary(P.kv_capacity_rows(cfg, kv_config(10, wide)), 10)
+    check(sw["per_group"] == [1, 56], "A9 window wider than the segment: need 65 >= 56 -> every block of the segment (reachable_block_mask returns None)")
+
+    # Unmodelled kinds withhold the capacity instead of guessing.
+    for label, mode in (("mamba_cache_mode=none", "none"),):
+        rr = P.kv_capacity_rows(live_cfg(mamba_mode=mode), kv_config(643))
+        ss = P.kv_capacity_summary(rr, 643)
+        check(ss["unmodelled"] == [2, 3, 4, 5] and ss["capacity_tokens"] is None and ss["segments"] is None, f"A10 {label}: mamba groups unmodelled, capacity withheld")
+        ll = P.kv_capacity_lines(rr, ss, LIVE_MAX_MODEL_LEN)[-1]
+        check("not derived (unmodelled: group 2 MambaSpec" in ll and "cached-conversation capacity at this alignment: not derived" in ll and "≈" not in ll, "A10 ... and the summary line says so")
+    rr = P.kv_capacity_rows(live_cfg(mamba_mode="all"), kv_config(643))
+    ss = P.kv_capacity_summary(rr, 643)
+    check([r["blocks_per_request"] for r in rr][2] == 287 and ss["per_group"][2] == 1 and ss["total"] == 38, "A10 mamba all-mode: 280+7 blocks/request, still one state per block position")
+    mixed = [group(FullAttentionSpec(16, 1), 1), group(ChunkedLocalAttentionSpec(16, 1), 1), group(CrossAttentionSpec(16, 1), 1)]
+    sm = P.kv_capacity_summary(P.kv_capacity_rows(c1, kv_config(100, mixed)), 100)
+    check(sm["per_group"] == [1, None, None] and sm["unmodelled"] == [1, 2] and sm["capacity_tokens"] is None, "A10 chunked-local / cross attention are unmodelled")
+    check(P.ids_per_segment({"prefix_cacheable": True, "block_size": 16, "kinds": ("WeirdSpec", "KVCacheSpec", "object"), "eagle": False, "sliding_window": None, "mamba_cache_mode": None}, 16) is None, "A10 an unknown spec kind is unmodelled (never silently costed)")
+    check(P.ids_per_segment({"prefix_cacheable": True, "block_size": 64, "kinds": ("SlidingWindowSpec", "AttentionSpec", "KVCacheSpec", "object"), "eagle": True, "sliding_window": None, "mamba_cache_mode": None}, 3584) is None, "A10 a sliding-window spec without a window is unmodelled")
+
+    # Null block / tiny pools / max_model_len below the alignment.
+    for nb, usable, cap in ((1, 0, 0), (0, 0, 0), (38, 37, 0), (39, 38, 3584)):
+        st = P.kv_capacity_summary(rows, nb)
+        check(st["usable"] == usable and st["capacity_tokens"] == cap, f"A11 num_blocks={nb}: usable={usable}, capacity={cap} (never negative)")
+    small = live_cfg(max_model_len=1000)
+    rs = P.kv_capacity_rows(small, kv_config(643))
+    ss = P.kv_capacity_summary(rs, 643)
+    check([r["blocks_per_request"] for r in rs][0] == 1 and ss["capacity_tokens"] == 57_344, "A11 max_model_len 1000 < alignment: 1 MLA block/request; the segment arithmetic is independent of max_model_len")
+    s_empty = P.kv_capacity_summary([], 643)
+    l_empty = P.kv_capacity_lines([], s_empty, 10)
+    check(s_empty["capacity_tokens"] is None and len(l_empty) == 1 and "not derived (no prefix-cacheable group costs ids" in l_empty[0] and "=> n/a" in l_empty[0], "A11 empty group list: one summary line, capacity not derived, no division by zero")
+    s_scratch = P.kv_capacity_summary(P.kv_capacity_rows(cfg, kv_config(10, [group(KpoolTailSpec(4, 8, 4), 1)])), 10)
+    check(s_scratch["total"] == 0 and s_scratch["capacity_tokens"] is None and "not derived (no prefix-cacheable group costs ids" in P.kv_capacity_lines([], s_scratch, 10)[-1], "A11 only opted-out groups: capacity not derived rather than infinite")
+
+    # Knob matrix (same contract as the launcher's _glm53_validate_bool_flag).
+    def knob(value):
+        saved = os.environ.get(P.ENV_NAME)
+        try:
+            if value is None:
+                os.environ.pop(P.ENV_NAME, None)
+            else:
+                os.environ[P.ENV_NAME] = value
+            return P.kv_capacity_log_enabled()
+        finally:
+            if saved is None:
+                os.environ.pop(P.ENV_NAME, None)
+            else:
+                os.environ[P.ENV_NAME] = saved
+
+    check(knob(None) is True and knob("1") is True and knob("0") is False, "A12 unset -> on, 1 -> on, 0 -> off")
+    for bad in ("", " ", "01", "2", "yes", "true", "1 ", " 1", "1\r", "0x1", "-1", "on"):
+        try:
+            knob(bad)
+            check(False, f"A12 {bad!r} raises")
+        except ValueError as exc:
+            check(P.ENV_NAME in str(exc), f"A12 {bad!r} raises ValueError naming the knob")
+    log = drive(cfg, kc, env="0")
+    check(log.info == ["[glm53-kv-capacity-log] disabled (GLM53_KV_CAPACITY_LOG=0)"] and not log.warnings, "A12 disabled: one line saying so, nothing derived")
+    try:
+        drive(cfg, kc, env="yes")
+        check(False, "A12 malformed knob raises out of the log call (not swallowed by the derivation guard)")
+    except ValueError:
+        check(True, "A12 malformed knob raises out of the log call (not swallowed by the derivation guard)")
+
+    # Derivation failure -> warning, boot proceeds, nothing else logged.
+    class _Broken(FullAttentionSpec):
+        def max_memory_usage_bytes(self, cfg):
+            raise RuntimeError("synthetic spec failure")
+
+    log = drive(cfg, kv_config(10, [group(_Broken(16, 1), 1)]))
+    check(log.info == [] and len(log.warnings) == 1 and "RuntimeError: synthetic spec failure" in log.warnings[0] and "serving unaffected" in log.warnings[0], "A13 derivation exception -> one warning naming it, no info lines, no raise")
+
+    # No config mutation.
+    cfg2, kc2 = live_cfg(), kv_config(643)
+    before = (copy.deepcopy(cfg2.__dict__["model_config"].__dict__), copy.deepcopy(cfg2.cache_config.__dict__), kc2.num_blocks, [(g.kv_cache_spec.block_size, g.is_eagle_group, list(g.layer_names)) for g in kc2.kv_cache_groups])
+    drive(cfg2, kc2)
+    after = (cfg2.model_config.__dict__, cfg2.cache_config.__dict__, kc2.num_blocks, [(g.kv_cache_spec.block_size, g.is_eagle_group, list(g.layer_names)) for g in kc2.kv_cache_groups])
+    check(before == after, "A14 the log call mutates neither vllm_config nor kv_cache_config")
+
+
+# --------------------------------------------------------------------------
+# Part B -- patch mechanics on a fixture of the live file
+# --------------------------------------------------------------------------
+# Verbatim excerpts of glm53-exl3-head's kv_cache_utils.py (vLLM
+# 0.1.dev20051+g487ecf187, read read-only 2026-09-01), trimmed to the lines the
+# overlay depends on, in file order, in a module that compiles. The in-image
+# docstring of get_max_concurrency_for_kv_cache_config differs from upstream
+# 22df3a3; the signature line (the anchor) and the log block are identical in
+# both.
+FIXTURE = (
+    '''# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""KV-Cache Utilities."""
+
+import copy
+import hashlib
+import math
+import os
+from collections import defaultdict
+
+from vllm import envs
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.utils.math_utils import cdiv, round_up
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    KVCacheGroupSpec,
+)
+
+
+logger = init_logger(__name__)
+
+# The hash seed for the first block of any prefix block sequence.
+NONE_HASH = 0
+
+
+def is_kv_cache_type_uniform(kv_cache_spec: dict) -> bool:
+    try:
+        kv_cache_spec_values = list(kv_cache_spec.values())
+        _ = kv_cache_spec_values[0].merge(kv_cache_spec_values)
+    except AssertionError:
+        return False
+    return True
+
+
+'''
+    + P.ANCHOR_HELPERS
+    + '''    """
+    Get the maximum concurrency for the given KV cache configuration.
+
+    Block ids are globally unique across groups (one BlockPool), so a
+    max-length request costs the sum over groups of that group's block
+    demand — layout-independent, each group divides by its own page size.
+    """
+    num_blocks_per_request = sum(
+        cdiv(
+            group.kv_cache_spec.max_memory_usage_bytes(vllm_config),
+            group.kv_cache_spec.page_size_bytes,
+        )
+        for group in kv_cache_config.kv_cache_groups
+    )
+    max_concurrency = kv_cache_config.num_blocks / num_blocks_per_request
+    return max_concurrency
+
+
+def may_override_num_blocks(vllm_config: VllmConfig, num_blocks: int) -> int:
+    """
+    Override the number of kv cache blocks if `num_gpu_blocks_override` is set.
+    The override is logged once, at the call site in `get_kv_cache_configs`.
+    """
+    if vllm_config.cache_config.num_gpu_blocks_override is not None:
+        num_blocks = vllm_config.cache_config.num_gpu_blocks_override
+    return num_blocks
+
+
+def get_kv_cache_capacity(
+    vllm_config: VllmConfig, kv_cache_config: KVCacheConfig
+) -> tuple[int, float]:
+    """
+    Get the group-aware KV cache token capacity and max concurrency.
+    """
+    max_model_len = vllm_config.model_config.max_model_len
+    max_concurrency = get_max_concurrency_for_kv_cache_config(
+        vllm_config, kv_cache_config
+    )
+    return int(max_concurrency * max_model_len), max_concurrency
+
+
+def update_kv_cache_capacity(
+    vllm_config: VllmConfig, kv_cache_config: KVCacheConfig
+) -> None:
+    """Store and log the resolved KV cache capacity."""
+    num_tokens, max_concurrency = get_kv_cache_capacity(vllm_config, kv_cache_config)
+    vllm_config.cache_config.kv_cache_size_tokens = num_tokens
+    vllm_config.cache_config.kv_cache_max_concurrency = max_concurrency
+    max_model_len = vllm_config.model_config.max_model_len
+'''
+    + P.ANCHOR_CALL
+    + '''
+
+def _max_memory_usage_bytes_from_groups(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> int:
+    return 0
+'''
+)
+
+
+def _stub_vllm(logger: P._RecordingLogger) -> dict:
+    """sys.modules stubs so the (patched) fixture can be exec'd end to end."""
+    mods = {}
+
+    def mod(name, **attrs):
+        m = types.ModuleType(name)
+        m.__dict__.update(attrs)
+        mods[name] = m
+        return m
+
+    mod("vllm", envs=types.SimpleNamespace())
+    mod("vllm.config", VllmConfig=object)
+    mod("vllm.logger", init_logger=lambda name: logger)
+    mod("vllm.utils")
+    mod("vllm.utils.math_utils", cdiv=P.cdiv, round_up=lambda x, y: -(-x // y) * y)
+    mod("vllm.v1")
+    mod("vllm.v1.kv_cache_interface", KVCacheConfig=object, KVCacheGroupSpec=object)
+    return mods
+
+
+def exec_module(text: str, logger: P._RecordingLogger) -> dict:
+    saved = {k: sys.modules.get(k) for k in _stub_vllm(logger)}
+    try:
+        sys.modules.update(_stub_vllm(logger))
+        ns: dict = {"__name__": "kv_cache_utils_fixture"}
+        exec(compile(text, "kv_cache_utils_fixture.py", "exec"), ns)
+        return ns
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+
+
+def run_overlay(target: Path, *args: str, env_extra: dict | None = None) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "GLM53_KV_CACHE_UTILS_PY": str(target)}
+    env.pop(P.ENV_NAME, None)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run([sys.executable, str(PATCH), *args], text=True, capture_output=True, env=env)
+
+
+def part_b() -> None:
+    print("Part B: patch mechanics (fixture of the live kv_cache_utils.py)")
+    compile(FIXTURE, "fixture", "exec")
+    check(FIXTURE.count(P.ANCHOR_HELPERS) == 1 and FIXTURE.count(P.ANCHOR_CALL) == 1, "B0 fixture carries both pinned anchors exactly once")
+    check(not P.verified_state(FIXTURE) and all(m not in FIXTURE for _n, m, _a, _p in P.SITES), "B0 pristine fixture is not in the verified state and carries no mark")
+
+    patched, action = P.prepare(FIXTURE)
+    compile(patched, "patched", "exec")
+    check(action == "patched" and P.verified_state(patched), "B1 prepare -> patched, verified state")
+    check(patched.count(P.ANCHOR_CALL) == 1 and patched.count(P.ANCHOR_HELPERS) == 1, "B1 the stock 'GPU KV cache size' info_once and the function signature survive byte-identical")
+    check(P.ANCHOR_CALL + P.MARK_CALL in patched, "B1 the overlay call is the very next line after the stock line (same function, same indentation)")
+    check(patched.index(P.MARK_HELPERS) < patched.index(P.ANCHOR_HELPERS) < patched.index(P.MARK_CALL), "B1 helpers precede the function they mirror, the call comes last")
+    check(P.HELPERS_SRC in patched, "B1 the injected helper text is HELPERS_SRC verbatim")
+    stock_before = FIXTURE[FIXTURE.index("def update_kv_cache_capacity") : FIXTURE.index(P.ANCHOR_CALL) + len(P.ANCHOR_CALL)]
+    stock_after = patched[patched.index("def update_kv_cache_capacity") : patched.index(P.ANCHOR_CALL) + len(P.ANCHOR_CALL)]
+    check(stock_before == stock_after, "B1 update_kv_cache_capacity up to and including the stock line is unchanged")
+
+    # End to end through the patched text: the stock line first, then ours.
+    log = P._RecordingLogger()
+    ns = exec_module(patched, log)
+    cfg, kc = live_cfg(), kv_config(643)
+    cfg.cache_config.num_gpu_blocks_override = None
+    saved = os.environ.pop(P.ENV_NAME, None)
+    try:
+        ns["update_kv_cache_capacity"](cfg, kc)
+    finally:
+        if saved is not None:
+            os.environ[P.ENV_NAME] = saved
+    check(log.info[0] == "GPU KV cache size: 1,553,140 tokens, Maximum concurrency for 1,000,000 tokens per request: 1.55x", "B2 patched update_kv_cache_capacity still logs the stock line first, verbatim")
+    check(len(log.info) == 9 and log.info[1].startswith("[glm53-kv-capacity-log] group 0: MLAAttentionSpec") and "usable block ids: 642" in log.info[8] and "38 (per group: [1, 0, 1, 1, 1, 1, 33])" in log.info[8] and not log.warnings, "B2 ... followed by the 7 group lines and the summary (642 / 38 / 57,344)")
+    check(cfg.cache_config.kv_cache_size_tokens == 1_553_140 and abs(cfg.cache_config.kv_cache_max_concurrency - 643 / 414) < 1e-12, "B2 kv_cache_size_tokens / kv_cache_max_concurrency stored exactly as stock")
+    log0 = P._RecordingLogger()
+    ns0 = exec_module(FIXTURE, log0)
+    cfg0 = live_cfg()
+    cfg0.cache_config.num_gpu_blocks_override = None
+    ns0["update_kv_cache_capacity"](cfg0, kv_config(643))
+    check(log0.info == log.info[:1], "B2 pristine fixture logs exactly the first of those lines (the overlay adds, never alters)")
+
+    again, action2 = P.prepare(patched)
+    check(again == patched and action2 == "already present", "B3 idempotent: prepare on a patched file is a byte-identical no-op")
+
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        target = tmp / "kv_cache_utils.py"
+        target.write_text(FIXTURE)
+        os.chmod(target, 0o644)
+        pyc_dir = tmp / "__pycache__"
+        pyc_dir.mkdir()
+        stale = pyc_dir / "kv_cache_utils.cpython-312.pyc"
+        stale.write_bytes(b"stale")
+
+        r = run_overlay(target, "--preflight")
+        check(r.returncode == 0 and "preflight OK (patched)" in r.stdout and target.read_text() == FIXTURE and stale.exists(), f"B4 --preflight on a pristine file: rc=0, reports 'patched', writes nothing (stdout={r.stdout.strip()!r})")
+        r = run_overlay(target)
+        check(r.returncode == 0 and "kv-capacity-log patched" in r.stdout and target.read_text() == patched, f"B4 apply: rc=0, file == prepare() output (stdout={r.stdout.strip()!r})")
+        check(not stale.exists(), "B4 stale bytecode for the target was cleared")
+        check(stat_mode(target) == 0o644 and not list(tmp.glob(".*.tmp")), "B4 mode preserved, no temp litter")
+        r = run_overlay(target)
+        check(r.returncode == 0 and "already present" in r.stdout and target.read_text() == patched, "B4 second apply: 'already present', byte-identical")
+        r = run_overlay(target, "--preflight", env_extra={P.ENV_NAME: ""})
+        check(r.returncode == 0 and "already present" in r.stdout, "B4 --preflight does not consult the knob (an empty knob is the runtime's error, not the installer's)")
+        r = run_overlay(target, env_extra={P.ENV_NAME: ""})
+        check(r.returncode == 0 and "GLM53_KV_CAPACITY_LOG=''" in r.stdout, "B4 apply reports the knob as set (empty shown as '', not normalised to 1)")
+
+        # Drift: each anchor altered by one character, one at a time -> refused, nothing written.
+        for name, _mark, anchor, _patched in P.SITES:
+            drifted = FIXTURE.replace(anchor, anchor.replace("_", "-", 1), 1)  # one character
+            assert drifted != FIXTURE
+            target.write_text(drifted)
+            r = run_overlay(target)
+            check(r.returncode != 0 and "drifted" in r.stderr and name in r.stderr and target.read_text() == drifted and not list(tmp.glob(".*.tmp")), f"B5 anchor '{name}' drifted -> non-zero exit naming it, file untouched")
+            try:
+                P.prepare(drifted)
+                check(False, f"B5 prepare() raises on drifted '{name}'")
+            except ValueError as exc:
+                check(name in str(exc), f"B5 prepare() raises on drifted '{name}'")
+
+        # Partial / altered markers refused.
+        half = FIXTURE.replace(P.ANCHOR_HELPERS, P.PATCHED_HELPERS, 1)
+        target.write_text(half)
+        r = run_overlay(target)
+        check(r.returncode != 0 and "partial" in r.stderr and target.read_text() == half, "B6 only the helpers present (marks=1 of 2) -> refused, untouched")
+        altered = patched.replace("_glm53_log_kv_capacity(vllm_config, kv_cache_config, max_model_len)  # [glm53-kv-capacity-log]", "_glm53_log_kv_capacity(vllm_config, kv_cache_config, 0)  # [glm53-kv-capacity-log]", 1)
+        target.write_text(altered)
+        r = run_overlay(target)
+        check(r.returncode != 0 and "partial" in r.stderr and target.read_text() == altered, "B6 marked but altered call -> refused, untouched")
+        dup = patched + "\n" + P.MARK_CALL
+        target.write_text(dup)
+        r = run_overlay(target)
+        check(r.returncode != 0 and target.read_text() == dup, "B6 duplicated mark -> refused, untouched")
+
+        # A file that lacks a binding the helpers need is refused before any write.
+        nobind = FIXTURE.replace("import math\n", "", 1)
+        target.write_text(nobind)
+        r = run_overlay(target)
+        check(r.returncode != 0 and "does not bind 'import math'" in r.stderr and target.read_text() == nobind, "B7 missing `import math` above the insert point -> refused (helpers would NameError)")
+        nolog = FIXTURE.replace("logger = init_logger(__name__)\n", "", 1)
+        target.write_text(nolog)
+        r = run_overlay(target)
+        check(r.returncode != 0 and "logger = init_logger" in r.stderr and target.read_text() == nolog, "B7 missing module logger -> refused")
+
+        r = run_overlay(tmp / "absent.py")
+        check(r.returncode != 0 and "missing" in r.stderr, "B7 missing target -> non-zero exit")
+
+    # The real installed file, when present (mandatory in the image).
+    installed = P.TARGET
+    if installed.is_file():
+        text = installed.read_text()
+        try:
+            out, act = P.prepare(text)
+            compile(out, str(installed), "exec")
+            check(act in ("patched", "already present") and P.verified_state(out), f"B8 installed {installed}: preflight OK ({act})")
+            check(text.count(P.ANCHOR_CALL) == 1, "B8 installed file carries the stock 'GPU KV cache size' block exactly once")
+        except ValueError as exc:
+            check(False, f"B8 installed {installed}: preflight failed: {exc}")
+    elif os.environ.get("GLM53_REQUIRE_TARGET") == "1":
+        check(False, f"B8 GLM53_REQUIRE_TARGET=1 but {installed} is missing")
+    else:
+        print(f"  skip B8 installed file not present ({installed})")
+
+
+def stat_mode(path: Path) -> int:
+    return path.stat().st_mode & 0o777
+
+
+# --------------------------------------------------------------------------
+# Part C -- launcher / image wiring
+# --------------------------------------------------------------------------
+def guard_source() -> str:
+    text = START.read_text()
+    begin = text.index("# GLM53 numeric config guard (begin)")
+    end_marker = "# GLM53 numeric config guard (end)"
+    return text[begin : text.index(end_marker, begin) + len(end_marker)]
+
+
+def part_c() -> None:
+    print("Part C: launcher / image wiring")
+    if not START.is_file():
+        check(False, "C0 start.sh missing")
+        return
+    src = START.read_text()
+    guard = guard_source()
+    check('_glm53_validate_bool_flag GLM53_KV_CAPACITY_LOG "${GLM53_KV_CAPACITY_LOG-1}"' in guard, "C1 the numeric guard validates GLM53_KV_CAPACITY_LOG with the 0/1 validator (unset -> 1)")
+    check('_cli_kvcap_set="${GLM53_KV_CAPACITY_LOG+1}"' in src and '_cli_kvcap="${GLM53_KV_CAPACITY_LOG-}"' in src and '[ -n "${_cli_kvcap_set}" ] && GLM53_KV_CAPACITY_LOG="$_cli_kvcap"' in src, "C1 caller export wins over .env, set-ness aware (an explicitly empty export is captured, then rejected)")
+    check(src.index('_cli_kvcap_set="${GLM53_KV_CAPACITY_LOG+1}"') < src.index('source "$SCRIPT_DIR/.env"') < src.index('[ -n "${_cli_kvcap_set}" ] && GLM53_KV_CAPACITY_LOG="$_cli_kvcap"'), "C1 capture before .env is sourced, replay after")
+    check('GLM53_KV_CAPACITY_LOG="${GLM53_KV_CAPACITY_LOG-1}"' in src, "C1 default 1 applies only when UNSET")
+    check('KVCAP_PATCH_HOST="${KVCAP_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kv_capacity_log.py}"' in src, "C2 KVCAP_PATCH_HOST defaults to the shipped overlay")
+    check('"$KVCAP_PATCH_HOST|[glm53-kv-capacity-log]|$main_guard"' in src and "validate_overlay_artifacts" in src, "C2 the overlay is in the fail-closed artifact guard (identity string + EOF sentinel)")
+    check("start|restart) validate_numeric_config; validate_overlay_artifacts ;;" in src, "C2 the guard runs on start|restart before anything else in main()")
+    check('[ -f "$KVCAP_PATCH_HOST" ] || die "$KVCAP_PATCH_HOST missing"' in src and 'scp -q -o BatchMode=yes "$KVCAP_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kv_capacity_log.py"' in src, "C2 preflight existence check + scp to the worker")
+    check("-v '/tmp/patch_kv_capacity_log.py:/opt/glm53/patch_kv_capacity_log.py:ro'" in src and '-v "$KVCAP_PATCH_HOST:/opt/glm53/patch_kv_capacity_log.py:ro"' in src, "C2 read-only mount on both ranks")
+    check('-e "GLM53_KV_CAPACITY_LOG=$GLM53_KV_CAPACITY_LOG"' in src, "C2 the knob is forwarded in nccl_common (both ranks)")
+    check('log "boot KV-capacity breakdown log: GLM53_KV_CAPACITY_LOG=${GLM53_KV_CAPACITY_LOG} (both ranks)"' in src, "C2 the launcher logs the effective value")
+    order = src[src.index("GLM53_OVERLAY_ORDER=(") : src.index(")", src.index("GLM53_OVERLAY_ORDER=("))]
+    names = order.split()[1:]
+    check("patch_kv_capacity_log.py" in names and names.index("patch_kv_capacity_log.py") > names.index("patch_glm5_drafter_group.py") and names.index("patch_kv_capacity_log.py") > names.index("patch_hybrid_prefix_hit.py") and names.index("patch_kv_capacity_log.py") < names.index("patch_xgrammar_termination.py"), f"C3 pinned order: drafter-group -> hybrid -> ... -> kv-capacity-log -> xgrammar ({names.index('patch_kv_capacity_log.py')})")
+    check('emit_overlay_block >> "$HEAD_SCRIPT"' in src and 'emit_overlay_block >> "$WORKER_SCRIPT"' in src, "C3 both rank scripts take the order from emit_overlay_block")
+    overlay_text = PATCH.read_text()
+    last = [ln for ln in overlay_text.splitlines() if ln.strip()][-1]
+    check(last == "    sys.exit(main())" and "[glm53-kv-capacity-log]" in overlay_text, "C3 overlay ends with the EOF sentinel and carries its identity string (artifact guard contract)")
+
+    def run(value):
+        script = guard + "\nGPU_MEM_UTIL=0.87; MAX_MODEL_LEN=1000000; MAX_NUM_SEQS=4; MAX_NUM_BATCHED_TOKENS=1024\n" + "validate_numeric_config || exit $?\n" + 'printf "%s\\n" "${GLM53_KV_CAPACITY_LOG-unset}"\n'
+        env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "LC_ALL": "C"}
+        if value is not None:
+            env["GLM53_KV_CAPACITY_LOG"] = value
+        r = subprocess.run(["bash", "-c", script], text=True, capture_output=True, env=env)
+        return r.returncode, r.stdout.strip(), r.stderr.strip()
+
+    for value, out in ((None, "unset"), ("0", "0"), ("1", "1")):
+        rc, o, e = run(value)
+        check(rc == 0 and o == out, f"C4 GLM53_KV_CAPACITY_LOG={value!r} accepted (rc={rc} out={o!r} {e[:60]})")
+    for value in ("", " ", "01", "2", "yes", "true", "1 ", " 1", "1\r", "0x1", "-1"):
+        rc, o, e = run(value)
+        check(rc == 2 and "GLM53_KV_CAPACITY_LOG" in e, f"C4 GLM53_KV_CAPACITY_LOG={value!r} rejected rc=2 with a named error (rc={rc} {e[:60]!r})")
+
+    if DOCKERFILE.is_file():
+        d = DOCKERFILE.read_text()
+        i_hyb = d.index("RUN python3 /opt/glm53/patch_hybrid_prefix_hit.py")
+        i_drf = d.index("RUN python3 /opt/glm53/patch_glm5_drafter_group.py")
+        i_tst = d.index("python3 /opt/glm53/test_kv_capacity_log.py")
+        i_pat = d.index("RUN python3 /opt/glm53/patch_kv_capacity_log.py")
+        check("COPY overlay/patch_kv_capacity_log.py /opt/glm53/patch_kv_capacity_log.py" in d and "COPY tests/test_kv_capacity_log.py /opt/glm53/test_kv_capacity_log.py" in d, "C5 Dockerfile copies overlay + test")
+        check(i_drf < i_hyb < i_tst < i_pat and "GLM53_REQUIRE_TARGET=1" in d[i_tst - 200 : i_tst], "C5 Dockerfile: drafter-group -> hybrid -> this test (installed file mandatory) -> this patch")
+    if ENV_EXAMPLE.is_file():
+        check("GLM53_KV_CAPACITY_LOG=1" in ENV_EXAMPLE.read_text(), "C6 .env.example documents the knob")
+    if README.is_file():
+        rd = README.read_text()
+        check("| `GLM53_KV_CAPACITY_LOG` | `1` |" in rd and "## What the KV cache boot line means" in rd and "`overlay/patch_kv_capacity_log.py`" in rd, "C6 README: knob row, section, overlay row")
+
+
+def main() -> int:
+    print(f"overlay: {PATCH}  python: {sys.executable}")
+    part_a()
+    part_b()
+    part_c()
+    print()
+    if FAILURES:
+        print(f"FAILED ({len(FAILURES)}/{CHECKS}): " + "; ".join(FAILURES))
+        return 1
+    print(f"kv-capacity-log overlay OK ({CHECKS} checks)")
+    return 0
+
+
+def test_kv_capacity_log() -> None:
+    """pytest entry point."""
+    FAILURES.clear()
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_launcher_rank_parity.py
+++ b/tests/test_launcher_rank_parity.py
@@ -1,0 +1,697 @@
+#!/usr/bin/env python3
+"""Static + dry-run regression for the two-rank launcher (start.sh).
+
+Hardening asked for by the production-like tester run on PRs #83/#84:
+
+  A  GLM53_APC_RETENTION_INTERVAL_SWA guard -- "" (auto) or 0 pass, anything
+     else must be a positive multiple of 3584 no larger than 1,000,000; the
+     canonical value is what the ranks receive. Runs on the checkout whose
+     launcher actually forwards that knob to the containers (detected from
+     the `-e VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA=` line, not guessed).
+  B  Pre-stop gate -- `./start.sh restart` with a bad knob, or with ANY
+     mounted overlay missing / empty / unparseable / pointed at a different
+     overlay, exits 2 BEFORE the first docker or ssh call, so healthy
+     containers are never stopped for a launch that cannot succeed.
+  C  Overlay order -- one list (GLM53_OVERLAY_ORDER) pinned
+     hybrid -> per-group -> fine-grained (-> kv-capacity-log, where shipped) is
+     emitted verbatim into BOTH rank inner scripts.
+  D  Rank parity -- for every /opt/glm53 patch the head bind-mounts host
+     file S, the worker's mount is fed from /tmp/X and the scp that produced
+     /tmp/X read the same S; both ranks receive identical effective values
+     for GLM53_APC_RETENTION_INTERVAL, GLM53_APC_RETENTION_INTERVAL_SWA,
+     GLM53_FINEGRAINED_APC and GLM53_KV_CAPACITY_LOG (launcher names) and the container-side names they
+     map to (VLLM_PREFIX_CACHE_RETENTION_INTERVAL[_SWA], GLM53_FINEGRAINED_APC);
+     a knob the launcher wires must be PRESENT on both ranks, not merely
+     equal. The comparison itself is exercised with a synthetic one-rank
+     mismatch so a silent pass cannot hide behind equality.
+
+Everything drives the shipped start.sh under bash from an allow-listed
+environment (PATH with docker / ssh / scp / rsync / curl / ip / nvidia-smi
+stubbed first, HOME pointed at a temp dir, no BASH_ENV / PYTHONPATH / HF_*
+/ GLM53_* / VLLM_* leakage). Nothing talks to a real host. The test is
+branch-agnostic: it discovers which prefix-cache overlays this checkout
+ships from the `*_PATCH_HOST="${*_PATCH_HOST:-` assignments and reports it.
+
+Run:  python3 tests/test_launcher_rank_parity.py   (or pytest)
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+START = ROOT / "start.sh"
+
+FAILURES: list[str] = []
+
+BLOCK = 3584
+RETENTION_MAX = 1_000_000
+SWA = "GLM53_APC_RETENTION_INTERVAL_SWA"
+SWA_FORWARD = '-e "VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA=$GLM53_APC_RETENTION_INTERVAL_SWA"'
+FG = "GLM53_FINEGRAINED_APC"
+FG_FORWARD = '-e "GLM53_FINEGRAINED_APC=$GLM53_FINEGRAINED_APC"'
+KV = "GLM53_KV_CAPACITY_LOG"
+KV_FORWARD = '-e "GLM53_KV_CAPACITY_LOG=$GLM53_KV_CAPACITY_LOG"'
+
+# Launcher knobs the tester asked to see reach both ranks identically, and the
+# container-side names the launcher maps them to.
+LAUNCHER_KNOBS = ("GLM53_APC_RETENTION_INTERVAL", SWA, FG, KV)
+CONTAINER_NAMES = LAUNCHER_KNOBS + (
+    "VLLM_PREFIX_CACHE_RETENTION_INTERVAL",
+    "VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA",
+)
+
+PINNED = (
+    "patch_hybrid_prefix_hit.py",
+    "patch_apc_per_group_retention.py",
+    "patch_apc_fine_grained_hits.py",
+)
+# Ships on its own (kv_cache_utils.py only, log-only; no coordinator anchors).
+# Where listed it must follow patch_glm5_drafter_group.py (same file) and, for
+# one pinned order, the three coordinator overlays.
+KVCAP = "patch_kv_capacity_log.py"
+DRAFTER = "patch_glm5_drafter_group.py"
+APC_HOST_VARS = {
+    "APC_PATCH_HOST": "patch_hybrid_prefix_hit.py",
+    "PERGROUP_PATCH_HOST": "patch_apc_per_group_retention.py",
+    "FINEHIT_PATCH_HOST": "patch_apc_fine_grained_hits.py",
+    "KVCAP_PATCH_HOST": KVCAP,
+}
+
+SEP = "\x1f"
+
+STUB = """#!/usr/bin/env bash
+# Records every invocation; never touches a host.
+{ printf '%s\\x1f' "$(basename "$0")" "$@"; printf '\\n'; } >> "$GLM53_STUB_LOG"
+case "$(basename "$0")" in
+    ip) printf 'inet %s/24\\n' "${GLM53_STUB_HEAD_IP:-10.0.0.1}" ;;
+esac
+exit 0
+"""
+
+
+def check(cond: bool, label: str) -> None:
+    print(("  ok   " if cond else "  FAIL ") + label)
+    if not cond:
+        FAILURES.append(label)
+
+
+def source() -> str:
+    return START.read_text()
+
+
+def guard_source() -> str:
+    """start.sh's numeric-config guard, lifted out by its sentinels (same
+    technique as tests/test_numeric_config.py)."""
+    text = source()
+    begin = text.index("# GLM53 numeric config guard (begin)")
+    end_marker = "# GLM53 numeric config guard (end)"
+    end = text.index(end_marker, begin) + len(end_marker)
+    return text[begin:end]
+
+
+def base_env(**extra: str) -> dict[str, str]:
+    """Allow-listed environment: nothing from the developer/CI shell leaks in
+    (no BASH_ENV, PYTHONPATH, HF_HOME, EXTRA_ARGS, SKIP_*, *_PATCH_HOST ...)."""
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", "/"),
+        "USER": "glm53-parity",
+        "LC_ALL": "C",
+        "TERM": "dumb",
+    }
+    env.update(extra)
+    return env
+
+
+def host_vars() -> dict[str, str]:
+    """Every `<NAME>_PATCH_HOST="${<NAME>_PATCH_HOST:-$SCRIPT_DIR/overlay/<file>}"`
+    assignment in start.sh, from the real assignment, not from substring hits."""
+    out: dict[str, str] = {}
+    for m in re.finditer(
+        r'^([A-Z_]+_PATCH_HOST)="\$\{\1:-\$SCRIPT_DIR/overlay/([A-Za-z0-9_.]+)\}"$', source(), re.M
+    ):
+        out[m.group(1)] = m.group(2)
+    return out
+
+
+def shipped_apc_vars() -> dict[str, str]:
+    return {v: b for v, b in host_vars().items() if v in APC_HOST_VARS}
+
+
+def wires_swa() -> bool:
+    return SWA_FORWARD in source()
+
+
+def wires_fg() -> bool:
+    return FG_FORWARD in source()
+
+
+def wires_kv() -> bool:
+    return KV_FORWARD in source()
+
+
+# ------------------------------------------------------------------ part A --
+
+
+def run_retention_guard(value: str | None) -> tuple[int, str, str]:
+    script = (
+        guard_source()
+        + "\nGPU_MEM_UTIL=0.87; MAX_MODEL_LEN=1000000; MAX_NUM_SEQS=4\n"
+        + "MAX_NUM_BATCHED_TOKENS=1024\n"
+        + f"{FG}=1\n"
+        + "validate_numeric_config || exit $?\n"
+        + f'printf "%s\\n" "${{{SWA}-unset}}"\n'
+    )
+    env = base_env()
+    if value is not None:
+        env[SWA] = value
+    r = subprocess.run(["bash", "-c", script], text=True, capture_output=True, env=env)
+    return r.returncode, r.stdout.strip(), r.stderr.strip()
+
+
+def part_a() -> None:
+    print("Part A: GLM53_APC_RETENTION_INTERVAL_SWA guard (numeric config block)")
+    if not wires_swa():
+        check(
+            f"_glm53_validate_retention_interval {SWA}" not in guard_source(),
+            "A0 this launcher does not forward the SWA knob and does not pretend to validate it",
+        )
+        print("  skip A1-A3 (knob not forwarded by this checkout; validate-what-you-forward)")
+        return
+    text = guard_source()
+    check(
+        f"_glm53_validate_retention_interval {SWA}" in text,
+        "A1 the forwarded SWA knob is validated inside the numeric config guard",
+    )
+    check(
+        f"GLM53_APC_BLOCK_TOKENS={BLOCK}" in text and f"GLM53_APC_RETENTION_MAX={RETENTION_MAX}" in text,
+        f"A1 grid {BLOCK} and cap {RETENTION_MAX:,} are the documented constants",
+    )
+    accepted = {
+        None: "unset",
+        "": "",
+        "0": "0",
+        "00": "0",
+        str(BLOCK): str(BLOCK),
+        "0014336": "14336",
+        str(279 * BLOCK): str(279 * BLOCK),  # 999,936 = largest legal value
+    }
+    for value, canonical in accepted.items():
+        rc, out, err = run_retention_guard(value)
+        check(
+            rc == 0 and out == canonical,
+            f"A2 {SWA}={value!r} accepted, ranks receive {canonical!r} (rc={rc} out={out!r} {err})",
+        )
+    rejected = [
+        "1", "3000", "3585", "1000000", str(280 * BLOCK), "-3584", "+3584",
+        "3584.0", "1e3", " 3584", "3584 ", "3584\r", "nope", "0x", "0 ",
+        "99999999999999999999",
+    ]
+    for value in rejected:
+        rc, out, err = run_retention_guard(value)
+        check(
+            rc == 2 and SWA in err,
+            f"A3 {SWA}={value!r} rejected with rc=2 and a named error (rc={rc} err={err[:60]!r})",
+        )
+
+
+# --------------------------------------------------------------- harness --
+
+
+class Harness:
+    """A throwaway copy of the launcher checkout plus a stub PATH."""
+
+    def __init__(self, tmp: Path) -> None:
+        self.tmp = tmp
+        self.repo = tmp / "repo"
+        self.repo.mkdir()
+        shutil.copy2(START, self.repo / "start.sh")
+        shutil.copy2(ROOT / ".env.example", self.repo / ".env.example")
+        (self.repo / ".env").write_text((ROOT / ".env.example").read_text())
+        for sub in ("overlay", "files", "ablit"):
+            if (ROOT / sub).is_dir():
+                shutil.copytree(ROOT / sub, self.repo / sub)
+        self.home = tmp / "home"
+        self.home.mkdir()
+        self.bin = tmp / "bin"
+        self.bin.mkdir()
+        for tool in ("docker", "ssh", "scp", "rsync", "curl", "ip", "nvidia-smi"):
+            p = self.bin / tool
+            p.write_text(STUB)
+            p.chmod(p.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        self.log = tmp / "calls.log"
+
+        # A copy whose trailing `main "$@"` is replaced by `"$@"`, so a single
+        # launcher function can be driven with the real configuration preamble.
+        text = (self.repo / "start.sh").read_text()
+        assert text.rstrip().endswith('\nmain "$@"'), "start.sh must end with main \"$@\""
+        (self.repo / "start.fn.sh").write_text(text.rstrip()[: -len('main "$@"')] + '"$@"\n')
+
+    def env(self, **extra: str) -> dict[str, str]:
+        return base_env(
+            PATH=f"{self.bin}{os.pathsep}{os.environ.get('PATH', '/usr/bin:/bin')}",
+            HOME=str(self.home),
+            GLM53_STUB_LOG=str(self.log),
+            **extra,
+        )
+
+    def calls(self) -> list[list[str]]:
+        if not self.log.exists():
+            return []
+        out = []
+        for line in self.log.read_text().splitlines():
+            argv = line.split(SEP)
+            if argv and argv[-1] == "":
+                argv.pop()
+            out.append(argv)
+        return out
+
+    def run(self, cmd: str, entry: str = "start.sh", **extra: str) -> subprocess.CompletedProcess[str]:
+        if self.log.exists():
+            self.log.unlink()
+        return subprocess.run(
+            ["bash", f"./{entry}", cmd],
+            cwd=self.repo,
+            text=True,
+            capture_output=True,
+            check=False,
+            env=self.env(**extra),
+        )
+
+    def host_touching_calls(self) -> list[list[str]]:
+        return [c for c in self.calls() if c and c[0] in ("docker", "ssh", "scp", "rsync")]
+
+
+# ------------------------------------------------------------------ part B --
+
+
+def parses(text: str) -> bool:
+    import ast
+    try:
+        ast.parse(text)
+        return True
+    except SyntaxError:
+        return False
+
+
+def longest_parseable_prefix(text: str) -> str | None:
+    lines = text.splitlines(keepends=True)
+    for cut in range(len(lines) - 1, 0, -1):
+        candidate = "".join(lines[:cut])
+        if candidate.strip() and parses(candidate):
+            return candidate
+    return None
+
+
+
+def control(h: Harness, label: str) -> None:
+    r = h.run("restart")
+    calls = h.host_touching_calls()
+    head_rm = any(c[:3] == ["docker", "rm", "-f"] for c in calls)
+    worker_rm = any(c[0] == "ssh" and "docker rm -f" in c[-1] for c in calls)
+    last = (r.stderr.strip().splitlines() or [""])[-1]
+    check(
+        head_rm and worker_rm,
+        f"{label} (head rm={head_rm} worker rm={worker_rm}; later rc={r.returncode} is the stubbed preflight: {last[:100]!r})",
+    )
+
+
+def part_b(h: Harness) -> None:
+    print("Part B: restart fails closed before any container is stopped")
+    text = source()
+    main_at = text.index("main() {")
+    v_num = text.index("validate_numeric_config", main_at)
+    v_art = text.index("validate_overlay_artifacts", main_at)
+    restart = text.index("restart)  stop; start", main_at)
+    check(v_num < restart and v_art < restart, "B1 main() runs both validators before `restart) stop; start`")
+    check(
+        "start|restart) validate_numeric_config; validate_overlay_artifacts ;;" in text,
+        "B1 the validators share the start|restart arm",
+    )
+    guard_begin = text.index("# GLM53 overlay artifact guard (begin)")
+    guard_end = text.index("# GLM53 overlay artifact guard (end)")
+    guard = text[guard_begin:guard_end]
+    check(guard_begin < guard_end, "B1 the artifact guard has its own sentinel block")
+    check("|-\"" not in guard and '|-"' not in guard, "B1 every artifact carries an identity string (no untagged entries)")
+    check(
+        guard.count("|$main_guard\"") >= 6 and '|    return report"' in guard and "| tail -n 1 || true)" in guard,
+        "B1 every artifact carries its exact last line as an EOF sentinel (checked against the last non-blank line)",
+    )
+    check(
+        '"$CHAT_TEMPLATE_HOST"' in guard and "ablit/LAYER_MAP.json" in guard,
+        "B1 the chat template and the ablit layer map are gated too",
+    )
+
+    vars_ = host_vars()
+    shipped = shipped_apc_vars()
+    check("APC_PATCH_HOST" in shipped, "B2 checkout ships patch_hybrid_prefix_hit.py")
+    check(
+        "PERGROUP_PATCH_HOST" in shipped or "FINEHIT_PATCH_HOST" in shipped or "KVCAP_PATCH_HOST" in shipped,
+        "B2 checkout ships at least one of per-group / fine-grained / kv-capacity-log",
+    )
+    for var in vars_:
+        check(f'"${var}|' in guard, f"B2 {var} ({vars_[var]}) is in the artifact guard")
+    check("overlay/patch_ablit.py|" in guard and "overlay/ablit_runtime.py|" in guard, "B2 ablit hook + runtime are in the artifact guard")
+    check(
+        'for entry in "${artifacts[@]}"' in guard and "artifacts[@]}\" -eq 0" in guard,
+        "B2 the guard iterates a bash array and refuses an empty list (no process-substitution status gap)",
+    )
+
+    # Control FIRST: with a valid configuration the entrypoint gets PAST the
+    # validators and reaches stop (the stubs then fail preflight, which is
+    # fine). Without this, every negative case below could pass for the
+    # wrong reason (a guard that refuses everything).
+    control(h, "B3 control: valid restart passes the gate and reaches stop on both ranks")
+
+    def fails_closed(label: str, **env: str) -> None:
+        r = h.run("restart", **env)
+        calls = h.host_touching_calls()
+        last = r.stderr.strip().splitlines()[-1] if r.stderr.strip() else ""
+        check(
+            r.returncode == 2 and not calls,
+            f"{label}: rc={r.returncode}, host-touching calls={len(calls)} ({last[:90]!r})",
+        )
+
+    if wires_swa():
+        fails_closed(f"B3 restart with {SWA}=3000 exits 2 with nothing stopped", **{SWA: "3000"})
+        fails_closed(f"B3 restart with {SWA}=1003520 exits 2 with nothing stopped", **{SWA: "1003520"})
+    if wires_fg():
+        fails_closed(f"B3 restart with {FG}=yes exits 2 with nothing stopped", **{FG: "yes"})
+    if wires_kv():
+        fails_closed(f"B3 restart with {KV}=yes exits 2 with nothing stopped", **{KV: "yes"})
+        fails_closed(f"B3 restart with {KV}= (explicitly empty) exits 2 with nothing stopped", **{KV: ""})
+
+    broken = h.tmp / "broken_patch.py"
+    broken.write_text("def (:\n    pass\n")
+    empty = h.tmp / "empty_patch.py"
+    empty.write_text("")
+    video = h.repo / "overlay" / "patch_glm_video_placeholders.py"
+    hybrid = h.repo / "overlay" / "patch_hybrid_prefix_hit.py"
+    for var, base in vars_.items():
+        wrong = hybrid if base == video.name else video
+        fails_closed(f"B4 {var} missing ({base})", **{var: str(h.tmp / "does-not-exist.py")})
+        fails_closed(f"B4 {var} pointed at a different overlay ({wrong.name})", **{var: str(wrong)})
+    blank = h.tmp / "whitespace_only.py"
+    blank.write_text("\n   \n\t\n")
+    for var, base in shipped.items():
+        fails_closed(f"B4 {var} empty file ({base})", **{var: str(empty)})
+        fails_closed(f"B4 {var} whitespace-only file ({base}; pipefail-safe rc=2 diagnostic)", **{var: str(blank)})
+        fails_closed(f"B4 {var} unparseable file ({base})", **{var: str(broken)})
+    # Truncation: for EVERY guarded Python artifact, the longest strict prefix
+    # (by lines) that still parses. It carries the identity string and is
+    # valid Python, so only the EOF-sentinel check can refuse it -- and must.
+    guarded = {var: h.repo / "overlay" / base for var, base in vars_.items()}
+    guarded["overlay/patch_ablit.py"] = h.repo / "overlay" / "patch_ablit.py"
+    guarded["overlay/ablit_runtime.py"] = h.repo / "overlay" / "ablit_runtime.py"
+    for var, path in guarded.items():
+        prefix_text = longest_parseable_prefix(path.read_text())
+        check(prefix_text is not None and parses(prefix_text), f"B4 {path.name}: a strict prefix that still parses exists ({len(prefix_text.splitlines()) if prefix_text else 0} lines)")
+        if prefix_text is None:
+            continue
+        if var.startswith("overlay/"):
+            original = path.read_text()
+            path.write_text(prefix_text)
+            try:
+                fails_closed(f"B4 {path.name} truncated to its longest parseable prefix (fixed-path artifact)")
+            finally:
+                path.write_text(original)
+        else:
+            prefix = h.tmp / f"truncated_{path.name}"
+            prefix.write_text(prefix_text)
+            fails_closed(f"B4 {var} truncated to its longest parseable prefix ({path.name})", **{var: str(prefix)})
+    fails_closed("B4 CHAT_TEMPLATE_HOST missing", CHAT_TEMPLATE_HOST=str(h.tmp / "no-template.jinja"))
+    (h.tmp / "template-dir").mkdir(exist_ok=True)
+    (h.tmp / "template-dir" / "x").write_text("x")
+    fails_closed("B4 CHAT_TEMPLATE_HOST is a (non-empty) directory", CHAT_TEMPLATE_HOST=str(h.tmp / "template-dir"))
+    layer_map = h.repo / "ablit" / "LAYER_MAP.json"
+    saved = layer_map.read_text()
+    layer_map.write_text("{ not json")
+    try:
+        fails_closed("B4 ablit/LAYER_MAP.json not JSON")
+    finally:
+        layer_map.write_text(saved)
+
+    control(h, "B5 control after the negative cases (the harness copy is intact)")
+
+
+# ------------------------------------------------------------------ part C --
+
+
+def overlay_order() -> list[str]:
+    m = re.search(r"^GLM53_OVERLAY_ORDER=\(\n(.*?)^\)\n", source(), re.S | re.M)
+    assert m, "GLM53_OVERLAY_ORDER=( ... ) not found in start.sh"
+    return [ln.strip().split()[0] for ln in m.group(1).splitlines() if ln.strip() and not ln.strip().startswith("#")]
+
+
+def apply_sequence(script: Path) -> list[str]:
+    return re.findall(r"^\s*python3 /opt/glm53/(patch_[a-z0-9_]+\.py)$", script.read_text(), re.M)
+
+
+def part_c(h: Harness) -> None:
+    print("Part C: overlay order pinned once, emitted to both ranks")
+    text = source()
+    order = overlay_order()
+    idx = {name: order.index(name) for name in PINNED if name in order}
+    check(len(idx) == 3, f"C1 all three prefix-cache overlays are listed: {sorted(idx)}")
+    check(
+        len(idx) == 3 and idx[PINNED[0]] < idx[PINNED[1]] < idx[PINNED[2]],
+        "C1 pinned order hybrid -> per-group -> fine-grained",
+    )
+    if wires_kv() or KVCAP in order:
+        check(
+            KVCAP in order and len(idx) == 3 and order.index(KVCAP) > idx[PINNED[2]],
+            "C1 kv-capacity-log is listed after fine-grained (no shared anchors, but one pinned order)",
+        )
+        check(
+            KVCAP in order and DRAFTER in order and order.index(KVCAP) > order.index(DRAFTER),
+            "C1 kv-capacity-log is listed after patch_glm5_drafter_group (it edits the same kv_cache_utils.py)",
+        )
+    check(
+        'emit_overlay_block >> "$HEAD_SCRIPT"' in text and 'emit_overlay_block >> "$WORKER_SCRIPT"' in text,
+        "C2 both inner scripts take the block from emit_overlay_block",
+    )
+    check("python3 /opt/glm53/patch_" not in text, "C2 no literal per-rank patch ladder remains in start.sh")
+
+    r = h.run("write_inner_scripts", entry="start.fn.sh")
+    head = h.repo / ".glm53-exl3-head.inner.sh"
+    worker = h.repo / ".glm53-exl3-worker.inner.sh"
+    check(
+        r.returncode == 0 and head.is_file() and worker.is_file(),
+        f"C3 write_inner_scripts produced both inner scripts (rc={r.returncode} {r.stderr.strip()[:80]!r})",
+    )
+    if head.is_file() and worker.is_file():
+        hs, ws = apply_sequence(head), apply_sequence(worker)
+        check(hs == order, f"C3 head applies exactly GLM53_OVERLAY_ORDER ({len(hs)} entries)")
+        check(ws == order, f"C3 worker applies exactly GLM53_OVERLAY_ORDER ({len(ws)} entries)")
+        check(hs == ws, "C3 head and worker apply sequences are identical")
+        for s in (head, worker):
+            body = s.read_text()
+            check(
+                body.index("/opt/glm53/patch_hybrid_prefix_hit.py")
+                < body.index("/opt/glm53/patch_apc_per_group_retention.py")
+                < body.index("/opt/glm53/patch_apc_fine_grained_hits.py"),
+                f"C3 {s.name}: hybrid -> per-group -> fine-grained in the generated script",
+            )
+            check(
+                "python3 /opt/glm53/patch_ablit.py" in body
+                and body.index("patch_kpool_tail_slotmap.py") < body.index("python3 /opt/glm53/patch_ablit.py"),
+                f"C3 {s.name}: ablit still applies last",
+            )
+            if KVCAP in order:
+                check(
+                    body.index(f"/opt/glm53/{DRAFTER}") < body.index("/opt/glm53/patch_apc_fine_grained_hits.py") < body.index(f"/opt/glm53/{KVCAP}") < body.index("/opt/glm53/patch_xgrammar_termination.py"),
+                    f"C3 {s.name}: drafter-group -> ... -> fine-grained -> kv-capacity-log -> xgrammar in the generated script",
+                )
+            check(
+                re.search(r"if \[ -f /opt/glm53/patch_apc_per_group_retention\.py \]; then\n\s+python3", body) is not None,
+                f"C3 {s.name}: every slot is `[ -f ]`-guarded (unmounted sibling slot is a no-op)",
+            )
+
+
+# ------------------------------------------------------------------ part D --
+
+
+class Rank:
+    def __init__(self, argv: list[str]) -> None:
+        self.env: dict[str, str] = {}
+        self.mounts: dict[str, str] = {}  # container path -> source path
+        i = 0
+        while i < len(argv):
+            tok = argv[i]
+            if tok == "-e" and i + 1 < len(argv):
+                k, _, v = argv[i + 1].partition("=")
+                self.env[k] = v
+                i += 2
+                continue
+            if tok == "-v" and i + 1 < len(argv):
+                parts = argv[i + 1].split(":")
+                if len(parts) >= 2 and parts[1].startswith("/opt/glm53/") and parts[1].endswith(".py"):
+                    self.mounts[parts[1]] = parts[0]
+                i += 2
+                continue
+            i += 1
+
+
+def parity_issues(head: Rank, worker: Rank, scp: dict[str, str], required: dict[str, str]) -> list[str]:
+    """Everything that would make the two ranks differ. `scp` maps the
+    worker-side /tmp file to the host file it was copied from; `required`
+    maps container env names the launcher wires to the value expected."""
+    issues = []
+    for name in CONTAINER_NAMES:
+        if head.env.get(name) != worker.env.get(name):
+            issues.append(f"env {name}: head={head.env.get(name)!r} worker={worker.env.get(name)!r}")
+    for name, value in required.items():
+        if head.env.get(name) != value or worker.env.get(name) != value:
+            issues.append(f"env {name} expected {value!r} on both ranks: head={head.env.get(name)!r} worker={worker.env.get(name)!r}")
+    if set(head.mounts) != set(worker.mounts):
+        issues.append(f"mount set differs: head-only={sorted(set(head.mounts) - set(worker.mounts))} worker-only={sorted(set(worker.mounts) - set(head.mounts))}")
+    for dest, head_src in head.mounts.items():
+        worker_tmp = worker.mounts.get(dest)
+        worker_src = scp.get(worker_tmp or "")
+        if worker_src != head_src:
+            issues.append(f"{dest}: head mounts {head_src}, worker mounts {worker_tmp} which scp fed from {worker_src}")
+    return issues
+
+
+def rank_runs(h: Harness, **env: str) -> tuple[Rank, Rank, dict[str, str]] | None:
+    r = h.run("launch_cluster", entry="start.fn.sh", MODEL_DIR="/root/.cache/huggingface/x", **env)
+    if r.returncode != 0:
+        print(f"    launch_cluster rc={r.returncode}: {r.stderr.strip()[-300:]}")
+        return None
+    head = worker = None
+    scp: dict[str, str] = {}
+    for c in h.calls():
+        if c[:2] == ["docker", "run"]:
+            head = Rank(c[2:])
+        elif c[0] == "ssh" and c[-1].lstrip().startswith("docker run"):
+            worker = Rank(shlex.split(c[-1])[2:])
+        elif c[0] == "scp" and len(c) >= 3 and ":" in c[-1]:
+            scp[c[-1].split(":", 1)[1]] = c[-2]
+    if head is None or worker is None:
+        print(f"    could not find both docker run lines (head={head is not None} worker={worker is not None})")
+        return None
+    return head, worker, scp
+
+
+def part_d(h: Harness) -> None:
+    print("Part D: both ranks mount the same host artifacts and get identical effective values")
+    shipped = shipped_apc_vars()
+    order = overlay_order()
+
+    scenarios: list[tuple[str, dict[str, str]]] = [("defaults", {})]
+    if wires_swa():
+        scenarios += [("SWA=14336", {SWA: "14336"}), ("SWA=0", {SWA: "0"}), ("SWA unset (auto)", {})]
+    if wires_fg():
+        scenarios += [("FINEGRAINED=0", {FG: "0"}), ("FINEGRAINED=1", {FG: "1"})]
+    if wires_swa() and wires_fg():
+        scenarios.append(("SWA=14336 + FINEGRAINED=0", {SWA: "14336", FG: "0"}))
+    if wires_kv():
+        scenarios += [("KVCAP=0", {KV: "0"}), ("KVCAP=1", {KV: "1"}), ("KVCAP unset (default 1)", {})]
+
+    first = None
+    for label, env in scenarios:
+        got = rank_runs(h, **env)
+        check(got is not None, f"D1 [{label}] launch_cluster dry-run captured both docker run lines")
+        if got is None:
+            continue
+        head, worker, scp = got
+        first = first or got
+        required: dict[str, str] = {}
+        if wires_swa() and env.get(SWA, ""):
+            required["VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA"] = env[SWA]
+        if wires_fg():
+            required[FG] = env.get(FG, "1")
+        if wires_kv():
+            required[KV] = env.get(KV, "1")
+        issues = parity_issues(head, worker, scp, required)
+        check(not issues, f"D2 [{label}] rank parity: " + ("; ".join(issues) if issues else "no differences"))
+        for name in CONTAINER_NAMES:
+            hv, wv = head.env.get(name), worker.env.get(name)
+            print(f"         {name}: head={hv!r} worker={wv!r}" + ("  (not wired by this launcher)" if hv is None and wv is None else ""))
+        if wires_swa() and not env.get(SWA, ""):
+            check(
+                "VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA" not in head.env and "VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA" not in worker.env,
+                f"D2 [{label}] empty SWA (auto) is forwarded to neither rank",
+            )
+        mounted = {Path(p).name for p in head.mounts}
+        check(len(head.mounts) >= 9, f"D3 [{label}] {len(head.mounts)} /opt/glm53 patch mounts, identical chain head-mount = scp source = worker-mount")
+        # Expected source -> destination map for EVERY *_PATCH_HOST: the head
+        # mount, the scp source and the worker mount must all be that file.
+        wrong_map = []
+        for var, base in host_vars().items():
+            dest = f"/opt/glm53/{base}"
+            src = head.mounts.get(dest, "")
+            if Path(src).resolve() != (h.repo / "overlay" / base).resolve() or dest not in worker.mounts:
+                wrong_map.append(f"{var}: {dest} <- {src or 'unmounted'}")
+        check(not wrong_map, f"D3 [{label}] every *_PATCH_HOST maps to its own /opt/glm53 destination on both ranks (wrong={wrong_map})")
+        for var, base in shipped.items():
+            src = head.mounts.get(f"/opt/glm53/{base}", "")
+            check(
+                base in mounted and Path(src).resolve() == (h.repo / "overlay" / base).resolve(),
+                f"D3 [{label}] {base} ({var}) mounted on both ranks from the checkout's overlay/ copy ({src})",
+            )
+        unlisted = sorted(m for m in mounted if m.startswith("patch_") and m not in order)
+        check(not unlisted, f"D3 [{label}] every mounted patch_*.py is in GLM53_OVERLAY_ORDER (unlisted={unlisted})")
+
+    # Negative self-check: the comparison must notice a one-rank difference.
+    if first is not None:
+        head, worker, scp = first
+        tampered = Rank([])
+        tampered.env = dict(worker.env)
+        tampered.mounts = dict(worker.mounts)
+        knob = FG if FG in tampered.env else (KV if KV in tampered.env else "GLM53_MIXED_PREFILL_CHUNK")
+        tampered.env[knob] = "0" if tampered.env.get(knob) != "0" else "1"
+        dest = next(iter(sorted(tampered.mounts)))
+        del tampered.mounts[dest]
+        issues = parity_issues(head, tampered, scp, {})
+        check(
+            any(f"env {knob}" in i for i in issues) and any("mount set differs" in i for i in issues),
+            f"D4 synthetic one-rank mismatch is reported ({len(issues)} issues: {issues[:2]})",
+        )
+        bad_scp = dict(scp)
+        wdest = sorted(worker.mounts)[0]
+        bad_scp[worker.mounts[wdest]] = "/somewhere/else.py"
+        issues = parity_issues(head, worker, bad_scp, {})
+        check(any(wdest in i for i in issues), f"D4 a worker scp fed from a different host file is reported ({issues[:1]})")
+
+
+# ------------------------------------------------------------------- main --
+
+
+def main() -> int:
+    if not START.is_file():
+        raise SystemExit(f"missing {START}")
+    print(f"launcher: {START}")
+    print(f"ships: {', '.join(f'{v}={b}' for v, b in shipped_apc_vars().items())}; forwards SWA={wires_swa()} FINEGRAINED={wires_fg()} KVCAP={wires_kv()}")
+    part_a()
+    with tempfile.TemporaryDirectory() as raw:
+        h = Harness(Path(raw))
+        part_b(h)
+        part_c(h)
+        part_d(h)
+    print()
+    if FAILURES:
+        print(f"FAILED ({len(FAILURES)}): " + "; ".join(FAILURES))
+        return 1
+    print("launcher rank-parity / order / pre-stop gate OK")
+    return 0
+
+
+def test_launcher_rank_parity() -> None:
+    """pytest entry point (the script form above is what the README documents)."""
+    FAILURES.clear()
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_xgrammar_termination.py
+++ b/tests/test_xgrammar_termination.py
@@ -385,7 +385,12 @@ def test_recipe_wiring_if_present() -> None:
     launcher = start.read_text()
     image = dockerfile.read_text()
     assert 'XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-' in launcher
-    assert launcher.count("python3 /opt/glm53/patch_xgrammar_termination.py") == 2
+    # Both ranks apply the one pinned list (GLM53_OVERLAY_ORDER) that
+    # write_inner_scripts emits into the head and worker inner scripts.
+    order = launcher[launcher.index("GLM53_OVERLAY_ORDER=(") : launcher.index(")", launcher.index("GLM53_OVERLAY_ORDER=("))]
+    assert "\n    patch_xgrammar_termination.py\n" in order
+    assert 'emit_overlay_block >> "$HEAD_SCRIPT"' in launcher
+    assert 'emit_overlay_block >> "$WORKER_SCRIPT"' in launcher
     assert (
         "-v '/tmp/patch_xgrammar_termination.py:"
         "/opt/glm53/patch_xgrammar_termination.py:ro'" in launcher


### PR DESCRIPTION
## Honest KV-capacity boot log for the hybrid model (`GLM53_KV_CAPACITY_LOG`)

### Problem (verified in the fork source and the boot log)
vLLM logs once per boot (`v1/core/kv_cache_utils.py`, `update_kv_cache_capacity`):

```
GPU KV cache size: 1,553,140 tokens, Maximum concurrency for 1,000,000 tokens per request: 1.55x
```

`N = int(max_concurrency × max_model_len)` with `max_concurrency = num_blocks / num_blocks_per_request`, and
`num_blocks_per_request` a **sum over KV-cache groups** of `cdiv(spec.max_memory_usage_bytes, spec.page_size_bytes)`
(`get_max_concurrency_for_kv_cache_config`). For a single-group model that is the pool's token capacity up to
rounding, which is what the label suggests. For GLM-5.3-Flash — MLA + kpool tail + 4 mamba + DFlash2 drafter SWA,
one shared `BlockPool` with globally unique block ids — it is a concurrency figure in token units. Neither
`num_blocks` nor `num_blocks_per_request` is logged and `max_concurrency` is printed at two decimals, so the pool
size cannot be recovered from the line. Behind the line above sat **643 block ids** (642 usable; id 0 is the null
block) and one cached 3584-token segment costs **38** of them (1 MLA + 4 mamba + 33 drafter SWA), i.e. ~**57K
tokens** of cached conversation with nothing running — the mechanism behind the "two ~55K conversations evict each
other" symptom that #79/#83/#84 addressed. Two reviewers independently read the line as a 1.5M-token prefix cache
before the arithmetic was redone by hand. Upstream feature request:
[vllm-project/vllm#54662](https://github.com/vllm-project/vllm/issues/54662); this PR is the recipe-side version.

### Change
Overlay `patch_kv_capacity_log.py` — **log-only**: no control flow, no allocation, no config mutation; runs once in
the engine core at boot. Two pinned anchors in `kv_cache_utils.py`, both preflighted before either is written,
atomic temp-file + `os.replace`, idempotent, one mark per site, exact post-state verification, drift → non-zero
exit; pinned after `patch_glm5_drafter_group.py` (same file, no shared anchors) in `GLM53_OVERLAY_ORDER`.
The stock line stays **byte-identical** (asserted), as do `kv_cache_size_tokens` / `kv_cache_max_concurrency`.
Immediately after it, from the same config objects:

- one line per KV-cache group: index, spec type (`UniformTypeKVCacheSpecs` unwrapped), layers, `block_size`, page
  size, `blocks/request@max_model_len` — the **same `cdiv` expression** as `get_max_concurrency_for_kv_cache_config`,
  so the column sum *is* the stock denominator — `prefix_caching` (fork `participates_in_prefix_caching` → upstream
  `prefix_cacheable` → true), window + EAGLE flag for sliding-window kinds, `mamba_cache_mode` for mamba;
- a summary: `usable block ids: X (num_blocks=N incl. the null block; D ids per L-token request => Rx); ids per
  A-token cached segment across groups: Y (per group: […]); cached-conversation capacity at this alignment ≈ Z
  tokens = S segments (aligned dense-retention prefix-cache upper bound: nothing running, every reachable block
  hashed, block-aligned hits). The 'GPU KV cache size' line above is max_concurrency x max_model_len, not this
  figure.` — `A` = lcm of the group block sizes (what the coordinator asserts its scheduler block to be).

Per-spec cost rule (dense retention, block-aligned hits — what each manager's `reachable_block_mask` hashes with no
retention interval), by **exact** class name so no spec is costed by its base class: `FullAttentionSpec` /
`MLAAttentionSpec` and `MambaSpec` in `align`/`all` (mode read from the spec the manager acts on) →
`A / block_size`; `SlidingWindowSpec` / `SlidingWindowMLASpec` → `min(cdiv(window − 1, block_size) + 1 if EAGLE,
A / block_size)` (`SlidingWindowManager._contiguous_blocks_for_hit`: 33 of 56 here); groups that opt out of prefix
caching (`KpoolTailSpec`) → 0. Anything else — `SinkFullAttentionSpec` (permanent sink blocks), TQ/RSWA/hidden-state
specs, chunked-local, cross/encoder, mamba mode `none` or a mixed uniform group, a window-less SWA spec, unknown
kinds — is reported as **unmodelled** and the capacity figure is withheld rather than guessed; likewise under
DCP/PCP > 1, where block sizes are rescaled per rank (not this kit). EAGLE detection mirrors the coordinator with
`patch_hybrid_prefix_hit.py` applied (`is_eagle_group` if any group carries it; else the exact `SlidingWindowSpec`
groups under `use_eagle()`; else every group). Not modelled on purpose: #83's per-group retention (drafter →
boundary tails only) and #84's fine-grained hits are resolved later in the coordinator; the summary states the
policy it assumes.

Knob `GLM53_KV_CAPACITY_LOG` (default `1`): `0` → one line `[glm53-kv-capacity-log] disabled (…=0)`; anything else
raises at the log site — validated **outside** the derivation's `try`, because a typo'd knob must not silently
pick a mode — and the launcher rejects the same set first. Any exception inside the derivation is one
`warning_once` naming it and boot proceeds (diagnostic feature; must never take the server down). All log
arguments are preformatted strings (`info_once` caches on its arguments).

Launcher: set-ness aware caller capture (`${VAR+1}`: an explicitly empty export is captured and rejected, not
replaced by `.env`), 0/1 validator in the numeric guard, the same fail-closed overlay-artifact gate as #83/#84/
pr/apc-no-store (existence / identity string / EOF sentinel / `ast.parse` for every mounted overlay, run on
`start|restart` before `restart` stops anything), `GLM53_OVERLAY_ORDER` emitted verbatim into both rank scripts,
scp + read-only mount on both ranks, `-e GLM53_KV_CAPACITY_LOG` in `nccl_common`, one launcher log line with the
effective value. Dockerfile: COPY overlay + test, run the test against the real `kv_cache_utils.py` (after
`patch_hybrid_prefix_hit.py`, before this patch), then the overlay. README: knob row, "What the KV cache boot line
means" section, overlay/test rows; `.env.example`; `docs/DESIGN-kv-capacity-log.md` (file:line for every rule).

### Host tests (Mac, python 3.14, no torch / vLLM)
- `tests/test_kv_capacity_log.py` — **144 checks**. Part A drives the **shipped helper text** (exec'd, not
  re-implemented; asserted verbatim-equal to what is written) against the deployment's synthetic hybrid layout
  (fork `max_memory_usage_bytes` formulas): blocks/request `[280, 1, 9, 9, 9, 9, 97]` = 414; 643 ids → the logged
  `1,553,140` / `1.55x`; 642 usable; alignment 3584; ids per segment `[1, 0, 1, 1, 1, 1, 33]` = 38; ≈ 57,344 tokens =
  16 segments; the current 820-id boot → `1,980,676` / `1.98x`, 819 usable, 21 segments, 75,264 tokens. Also:
  single full-attention group (capacity = stock figure minus exactly one block), uniform-type unwrap and
  participation aggregation, fork / upstream / absent participation flags, EAGLE authoritative vs fallback vs
  `SlidingWindowMLASpec` subclass vs no speculative config (32 ids), window wider than the segment (56), mamba
  `all` (287 blocks/request, still 1 id/segment), mamba mode read from the spec (spec `none` / config `align` →
  unmodelled; mixed uniform group → unmodelled), `SinkFullAttentionSpec` / `TQFullAttentionSpec` / `RSWASpec` never
  costed as dense, DCP=2 / PCP=2 withhold the figure, unmodelled kinds withhold the figure, null-block edges
  (`num_blocks` 0/1/38/39), `max_model_len` below the alignment, empty / opted-out-only layouts, knob matrix (3
  accepted, 12 rejected incl. `""`, `01`, `1\r`), disabled path, malformed knob raises out of the log call,
  derivation exception → one warning and no raise, no config mutation. Part B on a fixture of **verbatim in-image
  excerpts**: stock line and the whole of `update_kv_cache_capacity` up to it byte-identical; end-to-end call
  through the patched text with `vllm` stubbed logs the stock line first, then the 8 lines; pristine fixture logs
  exactly the first; idempotent; `--preflight` writes nothing; each anchor drifted one at a time → non-zero exit
  naming it with the file untouched and no temp litter; partial / altered / duplicated marks refused; missing
  `import math` / module logger refused; pyc cleared; the installed file when present (mandatory in-image). Part C:
  launcher capture/replay order, default-when-unset, artifact-guard entry, scp + both mounts + `-e`, order after the
  drafter-group patch and before xgrammar, EOF sentinel + identity string, 0/1 guard matrix, Dockerfile order,
  `.env.example`, README.
- `tests/test_launcher_rank_parity.py` — **116 checks** (the #83/#84 launcher test with this knob): `restart` with
  `GLM53_KV_CAPACITY_LOG=yes` or explicitly empty exits 2 with zero docker/ssh calls; every artifact missing /
  mis-pointed / empty / whitespace / unparseable / truncated refused before anything is stopped; order pinned in
  both generated rank scripts; head mount = scp source = worker mount for every `/opt/glm53` patch; both ranks
  receive identical `GLM53_KV_CAPACITY_LOG` for 0 / 1 / unset (→ 1); a synthetic one-rank mismatch is reported.
- Full suite on the Mac: `test_kv_capacity_log`, `test_launcher_rank_parity`, `test_bringup_robustness`,
  `test_kpool_tail_slotmap`, `test_numeric_config`, `test_start_overrides`, `test_suppress_stops`,
  `test_warm_restart_stdout`, `test_xgrammar_termination` PASS; `test_ablit`, `test_chat_template`,
  `test_exl3_overlay`, `test_hybrid_prefix_hit`, `test_mixed_prefill_decode`, `test_scheduler_decode_floor` need the
  image / a live server (torch, jinja2, vLLM sources), same as on #83/#84.

### Receipts (captured live, 2026-09-01; boot 04:27:31→04:35 UTC)

Environment: deploy branch `deploy/dogfood-next2` @ c90fe5c (= the production `deploy/dogfood-next` 338366b + this
branch + `pr/apc-no-store`; launcher hunks re-derived by scripted insertion onto the production launcher), production
`.env` byte-identical to the previous production checkout's (MAX_MODEL_LEN=1,000,000, MAX_NUM_SEQS=16,
MAX_NUM_BATCHED_TOKENS=2048, GPU_MEM_UTIL=0.87, GLM53_INDEXER_WORKSPACE=rightsize, dense retention + SWA=0,
fine-grained hits on, DFlash2 k=7). Full logs: `receipts-next2` on the kit.

0. **In-image test against the real file, before the restart** (the then-serving head container, booted 01:02 UTC
   from a checkout without this overlay; the test tree is copied repo-shaped so the launcher checks see the outer
   `start.sh`; `VLLM_PREFIX_CACHE_RETENTION_INTERVAL[_SWA]` are unset for the test process — the serving container
   exports them for the engine and the test's synthetic coordinators must not inherit engine retention knobs):
   ```
   CMD> docker exec glm53-exl3-head rm -rf /tmp/glm53-next2 && docker cp /tmp/glm53-next2-tree glm53-exl3-head:/tmp/glm53-next2 && docker exec -e GLM53_REQUIRE_TARGET=1 glm53-exl3-head env -u VLLM_PREFIX_CACHE_RETENTION_INTERVAL -u VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA python3 /tmp/glm53-next2/tests/test_kv_capacity_log.py
     ok   B8 installed /usr/local/lib/python3.12/dist-packages/vllm/v1/core/kv_cache_utils.py: preflight OK (patched)
  ok   B8 installed file carries the stock 'GPU KV cache size' block exactly once
   kv-capacity-log overlay OK (144 checks)
   ```
   (The test now counts **144** checks — two were added by the final-review commit after this body first said 142.)
   The same run in the **new** container after the restart: `kv-capacity-log overlay OK (144 checks)` with
   `B8 installed /usr/local/lib/python3.12/dist-packages/vllm/v1/core/kv_cache_utils.py: preflight OK (already present)`.

1. **Launcher and both ranks**:
   ```
[glm53-exl3] per-request prefix-cache no-store flag: GLM53_APC_NO_STORE=1 (both ranks)
[glm53-exl3] boot KV-capacity breakdown log: GLM53_KV_CAPACITY_LOG=1 (both ranks)
[glm53-exl3] GLM-5.3-Flash EXL3 is UP (TP=2, nnodes=2)
   ```
   In-container apply lines — head: `kv_cache_utils.py: kv-capacity-log patched (GLM53_KV_CAPACITY_LOG='1')`;
   worker (`ssh … docker logs glm53-exl3-worker`): same line. `docker exec glm53-exl3-head env` and the same on the
   worker both show `GLM53_KV_CAPACITY_LOG=1`.
   Negative (fail-closed pre-stop gate, run against the live pair): `GLM53_KV_CAPACITY_LOG=yes ./start.sh restart` →
   `GLM53_KV_CAPACITY_LOG must be exactly 0 or 1 (got: yes)`, rc=2, head and worker `StartedAt` unchanged,
   `/health` 200 throughout.

2. **Boot log, verbatim** (`docker logs glm53-exl3-head | grep -n -E 'Available KV cache memory|GPU KV cache size|glm53-kv-capacity-log'`):
   ```
288:(Worker_TP0 pid=2089) INFO 09-01 04:35:40 [gpu_worker.py:564] Available KV cache memory: 21.54 GiB
291:(EngineCore pid=1892) INFO 09-01 04:35:41 [kv_cache_utils.py:2570] GPU KV cache size: 1,942,028 tokens, Maximum concurrency for 1,000,000 tokens per request: 1.94x
292:(EngineCore pid=1892) INFO 09-01 04:35:41 [kv_cache_utils.py:1208] [glm53-kv-capacity-log] group 0: MLAAttentionSpec layers=22 block_size=3584 page_size=118,272 B blocks/request@1,000,000=280 prefix_caching=yes
293:(EngineCore pid=1892) INFO 09-01 04:35:41 [kv_cache_utils.py:1208] [glm53-kv-capacity-log] group 1: KpoolTailSpec layers=11 block_size=4 page_size=118,272 B blocks/request@1,000,000=1 prefix_caching=no (scratch) window=4 eagle=no
294:(EngineCore pid=1892) INFO 09-01 04:35:41 [kv_cache_utils.py:1208] [glm53-kv-capacity-log] group 2: MambaSpec layers=9 block_size=3584 page_size=2,351,104 B blocks/request@1,000,000=9 prefix_caching=yes mamba_cache_mode=align
295:(EngineCore pid=1892) INFO 09-01 04:35:41 [kv_cache_utils.py:1208] [glm53-kv-capacity-log] group 3: MambaSpec layers=9 block_size=3584 page_size=2,351,104 B blocks/request@1,000,000=9 prefix_caching=yes mamba_cache_mode=align
296:(EngineCore pid=1892) INFO 09-01 04:35:41 [kv_cache_utils.py:1208] [glm53-kv-capacity-log] group 4: MambaSpec layers=8 block_size=3584 page_size=2,351,104 B blocks/request@1,000,000=9 prefix_caching=yes mamba_cache_mode=align
297:(EngineCore pid=1892) INFO 09-01 04:35:41 [kv_cache_utils.py:1208] [glm53-kv-capacity-log] group 5: MambaSpec layers=8 block_size=3584 page_size=2,351,104 B blocks/request@1,000,000=9 prefix_caching=yes mamba_cache_mode=align
298:(EngineCore pid=1892) INFO 09-01 04:35:41 [kv_cache_utils.py:1208] [glm53-kv-capacity-log] group 6: SlidingWindowSpec layers=5 block_size=64 page_size=2,351,104 B blocks/request@1,000,000=97 prefix_caching=yes window=2048 eagle=yes
299:(EngineCore pid=1892) INFO 09-01 04:35:41 [kv_cache_utils.py:1208] [glm53-kv-capacity-log] usable block ids: 803 (num_blocks=804 incl. the null block; 414 ids per 1,000,000-token request => 1.94x); ids per 3584-token cached segment across groups: 38 (per group: [1, 0, 1, 1, 1, 1, 33]); cached-conversation capacity at this alignment ≈ 75,264 tokens = 21 segments (aligned dense-retention prefix-cache upper bound: nothing running, every reachable block hashed, block-aligned hits). The 'GPU KV cache size' line above is max_concurrency x max_model_len, not this figure.
   ```
   Pass criteria, all met: the stock line is byte-shaped as upstream and appears exactly once; the `blocks/request`
   column sums to **414**; `804 / 414 = 1.94x` (matches the stock line); `int(804 / 414 × 1,000,000) = 1,942,028`
   (matches); per-group ids `[1, 0, 1, 1, 1, 1, 33]`; `usable = num_blocks − 1 = 803`;
   `803 // 38 × 3584 = 75,264 tokens = 21 segments`. Placeholders read off the receipt: `page_size` is reported
   **per layer** (MLA group: 118,272 B × 22 layers; this body's earlier `<P0>` guess assumed a per-group figure),
   the 34 GDN layers split 9/9/8/8 across the four mamba groups, and the drafter SWA group spans 5 layers.
   **Boot-to-boot delta, stated honestly**: the previous production boot profiled `Available KV cache memory:
   21.56 GiB` → 820 blocks → `1,980,676 tokens … 1.98x`; this boot profiled **21.54 GiB → 804 blocks →
   `1,942,028 tokens … 1.94x`**. The block count follows the boot's own Available-KV line (memory-profiler
   variance between boots); the overlay reports whatever the boot actually has — which is this PR's point — and the
   cached-conversation capacity is 21 segments (75,264 tokens) in both cases.
   The worker logs the overlay-applied line but no engine-core boot breakdown (headless rank, no independent engine
   core); the head's lines are the receipt, as anticipated above.

3. `GLM53_KV_CAPACITY_LOG=0` boot: not run, as stated above (the launcher and overlay 0/1 matrices are host-tested;
   a `0` boot would only prove the one `disabled` line).

4. **Equivalence** (log-only claim; warm/cold probe re-run on this boot, unmodified probe byte-identical to the one
   shipped on #79 — sha256 `c050e5e2151d8cfc90f23a8d4731eb8ed75b1de11f86ff9f2365f305639509cd`):
   ```
[nostore] warm runs prefix-cache hit ratio 0.999
[nostore] cold1: 64.7s len=367 logprob positions=64
[nostore] cold2: 60.1s len=376 logprob positions=64
[nostore] cold3: 59.5s len=390 logprob positions=64
[nostore] warm1: 3.5s len=362 logprob positions=64
[nostore] warm2: 3.9s len=400 logprob positions=64
[nostore] text first-divergence: cold-vs-cold @42 | cold-vs-warm @99 | warm-vs-warm @42
[nostore] max|dlogprob|: cold-vs-cold floor 0.2736 (pairs 0.0460/0.0868/0.2736, 7 pos, pos-0 same=True) | cold-vs-warm 0.3033 (14 pos) | pos-0 token same=True
[nostore] cold1 pos0: ('An', -0.196726992726326, ('#', '##', '**', 'An', 'Audit'))
[nostore] cold2 pos0: ('An', -0.15073776245117188, ('#', '##', '**', 'An', 'Audit'))
[nostore] warm1 pos0: ('An', -0.18366527557373047, ('#', '##', '**', 'An', 'Audit'))
[nostore] warm2 pos0: ('An', -0.24148382246494293, ('#', '##', '**', 'An', 'Audit'))
[nostore] PASS: cold-vs-warm max|dlogprob| 0.3033 <= 3 x cold-vs-cold floor (0.8208); pos-0 chosen token identical=True
   ```

Not captured: nothing for this PR; every receipt above ran to completion. (For the record: an internet outage cut
the driving session mid-collection; the receipts are re-attributed from the timestamped on-kit logs, and the boot,
launcher and in-container receipts above all predate the outage on the same 04:35 UTC boot.)

### Audit log
Codex gpt-5.6-luna build-plan advisory (build-with-changes, 10 findings): usable=num_blocks−1 with the ≤1 guard,
dense-retention wording, warning-and-continue, hashable `info_once` args, patch hardening, set-ness launcher capture
and the pre-stop gate adopted; the generic alignment/participation/cost/EAGLE rules replaced by the exact-class
policy with everything else unmodelled + figure withheld. Adversarial review of the final diff (DO-NOT-SHIP, 7
findings): mamba mode read from each unwrapped spec, exact-class cost policy, DCP/PCP withhold and the README
figure reconciliation adopted (57aae4f); "production claims unreceipted" accepted as process — this section was the
gate and the PR was not opened until the boot receipt above was pasted; launcher-test-in-image and artifact-gate
TOCTOU rebutted (repo convention: launcher suites are the host gate; the gate guards operator error, not concurrent
tamper). Live receipts collected 2026-09-01 (above). Confirm pass: CODEX-PR5-CONFIRM.md.

---
Submitted by nood-co1 on behalf of Blockbrain Labs (https://x.com/blockbrain_labs, GitHub org blockbrain-ai). Measured on our 2× NVIDIA DGX Spark deployment.
