### PR TITLE
Per-request GPU prefix-cache no-store: skip_writing_prefix_cache via vllm_xargs (GLM53_APC_NO_STORE)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,6 +140,10 @@ GLM53_SUPPRESS_STOPS_IN_REASONING=1
 # When a decode seq is running, do not mix a peer prefill into that step
 # (issue #6). skip = decode-only steps; N>0 = cap mixed prefill tokens; 0 = off.
 GLM53_MIXED_PREFILL_CHUNK=skip
+# Honour a client's per-request GPU prefix-cache no-store flag
+# (vllm_xargs {"skip_writing_prefix_cache": 1}): 1 = yes (default; requests
+# never opt in on their own), 0 = ignore it (logged once). Exactly 0 or 1.
+GLM53_APC_NO_STORE=1
 # EngineCore execute timeout (seconds). Stock 300 is short for a cold JIT.
 # VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -446,6 +446,8 @@ COPY overlay/patch_scheduler_decode_floor.py /opt/glm53/patch_scheduler_decode_f
 COPY tests/test_scheduler_decode_floor.py /opt/glm53/test_scheduler_decode_floor.py
 COPY overlay/patch_hybrid_prefix_hit.py /opt/glm53/patch_hybrid_prefix_hit.py
 COPY tests/test_hybrid_prefix_hit.py /opt/glm53/test_hybrid_prefix_hit.py
+COPY overlay/patch_apc_no_store.py /opt/glm53/patch_apc_no_store.py
+COPY tests/test_apc_no_store.py /opt/glm53/test_apc_no_store.py
 COPY overlay/patch_xgrammar_termination.py /opt/glm53/patch_xgrammar_termination.py
 COPY tests/test_xgrammar_termination.py /opt/glm53/test_xgrammar_termination.py
 COPY overlay/patch_kpool_tail_slotmap.py /opt/glm53/patch_kpool_tail_slotmap.py
@@ -461,6 +463,13 @@ RUN python3 /opt/glm53/patch_glm5_drafter_group.py
 RUN python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
 RUN python3 /opt/glm53/patch_scheduler_decode_floor.py
 RUN python3 /opt/glm53/patch_hybrid_prefix_hit.py
+# Runs BEFORE the patch it validates: Part A needs the pristine
+# sampling_params.py / v1/request.py / v1/core/block_pool.py, and Part C
+# (real BlockPool / KVCacheManager / hybrid coordinator on patched copies)
+# is mandatory in-image (GLM53_REQUIRE_VLLM=1), including the KpoolTailSpec
+# group when the fork exposes it.
+RUN GLM53_VLLM_SRC_ROOT=/usr/local/lib/python3.12/dist-packages/vllm GLM53_REQUIRE_VLLM=1 python3 /opt/glm53/test_apc_no_store.py
+RUN python3 /opt/glm53/patch_apc_no_store.py
 RUN python3 /opt/glm53/patch_xgrammar_termination.py
 RUN python3 /opt/glm53/patch_kpool_tail_slotmap.py
 RUN python3 /opt/glm53/patch_ablit.py

--- a/README.md
+++ b/README.md
@@ -516,10 +516,11 @@ curl -s "$BASE/v1/chat/completions" -H 'Content-Type: application/json' -d '{
   "vllm_xargs": {"skip_writing_prefix_cache": 1}}'
 ```
 
-Send the **integer `1`** (or `"1"`): `vllm_xargs` is typed `dict[str, str | int | float | list]`,
-so JSON `true` is a pydantic 400 before it reaches vLLM, and any value other than `0`/`1`/`"0"`/`"1"`
-is rejected with HTTP 400 naming the field (validated in `SamplingParams.__post_init__`, i.e. in
-the API server — never a silent no-op). The request then:
+Send the integer `1` (`"1"` and JSON `true` also work: `vllm_xargs` is typed
+`dict[str, str | int | float | list]` and pydantic coerces a JSON boolean to `1`/`0` — verified on
+pydantic 2.13). Any other value (`1.0`, `"yes"`, `2`, …) is rejected with HTTP 400 naming the field
+(validated in `SamplingParams.__post_init__`, i.e. in the API server — never a silent no-op). The
+request then:
 
 - is **still allowed to read** the cache (a lane that shares the system prompt gets the free prefix;
   reading touches blocks, i.e. refreshes their LRU position — the flag is write-only);
@@ -535,8 +536,10 @@ the API server — never a silent no-op). The request then:
 
 Server-log receipts (each once per process): `[glm53-apc-no-store] first request resolved
 skip_writing_prefix_cache=1` (the flag reached the engine) and `[glm53-apc-no-store] suppressing
-prefix-cache store (full site)` / `(partial site)` (a store was actually cut). If the first line never
-appears, the flag did not reach the engine — do not trust an A/B measured without it. Not covered:
+prefix-cache store (full site)` / `(partial site)` (a store was actually cut; the partial site only
+fires where fine-grained hits are enabled, i.e. with `patch_apc_fine_grained_hits.py`, for a prompt whose
+64-token boundary is not a 3584 multiple). If the first line never appears, the flag did not reach the
+engine — do not trust an A/B measured without it. Not covered:
 KV connectors / CPU offload (none on this kit), pooling requests. Kill switch: `GLM53_APC_NO_STORE=0`.
 Design + receipts protocol: `docs/DESIGN-apc-no-store.md`.
 

--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ The Hub `generation_config.json` stamps `temperature=1.0` / `top_p=0.95` unless
 the request overrides. The launcher sets
 `--chat-template /opt/glm53/chat_template.jinja` (checkpoint jinja is language-only).
 
-Needs: Docker (no sudo) on both nodes, passwordless SSH head → worker,
+Needs: Docker (no sudo) on both nodes, python3 on the head (verifies the overlay artifacts before `restart` stops anything), passwordless SSH head → worker,
 `hf` / `huggingface-cli` + `curl` + `rsync` on the head, ~180 GiB free per
 node for the first download. The GHCR image is public; login is only needed
 if you hit anonymous pull rate limits (`GHCR_TOKEN` + `GHCR_USER`).
@@ -488,6 +488,7 @@ that are now documented/enforced:
 | `MAX_NUM_SEQS` | `4` | decode batch; MTP adds k+1 tokens/seq |
 | `MAX_NUM_BATCHED_TOKENS` | `2048` | prefill chunk (P1 keep). 3584/4096 lost; 8192 oversubscribes GB10 indexer topk |
 | `GLM53_MIXED_PREFILL_CHUNK` | `skip` | do not mix a peer prefill into a decode step (issue #6). `N>0` = cap tokens; `0` = off. Solo prefill stays MNBT (2048) |
+| `GLM53_APC_NO_STORE` | `1` | honour a client's per-request GPU prefix-cache **no-store** flag (overlay `patch_apc_no_store.py`; see [Opting a request out of the prefix cache](#opting-a-request-out-of-the-prefix-cache)). Requests never opt in on their own, so `1` changes nothing until a client sends the flag. `0` = ignore the flag (logged once); malformed values are rejected either way. Exactly `0` or `1`; the launcher refuses anything else before `restart` stops the pair |
 | `GLM53_SUPPRESS_STOPS_IN_REASONING` | `1` | ignore client `stop` strings until `</think>` (thinking-on default) |
 | `GLM53_BOOT_SHAPE_WARMUP` | `1` | after `/health`, burn DFlash2 BLOCK / sampler / kpool shapes (nonfatal) |
 | `TRITON_HOST_CACHE` / `TILELANG_HOST_CACHE` | `$CACHE_ROOT/triton` / `tilelang` | persist JIT caches across container recreate |
@@ -497,6 +498,47 @@ that are now documented/enforced:
 | `HEAD_CX7_IF` / `WORKER_CX7_IF` | `enp1s0f1np1` / `enp1s0f0np0` | NCCL sockets |
 | `HEAD_CX7_IB` / `WORKER_CX7_IB` | `rocep1s0f1` / `rocep1s0f0` | NCCL HCAs |
 | `USE_HOST_NCCL` | `0` | image nvidia-nccl; host preload duplicates DeepEP |
+
+## Opting a request out of the prefix cache
+
+`BlockPool.free_blocks` puts **hashed** blocks at the back of the free queue (LRU) and unhashed
+ones at the front (LIFO). A one-off batch/eval request therefore stores its blocks *behind* the
+owner's idle 80K conversation and the owner's blocks are what gets evicted next — the batch job
+re-orders the LRU in its own favour. `cache_salt` namespaces and still stores; vLLM's
+`skip_reading_prefix_cache` is read-side only. Overlay `patch_apc_no_store.py` adds the write-side
+opt-out: `SamplingParams.skip_writing_prefix_cache`, reachable on `/v1/chat/completions`,
+`/v1/completions` and `/v1/responses` through `vllm_xargs` (no entrypoint edits):
+
+```bash
+curl -s "$BASE/v1/chat/completions" -H 'Content-Type: application/json' -d '{
+  "model": "GLM-5.3-Flash-EXL3", "messages": [{"role": "user", "content": "classify: ..."}],
+  "max_tokens": 64, "cache_salt": "batch-lane-07",
+  "vllm_xargs": {"skip_writing_prefix_cache": 1}}'
+```
+
+Send the **integer `1`** (or `"1"`): `vllm_xargs` is typed `dict[str, str | int | float | list]`,
+so JSON `true` is a pydantic 400 before it reaches vLLM, and any value other than `0`/`1`/`"0"`/`"1"`
+is rejected with HTTP 400 naming the field (validated in `SamplingParams.__post_init__`, i.e. in
+the API server — never a silent no-op). The request then:
+
+- is **still allowed to read** the cache (a lane that shares the system prompt gets the free prefix;
+  reading touches blocks, i.e. refreshes their LRU position — the flag is write-only);
+- inserts **no** block hash in any KV-cache group (MLA, mamba partial tails, drafter SWA) and emits no
+  `BlockStored` event; all allocation bookkeeping (`num_cached_block`, partial-hit CoW for what it
+  *read*) proceeds exactly as for a normal request — the guards sit at the two `_insert_block_hash`
+  sites in `BlockPool`, not at `allocate_slots`, because `num_cached_block` doubles as the
+  running-request sentinel for SWA/drafter allocation;
+- has its blocks freed to the **front** of the free queue, so they are the next ids recycled and the
+  resident conversation is not displaced;
+- if preempted, resumes from whatever it could *read* — nothing, when its prefix was cold — so prefer
+  it for short lanes, ideally with a low `priority`.
+
+Server-log receipts (each once per process): `[glm53-apc-no-store] first request resolved
+skip_writing_prefix_cache=1` (the flag reached the engine) and `[glm53-apc-no-store] suppressing
+prefix-cache store (full site)` / `(partial site)` (a store was actually cut). If the first line never
+appears, the flag did not reach the engine — do not trust an A/B measured without it. Not covered:
+KV connectors / CPU offload (none on this kit), pooling requests. Kill switch: `GLM53_APC_NO_STORE=0`.
+Design + receipts protocol: `docs/DESIGN-apc-no-store.md`.
 
 ## Image / overlay
 
@@ -518,6 +560,9 @@ this Dockerfile instead. After CUDA compile, Python overlay edits
 | `overlay/patch_exl3_ext_aarch64.py` | stub AVX CPU allreduce so the ext builds on GB10 |
 | `overlay/patch_model_overrides.py` | `"exl3"` in ModelConfig overrides |
 | `tests/test_exl3_overlay.py` | registry, TP shard, `sm_121a` cubin, fused vs loop GEMM, `EXL3_FUSED_MOE=0` |
+| `overlay/patch_apc_no_store.py` | per-request GPU prefix-cache no-store (`skip_writing_prefix_cache` / `vllm_xargs`): strict 0/1 validation in `SamplingParams.__post_init__`, never-raising resolver on `Request`, guards at the two `_insert_block_hash` sites in `BlockPool`; transactional, fail-closed; kill switch `GLM53_APC_NO_STORE` |
+| `tests/test_apc_no_store.py` | host: anchors / idempotence / per-anchor drift with nothing written / partial-marker refusal; resolver accept-reject matrix + kill-switch matrix; on a CPU vLLM (`GLM53_VLLM_SRC_ROOT`, mandatory in the image): real `BlockPool` LIFO-front vs LRU-back, chunked-prefill `num_cached_block` parity with a normal twin, hybrid mamba partial-tail producer/reader/CoW, the live MLA+mamba×4+EAGLE-SWA layout (+`KpoolTailSpec` in-image), preemption, `skip_reading`+`skip_writing`, receipts; launcher 0/1 guard |
+| `tests/test_launcher_rank_parity.py` | launcher (CPU-only, docker/ssh stubbed): `GLM53_APC_RETENTION_INTERVAL_SWA` guard matrix where wired, `restart` fails closed on a bad knob or a missing / mis-pointed / broken overlay (every artifact) before anything is stopped, overlay order pinned `hybrid -> per-group -> fine-grained -> no-store` in both rank scripts, both ranks mount the same host artifacts (head mount = scp source = worker mount) and receive identical `GLM53_APC_RETENTION_INTERVAL[_SWA]` / `GLM53_FINEGRAINED_APC` / `GLM53_APC_NO_STORE` values |
 | `tests/bench_decode.py` | streaming decode + coherence; `--structured` is the count-1→200 median |
 | `start.sh` / `stop.sh` / `download.sh` | 2-node launch; Hub fetch on the head only |
 | `files/chat_template.jinja` | GLM-5.3 MM template (`<|image|>` / `<|video|>`); checkpoint jinja is language-only |

--- a/docs/DESIGN-apc-no-store.md
+++ b/docs/DESIGN-apc-no-store.md
@@ -1,0 +1,197 @@
+# DESIGN — per-request GPU prefix-cache no-store (`skip_writing_prefix_cache`)
+
+Overlay: `overlay/patch_apc_no_store.py`. Test: `tests/test_apc_no_store.py`. Knob: `GLM53_APC_NO_STORE`.
+`file:line` references are to the live fork inside `glm53-exl3-head` (vLLM `0.1.dev20051+g487ecf187`,
+`/usr/local/lib/python3.12/dist-packages/vllm/`), read read-only. **VERIFIED** = read in that source or a live
+log line; **INFERRED** = reasoned from verified code. Host tests ran against upstream vLLM `22df3a3`, whose
+`block_pool.py` carries the same anchors at the same lines.
+
+## 1. Problem
+
+`SamplingParams.skip_reading_prefix_cache` (`sampling_params.py:364`) is a **read**-side skip only: resolved at
+`v1/request.py:213`, consumed at `v1/core/kv_cache_manager.py:217`, auto-set for `prompt_logprobs`. There is no
+write-side counterpart (VERIFIED: 17 hits for `skip_reading_prefix_cache` in the fork, none on a store path;
+`skip_writing_prefix_cache` does not exist). `cache_salt` is a *namespace* (`kv_cache_utils.py:560-568`), the
+block is stored as usual. `delay_cache_blocks` (`kv_cache_manager.py:353`, `:552`) is a one-step P/D defer.
+
+Why the write matters (VERIFIED mechanism, `block_pool.py:719-743`):
+
+```python
+if block.block_hash is None or not self.enable_caching:
+    blocks_to_evict_first.append(block)     # LIFO, prepended
+else:
+    blocks_to_evict_last.append(block)      # FIFO / LRU, appended
+```
+
+`get_new_blocks` pops from the **front** (`:661`). A batch request's blocks are hashed, land at the back, and
+the owner's idle 80K conversation — freed earlier, so nearer the front — is what gets evicted next. The batch
+job *re-orders the eviction queue in its own favour*. With a no-store flag its blocks carry no hash, go to the
+front, and are the very next ids recycled. On a hybrid model one logical segment costs one block id per group
+out of one shared pool (MLA + 4 mamba + drafter SWA here), which amplifies the effect.
+
+## 2. Design
+
+### 2.1 Surface
+
+- `SamplingParams.skip_writing_prefix_cache: bool | None = None` (sibling of the read-side field; typed route
+  for a future upstream field).
+- `vllm_xargs: {"skip_writing_prefix_cache": 1}` on `/v1/chat/completions`, `/v1/completions`, `/v1/responses`.
+  Both already copy `vllm_xargs` into `SamplingParams.extra_args` (`chat_completion/protocol.py:487`/`:700`,
+  `completion/protocol.py:219`/`:357`, `responses/protocol.py`), so the overlay needs **zero entrypoint
+  edits** — which matters because this fork's `entrypoints/openai/` tree is restructured and an overlay
+  anchored there would be brittle. `skip_reading_prefix_cache` itself is *not* reachable from the OpenAI API
+  (not a `from_optional` parameter) and `cache_salt` travels the prompt/inputs path, so "expose it like
+  `cache_salt`" cannot be taken literally.
+- **Strict values**: bool, int `0`/`1`, str `"0"`/`"1"`. Everything else (floats incl. `1.0`, `"true"`,
+  `"yes"`, `2`, lists) is rejected. `bool("0")` is `True`, so a lenient parser would let string-valued clients
+  silently *enable* the flag (Codex finding). JSON `true`/`false` never reach vLLM: `vllm_xargs` is typed
+  `dict[str, str | int | float | list[...]]` and pydantic v2 rejects a bool in that union (400).
+- **Where rejection happens and why**: `Request` is materialised in the engine-core input thread
+  (`EngineCore.preprocess_add_request` → `Request.from_engine_core_request`), not in the API server, so a
+  `ValueError` raised from `Request.__init__` is **not** a request-scoped 400. Validation therefore runs in
+  `SamplingParams.__post_init__` (anchor: the read-side auto-set at `sampling_params.py:529-533`), which
+  executes in the API-server process for every OpenAI request (`to_sampling_params` → `from_optional` →
+  constructor) and in the caller's process for the offline `LLM` API. A `ValueError` there is mapped to
+  `BadRequestError` / HTTP 400 by the server's registered `ValueError` handler
+  (`entrypoints/serve/exception_handling/register.py`, `error_response.py`). The engine-side resolver on
+  `Request` re-parses strictly but **never raises**: an unparseable value there is unreachable through the
+  API (it was already rejected); if it happens anyway (a params object mutated after construction) it logs a
+  warning and stores normally.
+- **Kill switch** `GLM53_APC_NO_STORE` (launcher knob, both ranks): exactly `0` or `1`, unset = `1`. Rule:
+  malformed values are rejected *before* the switch is consulted; the switch only decides whether a valid `1`
+  is honoured (`0` → ignored, logged once). Any other value raises at import of `sampling_params.py` (boot
+  failure); the launcher's `_glm53_validate_bool_flag` refuses it before `restart` stops the pair. Default
+  `1` is behaviour-neutral: requests never opt in on their own.
+- **Receipts** (`logger.info_once`, no request id in the args so they really are one line per process):
+  `[glm53-apc-no-store] first request resolved skip_writing_prefix_cache=1` at resolution — emitted even for
+  a warm request that has nothing new to store — and `[glm53-apc-no-store] suppressing prefix-cache store
+  (full site)` / `(partial site)` when a store is actually cut. Per-request ids go to `debug`.
+
+### 2.2 Where the guard goes — and why *not* `kv_cache_manager.py:552`
+
+The obvious one-liner extends `if not self.enable_caching or delay_cache_blocks:` to skip
+`coordinator.cache_blocks`. **This is wrong and the bug is invisible locally.** Skipping the call skips
+`SingleTypeKVCacheManager.cache_blocks`, whose last statement is
+`self.num_cached_block[request.request_id] = num_full_blocks` (`single_type_kv_cache_manager.py:479`).
+Membership in that dict is the **"is this a running request?" sentinel**:
+
+- `get_num_blocks_to_allocate:196-202` — `if request_id in self.num_cached_block:` selects the fast path
+  (asserts `len(new_computed_blocks) == 0`, returns `max(num_required - num_req_blocks, 0)`);
+- `KVCacheCoordinator.allocate_new_computed_blocks:239-246` — skips `add_local_computed_blocks`, which
+  asserts `len(req_blocks) == 0`.
+
+A no-store request under chunked prefill would take the slow path on every later step, where
+`get_num_skipped_tokens` is `0` for `FullAttentionManager` but the out-of-window prefix for
+`SlidingWindowManager` — the drafter group's block accounting computed under the false premise "never
+allocated". `KpoolTailManager` (`:1097-1199`), the in-tree never-stores manager, has to override
+`get_num_blocks_to_allocate`, `get_num_skipped_tokens`, `remove_skipped_blocks` and
+`add_local_computed_blocks` precisely so that none consult `num_cached_block`; a per-request flag cannot buy
+those overrides.
+
+**Adopted: suppress the hash insertion, keep every piece of bookkeeping.** There are exactly two request-driven
+`_insert_block_hash` sites (VERIFIED: `grep -n _insert_block_hash block_pool.py` → `:293, :508, :607(def), :645`):
+
+| site | inserts | caller |
+|---|---|---|
+| `cache_full_blocks` → `:293` | full-block hashes | `SingleTypeKVCacheManager.cache_blocks:469-477` |
+| `cache_partial_block` → `:508` | fine-grained partial-tail entry | `FullAttentionManager._cache_partial_tail_block:815`, `MambaManager._cache_partial_tail_block:1858` |
+
+The guards return early at the top of each. Downstream self-corrects because the fork's **sparse retention**
+(`reachable_block_mask` → `block_mask`, `VLLM_PREFIX_CACHE_RETENTION_INTERVAL` live on this deployment)
+already taught every consumer to tolerate "an allocated full block with no hash":
+
+- `num_cached_block` still advances at `:479` → both sentinels correct, every manager, every step
+  (test C2/C3L: the per-group `num_cached_block` traces of a no-store request and a normal twin are identical).
+- `MambaManager._cache_partial_tail_block:1858` gets `None` → the request is never registered as a
+  partial-tail **producer** (`_partial_hit_reqs`, `_producer_partial_tail_reqs`; registration at `:1865` is
+  gated on `partial_hash is not None`), so `get_num_blocks_to_allocate`'s `has_partial_hit` term and
+  `allocate_new_blocks`' CoW branch stop *over*-reserving — they under-reserve nothing (test C3a).
+- `MambaManager.cache_blocks:1817-1827` already `continue`s on `block.block_hash is None` (`:1825`) →
+  `cached_blocks_this_step` stays empty for a no-store request (test C3L).
+- `free_blocks:733` sees `block_hash is None` → **front** of the free queue (tests C1/C2/C3b/C3L).
+- Returning early also skips the `BlockStored` event emission (`:301-341`): nothing was stored.
+
+**`move_block_hashes` (`:629-645`) is deliberately not guarded.** It has no request argument, it re-points
+*existing* hashes, and normal requests need it (a running partial-tail owner keeps writing into its block).
+Codex asked whether the Mamba `blocks_allocated` CoW branch (`:1751`) could land a hash on a no-store
+request's CoW block. It cannot: that branch requires `_partial_hit_reqs[request_id]` for a *running* request,
+and the only two writers of `_partial_hit_reqs` are (a) `add_local_computed_blocks:292` for a **new** request
+(consumed by the same allocation's `allocate_new_blocks` with `blocks_allocated=False` → `_apply_cow`, and
+unreachable later because `allocate_new_computed_blocks` skips requests already in `num_cached_block`), and
+(b) the producer registration at `:1892`, which the partial guard suppresses. `pop_blocks_for_free:1794`
+discards `_allocated_block_reqs` and `_partial_hit_reqs` on free, so a preempted request resumes as (a).
+Tests C3a (running no-store producer: no registration, no CoW copy sourced from its blocks after two decode
+steps) and C3b (no-store reader: source keeps its hash, private CoW block unhashed) are the executable form of
+this argument.
+
+### 2.3 Deliberately unchanged
+
+- **Lookups stay enabled.** A no-store lane sharing the system prompt gets the free prefix and pays nothing
+  back. Reading *touches* blocks (`add_local_computed_blocks:281` → `block_pool.touch`), i.e. refreshes their
+  LRU position — write suppression alone does not make a request invisible to residency. Combine with
+  `skip_reading_prefix_cache` for zero interaction (test C5); that field is not exposed on the OpenAI API by
+  upstream and this overlay does not add it.
+- **Reader-side partial-hit CoW is untouched** (test C3b): correctness there is about not writing into another
+  request's block; it has nothing to do with storing.
+- **KV connectors / CPU offload** are not touched: no `--kv-transfer-config` on this deployment (VERIFIED via
+  `docker inspect`). The flag is documented as *GPU prefix-cache* no-store; a connector-side suppression would
+  be a one-line addition in the offloading connector's offload decision, symmetric to its existing
+  `skip_reading_prefix_cache` check, and is an upstream RFC item, not an untestable overlay edit.
+- **PoolingParams** are out of scope (chat/completions only); the resolver reads `SamplingParams` only.
+
+## 3. Risks
+
+- **R1 preemption.** `Scheduler._preempt_request` frees all blocks and sets `num_computed_tokens = 0`. A no-store
+  request resumes from whatever it can *read*: nothing if its prefix was cold (full recompute, the
+  `--no-enable-prefix-caching` resume path, structurally supported), or the cached prefix if it read-hit one
+  (test C4 covers both). Residual risk is thrash, not corruption: mark short lanes, run them at low `priority`
+  (`--scheduling-policy priority` picks the preemption victim by `(priority, arrival_time)`), watch
+  `num_preemptions` in the live test.
+- **R2 metrics.** A no-store request still reads, so it is counted in `vllm:prefix_cache_queries/hits`. Measure the
+  owner conversation's own `usage.prompt_tokens_details.cached_tokens` (per response, straight from
+  `prefill_stats.num_cached_tokens`), never the aggregates, and not `kv_cache_usage_perc` (live-referenced
+  blocks only).
+- **R3 silent no-op.** Mis-typed key, JSON `true`, kill switch at `0`: the system behaves exactly as today. Hence the
+  resolution receipt line; do not trust an A/B without it in `docker logs`.
+- **R4 structured output.** No interaction: grammar state lives on `StructuredOutputRequest` and the per-step
+  bitmask, never in a KV block. Structured-output batch lanes are exactly the lanes to mark no-store.
+- **R5 cascade attention.** `get_num_common_prefix_blocks` counts `ref_cnt == len(req_to_blocks)`; a no-store
+  request raises the denominator and can only *disable* an optimisation, as any divergent-prefix request does.
+
+## 4. Receipts protocol (live; server must be idle)
+
+Identical owner turn in every arm (Codex: A0 turn 3 vs A1/A2 turn 4 was not a clean comparison).
+
+| arm | batch | steps |
+|---|---|---|
+| A0 | none | owner `C` (~80K, one salt) turns 1–3 → **turn 4** |
+| A1 | 16 lanes, ~30K each, distinct prefixes, own salts, **no flag** | `C` 1–3 → batch to completion → **turn 4** |
+| A2 | same lanes with `vllm_xargs {"skip_writing_prefix_cache": 1}` | as A1 |
+| A3 (informational) | lanes that **share** `C`'s system prompt, flag on | as A1 — shows the residual read-touch effect |
+
+`/reset_prefix_cache` between arms; each arm twice; deterministic generation. Primary metric: turn-4
+`cached_tokens / prompt_tokens` of `C`. Secondary: turn-4 TTFT, `C`'s `num_preemptions` (log), the batch's
+own `cached_tokens` in A2 (must stay > 0 on a second flagged lane that shares a prefix: reads still work).
+**Pass criterion fixed in advance: A2 ≥ 0.9 × A0 and A2 − A1 ≥ 0.3 × A0.** If A1 ≈ A0 the premise fails on
+this pool and the PR is closed as a negative result. Also: both-rank `GLM53_APC_NO_STORE` in `docker exec …
+env`; the resolution + suppression receipt lines after the first flagged request; `"skip_writing_prefix_cache":
+"yes"` → HTTP 400 naming the field; JSON `true` → pydantic 400; `tests/probe_prefix_equivalence.py` PASS with
+the flag on the warm runs (reads unaffected) and a no-store→cold pair (same prompt re-sent after a flagged run
+reports `cached_tokens` 0 with an identical position-0 token / ≤ 3× floor).
+
+## 5. Upstream
+
+The mechanism is generic (any hybrid/Mamba/SWA model in vLLM has the LRU re-ordering problem). RFC outline:
+typed `skip_writing_prefix_cache` on `SamplingParams`/`PoolingParams`, `from_optional`, the OpenAI request
+models; guards at the two `BlockPool` sites with the `num_cached_block` sentinel argument above; connector
+offload-decision symmetry; tests mirroring C1–C6. Not filed yet — gated on the live receipts.
+
+## 6. Audit log
+
+- Codex design advisory (research train, 12 findings): kept the `BlockPool` placement; adopted strict value
+  parsing, explicit read semantics, connector scope statement, same-turn A/B, hybrid/CoW/preemption tests.
+- Codex build-plan advisory (`CODEX-PR4-PLAN.md`, build-with-changes, 9 findings): adopted — isolated C1 legs,
+  live 6/7-group fixture, both preemption cases, API-boundary validation (finding 5 matched an independent
+  read of `EngineCore.preprocess_add_request`), typed PoolingParams dropped, resolution-time receipt,
+  parse-before-kill-switch rule, placement-discriminating multi-step tests. Rebutted with evidence (§2.2):
+  `move_block_hashes` reachability for a no-store request.

--- a/docs/DESIGN-apc-no-store.md
+++ b/docs/DESIGN-apc-no-store.md
@@ -44,8 +44,10 @@ out of one shared pool (MLA + 4 mamba + drafter SWA here), which amplifies the e
   `cache_salt`" cannot be taken literally.
 - **Strict values**: bool, int `0`/`1`, str `"0"`/`"1"`. Everything else (floats incl. `1.0`, `"true"`,
   `"yes"`, `2`, lists) is rejected. `bool("0")` is `True`, so a lenient parser would let string-valued clients
-  silently *enable* the flag (Codex finding). JSON `true`/`false` never reach vLLM: `vllm_xargs` is typed
-  `dict[str, str | int | float | list[...]]` and pydantic v2 rejects a bool in that union (400).
+  silently *enable* the flag (Codex finding). JSON `true`/`false` in `vllm_xargs` (typed
+  `dict[str, str | int | float | list[...]]`) are **coerced by pydantic v2 to `1`/`0`** before vLLM sees them
+  (VERIFIED on pydantic 2.13; test B1) — the intended meaning, so booleans are accepted; an earlier draft
+  claimed they were rejected, which Codex's final review corrected.
 - **Where rejection happens and why**: `Request` is materialised in the engine-core input thread
   (`EngineCore.preprocess_add_request` → `Request.from_engine_core_request`), not in the API server, so a
   `ValueError` raised from `Request.__init__` is **not** a request-scoped 400. Validation therefore runs in
@@ -65,7 +67,12 @@ out of one shared pool (MLA + 4 mamba + drafter SWA here), which amplifies the e
 - **Receipts** (`logger.info_once`, no request id in the args so they really are one line per process):
   `[glm53-apc-no-store] first request resolved skip_writing_prefix_cache=1` at resolution — emitted even for
   a warm request that has nothing new to store — and `[glm53-apc-no-store] suppressing prefix-cache store
-  (full site)` / `(partial site)` when a store is actually cut. Per-request ids go to `debug`.
+  (full site)` / `(partial site)` when a store is actually cut. Per-request ids go to `debug`. The partial
+  site is reached only where the fork's fine-grained partial-hit producer is enabled (#84,
+  `patch_apc_fine_grained_hits.py`; upstream's coordinator vetoes it for this model otherwise) and, for the
+  mamba path, only when the prompt length is a `hash_block_size` (64) multiple that is not a 3584 multiple
+  (`_cache_partial_tail_block:1866-1874`); the full-attention path fires for any prompt whose 64-token
+  boundary is not a 3584 multiple.
 
 ### 2.2 Where the guard goes — and why *not* `kv_cache_manager.py:552`
 
@@ -190,6 +197,12 @@ offload-decision symmetry; tests mirroring C1–C6. Not filed yet — gated on t
 
 - Codex design advisory (research train, 12 findings): kept the `BlockPool` placement; adopted strict value
   parsing, explicit read semantics, connector scope statement, same-turn A/B, hybrid/CoW/preemption tests.
+- Codex final-diff review (`CODEX-PR4-REVIEW.md`, ship-with-changes, 4 findings): JSON boolean claim corrected
+  (coerced, not rejected — accepted with the intended meaning; the proposed pre-validation in the three API
+  models is not adopted: it would add entrypoint anchors for a case that is already semantically exact);
+  equivalence probe origin/invocation stated (it ships on #79, not on this branch); partial-site receipt
+  stimulus corrected; patcher now verifies every generated snippet verbatim on an already-marked file and
+  writes atomically (temp file + `os.replace`). `move_block_hashes` rebuttal accepted as sound.
 - Codex build-plan advisory (`CODEX-PR4-PLAN.md`, build-with-changes, 9 findings): adopted — isolated C1 legs,
   live 6/7-group fixture, both preemption cases, API-boundary validation (finding 5 matched an independent
   read of `EngineCore.preprocess_add_request`), typed PoolingParams dropped, resolution-time receipt,

--- a/overlay/patch_apc_no_store.py
+++ b/overlay/patch_apc_no_store.py
@@ -60,9 +60,10 @@ Surface:
   ``SamplingParams.extra_args`` by the fork; zero entrypoint edits). Values are
   STRICT -- bool, int 0/1, str "0"/"1" -- and validated in
   ``SamplingParams.__post_init__`` (API-server side; a bad value is an HTTP 400
-  via the ValueError handler, never a silent no-op). JSON ``true`` is rejected
-  even earlier by pydantic (``vllm_xargs`` is ``dict[str, str|int|float|list]``):
-  send the integer 1. ``Request`` is materialised in the engine-core input
+  via the ValueError handler, never a silent no-op). ``vllm_xargs`` is typed
+  ``dict[str, str|int|float|list]``; pydantic v2 coerces JSON ``true``/``false``
+  to ``1``/``0`` there (verified, pydantic 2.13), which is exactly the intended
+  meaning, so booleans work too. ``Request`` is materialised in the engine-core input
   thread, so its resolver never raises; an unparseable value there (unreachable
   through the API) logs once and stores normally.
 
@@ -80,13 +81,16 @@ Receipts in the server log (both ``logger.info_once``):
 
 Fail closed if any anchor drifts: every anchor in every file is checked
 BEFORE anything is written; a file that already carries the MARK must carry
-the complete set of its markers (else refuse); complete files are skipped.
+every generated snippet verbatim and still parse (else refuse); complete files
+are skipped; each write is a temp-file + os.replace (never a truncated target).
 """
 
 from __future__ import annotations
 
+import ast
 import os
 import sys
+import tempfile
 from pathlib import Path
 
 MARK = "# [glm53-apc-no-store]"
@@ -116,7 +120,8 @@ SP_FIELD_NEW = '''    skip_reading_prefix_cache: bool | None = None
     queue instead of queueing them behind -- and thereby evicting -- other
     sessions' cached blocks. For one-off batch lanes whose prefix will never be
     reused. Also reachable as ``vllm_xargs: {"skip_writing_prefix_cache": 1}``
-    (``extra_args``); accepted values are bool, int 0/1 and str "0"/"1"."""
+    (``extra_args``); accepted values are bool, int 0/1 and str "0"/"1"
+    (pydantic coerces a JSON boolean in ``vllm_xargs`` to 1/0)."""
 '''
 
 # 2. module-level helpers, inserted before the SamplingParams class.
@@ -142,8 +147,8 @@ def _glm53_parse_no_store(value, where):  # [glm53-apc-no-store]
     if isinstance(value, str) and value in ("0", "1"):
         return value == "1"
     raise ValueError(
-        f"{where} must be 0 or 1 (int) or \\"0\\"/\\"1\\" (str); got {value!r}. "
-        "JSON true/false is not accepted by vllm_xargs; send the integer 1."
+        f"{where} must be 0 or 1 (int), \\"0\\"/\\"1\\" (str) or a JSON boolean; "
+        f"got {value!r}."
     )
 
 
@@ -401,11 +406,20 @@ def expected_marks(edits) -> int:
 # ------------------------------------------------------------------ apply ----
 
 
+def _parses(text: str, path: Path) -> None:
+    try:
+        ast.parse(text, str(path))
+    except SyntaxError as exc:
+        raise SystemExit(f"{path}: does not parse: {exc}") from None
+
+
 def preflight(name: str, path: Path, edits, requires) -> str | None:
     """Return the patched text, or None if the file is already complete.
 
     Raises SystemExit on a missing file, a drifted anchor, or a file that
-    carries the MARK without the complete set of this overlay's edits.
+    carries the MARK without every one of this overlay's generated snippets
+    (verbatim, exactly once) -- a partially applied, edited or truncated
+    target is refused rather than skipped as "already done".
     """
     if not path.is_file():
         raise SystemExit(f"missing {path}")
@@ -413,12 +427,14 @@ def preflight(name: str, path: Path, edits, requires) -> str | None:
     have = text.count(MARK)
     want = expected_marks(edits)
     if have:
-        if have != want:
+        missing = [label for label, _old, new in edits if text.count(new) != 1]
+        if have != want or missing:
             raise SystemExit(
-                f"{path}: carries {have} '{MARK}' marker(s) but a complete "
-                f"application has {want}; refusing to patch a partially "
-                "modified file (restore the pristine file first)"
+                f"{path}: carries {have} '{MARK}' marker(s) (complete = {want}) "
+                f"and lacks the verbatim snippet(s) {missing}; refusing to patch "
+                "a partially modified file (restore the pristine file first)"
             )
+        _parses(text, path)
         return None
     for needle in requires:
         if text.count(needle) != 1:
@@ -430,7 +446,24 @@ def preflight(name: str, path: Path, edits, requires) -> str | None:
         text = text.replace(old, new, 1)
     if text.count(MARK) != want:
         raise SystemExit(f"{path}: internal error, marker count after apply")
+    _parses(text, path)
     return text
+
+
+def atomic_write(path: Path, text: str) -> None:
+    """Write via a sibling temp file + os.replace: the target is never left
+    truncated, even if this process dies mid-write."""
+    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".glm53", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(text)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 def main() -> int:
@@ -443,7 +476,7 @@ def main() -> int:
             staged[name] = (path, patched)
     # Every anchor in every file has been verified; only now write anything.
     for name, (path, patched) in staged.items():
-        path.write_text(patched)
+        atomic_write(path, patched)
         print(f"patched {path.name} ({name}: {expected_marks(PLAN[name][1])} marks)")
     if staged:
         print(

--- a/overlay/patch_apc_no_store.py
+++ b/overlay/patch_apc_no_store.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""Per-request GPU prefix-cache "no-store" (``skip_writing_prefix_cache``).
+
+Recipe-overlay style: fail-closed, idempotent, transactional, MARK/anchor,
+matching overlay/patch_apc_per_group_retention.py. See
+docs/DESIGN-apc-no-store.md for the analysis and the receipts protocol.
+
+Problem (all line refs = the live fork, read-only):
+
+  vLLM has a READ-side opt-out (``SamplingParams.skip_reading_prefix_cache`` ->
+  ``Request.skip_reading_prefix_cache`` -> ``KVCacheManager.get_computed_blocks``)
+  but no WRITE-side one. ``cache_salt`` namespaces and still stores;
+  ``delay_cache_blocks`` (kv_cache_manager.py:552) is a one-step P/D defer.
+  ``BlockPool.free_blocks`` (block_pool.py:719-743) appends HASHED blocks to the
+  back of the free queue (LRU) and prepends UNHASHED ones (LIFO);
+  ``get_new_blocks`` pops from the front. A one-off batch/eval request's blocks
+  are therefore hashed, queue behind the owner's idle 80K conversation, and the
+  owner's blocks are what gets evicted next: the batch job re-orders the LRU in
+  its own favour. With a no-store flag its blocks carry no hash, go to the
+  FRONT, and are the very next ids recycled.
+
+Mechanism: suppress the HASH INSERTION, keep every piece of bookkeeping.
+
+  The two request-driven ``_insert_block_hash`` sites in block_pool.py --
+  ``cache_full_blocks`` (:293) and ``cache_partial_block`` (:508) -- return early
+  for a no-store request. NOT the obvious ``allocate_slots`` one-liner
+  (``if not self.enable_caching or delay_cache_blocks``): skipping
+  ``coordinator.cache_blocks`` skips ``SingleTypeKVCacheManager.cache_blocks``'
+  last line ``self.num_cached_block[request_id] = num_full_blocks``, and
+  membership in ``num_cached_block`` is the running-request sentinel read by
+  ``get_num_blocks_to_allocate`` (:196, fast path asserting no new computed
+  blocks) and ``KVCacheCoordinator.allocate_new_computed_blocks`` (:241). With
+  the block_pool placement ``num_cached_block`` advances identically for every
+  manager on every step; ``MambaManager._cache_partial_tail_block`` gets
+  ``None`` back so the request is never registered as a partial-tail PRODUCER
+  in ``_partial_hit_reqs`` (:1865, gated on ``partial_hash is not None``); the
+  READER-side partial-hit CoW (``add_local_computed_blocks`` :285-291) is
+  untouched; ``MambaManager.cache_blocks``' ``cached_blocks_this_step`` loop
+  already ``continue``s on ``block.block_hash is None`` (:1825). Every consumer
+  already tolerates an allocated full block without a hash: that is exactly
+  what the fork's sparse retention (``reachable_block_mask``) produces.
+  ``move_block_hashes`` is deliberately NOT guarded: it relocates hashes that
+  already exist and normal requests need it; for a no-store request the only
+  path into it (a running request with a registered partial hit) requires the
+  producer registration this overlay suppresses (test C3a/C3e).
+
+Semantics (write-only, GPU prefix cache only):
+  * lookups stay enabled: a no-store request may still read-hit, and reading
+    touches blocks (refreshes their LRU position). Combine with
+    ``skip_reading_prefix_cache`` for zero cache interaction.
+  * a no-store request that is preempted resumes from whatever it could READ
+    (nothing, if its prefix was cold) -- the --no-enable-prefix-caching resume
+    path; prefer it for short lanes, ideally with a low ``priority``.
+  * KV connectors / CPU offload are not touched (none active on this kit).
+
+Surface:
+  ``SamplingParams.skip_writing_prefix_cache: bool | None`` (typed) or
+  ``vllm_xargs: {"skip_writing_prefix_cache": 1}`` on /v1/chat/completions,
+  /v1/completions, /v1/responses (already forwarded to
+  ``SamplingParams.extra_args`` by the fork; zero entrypoint edits). Values are
+  STRICT -- bool, int 0/1, str "0"/"1" -- and validated in
+  ``SamplingParams.__post_init__`` (API-server side; a bad value is an HTTP 400
+  via the ValueError handler, never a silent no-op). JSON ``true`` is rejected
+  even earlier by pydantic (``vllm_xargs`` is ``dict[str, str|int|float|list]``):
+  send the integer 1. ``Request`` is materialised in the engine-core input
+  thread, so its resolver never raises; an unparseable value there (unreachable
+  through the API) logs once and stores normally.
+
+Kill switch: ``GLM53_APC_NO_STORE`` exactly ``0`` or ``1`` (unset = 1). ``0``
+  = a valid ``1`` from the client is ignored (logged once); malformed values
+  are still rejected. Anything else fails closed at import (boot failure; the
+  launcher refuses it before the pair is stopped).
+
+Receipts in the server log (both ``logger.info_once``):
+  ``[glm53-apc-no-store] first request resolved skip_writing_prefix_cache=1``
+      the flag reached the engine (emitted at resolution, so a warm request
+      that never stores anything still leaves proof);
+  ``[glm53-apc-no-store] suppressing prefix-cache store (full site)`` /
+  ``(partial site)`` -- the store path was actually cut.
+
+Fail closed if any anchor drifts: every anchor in every file is checked
+BEFORE anything is written; a file that already carries the MARK must carry
+the complete set of its markers (else refuse); complete files are skipped.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+MARK = "# [glm53-apc-no-store]"
+NO_STORE_KEY = "skip_writing_prefix_cache"
+
+_VLLM = "/usr/local/lib/python3.12/dist-packages/vllm"
+SAMPLING_PARAMS_PY = Path(
+    os.environ.get("GLM53_SAMPLING_PARAMS_PY", f"{_VLLM}/sampling_params.py")
+)
+REQUEST_PY = Path(os.environ.get("GLM53_REQUEST_PY", f"{_VLLM}/v1/request.py"))
+BLOCK_POOL_PY = Path(
+    os.environ.get("GLM53_BLOCK_POOL_PY", f"{_VLLM}/v1/core/block_pool.py")
+)
+
+# ---------------------------------------------------------------- anchors ----
+
+# sampling_params.py ----------------------------------------------------------
+
+# 1. the read-side field (sampling_params.py:364): add its write-side sibling.
+SP_FIELD_OLD = "    skip_reading_prefix_cache: bool | None = None\n"
+SP_FIELD_NEW = '''    skip_reading_prefix_cache: bool | None = None
+    skip_writing_prefix_cache: bool | None = None  # [glm53-apc-no-store]
+    """If True, this request's KV blocks are never inserted into the GPU
+    prefix cache (overlay/patch_apc_no_store.py). Lookups are unaffected: the
+    request may still read-hit. Its blocks stay unhashed, so
+    ``BlockPool.free_blocks`` recycles them LIFO from the front of the free
+    queue instead of queueing them behind -- and thereby evicting -- other
+    sessions' cached blocks. For one-off batch lanes whose prefix will never be
+    reused. Also reachable as ``vllm_xargs: {"skip_writing_prefix_cache": 1}``
+    (``extra_args``); accepted values are bool, int 0/1 and str "0"/"1"."""
+'''
+
+# 2. module-level helpers, inserted before the SamplingParams class.
+SP_CLASS_ANCHOR = "\nclass SamplingParams(\n"
+SP_HELPERS = '''
+# [glm53-apc-no-store] helper-begin
+_GLM53_NO_STORE_KEY = "skip_writing_prefix_cache"
+_GLM53_NO_STORE_ENV = "GLM53_APC_NO_STORE"
+
+
+def _glm53_parse_no_store(value, where):  # [glm53-apc-no-store]
+    """Strict 0/1 parser for the per-request no-store flag.
+
+    Accepts bool, int 0/1 and str "0"/"1" -- nothing else. ``bool("0")`` is
+    True, floats are ambiguous, "yes"/"true" are not part of the contract, so
+    all of those raise ValueError (an HTTP 400 through the OpenAI server's
+    ValueError handler when raised from SamplingParams.__post_init__).
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and value in (0, 1):
+        return bool(value)
+    if isinstance(value, str) and value in ("0", "1"):
+        return value == "1"
+    raise ValueError(
+        f"{where} must be 0 or 1 (int) or \\"0\\"/\\"1\\" (str); got {value!r}. "
+        "JSON true/false is not accepted by vllm_xargs; send the integer 1."
+    )
+
+
+def _glm53_no_store_env():  # [glm53-apc-no-store]
+    """GLM53_APC_NO_STORE: unset -> enabled; exactly "0"/"1"; else fail closed."""
+    import os as _os
+
+    raw = _os.environ.get(_GLM53_NO_STORE_ENV)
+    if raw is None:
+        return True
+    if raw in ("0", "1"):
+        return raw == "1"
+    raise ValueError(
+        f"{_GLM53_NO_STORE_ENV} must be exactly 0 or 1 (got {raw!r}); "
+        "unset it to keep the per-request no-store flag honoured."
+    )
+
+
+_GLM53_NO_STORE_ENABLED = _glm53_no_store_env()
+
+
+def _glm53_validate_no_store_params(params):  # [glm53-apc-no-store]
+    """Reject a malformed flag where the request is still the client's.
+
+    Runs from ``SamplingParams.__post_init__`` -- i.e. in the API-server
+    process for /v1/chat/completions etc. (``to_sampling_params`` ->
+    ``from_optional``) and in the caller's process for the offline ``LLM``
+    API -- BEFORE the kill switch is consulted, so ``GLM53_APC_NO_STORE=0``
+    never turns a typo into a silent no-op. The typed field is normalised to
+    a bool; ``extra_args`` is left as sent.
+    """
+    typed = params.skip_writing_prefix_cache
+    if typed is not None:
+        params.skip_writing_prefix_cache = _glm53_parse_no_store(
+            typed, "SamplingParams.skip_writing_prefix_cache"
+        )
+    extra = params.extra_args
+    if extra and _GLM53_NO_STORE_KEY in extra:
+        _glm53_parse_no_store(
+            extra[_GLM53_NO_STORE_KEY], 'vllm_xargs["skip_writing_prefix_cache"]'
+        )
+
+
+def _glm53_resolve_no_store(sampling_params, request_id):  # [glm53-apc-no-store]
+    """Engine-side resolution: typed field first, then ``extra_args``.
+
+    Never raises: ``Request`` is materialised in the engine-core input thread
+    (``EngineCore.preprocess_add_request``), where an exception is not a
+    request-scoped error. A value that fails the strict parser here is
+    unreachable through the OpenAI API (``_glm53_validate_no_store_params``
+    already rejected it with a 400); if it happens anyway it is logged once and
+    the request stores normally. Malformed values are rejected BEFORE the kill
+    switch is applied; the switch only decides whether a valid 1 is honoured.
+    """
+    if sampling_params is None:
+        return False
+    raw = getattr(sampling_params, _GLM53_NO_STORE_KEY, None)
+    where = "SamplingParams.skip_writing_prefix_cache"
+    if raw is None:
+        extra = getattr(sampling_params, "extra_args", None)
+        if not extra or _GLM53_NO_STORE_KEY not in extra:
+            return False
+        raw = extra[_GLM53_NO_STORE_KEY]
+        where = 'vllm_xargs["skip_writing_prefix_cache"]'
+    try:
+        value = _glm53_parse_no_store(raw, where)
+    except ValueError as exc:
+        logger.warning(
+            "[glm53-apc-no-store] %s -- request %s stores normally "
+            "(this value should have been rejected at the API boundary)",
+            exc,
+            request_id,
+        )
+        return False
+    if not value:
+        return False
+    # ``*_once`` is keyed on (msg, args): keep the request id OUT of the args
+    # so these really are one line per process; the per-request id is a debug
+    # line.
+    if not _GLM53_NO_STORE_ENABLED:
+        logger.info_once(
+            "[glm53-apc-no-store] ignoring skip_writing_prefix_cache=1: "
+            "GLM53_APC_NO_STORE=0 (first occurrence; later ones not logged)"
+        )
+        logger.debug("[glm53-apc-no-store] ignored for request %s", request_id)
+        return False
+    logger.info_once(
+        "[glm53-apc-no-store] first request resolved skip_writing_prefix_cache=1 "
+        "(lookups unaffected, prefix-cache stores suppressed; later "
+        "occurrences not logged)"
+    )
+    logger.debug("[glm53-apc-no-store] request %s is no-store", request_id)
+    return True
+# [glm53-apc-no-store] helper-end
+
+'''
+
+# 3. the tail of SamplingParams.__post_init__ (:529-533): validate after the
+#    read-side auto-set so a bad value is a 400, not a silent no-op.
+SP_POST_OLD = (
+    "            self.skip_reading_prefix_cache = self.prompt_logprobs is not None\n"
+)
+SP_POST_NEW = (
+    "            self.skip_reading_prefix_cache = self.prompt_logprobs is not None\n"
+    "        _glm53_validate_no_store_params(self)  # [glm53-apc-no-store]\n"
+)
+
+# v1/request.py ---------------------------------------------------------------
+
+# 4. resolve the flag once, next to the read-side one (request.py:213).
+REQ_RESOLVE_OLD = (
+    "        self.skip_reading_prefix_cache = self.get_skip_reading_prefix_cache()\n"
+)
+REQ_RESOLVE_NEW = (
+    "        self.skip_reading_prefix_cache = self.get_skip_reading_prefix_cache()\n"
+    "        # [glm53-apc-no-store] write-side sibling; resolved once, never raises\n"
+    "        self.skip_writing_prefix_cache = self.get_skip_writing_prefix_cache()\n"
+)
+
+# 5. the resolver, after get_skip_reading_prefix_cache (request.py:294-305).
+REQ_METHOD_OLD = """        return False
+
+    def is_finished(self) -> bool:
+"""
+REQ_METHOD_NEW = '''        return False
+
+    def get_skip_writing_prefix_cache(self) -> bool:  # [glm53-apc-no-store]
+        """Whether this request's blocks must never enter the prefix cache.
+
+        Typed ``SamplingParams.skip_writing_prefix_cache`` first, then
+        ``SamplingParams.extra_args`` (the ``vllm_xargs`` route). Strict 0/1
+        values; the kill switch GLM53_APC_NO_STORE=0 makes a valid 1 a logged
+        no-op. Never raises (see _glm53_resolve_no_store). PoolingParams are
+        out of scope (chat/completions only).
+        """
+        from vllm.sampling_params import _glm53_resolve_no_store
+
+        return _glm53_resolve_no_store(self.sampling_params, self.request_id)
+
+    def is_finished(self) -> bool:
+'''
+
+# v1/core/block_pool.py -------------------------------------------------------
+
+# 6. proof-of-life helper above the class (module logger exists at :30).
+BP_CLASS_ANCHOR = "\nclass BlockPool:\n"
+BP_HELPER = '''
+def _glm53_log_nostore(request, site) -> None:  # [glm53-apc-no-store]
+    """Proof-of-life: log the first time a no-store request suppresses a store.
+
+    Pair with the resolution receipt logged by Request: that one proves the
+    flag reached the engine, this one proves the store path was cut. A warm
+    no-store request that has nothing new to store legitimately emits only
+    the first.
+    """
+    # ``info_once`` is keyed on (msg, args): the site is a bounded set (two
+    # values), the request id is deliberately not an arg.
+    logger.info_once(
+        "[glm53-apc-no-store] suppressing prefix-cache store (%s site); "
+        "lookups still enabled; later occurrences not logged",
+        site,
+    )
+    logger.debug(
+        "[glm53-apc-no-store] %s store suppressed for request %s",
+        site,
+        getattr(request, "request_id", "<unknown>"),
+    )
+
+'''
+
+# 7. cache_full_blocks (:259-261): the first request-driven _insert_block_hash
+#    site. Returning here also skips the BlockStored event: nothing was stored.
+BP_FULL_OLD = """        if num_cached_blocks >= num_full_blocks:
+            return
+        new_full_blocks = blocks[num_cached_blocks:num_full_blocks]
+"""
+BP_FULL_NEW = """        if num_cached_blocks >= num_full_blocks:
+            return
+        if getattr(request, "skip_writing_prefix_cache", False):  # [glm53-apc-no-store]
+            # No-store request: insert no hash, emit no BlockStored event.
+            # The caller (SingleTypeKVCacheManager.cache_blocks) still advances
+            # ``num_cached_block`` -- the running-request sentinel read at
+            # single_type_kv_cache_manager.py:196 and kv_cache_coordinator.py:241
+            # -- so allocation accounting is unchanged. These blocks keep
+            # ``block_hash is None`` and are recycled LIFO from the front of the
+            # free queue by ``free_blocks`` below, ahead of anything cached.
+            _glm53_log_nostore(request, "full")
+            return
+        new_full_blocks = blocks[num_cached_blocks:num_full_blocks]
+"""
+
+# 8. cache_partial_block (:484-487): the second site (fine-grained partial tail).
+#    Returning None also stops MambaManager._cache_partial_tail_block from
+#    registering this request as a partial-tail *producer* (:1865-1866).
+BP_PARTIAL_OLD = """        if block.is_null:
+            return None
+
+        assert block_size > self.hash_block_size
+"""
+BP_PARTIAL_NEW = """        if block.is_null:
+            return None
+        if getattr(request, "skip_writing_prefix_cache", False):  # [glm53-apc-no-store]
+            # No-store request: no partial entry. Returning None also stops
+            # MambaManager._cache_partial_tail_block from registering this
+            # request in ``_partial_hit_reqs`` as a partial-tail *producer*
+            # (single_type_kv_cache_manager.py:1865), which keeps
+            # get_num_blocks_to_allocate and allocate_new_blocks in agreement
+            # and keeps move_block_hashes unreachable for it. The *reader* side
+            # of the partial-hit CoW (add_local_computed_blocks:285-291) is
+            # untouched: lookups remain enabled for no-store requests.
+            _glm53_log_nostore(request, "partial")
+            return None
+
+        assert block_size > self.hash_block_size
+"""
+
+# (label, old, new) per file, applied in order. ``old`` must occur exactly once
+# in the pristine text; the helper anchors are re-inserted in front of their
+# anchor line.
+PLAN = {
+    "sampling_params.py": (
+        SAMPLING_PARAMS_PY,
+        (
+            ("sampling-field", SP_FIELD_OLD, SP_FIELD_NEW),
+            ("sampling-helpers", SP_CLASS_ANCHOR, SP_HELPERS + SP_CLASS_ANCHOR),
+            ("sampling-post-init", SP_POST_OLD, SP_POST_NEW),
+        ),
+        ("logger = init_logger(__name__)\n",),
+    ),
+    "request.py": (
+        REQUEST_PY,
+        (
+            ("request-resolve", REQ_RESOLVE_OLD, REQ_RESOLVE_NEW),
+            ("request-method", REQ_METHOD_OLD, REQ_METHOD_NEW),
+        ),
+        (),
+    ),
+    "block_pool.py": (
+        BLOCK_POOL_PY,
+        (
+            ("block-pool-helper", BP_CLASS_ANCHOR, BP_HELPER + BP_CLASS_ANCHOR),
+            ("block-pool-full", BP_FULL_OLD, BP_FULL_NEW),
+            ("block-pool-partial", BP_PARTIAL_OLD, BP_PARTIAL_NEW),
+        ),
+        ("logger = init_logger(__name__)\n",),
+    ),
+}
+
+
+def expected_marks(edits) -> int:
+    """How many MARK occurrences a completely patched file carries."""
+    return sum(new.count(MARK) - old.count(MARK) for _, old, new in edits)
+
+
+# ------------------------------------------------------------------ apply ----
+
+
+def preflight(name: str, path: Path, edits, requires) -> str | None:
+    """Return the patched text, or None if the file is already complete.
+
+    Raises SystemExit on a missing file, a drifted anchor, or a file that
+    carries the MARK without the complete set of this overlay's edits.
+    """
+    if not path.is_file():
+        raise SystemExit(f"missing {path}")
+    text = path.read_text()
+    have = text.count(MARK)
+    want = expected_marks(edits)
+    if have:
+        if have != want:
+            raise SystemExit(
+                f"{path}: carries {have} '{MARK}' marker(s) but a complete "
+                f"application has {want}; refusing to patch a partially "
+                "modified file (restore the pristine file first)"
+            )
+        return None
+    for needle in requires:
+        if text.count(needle) != 1:
+            raise SystemExit(f"{path}: prerequisite {needle.strip()!r} not unique")
+    for label, old, new in edits:
+        n = text.count(old)
+        if n != 1:
+            raise SystemExit(f"{path}: expected one {label} target, found {n}")
+        text = text.replace(old, new, 1)
+    if text.count(MARK) != want:
+        raise SystemExit(f"{path}: internal error, marker count after apply")
+    return text
+
+
+def main() -> int:
+    staged: dict[str, tuple[Path, str]] = {}
+    for name, (path, edits, requires) in PLAN.items():
+        patched = preflight(name, path, edits, requires)
+        if patched is None:
+            print(f"{path.name}: {MARK} already present - skipping")
+        else:
+            staged[name] = (path, patched)
+    # Every anchor in every file has been verified; only now write anything.
+    for name, (path, patched) in staged.items():
+        path.write_text(patched)
+        print(f"patched {path.name} ({name}: {expected_marks(PLAN[name][1])} marks)")
+    if staged:
+        print(
+            "patched no-store overlay (per-request GPU prefix-cache no-store via "
+            f"SamplingParams.{NO_STORE_KEY} / vllm_xargs; kill switch "
+            "GLM53_APC_NO_STORE)"
+        )
+    else:
+        print("no-store overlay: already applied, nothing to do")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/start.sh
+++ b/start.sh
@@ -419,7 +419,7 @@ validate_overlay_artifacts() {
         "$NOSTORE_PATCH_HOST|[glm53-apc-no-store]|$main_guard"
         "$XGRAMMAR_PATCH_HOST|vllm/v1/structured_output/|$main_guard"
         "$KPOOL_TAIL_PATCH_HOST|[glm53-kpool-tail-slotmap]|$main_guard"
-        "$SPINWAIT_PATCH_HOST|glm53-spinwait|$main_guard"
+        "$SPINWAIT_PATCH_HOST|device_communicators/shm_broadcast.py|$main_guard"
         "$SCRIPT_DIR/overlay/patch_ablit.py|$ablit_marker|    main()"
         "$SCRIPT_DIR/overlay/ablit_runtime.py|o_proj abliteration (ABLIT)|    return report"
     )

--- a/start.sh
+++ b/start.sh
@@ -73,11 +73,14 @@ _cli_ablit_direction="${ABLIT_DIRECTION-}"
 _cli_ablit_layers="${ABLIT_LAYERS-}"
 _cli_ablit_alpha="${ABLIT_ALPHA-}"
 _cli_ablit_mtp="${ABLIT_INCLUDE_MTP-}"
+_cli_no_store_set="${GLM53_APC_NO_STORE+1}"
+_cli_no_store="${GLM53_APC_NO_STORE-}"
 set -a
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/.env"
 set +a
 [ -n "${_cli_mtp}" ] && MTP_TOKENS="$_cli_mtp"
+[ -n "${_cli_no_store_set}" ] && GLM53_APC_NO_STORE="$_cli_no_store"
 [ -n "${_cli_spec}" ] && SPEC_METHOD="$_cli_spec"
 [ -n "${_cli_eager}" ] && ENFORCE_EAGER="$_cli_eager"
 [ -n "${_cli_fused}" ] && EXL3_FUSED_MOE="$_cli_fused"
@@ -173,6 +176,7 @@ STOP_PATCH_HOST="${STOP_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_suppress_stops_in_
 SCHED_PATCH_HOST="${SCHED_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_scheduler_decode_floor.py}"
 DRAFTER_PATCH_HOST="${DRAFTER_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm5_drafter_group.py}"
 APC_PATCH_HOST="${APC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_hybrid_prefix_hit.py}"
+NOSTORE_PATCH_HOST="${NOSTORE_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_apc_no_store.py}"
 XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_xgrammar_termination.py}"
 KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kpool_tail_slotmap.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
@@ -227,6 +231,12 @@ GLM53_SUPPRESS_STOPS_IN_REASONING="${GLM53_SUPPRESS_STOPS_IN_REASONING:-1}"
 # Mixed-step prefill policy when a peer is already decoding (issue #6).
 # skip = do not mix; N>0 = cap tokens; 0 = off.
 GLM53_MIXED_PREFILL_CHUNK="${GLM53_MIXED_PREFILL_CHUNK:-skip}"
+# 1 = honour the per-request GPU prefix-cache no-store flag
+# (vllm_xargs {"skip_writing_prefix_cache": 1}; overlay patch_apc_no_store.py);
+# 0 = ignore it (logged once). Requests never opt in by default, so 1 changes
+# nothing until a client asks. Default applies only when UNSET: an explicitly
+# empty value is an operator error and validate_numeric_config rejects it.
+GLM53_APC_NO_STORE="${GLM53_APC_NO_STORE-1}"
 # EngineCore stock timeout is 300s; mid-serve Triton/TileLang JIT on TP=2 can
 # exceed that without being a true hang. NCCL watchdog is still 600s.
 VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS="${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-1800}"
@@ -291,6 +301,20 @@ _glm53_canonical_positive_int() {
     export "$name"
 }
 
+# Kill switches are exactly 0 or 1. Not "non-empty means on", not `[ "$v" = 0 ]`
+# with everything else treated as on: a typo'd knob must not silently pick a
+# serving mode. GLM53_APC_NO_STORE decides whether a client's per-request
+# no-store flag is honoured, and the overlay itself refuses at import on
+# anything but 0/1 (overlay/patch_apc_no_store.py, _glm53_no_store_env), so
+# catching it here turns a container boot failure into a launcher error.
+_glm53_validate_bool_flag() {
+    local name="$1" value="$2"
+    if [ "$value" != 0 ] && [ "$value" != 1 ]; then
+        echo "$name must be exactly 0 or 1 (got: $value)" >&2
+        return 2
+    fi
+}
+
 validate_numeric_config() {
     if ! [[ "$GPU_MEM_UTIL" =~ ^(0([.][0-9]+)?|[.][0-9]+|1([.]0+)?)$ ]] \
        || ! awk -v u="$GPU_MEM_UTIL" 'BEGIN { exit !(u > 0 && u <= 1) }'; then
@@ -300,8 +324,88 @@ validate_numeric_config() {
     _glm53_canonical_positive_int MAX_MODEL_LEN "$MAX_MODEL_LEN" 1000000 || return
     _glm53_canonical_positive_int MAX_NUM_SEQS "$MAX_NUM_SEQS" 4096 || return
     _glm53_canonical_positive_int MAX_NUM_BATCHED_TOKENS "$MAX_NUM_BATCHED_TOKENS" 8388608 || return
+    _glm53_validate_bool_flag GLM53_APC_NO_STORE "${GLM53_APC_NO_STORE-1}" || return
 }
 # GLM53 numeric config guard (end)
+
+# GLM53 overlay artifact guard (begin)
+# Every file both rank containers mount. main() runs validate_overlay_artifacts
+# on start|restart BEFORE `restart` stops anything: a missing, empty,
+# mis-pointed, truncated or syntactically broken input is a launcher error
+# with the healthy pair left serving, not a container that dies at boot after
+# the old one is gone. Python overlays: path|identity string|last line -
+# the identity string (MARK / target path / hook marker) is distinct per file
+# so a *_PATCH_HOST pointed at a different overlay is caught, and the last
+# non-blank line must match exactly so a copy truncated anywhere before EOF
+# (even one that still parses) is caught too. This guards against operator
+# error (wrong path, stale checkout, truncated copy); it is not a
+# tamper-proof manifest. Needs python3 on the head (DGX OS ships it).
+# preflight() re-checks existence later; this is the fail-closed early gate.
+validate_overlay_artifacts() {
+    # Sentinels that contain quotes live in single-quoted locals.
+    local main_guard='    sys.exit(main())'
+    local video_end='    print("glm53: overlay install ok aligned=True", file=sys.stderr)'
+    local ablit_marker='MARKER = "ABLIT-HOOK"'
+    local -a artifacts=(
+        "$VIDEO_PATCH_HOST|vllm/model_executor/layers/|$video_end"
+        "$STOP_PATCH_HOST|[suppress-stops-in-reasoning]|    raise SystemExit(main(sys.argv))"
+        "$SCHED_PATCH_HOST|[glm53-decode-floor]|$main_guard"
+        "$DRAFTER_PATCH_HOST|vllm/v1/core/kv_cache_utils.py|$main_guard"
+        "$APC_PATCH_HOST|[glm53-hybrid-apc]|$main_guard"
+        "$NOSTORE_PATCH_HOST|[glm53-apc-no-store]|$main_guard"
+        "$XGRAMMAR_PATCH_HOST|vllm/v1/structured_output/|$main_guard"
+        "$KPOOL_TAIL_PATCH_HOST|[glm53-kpool-tail-slotmap]|$main_guard"
+        "$SCRIPT_DIR/overlay/patch_ablit.py|$ablit_marker|    main()"
+        "$SCRIPT_DIR/overlay/ablit_runtime.py|o_proj abliteration (ABLIT)|    return report"
+    )
+    local entry path rest tag tail last
+    if [ "${#artifacts[@]}" -eq 0 ]; then
+        echo "overlay artifact list is empty - refusing to launch" >&2
+        return 2
+    fi
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "python3 is required on the head to verify overlay artifacts before launch" >&2
+        return 2
+    fi
+    for entry in "${artifacts[@]}"; do
+        path="${entry%%|*}"
+        rest="${entry#*|}"
+        tag="${rest%%|*}"
+        tail="${rest#*|}"
+        if [ ! -f "$path" ] || [ ! -r "$path" ] || [ ! -s "$path" ]; then
+            echo "overlay artifact missing, unreadable or empty: $path" >&2
+            return 2
+        fi
+        if ! grep -qF -- "$tag" "$path"; then
+            echo "overlay artifact $path does not carry its identity string '$tag' (wrong file?)" >&2
+            return 2
+        fi
+        # `|| true`: under pipefail a whitespace-only file makes grep exit 1,
+        # which must surface as the rc=2 diagnostic below, not a bare exit 1.
+        last="$(grep -v '^[[:space:]]*$' "$path" | tail -n 1 || true)"
+        if [ "$last" != "$tail" ]; then
+            echo "overlay artifact $path does not end with '$tail' (truncated copy? last line: '$last')" >&2
+            return 2
+        fi
+        # Parse-only: proves the file is importable Python without executing it
+        # or leaving __pycache__ litter in the checkout.
+        if ! python3 -c 'import ast, sys; ast.parse(open(sys.argv[1], encoding="utf-8").read(), sys.argv[1])' "$path" 2>/dev/null; then
+            echo "overlay artifact does not parse as Python: $path" >&2
+            return 2
+        fi
+    done
+    # Non-Python inputs both ranks mount: the chat template and the ablit
+    # layer map (the .pt payloads are ABLIT's own concern at hook time).
+    if [ ! -f "$CHAT_TEMPLATE_HOST" ] || [ ! -r "$CHAT_TEMPLATE_HOST" ] || [ ! -s "$CHAT_TEMPLATE_HOST" ]; then
+        echo "chat template missing, unreadable, empty or not a regular file: $CHAT_TEMPLATE_HOST" >&2
+        return 2
+    fi
+    if ! python3 -c 'import json, sys; json.load(open(sys.argv[1], encoding="utf-8"))' "$SCRIPT_DIR/ablit/LAYER_MAP.json" 2>/dev/null; then
+        echo "ablit layer map missing or not JSON: $SCRIPT_DIR/ablit/LAYER_MAP.json" >&2
+        return 2
+    fi
+}
+# GLM53 overlay artifact guard (end)
 
 banner() {
     local label="${1:-start.sh}"
@@ -435,6 +539,7 @@ preflight() {
     [ -f "$SCHED_PATCH_HOST" ] || die "$SCHED_PATCH_HOST missing"
     [ -f "$DRAFTER_PATCH_HOST" ] || die "$DRAFTER_PATCH_HOST missing"
     [ -f "$APC_PATCH_HOST" ] || die "$APC_PATCH_HOST missing"
+    [ -f "$NOSTORE_PATCH_HOST" ] || die "$NOSTORE_PATCH_HOST missing"
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "$XGRAMMAR_PATCH_HOST missing"
     [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "$KPOOL_TAIL_PATCH_HOST missing"
     [ -f "$SCRIPT_DIR/overlay/patch_ablit.py" ] || die "$SCRIPT_DIR/overlay/patch_ablit.py missing"
@@ -822,6 +927,39 @@ sync_weights() {
 }
 
 # ------------------------ inner container scripts --------------------------
+# Overlay application order inside BOTH rank containers. write_inner_scripts
+# emits this one list verbatim into the head and the worker inner script, so
+# the two ranks cannot drift apart. Pinned for the prefix-cache overlays,
+# which share the kv_cache_coordinator.py helper insert point:
+#   patch_hybrid_prefix_hit -> patch_apc_per_group_retention -> patch_apc_fine_grained_hits
+# (hybrid = Mia's partial-hit base, per-group = PR #83, fine-grained = PR #84),
+# then patch_apc_no_store (sampling_params / request / block_pool only; no
+# shared anchors with the coordinator overlays).
+# Entries that are not mounted are skipped in-container (`[ -f ]`); which ones
+# MUST exist is decided by the overlay artifact guard above, not here.
+GLM53_OVERLAY_ORDER=(
+    patch_glm_video_placeholders.py
+    patch_suppress_stops_in_reasoning.py
+    patch_scheduler_decode_floor.py
+    patch_glm5_drafter_group.py
+    patch_hybrid_prefix_hit.py
+    patch_apc_per_group_retention.py
+    patch_apc_fine_grained_hits.py
+    patch_apc_no_store.py
+    patch_xgrammar_termination.py
+    patch_kpool_tail_slotmap.py
+    patch_ablit.py
+)
+
+# Emits the in-container apply block for GLM53_OVERLAY_ORDER (same bytes for
+# both ranks).
+emit_overlay_block() {
+    local p
+    for p in "${GLM53_OVERLAY_ORDER[@]}"; do
+        printf 'if [ -f /opt/glm53/%s ]; then\n    python3 /opt/glm53/%s\nfi\n' "$p" "$p"
+    done
+}
+
 write_inner_scripts() {
     cat > "$HEAD_SCRIPT" <<'EOF'
 #!/bin/bash
@@ -881,30 +1019,9 @@ if [ -n "${EXTRA_ARGS:-}" ]; then
 fi
 
 [ -f "${MODEL_DIR}/config.json" ] || { say "FATAL: ${MODEL_DIR}/config.json missing"; ls -la "${MODEL_DIR}" | head; exit 1; }
-if [ -f /opt/glm53/patch_glm_video_placeholders.py ]; then
-    python3 /opt/glm53/patch_glm_video_placeholders.py
-fi
-if [ -f /opt/glm53/patch_suppress_stops_in_reasoning.py ]; then
-    python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
-fi
-if [ -f /opt/glm53/patch_scheduler_decode_floor.py ]; then
-    python3 /opt/glm53/patch_scheduler_decode_floor.py
-fi
-if [ -f /opt/glm53/patch_glm5_drafter_group.py ]; then
-    python3 /opt/glm53/patch_glm5_drafter_group.py
-fi
-if [ -f /opt/glm53/patch_hybrid_prefix_hit.py ]; then
-    python3 /opt/glm53/patch_hybrid_prefix_hit.py
-fi
-if [ -f /opt/glm53/patch_xgrammar_termination.py ]; then
-    python3 /opt/glm53/patch_xgrammar_termination.py
-fi
-if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
-    python3 /opt/glm53/patch_kpool_tail_slotmap.py
-fi
-if [ -f /opt/glm53/patch_ablit.py ]; then
-    python3 /opt/glm53/patch_ablit.py
-fi
+EOF
+    emit_overlay_block >> "$HEAD_SCRIPT"
+    cat >> "$HEAD_SCRIPT" <<'EOF'
 if [ "${ABLIT:-0}" = "1" ]; then
     say "ablit: o_proj orthogonalization ON (method=${ABLIT_METHOD:-auto} direction=${ABLIT_DIRECTION:-dealign} layers=${ABLIT_LAYERS:-15-45} alpha=${ABLIT_ALPHA:-3.0})"
 else
@@ -971,30 +1088,9 @@ if [ -n "${EXTRA_ARGS:-}" ]; then
 fi
 
 [ -f "${MODEL_DIR}/config.json" ] || { say "FATAL: ${MODEL_DIR}/config.json missing"; ls -la "${MODEL_DIR}" | head; exit 1; }
-if [ -f /opt/glm53/patch_glm_video_placeholders.py ]; then
-    python3 /opt/glm53/patch_glm_video_placeholders.py
-fi
-if [ -f /opt/glm53/patch_suppress_stops_in_reasoning.py ]; then
-    python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
-fi
-if [ -f /opt/glm53/patch_scheduler_decode_floor.py ]; then
-    python3 /opt/glm53/patch_scheduler_decode_floor.py
-fi
-if [ -f /opt/glm53/patch_glm5_drafter_group.py ]; then
-    python3 /opt/glm53/patch_glm5_drafter_group.py
-fi
-if [ -f /opt/glm53/patch_hybrid_prefix_hit.py ]; then
-    python3 /opt/glm53/patch_hybrid_prefix_hit.py
-fi
-if [ -f /opt/glm53/patch_xgrammar_termination.py ]; then
-    python3 /opt/glm53/patch_xgrammar_termination.py
-fi
-if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
-    python3 /opt/glm53/patch_kpool_tail_slotmap.py
-fi
-if [ -f /opt/glm53/patch_ablit.py ]; then
-    python3 /opt/glm53/patch_ablit.py
-fi
+EOF
+    emit_overlay_block >> "$WORKER_SCRIPT"
+    cat >> "$WORKER_SCRIPT" <<'EOF'
 if [ "${ABLIT:-0}" = "1" ]; then
     say "ablit: o_proj orthogonalization ON (method=${ABLIT_METHOD:-auto} direction=${ABLIT_DIRECTION:-dealign} layers=${ABLIT_LAYERS:-15-45} alpha=${ABLIT_ALPHA:-3.0})"
 else
@@ -1025,7 +1121,9 @@ launch_cluster() {
     [ -f "$DRAFTER_PATCH_HOST" ] || die "missing $DRAFTER_PATCH_HOST"
     scp -q -o BatchMode=yes "$DRAFTER_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_glm5_drafter_group.py"
     [ -f "$APC_PATCH_HOST" ] || die "missing $APC_PATCH_HOST"
+    [ -f "$NOSTORE_PATCH_HOST" ] || die "missing $NOSTORE_PATCH_HOST"
     scp -q -o BatchMode=yes "$APC_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_hybrid_prefix_hit.py"
+    scp -q -o BatchMode=yes "$NOSTORE_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_apc_no_store.py"
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "missing $XGRAMMAR_PATCH_HOST"
     scp -q -o BatchMode=yes "$XGRAMMAR_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_xgrammar_termination.py"
     [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "missing $KPOOL_TAIL_PATCH_HOST"
@@ -1053,6 +1151,7 @@ launch_cluster() {
         -e VLLM_CACHE_ROOT=/root/.cache/vllm
         -e "GLM53_SUPPRESS_STOPS_IN_REASONING=$GLM53_SUPPRESS_STOPS_IN_REASONING"
         -e "GLM53_MIXED_PREFILL_CHUNK=$GLM53_MIXED_PREFILL_CHUNK"
+        -e "GLM53_APC_NO_STORE=$GLM53_APC_NO_STORE"
         -e "TRITON_CACHE_DIR=$TRITON_CACHE_DIR"
         -e "TILELANG_CACHE_DIR=$TILELANG_CACHE_DIR"
         -e "VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=$VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS"
@@ -1067,6 +1166,7 @@ launch_cluster() {
         -e DO_NOT_TRACK=1
         -e "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=$CG_ESTIMATE"
     )
+    log "per-request prefix-cache no-store flag: GLM53_APC_NO_STORE=${GLM53_APC_NO_STORE} (both ranks)"
     local worker_nccl="" e
     for e in "${nccl_common[@]}"; do
         [ "$e" = "-e" ] && continue
@@ -1123,6 +1223,7 @@ launch_cluster() {
         -v '/tmp/patch_scheduler_decode_floor.py:/opt/glm53/patch_scheduler_decode_floor.py:ro' \
         -v '/tmp/patch_glm5_drafter_group.py:/opt/glm53/patch_glm5_drafter_group.py:ro' \
         -v '/tmp/patch_hybrid_prefix_hit.py:/opt/glm53/patch_hybrid_prefix_hit.py:ro' \
+        -v '/tmp/patch_apc_no_store.py:/opt/glm53/patch_apc_no_store.py:ro' \
         -v '/tmp/patch_xgrammar_termination.py:/opt/glm53/patch_xgrammar_termination.py:ro' \
         -v '/tmp/patch_kpool_tail_slotmap.py:/opt/glm53/patch_kpool_tail_slotmap.py:ro' \
         -v '/tmp/glm53-ablit:/opt/glm53/ablit:ro' \
@@ -1154,6 +1255,7 @@ launch_cluster() {
         -v "$SCHED_PATCH_HOST:/opt/glm53/patch_scheduler_decode_floor.py:ro" \
         -v "$DRAFTER_PATCH_HOST:/opt/glm53/patch_glm5_drafter_group.py:ro" \
         -v "$APC_PATCH_HOST:/opt/glm53/patch_hybrid_prefix_hit.py:ro" \
+        -v "$NOSTORE_PATCH_HOST:/opt/glm53/patch_apc_no_store.py:ro" \
         -v "$XGRAMMAR_PATCH_HOST:/opt/glm53/patch_xgrammar_termination.py:ro" \
         -v "$KPOOL_TAIL_PATCH_HOST:/opt/glm53/patch_kpool_tail_slotmap.py:ro" \
         -v "$SCRIPT_DIR/ablit:/opt/glm53/ablit:ro" \
@@ -1391,7 +1493,7 @@ logs() {
 main() {
     local cmd="${1:-start}"
     case "$cmd" in
-        start|restart) validate_numeric_config ;;
+        start|restart) validate_numeric_config; validate_overlay_artifacts ;;
     esac
     case "$cmd" in
         stop)     banner stop.sh ;;

--- a/tests/test_apc_no_store.py
+++ b/tests/test_apc_no_store.py
@@ -674,12 +674,18 @@ cb, n, _ = mN.get_computed_blocks(gN); mN.allocate_slots(gN, 4, n, cb)
 cb, n, _ = mQ.get_computed_blocks(gQ); mQ.allocate_slots(gQ, 4, n, cb)
 check(block_ids(mQ, "gQ") <= idsQ, "C2 [nostore] the next allocation recycles the freed no-store block first (front of the free queue)")
 check(not (block_ids(mN, "gN") & idsN), "C2 [normal] the next allocation does NOT touch the freed cached blocks (they sit at the back)")
-# C2r: sparse retention interval on the same shape -> still no hashes for no-store, sentinel still advances
-from dataclasses import replace
-m = manager(replace(full_cfg(4, 24), prefix_cache_retention_interval=4), 2, 4)
-req = mk("ret", toks, no_store=True)
-_, trace = prefill(m, req, (4, 4, 4, 2))
-check(not any(t[1] for t in trace) and [t[0][0] for t in trace] == [1, 2, 3, 3], "C2 [nostore + retention_interval] no hashes, sentinel unchanged")
+# C2r: sparse retention interval on the same shape -> still no hashes for no-store, sentinel still advances.
+# Upstream KVCacheConfig (22df3a3) carries prefix_cache_retention_interval as a dataclass field; the fork's
+# in-image build drives retention through VLLM_PREFIX_CACHE_RETENTION_INTERVAL instead and has no such field,
+# so this sub-check feature-detects it (found by the in-fork receipt run, 2026-09-01).
+from dataclasses import replace, fields
+if any(f.name == "prefix_cache_retention_interval" for f in fields(type(full_cfg(4, 24)))):
+    m = manager(replace(full_cfg(4, 24), prefix_cache_retention_interval=4), 2, 4)
+    req = mk("ret", toks, no_store=True)
+    _, trace = prefill(m, req, (4, 4, 4, 2))
+    check(not any(t[1] for t in trace) and [t[0][0] for t in trace] == [1, 2, 3, 3], "C2 [nostore + retention_interval] no hashes, sentinel unchanged")
+else:
+    check(True, "C2 [nostore + retention_interval] skipped: this vLLM's KVCacheConfig has no prefix_cache_retention_interval field (the fork build reads VLLM_PREFIX_CACHE_RETENTION_INTERVAL instead; upstream 22df3a3 field-based path is covered by the Mac venv run)")
 
 # C3 -- hybrid Full(hash 2) + Mamba(align, block 4): the upstream partial-tail fixture shape.
 def mamba(m):

--- a/tests/test_apc_no_store.py
+++ b/tests/test_apc_no_store.py
@@ -337,10 +337,26 @@ def part_a(root: Path | None) -> None:
     with tempfile.TemporaryDirectory() as raw:
         tmp = Path(raw)
         staged = stage(tmp, root, pristine_only=True)
+        run_patcher(staged)
+        bp = staged["GLM53_BLOCK_POOL_PY"]
+        text = bp.read_text()
+        # every MARK still present, but one guard body edited -> not "complete"
+        edited = text.replace('_glm53_log_nostore(request, "full")', 'pass  # edited', 1)
+        check(edited != text and edited.count(MARK) == text.count(MARK), "A5 fixture: marks intact, one snippet altered")
+        bp.write_text(edited)
+        r = run_patcher(staged)
+        check(r.returncode != 0 and "lacks the verbatim snippet" in r.stderr and bp.read_text() == edited, f"A5 fully-marked file with an altered snippet is refused (rc={r.returncode}), not skipped as applied")
+        bp.write_text(text[: len(text) // 2])
+        r = run_patcher(staged)
+        check(r.returncode != 0 and bp.read_text() == text[: len(text) // 2], f"A5 truncated (already-marked) file is refused (rc={r.returncode})")
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        staged = stage(tmp, root, pristine_only=True)
         missing = staged["GLM53_REQUEST_PY"]
         missing.unlink()
         r = run_patcher(staged)
         check(r.returncode != 0 and "missing" in r.stderr and MARK not in staged["GLM53_SAMPLING_PARAMS_PY"].read_text(), "A6 missing target -> refused, nothing written")
+        check(not [p for p in tmp.iterdir() if p.suffix == ".glm53"], "A6 no temp-file litter left behind")
 
 
 BLOCK_POOL_PARTIAL_LINE = '        if getattr(request, "skip_writing_prefix_cache", False):  # [glm53-apc-no-store]\n'
@@ -421,6 +437,17 @@ def part_b() -> None:
     rejected = [2, -1, 1.0, 0.0, "true", "false", "yes", "no", " 1", "1 ", "01", "", None, [1], {"a": 1}, b"1", "True"]
     for value in rejected:
         check(raises_value_error(parse, value, "t"), f"B1 reject {value!r}")
+
+    try:
+        from pydantic import TypeAdapter
+        xargs_type = dict[str, str | int | float | list[str | int | float]] | None
+        ta = TypeAdapter(xargs_type)
+        coerced = {j: ta.validate_json(j)["skip_writing_prefix_cache"] for j in ('{"skip_writing_prefix_cache": true}', '{"skip_writing_prefix_cache": false}', '{"skip_writing_prefix_cache": "1"}', '{"skip_writing_prefix_cache": 1.0}')}
+        check(coerced['{"skip_writing_prefix_cache": true}'] == 1 and coerced['{"skip_writing_prefix_cache": false}'] == 0 and all(not isinstance(v, bool) for v in coerced.values()), f"B1 pydantic coerces a JSON boolean in the vllm_xargs type to int 1/0 (never a bool) -> {coerced}")
+        check(parse(coerced['{"skip_writing_prefix_cache": true}'], "t") is True and parse(coerced['{"skip_writing_prefix_cache": false}'], "t") is False, "B1 ... which the strict parser accepts with the intended meaning")
+        check(raises_value_error(parse, coerced['{"skip_writing_prefix_cache": 1.0}'], "t"), "B1 ... while JSON 1.0 stays a float and is rejected")
+    except ImportError:
+        print("  --   B1 pydantic not importable here: vllm_xargs coercion leg skipped (runs in the image / venv)")
 
     validate = ns["_glm53_validate_no_store_params"]
     resolve = ns["_glm53_resolve_no_store"]

--- a/tests/test_apc_no_store.py
+++ b/tests/test_apc_no_store.py
@@ -1,0 +1,900 @@
+#!/usr/bin/env python3
+"""Host test for overlay/patch_apc_no_store.py (no GPU).
+
+Part A  patch mechanics on COPIES of the three target files: anchors land,
+        the result parses, byte-identical idempotent re-apply, every anchor
+        individually drifted -> non-zero exit AND no file written
+        (transactional), a partially-marked file is refused, the off-limits
+        files (kv_cache_manager / kv_cache_coordinator / single_type managers)
+        are not targets, both guards precede their ``_insert_block_hash`` call,
+        ``move_block_hashes`` is unguarded.
+Part B  resolver semantics: the injected helper block is exec'd in a bare
+        namespace with a capturing logger and driven over the full
+        accept/reject matrix, the typed > extra_args precedence, and the
+        GLM53_APC_NO_STORE kill-switch matrix (parse/reject happens BEFORE the
+        switch).
+Part C  behaviour on a real vLLM (CPU is enough): patched COPIES of the three
+        files are injected into ``sys.modules`` before ``vllm.v1.core`` is
+        imported, so real ``BlockPool`` / ``KVCacheManager`` /
+        ``HybridKVCacheCoordinator`` / managers run on top of the patched code.
+        Skipped with a loud line when ``import vllm`` fails; set
+        ``GLM53_REQUIRE_VLLM=1`` to make that a failure (the Dockerfile does).
+Part D  launcher: the "GLM53 numeric config guard" block of start.sh accepts
+        GLM53_APC_NO_STORE only as exactly 0 or 1 (unset -> 1).
+
+Sources: ``GLM53_VLLM_SRC_ROOT`` = a vLLM package directory holding
+``sampling_params.py``, ``v1/request.py``, ``v1/core/block_pool.py`` (default:
+the in-image path). Files that already carry the overlay MARK are accepted
+(Part A's apply/drift legs then run on the vendored anchor-context replicas
+below; Part C injects them as they are). With no source at all, Part A runs on
+the replicas only and Part C is skipped.
+
+Run:  python3 tests/test_apc_no_store.py
+      GLM53_VLLM_SRC_ROOT=/path/to/vllm python3 tests/test_apc_no_store.py
+      (Part C on the Mac: PYTHONPATH=<upstream clone> <cpu venv python> ...)
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+PATCH = next(
+    (
+        p
+        for p in (HERE / "patch_apc_no_store.py", HERE.parent / "overlay" / "patch_apc_no_store.py")
+        if p.is_file()
+    ),
+    None,
+)
+START = HERE.parent / "start.sh"
+DEFAULT_SRC_ROOT = Path("/usr/local/lib/python3.12/dist-packages/vllm")
+MARK = "# [glm53-apc-no-store]"
+REL = {
+    "GLM53_SAMPLING_PARAMS_PY": "sampling_params.py",
+    "GLM53_REQUEST_PY": "v1/request.py",
+    "GLM53_BLOCK_POOL_PY": "v1/core/block_pool.py",
+}
+FAILURES: list[str] = []
+CHECKS = 0
+
+
+def check(cond: bool, label: str) -> None:
+    global CHECKS
+    CHECKS += 1
+    print(("  ok   " if cond else "  FAIL ") + label)
+    if not cond:
+        FAILURES.append(label)
+
+
+def load_patcher():
+    spec = importlib.util.spec_from_file_location("glm53_patch_apc_no_store", PATCH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ------------------------------------------------------------- replicas -----
+# Vendored anchor context: the exact lines the overlay anchors on, embedded in
+# enough surrounding code to parse. Used when no pristine source is available
+# (or the available one is already patched) so Parts A/B run anywhere.
+
+REPLICA_SAMPLING = '''# replica of vllm/sampling_params.py (anchor context only)
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class SamplingParams(
+    object,
+):
+    """replica"""
+
+    n: int = 1
+    extra_args: dict | None = None
+    prompt_logprobs: int | None = None
+    skip_reading_prefix_cache: bool | None = None
+    thinking_token_budget: int | None = None
+
+    def __post_init__(self) -> None:
+        self._verify_args()
+
+        if self.skip_reading_prefix_cache is None:
+            # If prefix caching is enabled,
+            # the output of prompt logprobs may less than n_prompt_tokens,
+            # we need to skip reading cache at this request.
+            self.skip_reading_prefix_cache = self.prompt_logprobs is not None
+
+    def _verify_args(self) -> None:
+        pass
+'''
+
+REPLICA_REQUEST = '''# replica of vllm/v1/request.py (anchor context only)
+from vllm.sampling_params import SamplingParams
+
+
+class Request:
+    def __init__(self, request_id, sampling_params=None, pooling_params=None):
+        self.request_id = request_id
+        self.sampling_params = sampling_params
+        self.pooling_params = pooling_params
+        self.status = None
+
+        self.skip_reading_prefix_cache = self.get_skip_reading_prefix_cache()
+
+    def get_skip_reading_prefix_cache(self) -> bool:
+        if (
+            self.sampling_params is not None
+            and self.sampling_params.skip_reading_prefix_cache is not None
+        ):
+            return self.sampling_params.skip_reading_prefix_cache
+        elif (
+            self.pooling_params is not None
+            and self.pooling_params.skip_reading_prefix_cache is not None
+        ):
+            return self.pooling_params.skip_reading_prefix_cache
+        return False
+
+    def is_finished(self) -> bool:
+        return False
+'''
+
+REPLICA_BLOCK_POOL = '''# replica of vllm/v1/core/block_pool.py (anchor context only)
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class BlockPool:
+    def __init__(self, hash_block_size):
+        self.hash_block_size = hash_block_size
+        self.enable_kv_cache_events = False
+
+    def cache_full_blocks(
+        self,
+        request,
+        blocks,
+        num_cached_blocks,
+        num_full_blocks,
+        block_size,
+        kv_cache_group_id,
+        block_mask=None,
+    ) -> None:
+        if num_cached_blocks >= num_full_blocks:
+            return
+        new_full_blocks = blocks[num_cached_blocks:num_full_blocks]
+        for i, blk in enumerate(new_full_blocks):
+            self._insert_block_hash(
+                (kv_cache_group_id, i),
+                blk,
+                num_tokens=(num_cached_blocks + i + 1) * block_size,
+            )
+
+    def cache_partial_block(
+        self,
+        request,
+        block,
+        num_tokens,
+        kv_cache_group_id,
+        block_size,
+    ):
+        if block.is_null:
+            return None
+
+        assert block_size > self.hash_block_size
+        block_hash_with_group_id = (kv_cache_group_id, num_tokens)
+        self._insert_block_hash(
+            block_hash_with_group_id,
+            block,
+            num_tokens=num_tokens,
+        )
+        return block_hash_with_group_id
+
+    def _insert_block_hash(self, block_hash_with_group_id, block, num_tokens):
+        block.block_hash = block_hash_with_group_id
+
+    def move_block_hashes(self, src_block, dst_block) -> None:
+        assert dst_block.block_hash is None
+        for block_hash in [src_block.block_hash]:
+            self._insert_block_hash(block_hash, dst_block, num_tokens=None)
+'''
+
+REPLICAS = {
+    "GLM53_SAMPLING_PARAMS_PY": REPLICA_SAMPLING,
+    "GLM53_REQUEST_PY": REPLICA_REQUEST,
+    "GLM53_BLOCK_POOL_PY": REPLICA_BLOCK_POOL,
+}
+
+
+def source_root() -> Path | None:
+    raw = os.environ.get("GLM53_VLLM_SRC_ROOT", "").strip()
+    root = Path(raw) if raw else DEFAULT_SRC_ROOT
+    if all((root / rel).is_file() for rel in REL.values()):
+        return root
+    if raw:
+        raise SystemExit(f"GLM53_VLLM_SRC_ROOT={root} lacks one of {sorted(REL.values())}")
+    return None
+
+
+def stage(into: Path, root: Path | None, pristine_only: bool) -> dict[str, Path]:
+    """Copy the three targets (real sources, or replicas) into ``into``."""
+    staged = {}
+    for env, rel in REL.items():
+        dst = into / Path(rel).name
+        src = (root / rel) if root else None
+        if src is not None and (not pristine_only or MARK not in src.read_text()):
+            shutil.copyfile(src, dst)
+        else:
+            dst.write_text(REPLICAS[env])
+        staged[env] = dst
+    return staged
+
+
+def run_patcher(staged: dict[str, Path]) -> subprocess.CompletedProcess[str]:
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GLM53_")}
+    env.update({k: str(v) for k, v in staged.items()})
+    return subprocess.run([sys.executable, str(PATCH)], env=env, capture_output=True, text=True)
+
+
+def func_src(text: str, name: str) -> str:
+    for node in ast.walk(ast.parse(text)):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return ast.get_source_segment(text, node) or ""
+    return ""
+
+
+# ---------------------------------------------------------------- part A ----
+
+
+def part_a(root: Path | None) -> None:
+    print("Part A: patch mechanics")
+    patcher = load_patcher()
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        staged = stage(tmp, root, pristine_only=True)
+        using_real = root is not None and all(MARK not in (root / r).read_text() for r in REL.values())
+        print(f"  sources: {'pristine ' + str(root) if using_real else 'vendored replicas'}")
+        for p in staged.values():
+            check(MARK not in p.read_text(), f"A0 {p.name} starts pristine")
+        pristine = {k: p.read_text() for k, p in staged.items()}
+
+        r = run_patcher(staged)
+        check(r.returncode == 0, f"A1 first application exits 0 ({r.stdout.strip().splitlines()[-1] if r.stdout.strip() else r.stderr.strip()[:120]})")
+        texts = {k: p.read_text() for k, p in staged.items()}
+        for k, p in staged.items():
+            want = patcher.expected_marks(patcher.PLAN[p.name][1])
+            check(texts[k].count(MARK) == want, f"A1 {p.name} carries exactly {want} marks")
+            try:
+                ast.parse(texts[k])
+                ok = True
+            except SyntaxError as exc:
+                ok = False
+                print(f"       {exc}")
+            check(ok, f"A1 {p.name} parses")
+
+        sp = texts["GLM53_SAMPLING_PARAMS_PY"]
+        check("    skip_writing_prefix_cache: bool | None = None  # [glm53-apc-no-store]" in sp, "A2 SamplingParams field added")
+        check("_glm53_validate_no_store_params(self)  # [glm53-apc-no-store]" in sp, "A2 __post_init__ validates the flag")
+        check(sp.index("# [glm53-apc-no-store] helper-begin") < sp.index("\nclass SamplingParams("), "A2 helpers precede the class")
+        check(sp.index("logger = init_logger(__name__)") < sp.index("# [glm53-apc-no-store] helper-begin"), "A2 helpers follow the module logger")
+        rq = texts["GLM53_REQUEST_PY"]
+        check("self.skip_writing_prefix_cache = self.get_skip_writing_prefix_cache()" in rq, "A2 Request resolves the flag once")
+        check("def get_skip_writing_prefix_cache(self) -> bool:" in rq, "A2 Request.get_skip_writing_prefix_cache defined")
+        check(rq.index("def get_skip_reading_prefix_cache") < rq.index("def get_skip_writing_prefix_cache") < rq.index("def is_finished"), "A2 resolver sits between its read-side sibling and is_finished")
+        bp = texts["GLM53_BLOCK_POOL_PY"]
+        for fn in ("cache_full_blocks", "cache_partial_block"):
+            src = func_src(bp, fn)
+            check("skip_writing_prefix_cache" in src and "self._insert_block_hash(" in src and src.index("skip_writing_prefix_cache") < src.index("self._insert_block_hash("), f"A2 {fn}: guard precedes _insert_block_hash")
+        check("skip_writing_prefix_cache" not in func_src(bp, "move_block_hashes"), "A2 move_block_hashes is NOT guarded")
+        check(bp.index("def _glm53_log_nostore(") > bp.index("logger = init_logger(__name__)") and bp.index("def _glm53_log_nostore(") < bp.index("\nclass BlockPool:"), "A2 proof-of-life helper between the logger and the class")
+        # Non-targets: the whole point of the placement.
+        targets = {p.name for p, _, _ in patcher.PLAN.values()}
+        check(targets == {"sampling_params.py", "request.py", "block_pool.py"}, f"A2 the only targets are sampling_params / request / block_pool -> {sorted(targets)}")
+        for name in ("kv_cache_manager.py", "kv_cache_coordinator.py", "single_type_kv_cache_manager.py", "scheduler.py"):
+            check(name not in targets, f"A2 {name} is not a patch target")
+
+        r2 = run_patcher(staged)
+        check(r2.returncode == 0 and all(p.read_text() == texts[k] for k, p in staged.items()), "A3 re-apply exits 0 and is byte-identical (idempotent)")
+
+    # A4 drift: every anchor, one at a time, and no file may be written.
+    for fname, (_, edits, _requires) in patcher.PLAN.items():
+        env_key = next(k for k, rel in REL.items() if Path(rel).name == fname)
+        for label, old, _new in edits:
+            with tempfile.TemporaryDirectory() as raw:
+                tmp = Path(raw)
+                staged = stage(tmp, root, pristine_only=True)
+                victim = staged[env_key]
+                text = victim.read_text()
+                # duplicate the anchor -> count 2 -> replace_once must refuse
+                text = text.replace(old, old + old, 1)
+                victim.write_text(text)
+                before = {k: p.read_text() for k, p in staged.items()}
+                r = run_patcher(staged)
+                untouched = all(p.read_text() == before[k] for k, p in staged.items())
+                check(r.returncode != 0 and label in (r.stderr + r.stdout) and untouched, f"A4 drifted {fname}:{label} -> exit {r.returncode}, named in the error, nothing written")
+    # A5 partial marker: a file with SOME of its marks is refused, nothing written.
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        staged = stage(tmp, root, pristine_only=True)
+        run_patcher(staged)
+        bp = staged["GLM53_BLOCK_POOL_PY"]
+        text = bp.read_text()
+        text = text.replace(BLOCK_POOL_PARTIAL_LINE, "        if getattr(request, \"skip_writing_prefix_cache\", False):\n", 1)
+        bp.write_text(text)
+        # and make the other two pristine again so they WOULD be written
+        pristine = stage(tmp, root, pristine_only=True)
+        bp.write_text(text)
+        before = {k: p.read_text() for k, p in pristine.items()}
+        r = run_patcher(pristine)
+        check(r.returncode != 0 and "partially" in r.stderr and all(p.read_text() == before[k] for k, p in pristine.items()), f"A5 partially-marked block_pool.py refused (rc={r.returncode}) and the other two files stay untouched")
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        staged = stage(tmp, root, pristine_only=True)
+        missing = staged["GLM53_REQUEST_PY"]
+        missing.unlink()
+        r = run_patcher(staged)
+        check(r.returncode != 0 and "missing" in r.stderr and MARK not in staged["GLM53_SAMPLING_PARAMS_PY"].read_text(), "A6 missing target -> refused, nothing written")
+
+
+BLOCK_POOL_PARTIAL_LINE = '        if getattr(request, "skip_writing_prefix_cache", False):  # [glm53-apc-no-store]\n'
+
+
+# ---------------------------------------------------------------- part B ----
+
+
+class CapturingLogger:
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+
+    def _rec(self, level, msg, *args):
+        self.lines.append(f"{level}: {msg % args if args else msg}")
+
+    def info_once(self, msg, *args, **kw):
+        self._rec("INFO", msg, *args)
+
+    def warning_once(self, msg, *args, **kw):
+        self._rec("WARN", msg, *args)
+
+    def warning(self, msg, *args, **kw):
+        self._rec("WARN", msg, *args)
+
+    def info(self, msg, *args, **kw):
+        self._rec("INFO", msg, *args)
+
+    def debug(self, msg, *args, **kw):
+        self._rec("DEBUG", msg, *args)
+
+
+def helper_namespace(env_value: str | None) -> tuple[dict, CapturingLogger]:
+    """exec the injected helper block from a freshly patched replica."""
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        staged = stage(tmp, None, pristine_only=True)
+        r = run_patcher(staged)
+        assert r.returncode == 0, r.stderr
+        text = staged["GLM53_SAMPLING_PARAMS_PY"].read_text()
+    begin = text.index("# [glm53-apc-no-store] helper-begin")
+    end = text.index("# [glm53-apc-no-store] helper-end")
+    block = text[begin:end]
+    log = CapturingLogger()
+    ns = {"logger": log}
+    saved = os.environ.pop("GLM53_APC_NO_STORE", None)
+    try:
+        if env_value is not None:
+            os.environ["GLM53_APC_NO_STORE"] = env_value
+        exec(compile(block, "<glm53-no-store-helpers>", "exec"), ns)  # noqa: S102
+    finally:
+        os.environ.pop("GLM53_APC_NO_STORE", None)
+        if saved is not None:
+            os.environ["GLM53_APC_NO_STORE"] = saved
+    return ns, log
+
+
+class Params:
+    def __init__(self, typed=None, extra=None):
+        self.skip_writing_prefix_cache = typed
+        self.extra_args = extra
+
+
+def raises_value_error(fn, *a):
+    try:
+        fn(*a)
+    except ValueError:
+        return True
+    return False
+
+
+def part_b() -> None:
+    print("Part B: resolver semantics (helper block exec'd in a bare namespace)")
+    ns, log = helper_namespace(None)
+    parse = ns["_glm53_parse_no_store"]
+    accepted = {True: True, False: False, 1: True, 0: False, "1": True, "0": False}
+    for value, want in accepted.items():
+        check(parse(value, "t") is want, f"B1 accept {value!r} -> {want}")
+    rejected = [2, -1, 1.0, 0.0, "true", "false", "yes", "no", " 1", "1 ", "01", "", None, [1], {"a": 1}, b"1", "True"]
+    for value in rejected:
+        check(raises_value_error(parse, value, "t"), f"B1 reject {value!r}")
+
+    validate = ns["_glm53_validate_no_store_params"]
+    resolve = ns["_glm53_resolve_no_store"]
+    p = Params(typed="1")
+    validate(p)
+    check(p.skip_writing_prefix_cache is True, "B2 typed field normalised to bool by validation")
+    check(raises_value_error(validate, Params(typed="yes")), "B2 typed 'yes' rejected at the API boundary")
+    check(raises_value_error(validate, Params(extra={"skip_writing_prefix_cache": 1.0})), "B2 extra_args 1.0 rejected at the API boundary")
+    validate(Params(extra={"other": "x"}))
+    validate(Params())
+    check(True, "B2 params without the flag validate clean")
+
+    check(resolve(None, "r") is False, "B3 no sampling params -> False")
+    check(resolve(Params(), "r") is False, "B3 unset -> False")
+    check(resolve(Params(extra={"skip_writing_prefix_cache": 1}), "r") is True, "B3 extra_args 1 -> True")
+    check(resolve(Params(extra={"skip_writing_prefix_cache": "0"}), "r") is False, "B3 extra_args '0' -> False")
+    check(resolve(Params(typed=True), "r") is True, "B3 typed True -> True")
+    check(resolve(Params(typed=False, extra={"skip_writing_prefix_cache": 1}), "r") is False, "B3 typed False wins over extra_args 1 (precedence typed > extra_args)")
+    check(resolve(Params(typed=True, extra={"skip_writing_prefix_cache": 0}), "r") is True, "B3 typed True wins over extra_args 0")
+    n_before = len(log.lines)
+    check(resolve(Params(extra={"skip_writing_prefix_cache": "yes"}), "r") is False, "B3 unparseable value in the engine -> False, never raises")
+    check(any("WARN" in ln and "stores normally" in ln for ln in log.lines[n_before:]), "B3 ... and it is logged as a warning")
+    check(any("INFO" in ln and "first request resolved skip_writing_prefix_cache=1" in ln for ln in log.lines), "B3 resolution receipt logged")
+
+    # Kill switch matrix. Rule: parse/reject BEFORE the switch; the switch only
+    # decides whether a valid 1 is honoured.
+    for env_value, enabled in ((None, True), ("1", True), ("0", False)):
+        ns2, log2 = helper_namespace(env_value)
+        check(ns2["_GLM53_NO_STORE_ENABLED"] is enabled, f"B4 GLM53_APC_NO_STORE={env_value!r} -> enabled={enabled}")
+        got = ns2["_glm53_resolve_no_store"](Params(extra={"skip_writing_prefix_cache": 1}), "r")
+        check(got is enabled, f"B4 valid 1 under GLM53_APC_NO_STORE={env_value!r} -> {enabled}")
+        check(raises_value_error(ns2["_glm53_validate_no_store_params"], Params(extra={"skip_writing_prefix_cache": "yes"})), f"B4 malformed value still rejected under GLM53_APC_NO_STORE={env_value!r}")
+        if not enabled:
+            check(any("ignoring skip_writing_prefix_cache=1" in ln for ln in log2.lines), "B4 kill switch logs the ignore once")
+    for bad in ("", " 1", "yes", "2", "true", "01"):
+        try:
+            helper_namespace(bad)
+            ok = False
+        except ValueError:
+            ok = True
+        check(ok, f"B4 GLM53_APC_NO_STORE={bad!r} fails closed at import")
+
+
+# ---------------------------------------------------------------- part C ----
+
+PART_C = r'''
+import logging, os, sys, importlib.util, shutil, subprocess
+from pathlib import Path
+
+ROOT = Path(sys.argv[1]); PATCH = Path(sys.argv[2]); TMP = Path(sys.argv[3])
+REL = {"GLM53_SAMPLING_PARAMS_PY": "sampling_params.py", "GLM53_REQUEST_PY": "v1/request.py", "GLM53_BLOCK_POOL_PY": "v1/core/block_pool.py"}
+staged = {}
+for env, rel in REL.items():
+    dst = TMP / Path(rel).name
+    shutil.copyfile(ROOT / rel, dst)
+    staged[env] = dst
+env = {k: v for k, v in os.environ.items() if not k.startswith("GLM53_")}
+env.update({k: str(v) for k, v in staged.items()})
+r = subprocess.run([sys.executable, str(PATCH)], env=env, capture_output=True, text=True)
+assert r.returncode == 0, r.stderr
+MARK = "# [glm53-apc-no-store]"
+assert all(MARK in p.read_text() for p in staged.values())
+
+FAIL = []
+N = 0
+def check(cond, label):
+    global N
+    N += 1
+    print(("  ok   " if cond else "  FAIL ") + label)
+    if not cond:
+        FAIL.append(label)
+
+import vllm  # noqa: F401  (package init only)
+
+def inject(modname, path):
+    spec = importlib.util.spec_from_file_location(modname, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[modname] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+sp_mod = inject("vllm.sampling_params", staged["GLM53_SAMPLING_PARAMS_PY"])
+import vllm.v1  # noqa: F401
+req_mod = inject("vllm.v1.request", staged["GLM53_REQUEST_PY"])
+import vllm.v1.core  # noqa: F401
+bp_mod = inject("vllm.v1.core.block_pool", staged["GLM53_BLOCK_POOL_PY"])
+
+import torch
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import init_none_hash, get_request_block_hasher, get_block_hash
+from vllm.v1.core.kv_cache_manager import KVCacheManager
+from vllm.v1.core import kv_cache_coordinator as kvc_mod
+from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheGroupSpec, FullAttentionSpec, MambaSpec, SlidingWindowSpec, MLAAttentionSpec
+try:
+    from vllm.v1.kv_cache_interface import KpoolTailSpec  # fork-only
+except Exception:
+    KpoolTailSpec = None
+SamplingParams = sp_mod.SamplingParams
+Request = req_mod.Request
+BlockPool = bp_mod.BlockPool
+check(kvc_mod.BlockPool is BlockPool, "C0 the coordinator (and so KVCacheManager) uses the patched BlockPool")
+check("skip_writing_prefix_cache" in BlockPool.cache_full_blocks.__code__.co_consts and "skip_writing_prefix_cache" in BlockPool.cache_partial_block.__code__.co_consts, "C0 guards present in the loaded BlockPool")
+init_none_hash(sha256)
+
+records = []
+class H(logging.Handler):
+    def emit(self, rec):
+        records.append(rec.getMessage())
+for name in ("vllm.sampling_params", "vllm.v1.core.block_pool"):
+    lg = logging.getLogger(name); lg.addHandler(H()); lg.setLevel(logging.DEBUG)
+
+def mk(rid, toks, no_store=None, extra=None, skip_reading=None, hbs=2):
+    sp = SamplingParams(max_tokens=17, skip_writing_prefix_cache=no_store, extra_args=extra, skip_reading_prefix_cache=skip_reading)
+    return Request(request_id=rid, prompt_token_ids=list(toks), sampling_params=sp, pooling_params=None, block_hasher=get_request_block_hasher(hbs, sha256))
+
+def full_cfg(block, num_blocks):
+    """Full attention (block > hash) + one mamba(align) group: the smallest
+    layout with a partial tail in the attention group (UnitaryKVCacheCoordinator
+    requires hash_block_size == block_size, so a single group cannot do it)."""
+    return KVCacheConfig(num_blocks=num_blocks, kv_cache_tensors=[], kv_cache_groups=[
+        KVCacheGroupSpec(["full"], FullAttentionSpec(block_size=block, num_kv_heads=1, head_size=1, dtype=torch.float32)),
+        KVCacheGroupSpec(["mamba"], MambaSpec(block_size=block, shapes=(1, 1), dtypes=(torch.float32,), mamba_cache_mode="align")),
+    ])
+
+def hybrid_cfg(hbs, block, num_blocks):
+    return KVCacheConfig(num_blocks=num_blocks, kv_cache_tensors=[], kv_cache_groups=[
+        KVCacheGroupSpec(["full"], FullAttentionSpec(block_size=hbs, num_kv_heads=1, head_size=1, dtype=torch.float32)),
+        KVCacheGroupSpec(["mamba"], MambaSpec(block_size=block, shapes=(1, 1), dtypes=(torch.float32,), mamba_cache_mode="align")),
+    ])
+
+def live_cfg(hbs, block, num_blocks):
+    groups = [KVCacheGroupSpec(["mla"], MLAAttentionSpec(block_size=block, num_kv_heads=1, head_size=1, dtype=torch.float32))]
+    if KpoolTailSpec is not None:
+        try:
+            groups.append(KVCacheGroupSpec(["kpool"], KpoolTailSpec(block_size=hbs, num_kv_heads=1, head_size=1, dtype=torch.float32, sliding_window=block)))
+        except Exception as exc:  # constructor shape differs -> say so, keep going
+            print(f"       note: KpoolTailSpec present but not constructible here ({exc}); 6-group layout")
+    for i in range(4):
+        groups.append(KVCacheGroupSpec([f"m{i}"], MambaSpec(block_size=block, shapes=((1, 1),), dtypes=(torch.float32,), mamba_cache_mode="align")))
+    groups.append(KVCacheGroupSpec(["swa"], SlidingWindowSpec(block_size=hbs, num_kv_heads=1, head_size=1, dtype=torch.float32, sliding_window=block), is_eagle_group=True))
+    return KVCacheConfig(num_blocks=num_blocks, kv_cache_tensors=[], kv_cache_groups=groups)
+
+def manager(cfg, hbs, sched, **kw):
+    return KVCacheManager(cfg, max_model_len=8192, scheduler_block_size=sched, hash_block_size=hbs, enable_caching=True, **kw)
+
+def hashes(m, rid):
+    return [[b.block_hash for b in grp] for grp in m.get_blocks(rid).blocks]
+
+def any_hash(m, rid):
+    return any(h is not None for grp in hashes(m, rid) for h in grp)
+
+def managers(m):
+    return list(m.coordinator.single_type_managers)
+
+def ncb(m, rid):
+    return [mgr.num_cached_block.get(rid) for mgr in managers(m)]
+
+def block_ids(m, rid):
+    return {b.block_id for grp in m.get_blocks(rid).blocks for b in grp if not b.is_null}
+
+def prefill(m, req, chunks):
+    """Chunked prefill: returns the per-step (num_cached_block vector, has-hash) trace."""
+    cb, n, _ = m.get_computed_blocks(req)
+    trace = []
+    done = 0
+    for i, c in enumerate(chunks):
+        out = m.allocate_slots(req, c, n if i == 0 else 0, cb if i == 0 else None)
+        assert out is not None, "allocate_slots returned None"
+        done += c
+        req.num_computed_tokens = n + done if i == 0 else req.num_computed_tokens + c
+        trace.append((ncb(m, req.request_id), any_hash(m, req.request_id)))
+    return n, trace
+
+# C1 -- BlockPool alone: LIFO front vs LRU back, isolated legs (distinct tokens).
+pool = BlockPool(num_gpu_blocks=32, enable_caching=True, hash_block_size=4)
+def store(pool, rid, toks, no_store):
+    req = mk(rid, toks, no_store=no_store, hbs=4)
+    blocks = pool.get_new_blocks(len(toks) // 4)
+    pool.cache_full_blocks(request=req, blocks=blocks, num_cached_blocks=0, num_full_blocks=len(blocks), block_size=4, kv_cache_group_id=0)
+    return blocks
+normal = store(pool, "n", range(100, 112), False)
+quiet = store(pool, "q", range(200, 212), True)
+check(all(b.block_hash is not None for b in normal), "C1 normal request: every full block hashed")
+check(all(b.block_hash is None for b in quiet), "C1 no-store request (distinct tokens): no block hashed")
+check(pool.get_cached_block(mk("x", range(200, 212), hbs=4).block_hashes[0], [0]) is None, "C1 no-store hashes are not reachable in the cache map")
+check(pool.get_cached_block(mk("y", range(100, 112), hbs=4).block_hashes[0], [0]) is not None, "C1 normal hashes are reachable in the cache map")
+pool.free_blocks(reversed(normal)); pool.free_blocks(reversed(quiet))
+reused = pool.get_new_blocks(3)
+check({b.block_id for b in reused} == {b.block_id for b in quiet}, "C1 after freeing both, the next 3 blocks recycled are exactly the no-store ones (LIFO front)")
+check(all(b.block_hash is not None for b in normal), "C1 the normal request's blocks are still cached after the recycle")
+blk = pool.get_new_blocks(1)[0]
+out = pool.cache_partial_block(request=mk("p", range(300, 316), no_store=True, hbs=4), block=blk, num_tokens=4, kv_cache_group_id=0, block_size=8)
+check(out is None and blk.block_hash is None, "C1 cache_partial_block returns None and inserts nothing for a no-store request")
+out = pool.cache_partial_block(request=mk("p2", range(400, 416), hbs=4), block=blk, num_tokens=4, kv_cache_group_id=0, block_size=8)
+check(out is not None and blk.block_hash is not None, "C1 control: cache_partial_block inserts for a normal request")
+
+# C2 -- KVCacheManager (full attention, hash 2 / block 4), multi-step, isolated legs.
+toks = list(range(1000, 1014))  # 14 tokens: 3 full blocks + 2-token partial tail
+legs = {}
+for label, ns in (("normal", False), ("nostore", True)):
+    m = manager(full_cfg(4, 20), 2, 4)
+    req = mk(label, toks, no_store=ns)
+    n, trace = prefill(m, req, (4, 4, 4, 2))
+    check(n == 0, f"C2 [{label}] cold start: 0 computed")
+    mgr = managers(m)[0]
+    check([t[0][0] for t in trace] == [1, 2, 3, 3], f"C2 [{label}] attention-group num_cached_block advances 1,2,3,3 over the four steps (sentinel) -> {[t[0] for t in trace]}")
+    check(req.request_id in mgr.num_cached_block, f"C2 [{label}] request is in num_cached_block after step 1 (fast path from step 2)")
+    legs[label] = (m, req, trace)
+mN, rN, tN = legs["normal"]; mQ, rQ, tQ = legs["nostore"]
+check(all(t[1] for t in tN), "C2 [normal] hashes present after every step")
+check(not any(t[1] for t in tQ), "C2 [nostore] no hash after any step")
+check([t[0] for t in tN] == [t[0] for t in tQ], "C2 the two legs' num_cached_block traces are identical (placement invariant)")
+blkN = mN.get_blocks("normal").blocks[0]; blkQ = mQ.get_blocks("nostore").blocks[0]
+check(blkN[3].block_hash is not None and blkN[3].block_hash_num_tokens == 14, "C2 [normal] partial tail entry at 14 tokens")
+check(blkQ[3].block_hash is None and blkQ[3].block_hash_num_tokens is None, "C2 [nostore] no partial tail entry")
+fN = mk("fN", toks + [7, 7]); fQ = mk("fQ", toks + [7, 7])
+_, nN, _ = mN.get_computed_blocks(fN); _, nQ, _ = mQ.get_computed_blocks(fQ)
+check(nN == 14, f"C2 [normal] same-prefix follow-up hits 14 (12 full + 2-token partial tail) -> {nN}")
+check(nQ == 0, f"C2 [nostore] same-prefix follow-up hits 0 -> {nQ}")
+idsN = block_ids(mN, "normal"); idsQ = block_ids(mQ, "nostore")
+mN.free(rN); mQ.free(rQ)
+gN = mk("gN", range(5000, 5004)); gQ = mk("gQ", range(5000, 5004))
+cb, n, _ = mN.get_computed_blocks(gN); mN.allocate_slots(gN, 4, n, cb)
+cb, n, _ = mQ.get_computed_blocks(gQ); mQ.allocate_slots(gQ, 4, n, cb)
+check(block_ids(mQ, "gQ") <= idsQ, "C2 [nostore] the next allocation recycles the freed no-store block first (front of the free queue)")
+check(not (block_ids(mN, "gN") & idsN), "C2 [normal] the next allocation does NOT touch the freed cached blocks (they sit at the back)")
+# C2r: sparse retention interval on the same shape -> still no hashes for no-store, sentinel still advances
+from dataclasses import replace
+m = manager(replace(full_cfg(4, 24), prefix_cache_retention_interval=4), 2, 4)
+req = mk("ret", toks, no_store=True)
+_, trace = prefill(m, req, (4, 4, 4, 2))
+check(not any(t[1] for t in trace) and [t[0][0] for t in trace] == [1, 2, 3, 3], "C2 [nostore + retention_interval] no hashes, sentinel unchanged")
+
+# C3 -- hybrid Full(hash 2) + Mamba(align, block 4): the upstream partial-tail fixture shape.
+def mamba(m):
+    return managers(m)[1]
+# (a) no-store PRODUCER of an unaligned tail, then continue-decode (running request).
+m = manager(hybrid_cfg(2, 4, 24), 2, 4)
+r0 = mk("p0", [0, 0, 1, 1, 2, 2], no_store=True)
+cb, n, _ = m.get_computed_blocks(r0)
+check(m.allocate_slots(r0, 6, n, cb) is not None, "C3a no-store producer: allocate 6 tokens (partial tail at 6)")
+check(not any_hash(m, "p0"), "C3a no hashes in either group")
+check("p0" not in mamba(m)._partial_hit_reqs and "p0" not in mamba(m)._producer_partial_tail_reqs, "C3a not registered as a partial-tail producer (no _partial_hit_reqs / _producer_partial_tail_reqs entry)")
+check(ncb(m, "p0") == [3, 1], f"C3a num_cached_block advanced as for a normal producer ([3,1]) -> {ncb(m, 'p0')}")
+ph = r0.block_hashes[6 // 2 - 1]
+check(m.block_pool.get_cached_block(ph, [1]) is None and m.block_pool.get_cached_block(ph, [0]) is None, "C3a partial hash not in the cache map for either group")
+r0.num_computed_tokens = 6; r0.append_output_token_ids([3])
+before_ids = block_ids(m, "p0")
+nb = m.allocate_slots(r0, 1)
+check(nb is not None, "C3a continue-decode allocates (get_num_blocks_to_allocate / allocate_new_blocks agree, no assertion)")
+copies, _ = m.take_kv_cache_block_copies()
+check(not any(c.src_block_id in before_ids for c in copies), "C3a no CoW copy sourced from the no-store producer's blocks (move_block_hashes path unreachable)")
+check(not any_hash(m, "p0"), "C3a still no hash on any of its blocks after the continue step")
+r0.num_computed_tokens = 7; r0.append_output_token_ids([4]); m.allocate_slots(r0, 1)
+check(not any_hash(m, "p0") and "p0" not in mamba(m)._partial_hit_reqs, "C3a second decode step: still unhashed, still no partial-hit registration")
+# control on a fresh manager: a NORMAL producer does get the partial entry and the CoW.
+m = manager(hybrid_cfg(2, 4, 24), 2, 4)
+c0 = mk("c0", [0, 0, 1, 1, 2, 2])
+cb, n, _ = m.get_computed_blocks(c0); m.allocate_slots(c0, 6, n, cb)
+check(m.block_pool.get_cached_block(c0.block_hashes[2], [1]) is not None, "C3a control: normal producer registers the mamba partial tail")
+c0.num_computed_tokens = 6; c0.append_output_token_ids([3]); m.allocate_slots(c0, 1)
+copies, _ = m.take_kv_cache_block_copies()
+check(len(copies) >= 1, "C3a control: normal producer's continue step queues a CoW copy")
+# (b)/(c) no-store READER of a normal producer's partial tail (with and without delay_cache_blocks)
+for delay in (False, True):
+    m = manager(hybrid_cfg(2, 4, 24), 2, 4)
+    c0 = mk("c0", [0, 0, 1, 1, 2, 2])
+    cb, n, _ = m.get_computed_blocks(c0); m.allocate_slots(c0, 6, n, cb); m.free(c0); m.new_step_starts()
+    ph = c0.block_hashes[2]
+    src = m.block_pool.get_cached_block(ph, [1])[0]
+    r1 = mk("r1", [0, 0, 1, 1, 2, 2, 3, 3], no_store=True)
+    cb, n, _ = m.get_computed_blocks(r1)
+    check(n == 6, f"C3b[delay={delay}] no-store reader read-hits 6 (lookups enabled)")
+    nb = m.allocate_slots(r1, 2, n, cb, delay_cache_blocks=delay)
+    check(nb is not None, f"C3b[delay={delay}] allocation ok")
+    cow = m.get_blocks("r1").blocks[1][1]
+    check(cow.block_id != src.block_id, f"C3b[delay={delay}] reader CoWs into a private mamba block")
+    copies, _ = m.take_kv_cache_block_copies()
+    check(any(c.src_block_id == src.block_id and c.dst_block_id == cow.block_id for c in copies), f"C3b[delay={delay}] CoW copy src->private queued")
+    check(src.block_hash is not None and get_block_hash(src.block_hash) == ph and src.block_hash_num_tokens == 6, f"C3b[delay={delay}] source partial entry kept its hash (no move onto the no-store request)")
+    check(cow.block_hash is None and cow.block_hash_num_tokens is None, f"C3b[delay={delay}] the private CoW block is unhashed (normal reader would carry the 8-token hash)")
+    own = {b.block_id for grp in m.get_blocks("r1").blocks for b in grp if not b.is_null} - {b.block_id for grp in cb.blocks for b in grp if not b.is_null}
+    check(own and not any(b.block_hash is not None for grp in m.get_blocks("r1").blocks for b in grp if b.block_id in own), f"C3b[delay={delay}] every block the no-store reader allocated itself is unhashed")
+    m.free(r1)
+    nxt = m.block_pool.get_new_blocks(1)[0]
+    check(nxt.block_id in own, f"C3b[delay={delay}] after free, the next block recycled is one of the reader's own (front of queue)")
+    m.block_pool.free_blocks([nxt])
+# (d) control: normal reader gets the 8-token hash on its CoW block
+m = manager(hybrid_cfg(2, 4, 24), 2, 4)
+c0 = mk("c0", [0, 0, 1, 1, 2, 2]); cb, n, _ = m.get_computed_blocks(c0); m.allocate_slots(c0, 6, n, cb); m.free(c0); m.new_step_starts()
+r1 = mk("r1", [0, 0, 1, 1, 2, 2, 3, 3]); cb, n, _ = m.get_computed_blocks(r1); m.allocate_slots(r1, 2, n, cb)
+check(m.get_blocks("r1").blocks[1][1].block_hash_num_tokens == 8, "C3d control: normal reader's CoW block is hashed at 8 tokens")
+
+# C3L -- the live layout: MLA + [KpoolTail] + 4 Mamba(align) + EAGLE SWA drafter, chunked prefill + decode
+for label, ns in (("normal", False), ("nostore", True)):
+    m = manager(live_cfg(2, 4, 96), 2, 4, use_eagle=True)
+    if label == "normal":
+        print(f"       layout: {[type(x).__name__ for x in managers(m)]} eagle={sorted(m.coordinator.eagle_group_ids)}")
+    req = mk(label, list(range(2000, 2014)), no_store=ns)
+    n, trace = prefill(m, req, (4, 4, 4, 2))
+    req.append_output_token_ids([9]); check(m.allocate_slots(req, 1) is not None, f"C3L [{label}] decode step after chunked prefill")
+    req.num_computed_tokens += 1; req.append_output_token_ids([9]); check(m.allocate_slots(req, 1) is not None, f"C3L [{label}] second decode step")
+    legs[label] = (m, req, trace)
+mN, rN, tN = legs["normal"]; mQ, rQ, tQ = legs["nostore"]
+check([t[0] for t in tN] == [t[0] for t in tQ], f"C3L per-group num_cached_block traces identical across all groups -> {[t[0] for t in tQ]}")
+check(all(t[1] for t in tN), "C3L [normal] hashes present")
+check(not any_hash(mQ, "nostore"), "C3L [nostore] no hash in ANY group (MLA, mamba x4, EAGLE SWA) after prefill + decode")
+check(all(mgr.cached_blocks_this_step == set() for mgr in managers(mQ) if hasattr(mgr, "cached_blocks_this_step")), "C3L [nostore] mamba cached_blocks_this_step stays empty")
+f = mk("f", list(range(2000, 2016)))
+_, nQ, _ = mQ.get_computed_blocks(f); _, nN, _ = mN.get_computed_blocks(mk("f2", list(range(2000, 2016))))
+check(nQ == 0 and nN > 0, f"C3L same-prefix follow-up: normal hits {nN}, no-store hits {nQ}")
+idsQ = block_ids(mQ, "nostore"); mQ.free(rQ)
+nxt = mQ.block_pool.get_new_blocks(4)
+check({b.block_id for b in nxt} <= idsQ, "C3L [nostore] freed blocks are the very next ids recycled")
+
+# C4 -- preemption bookkeeping: cold no-store recomputes from 0; a read-hit no-store resumes from what it read.
+m = manager(full_cfg(4, 20), 2, 4)
+req = mk("pre", toks, no_store=True)
+n, trace = prefill(m, req, (4, 4))
+m.free(req); req.num_computed_tokens = 0
+cb, n, _ = m.get_computed_blocks(req)
+check(n == 0, "C4 cold no-store request preempted mid-prefill resumes with 0 computed (nothing was stored)")
+check(m.allocate_slots(req, 4, n, cb) is not None and ncb(m, "pre")[0] == 1, "C4 ... and re-allocates cleanly from zero")
+m = manager(full_cfg(4, 20), 2, 4)
+a = mk("a", toks[:8]); cb, n, _ = m.get_computed_blocks(a); m.allocate_slots(a, 8, n, cb); m.free(a)
+b = mk("b", toks, no_store=True); cb, n, _ = m.get_computed_blocks(b)
+check(n == 8, "C4 read-hit no-store request hits the 8 cached tokens")
+m.allocate_slots(b, 6, n, cb); m.free(b); b.num_computed_tokens = 0
+cb, n2, _ = m.get_computed_blocks(b)
+check(n2 == 8, "C4 ... and after preemption resumes from those same 8 (its own 6 were never stored)")
+
+# C5 -- Request-level resolution on real SamplingParams; boundary rejection; zero-interaction combination.
+check(mk("x1", toks, extra={"skip_writing_prefix_cache": 1}).skip_writing_prefix_cache is True, "C5 extra_args 1 -> True on a real Request")
+check(mk("x2", toks, extra={"skip_writing_prefix_cache": "0"}).skip_writing_prefix_cache is False, "C5 extra_args '0' -> False")
+check(mk("x3", toks, no_store=True).skip_writing_prefix_cache is True, "C5 typed True -> True")
+check(mk("x4", toks).skip_writing_prefix_cache is False, "C5 default -> False")
+try:
+    SamplingParams(max_tokens=1, extra_args={"skip_writing_prefix_cache": "yes"}); rejected = False
+except ValueError as exc:
+    rejected = "skip_writing_prefix_cache" in str(exc)
+check(rejected, "C5 SamplingParams(extra_args={...: 'yes'}) raises ValueError naming the field (API boundary -> 400)")
+try:
+    SamplingParams(max_tokens=1, skip_writing_prefix_cache=1.0); rejected = False
+except ValueError:
+    rejected = True
+check(rejected, "C5 SamplingParams(skip_writing_prefix_cache=1.0) rejected")
+sp = SamplingParams(max_tokens=1, extra_args={"skip_writing_prefix_cache": 1}); sp.extra_args["skip_writing_prefix_cache"] = "yes"
+n_before = len(records)
+rr = Request(request_id="mut", prompt_token_ids=toks, sampling_params=sp, pooling_params=None, block_hasher=get_request_block_hasher(2, sha256))
+check(rr.skip_writing_prefix_cache is False and any("stores normally" in x for x in records[n_before:]), "C5 a value mutated after validation never raises in Request: False + warning")
+m = manager(full_cfg(4, 20), 2, 4)
+a = mk("a", toks[:8]); cb, n, _ = m.get_computed_blocks(a); m.allocate_slots(a, 8, n, cb); m.free(a)
+z = mk("z", toks, no_store=True, skip_reading=True); cb, n, _ = m.get_computed_blocks(z)
+check(n == 0, "C5 skip_reading + skip_writing: no read hit despite a cached prefix")
+m.allocate_slots(z, 14, n, cb)
+check(not any_hash(m, "z"), "C5 skip_reading + skip_writing: nothing stored either (zero cache interaction)")
+sp_mod._GLM53_NO_STORE_ENABLED = False
+check(mk("ks", toks, no_store=True).skip_writing_prefix_cache is False, "C5 kill switch off: typed True resolves to False (ignored)")
+sp_mod._GLM53_NO_STORE_ENABLED = True
+
+# C6 -- receipts
+res = [x for x in records if "first request resolved skip_writing_prefix_cache=1" in x]
+full = [x for x in records if "suppressing prefix-cache store (full site)" in x]
+part = [x for x in records if "suppressing prefix-cache store (partial site)" in x]
+check(len(res) == 1, f"C6 resolution receipt logged exactly once for the whole run ({len(res)})")
+check(len(full) == 1 and len(part) == 1, f"C6 suppression receipts logged exactly once per site (full={len(full)} partial={len(part)})")
+check(any("ignoring skip_writing_prefix_cache=1" in x for x in records), "C6 kill-switch ignore receipt logged")
+
+print(f"PARTC_RESULT checks={N} failures={len(FAIL)}")
+for f in FAIL:
+    print("PARTC_FAIL " + f)
+sys.exit(1 if FAIL else 0)
+'''
+
+
+def part_c(root: Path | None) -> None:
+    print("Part C: behaviour on a real vLLM (patched copies injected via sys.modules)")
+    require = os.environ.get("GLM53_REQUIRE_VLLM", "") == "1"
+    if root is None:
+        check(not require, "C0 no vLLM source root -> Part C skipped" + (" (GLM53_REQUIRE_VLLM=1: failing)" if require else ""))
+        return
+    probe = subprocess.run([sys.executable, "-c", "import vllm.v1.core.kv_cache_manager, torch"], capture_output=True, text=True)
+    if probe.returncode != 0:
+        msg = probe.stderr.strip().splitlines()[-1] if probe.stderr.strip() else "?"
+        check(not require, f"C0 `import vllm` failed under {sys.executable}: {msg} -> Part C skipped" + (" (GLM53_REQUIRE_VLLM=1: failing)" if require else ""))
+        return
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        script = tmp / "part_c.py"
+        script.write_text(PART_C)
+        env = {k: v for k, v in os.environ.items() if not k.startswith("GLM53_")}
+        env.setdefault("VLLM_LOGGING_LEVEL", "DEBUG")
+        r = subprocess.run([sys.executable, str(script), str(root), str(PATCH), str(tmp)], capture_output=True, text=True, env=env)
+        for line in r.stdout.splitlines():
+            if line.startswith("  ok") or line.startswith("  FAIL") or line.startswith("       "):
+                print(line)
+        summary = next((ln for ln in r.stdout.splitlines() if ln.startswith("PARTC_RESULT")), "")
+        fails = [ln[len("PARTC_FAIL "):] for ln in r.stdout.splitlines() if ln.startswith("PARTC_FAIL ")]
+        FAILURES.extend(fails)
+        global CHECKS
+        try:
+            CHECKS += int(summary.split("checks=")[1].split()[0])
+        except (IndexError, ValueError):
+            pass
+        if r.returncode != 0 and not fails:
+            tail = "\n".join((r.stderr or r.stdout).strip().splitlines()[-25:])
+            check(False, f"C0 Part C crashed (rc={r.returncode}):\n{tail}")
+        else:
+            check(r.returncode == 0, f"C summary: {summary or 'no summary line'}")
+
+
+# ---------------------------------------------------------------- part D ----
+
+
+def guard_source() -> str:
+    text = START.read_text()
+    begin = text.index("# GLM53 numeric config guard (begin)")
+    end_marker = "# GLM53 numeric config guard (end)"
+    return text[begin : text.index(end_marker, begin) + len(end_marker)]
+
+
+def part_d() -> None:
+    print("Part D: launcher knob GLM53_APC_NO_STORE (numeric config guard)")
+    if not START.is_file():
+        check(False, "D0 start.sh missing")
+        return
+    guard = guard_source()
+    check('_glm53_validate_bool_flag GLM53_APC_NO_STORE "${GLM53_APC_NO_STORE-1}"' in guard, "D1 the guard validates GLM53_APC_NO_STORE with the 0/1 validator (unset -> 1)")
+    src = START.read_text()
+    check('-e "GLM53_APC_NO_STORE=$GLM53_APC_NO_STORE"' in src, "D1 the knob is forwarded to the containers (nccl_common, both ranks)")
+    check('_cli_no_store_set="${GLM53_APC_NO_STORE+1}"' in src and '_cli_no_store="${GLM53_APC_NO_STORE-}"' in src and '[ -n "${_cli_no_store_set}" ] && GLM53_APC_NO_STORE="$_cli_no_store"' in src, "D1 caller export wins over .env (set-ness aware: an explicitly empty export is captured and then rejected)")
+    check('GLM53_APC_NO_STORE="${GLM53_APC_NO_STORE-1}"' in src, "D1 default 1 applies only when UNSET")
+
+    def run(value: str | None) -> tuple[int, str, str]:
+        script = guard + "\nGPU_MEM_UTIL=0.87; MAX_MODEL_LEN=1000000; MAX_NUM_SEQS=4; MAX_NUM_BATCHED_TOKENS=1024\n" + "validate_numeric_config || exit $?\n" + 'printf "%s\\n" "${GLM53_APC_NO_STORE-unset}"\n'
+        env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "LC_ALL": "C"}
+        if value is not None:
+            env["GLM53_APC_NO_STORE"] = value
+        r = subprocess.run(["bash", "-c", script], text=True, capture_output=True, env=env)
+        return r.returncode, r.stdout.strip(), r.stderr.strip()
+
+    for value, out in ((None, "unset"), ("0", "0"), ("1", "1")):
+        rc, o, e = run(value)
+        check(rc == 0 and o == out, f"D2 GLM53_APC_NO_STORE={value!r} accepted (rc={rc} out={o!r} {e[:60]})")
+    for value in ("", " ", "01", "2", "yes", "true", "1 ", " 1", "1\r", "0x1", "-1"):
+        rc, o, e = run(value)
+        check(rc == 2 and "GLM53_APC_NO_STORE" in e, f"D3 GLM53_APC_NO_STORE={value!r} rejected rc=2 with a named error (rc={rc} {e[:60]!r})")
+
+
+# ------------------------------------------------------------------ main -----
+
+
+def main() -> int:
+    if PATCH is None:
+        raise SystemExit("missing overlay/patch_apc_no_store.py")
+    root = source_root()
+    print(f"overlay: {PATCH}\nsources: {root or '(none: replicas only, Part C skipped)'}  python: {sys.executable}")
+    part_a(root)
+    part_b()
+    part_c(root)
+    part_d()
+    print()
+    if FAILURES:
+        print(f"FAILED ({len(FAILURES)}/{CHECKS}): " + "; ".join(FAILURES))
+        return 1
+    print(f"no-store overlay OK ({CHECKS} checks)")
+    return 0
+
+
+def test_apc_no_store() -> None:
+    """pytest entry point."""
+    FAILURES.clear()
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_kpool_tail_slotmap.py
+++ b/tests/test_kpool_tail_slotmap.py
@@ -182,7 +182,12 @@ def test_recipe_wiring_if_present() -> None:
     launcher = start.read_text()
     image = dockerfile.read_text()
     assert 'KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-' in launcher
-    assert launcher.count("python3 /opt/glm53/patch_kpool_tail_slotmap.py") == 2
+    # Both ranks apply the one pinned list (GLM53_OVERLAY_ORDER) that
+    # write_inner_scripts emits into the head and worker inner scripts.
+    order = launcher[launcher.index("GLM53_OVERLAY_ORDER=(") : launcher.index(")", launcher.index("GLM53_OVERLAY_ORDER=("))]
+    assert "\n    patch_kpool_tail_slotmap.py\n" in order
+    assert 'emit_overlay_block >> "$HEAD_SCRIPT"' in launcher
+    assert 'emit_overlay_block >> "$WORKER_SCRIPT"' in launcher
     assert (
         "-v '/tmp/patch_kpool_tail_slotmap.py:"
         "/opt/glm53/patch_kpool_tail_slotmap.py:ro'" in launcher

--- a/tests/test_launcher_rank_parity.py
+++ b/tests/test_launcher_rank_parity.py
@@ -1,0 +1,691 @@
+#!/usr/bin/env python3
+"""Static + dry-run regression for the two-rank launcher (start.sh).
+
+Hardening asked for by the production-like tester run on PRs #83/#84:
+
+  A  GLM53_APC_RETENTION_INTERVAL_SWA guard -- "" (auto) or 0 pass, anything
+     else must be a positive multiple of 3584 no larger than 1,000,000; the
+     canonical value is what the ranks receive. Runs on the checkout whose
+     launcher actually forwards that knob to the containers (detected from
+     the `-e VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA=` line, not guessed).
+  B  Pre-stop gate -- `./start.sh restart` with a bad knob, or with ANY
+     mounted overlay missing / empty / unparseable / pointed at a different
+     overlay, exits 2 BEFORE the first docker or ssh call, so healthy
+     containers are never stopped for a launch that cannot succeed.
+  C  Overlay order -- one list (GLM53_OVERLAY_ORDER) pinned
+     hybrid -> per-group -> fine-grained (-> no-store, where shipped) is
+     emitted verbatim into BOTH rank inner scripts.
+  D  Rank parity -- for every /opt/glm53 patch the head bind-mounts host
+     file S, the worker's mount is fed from /tmp/X and the scp that produced
+     /tmp/X read the same S; both ranks receive identical effective values
+     for GLM53_APC_RETENTION_INTERVAL, GLM53_APC_RETENTION_INTERVAL_SWA,
+     GLM53_FINEGRAINED_APC and GLM53_APC_NO_STORE (launcher names) and the container-side names they
+     map to (VLLM_PREFIX_CACHE_RETENTION_INTERVAL[_SWA], GLM53_FINEGRAINED_APC);
+     a knob the launcher wires must be PRESENT on both ranks, not merely
+     equal. The comparison itself is exercised with a synthetic one-rank
+     mismatch so a silent pass cannot hide behind equality.
+
+Everything drives the shipped start.sh under bash from an allow-listed
+environment (PATH with docker / ssh / scp / rsync / curl / ip / nvidia-smi
+stubbed first, HOME pointed at a temp dir, no BASH_ENV / PYTHONPATH / HF_*
+/ GLM53_* / VLLM_* leakage). Nothing talks to a real host. The test is
+branch-agnostic: it discovers which prefix-cache overlays this checkout
+ships from the `*_PATCH_HOST="${*_PATCH_HOST:-` assignments and reports it.
+
+Run:  python3 tests/test_launcher_rank_parity.py   (or pytest)
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+START = ROOT / "start.sh"
+
+FAILURES: list[str] = []
+
+BLOCK = 3584
+RETENTION_MAX = 1_000_000
+SWA = "GLM53_APC_RETENTION_INTERVAL_SWA"
+SWA_FORWARD = '-e "VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA=$GLM53_APC_RETENTION_INTERVAL_SWA"'
+FG = "GLM53_FINEGRAINED_APC"
+FG_FORWARD = '-e "GLM53_FINEGRAINED_APC=$GLM53_FINEGRAINED_APC"'
+NS = "GLM53_APC_NO_STORE"
+NS_FORWARD = '-e "GLM53_APC_NO_STORE=$GLM53_APC_NO_STORE"'
+
+# Launcher knobs the tester asked to see reach both ranks identically, and the
+# container-side names the launcher maps them to.
+LAUNCHER_KNOBS = ("GLM53_APC_RETENTION_INTERVAL", SWA, FG, NS)
+CONTAINER_NAMES = LAUNCHER_KNOBS + (
+    "VLLM_PREFIX_CACHE_RETENTION_INTERVAL",
+    "VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA",
+)
+
+PINNED = (
+    "patch_hybrid_prefix_hit.py",
+    "patch_apc_per_group_retention.py",
+    "patch_apc_fine_grained_hits.py",
+)
+# Ships on its own (sampling_params / request / block_pool, no coordinator
+# anchors) and, where listed, must follow the three coordinator overlays.
+NO_STORE = "patch_apc_no_store.py"
+APC_HOST_VARS = {
+    "APC_PATCH_HOST": "patch_hybrid_prefix_hit.py",
+    "PERGROUP_PATCH_HOST": "patch_apc_per_group_retention.py",
+    "FINEHIT_PATCH_HOST": "patch_apc_fine_grained_hits.py",
+    "NOSTORE_PATCH_HOST": NO_STORE,
+}
+
+SEP = "\x1f"
+
+STUB = """#!/usr/bin/env bash
+# Records every invocation; never touches a host.
+{ printf '%s\\x1f' "$(basename "$0")" "$@"; printf '\\n'; } >> "$GLM53_STUB_LOG"
+case "$(basename "$0")" in
+    ip) printf 'inet %s/24\\n' "${GLM53_STUB_HEAD_IP:-10.0.0.1}" ;;
+esac
+exit 0
+"""
+
+
+def check(cond: bool, label: str) -> None:
+    print(("  ok   " if cond else "  FAIL ") + label)
+    if not cond:
+        FAILURES.append(label)
+
+
+def source() -> str:
+    return START.read_text()
+
+
+def guard_source() -> str:
+    """start.sh's numeric-config guard, lifted out by its sentinels (same
+    technique as tests/test_numeric_config.py)."""
+    text = source()
+    begin = text.index("# GLM53 numeric config guard (begin)")
+    end_marker = "# GLM53 numeric config guard (end)"
+    end = text.index(end_marker, begin) + len(end_marker)
+    return text[begin:end]
+
+
+def base_env(**extra: str) -> dict[str, str]:
+    """Allow-listed environment: nothing from the developer/CI shell leaks in
+    (no BASH_ENV, PYTHONPATH, HF_HOME, EXTRA_ARGS, SKIP_*, *_PATCH_HOST ...)."""
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", "/"),
+        "USER": "glm53-parity",
+        "LC_ALL": "C",
+        "TERM": "dumb",
+    }
+    env.update(extra)
+    return env
+
+
+def host_vars() -> dict[str, str]:
+    """Every `<NAME>_PATCH_HOST="${<NAME>_PATCH_HOST:-$SCRIPT_DIR/overlay/<file>}"`
+    assignment in start.sh, from the real assignment, not from substring hits."""
+    out: dict[str, str] = {}
+    for m in re.finditer(
+        r'^([A-Z_]+_PATCH_HOST)="\$\{\1:-\$SCRIPT_DIR/overlay/([A-Za-z0-9_.]+)\}"$', source(), re.M
+    ):
+        out[m.group(1)] = m.group(2)
+    return out
+
+
+def shipped_apc_vars() -> dict[str, str]:
+    return {v: b for v, b in host_vars().items() if v in APC_HOST_VARS}
+
+
+def wires_swa() -> bool:
+    return SWA_FORWARD in source()
+
+
+def wires_fg() -> bool:
+    return FG_FORWARD in source()
+
+
+def wires_ns() -> bool:
+    return NS_FORWARD in source()
+
+
+# ------------------------------------------------------------------ part A --
+
+
+def run_retention_guard(value: str | None) -> tuple[int, str, str]:
+    script = (
+        guard_source()
+        + "\nGPU_MEM_UTIL=0.87; MAX_MODEL_LEN=1000000; MAX_NUM_SEQS=4\n"
+        + "MAX_NUM_BATCHED_TOKENS=1024\n"
+        + f"{FG}=1\n"
+        + "validate_numeric_config || exit $?\n"
+        + f'printf "%s\\n" "${{{SWA}-unset}}"\n'
+    )
+    env = base_env()
+    if value is not None:
+        env[SWA] = value
+    r = subprocess.run(["bash", "-c", script], text=True, capture_output=True, env=env)
+    return r.returncode, r.stdout.strip(), r.stderr.strip()
+
+
+def part_a() -> None:
+    print("Part A: GLM53_APC_RETENTION_INTERVAL_SWA guard (numeric config block)")
+    if not wires_swa():
+        check(
+            f"_glm53_validate_retention_interval {SWA}" not in guard_source(),
+            "A0 this launcher does not forward the SWA knob and does not pretend to validate it",
+        )
+        print("  skip A1-A3 (knob not forwarded by this checkout; validate-what-you-forward)")
+        return
+    text = guard_source()
+    check(
+        f"_glm53_validate_retention_interval {SWA}" in text,
+        "A1 the forwarded SWA knob is validated inside the numeric config guard",
+    )
+    check(
+        f"GLM53_APC_BLOCK_TOKENS={BLOCK}" in text and f"GLM53_APC_RETENTION_MAX={RETENTION_MAX}" in text,
+        f"A1 grid {BLOCK} and cap {RETENTION_MAX:,} are the documented constants",
+    )
+    accepted = {
+        None: "unset",
+        "": "",
+        "0": "0",
+        "00": "0",
+        str(BLOCK): str(BLOCK),
+        "0014336": "14336",
+        str(279 * BLOCK): str(279 * BLOCK),  # 999,936 = largest legal value
+    }
+    for value, canonical in accepted.items():
+        rc, out, err = run_retention_guard(value)
+        check(
+            rc == 0 and out == canonical,
+            f"A2 {SWA}={value!r} accepted, ranks receive {canonical!r} (rc={rc} out={out!r} {err})",
+        )
+    rejected = [
+        "1", "3000", "3585", "1000000", str(280 * BLOCK), "-3584", "+3584",
+        "3584.0", "1e3", " 3584", "3584 ", "3584\r", "nope", "0x", "0 ",
+        "99999999999999999999",
+    ]
+    for value in rejected:
+        rc, out, err = run_retention_guard(value)
+        check(
+            rc == 2 and SWA in err,
+            f"A3 {SWA}={value!r} rejected with rc=2 and a named error (rc={rc} err={err[:60]!r})",
+        )
+
+
+# --------------------------------------------------------------- harness --
+
+
+class Harness:
+    """A throwaway copy of the launcher checkout plus a stub PATH."""
+
+    def __init__(self, tmp: Path) -> None:
+        self.tmp = tmp
+        self.repo = tmp / "repo"
+        self.repo.mkdir()
+        shutil.copy2(START, self.repo / "start.sh")
+        shutil.copy2(ROOT / ".env.example", self.repo / ".env.example")
+        (self.repo / ".env").write_text((ROOT / ".env.example").read_text())
+        for sub in ("overlay", "files", "ablit"):
+            if (ROOT / sub).is_dir():
+                shutil.copytree(ROOT / sub, self.repo / sub)
+        self.home = tmp / "home"
+        self.home.mkdir()
+        self.bin = tmp / "bin"
+        self.bin.mkdir()
+        for tool in ("docker", "ssh", "scp", "rsync", "curl", "ip", "nvidia-smi"):
+            p = self.bin / tool
+            p.write_text(STUB)
+            p.chmod(p.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        self.log = tmp / "calls.log"
+
+        # A copy whose trailing `main "$@"` is replaced by `"$@"`, so a single
+        # launcher function can be driven with the real configuration preamble.
+        text = (self.repo / "start.sh").read_text()
+        assert text.rstrip().endswith('\nmain "$@"'), "start.sh must end with main \"$@\""
+        (self.repo / "start.fn.sh").write_text(text.rstrip()[: -len('main "$@"')] + '"$@"\n')
+
+    def env(self, **extra: str) -> dict[str, str]:
+        return base_env(
+            PATH=f"{self.bin}{os.pathsep}{os.environ.get('PATH', '/usr/bin:/bin')}",
+            HOME=str(self.home),
+            GLM53_STUB_LOG=str(self.log),
+            **extra,
+        )
+
+    def calls(self) -> list[list[str]]:
+        if not self.log.exists():
+            return []
+        out = []
+        for line in self.log.read_text().splitlines():
+            argv = line.split(SEP)
+            if argv and argv[-1] == "":
+                argv.pop()
+            out.append(argv)
+        return out
+
+    def run(self, cmd: str, entry: str = "start.sh", **extra: str) -> subprocess.CompletedProcess[str]:
+        if self.log.exists():
+            self.log.unlink()
+        return subprocess.run(
+            ["bash", f"./{entry}", cmd],
+            cwd=self.repo,
+            text=True,
+            capture_output=True,
+            check=False,
+            env=self.env(**extra),
+        )
+
+    def host_touching_calls(self) -> list[list[str]]:
+        return [c for c in self.calls() if c and c[0] in ("docker", "ssh", "scp", "rsync")]
+
+
+# ------------------------------------------------------------------ part B --
+
+
+def parses(text: str) -> bool:
+    import ast
+    try:
+        ast.parse(text)
+        return True
+    except SyntaxError:
+        return False
+
+
+def longest_parseable_prefix(text: str) -> str | None:
+    lines = text.splitlines(keepends=True)
+    for cut in range(len(lines) - 1, 0, -1):
+        candidate = "".join(lines[:cut])
+        if candidate.strip() and parses(candidate):
+            return candidate
+    return None
+
+
+
+def control(h: Harness, label: str) -> None:
+    r = h.run("restart")
+    calls = h.host_touching_calls()
+    head_rm = any(c[:3] == ["docker", "rm", "-f"] for c in calls)
+    worker_rm = any(c[0] == "ssh" and "docker rm -f" in c[-1] for c in calls)
+    last = (r.stderr.strip().splitlines() or [""])[-1]
+    check(
+        head_rm and worker_rm,
+        f"{label} (head rm={head_rm} worker rm={worker_rm}; later rc={r.returncode} is the stubbed preflight: {last[:100]!r})",
+    )
+
+
+def part_b(h: Harness) -> None:
+    print("Part B: restart fails closed before any container is stopped")
+    text = source()
+    main_at = text.index("main() {")
+    v_num = text.index("validate_numeric_config", main_at)
+    v_art = text.index("validate_overlay_artifacts", main_at)
+    restart = text.index("restart)  stop; start", main_at)
+    check(v_num < restart and v_art < restart, "B1 main() runs both validators before `restart) stop; start`")
+    check(
+        "start|restart) validate_numeric_config; validate_overlay_artifacts ;;" in text,
+        "B1 the validators share the start|restart arm",
+    )
+    guard_begin = text.index("# GLM53 overlay artifact guard (begin)")
+    guard_end = text.index("# GLM53 overlay artifact guard (end)")
+    guard = text[guard_begin:guard_end]
+    check(guard_begin < guard_end, "B1 the artifact guard has its own sentinel block")
+    check("|-\"" not in guard and '|-"' not in guard, "B1 every artifact carries an identity string (no untagged entries)")
+    check(
+        guard.count("|$main_guard\"") >= 6 and '|    return report"' in guard and "| tail -n 1 || true)" in guard,
+        "B1 every artifact carries its exact last line as an EOF sentinel (checked against the last non-blank line)",
+    )
+    check(
+        '"$CHAT_TEMPLATE_HOST"' in guard and "ablit/LAYER_MAP.json" in guard,
+        "B1 the chat template and the ablit layer map are gated too",
+    )
+
+    vars_ = host_vars()
+    shipped = shipped_apc_vars()
+    check("APC_PATCH_HOST" in shipped, "B2 checkout ships patch_hybrid_prefix_hit.py")
+    check(
+        "PERGROUP_PATCH_HOST" in shipped or "FINEHIT_PATCH_HOST" in shipped or "NOSTORE_PATCH_HOST" in shipped,
+        "B2 checkout ships at least one of per-group / fine-grained / no-store",
+    )
+    for var in vars_:
+        check(f'"${var}|' in guard, f"B2 {var} ({vars_[var]}) is in the artifact guard")
+    check("overlay/patch_ablit.py|" in guard and "overlay/ablit_runtime.py|" in guard, "B2 ablit hook + runtime are in the artifact guard")
+    check(
+        'for entry in "${artifacts[@]}"' in guard and "artifacts[@]}\" -eq 0" in guard,
+        "B2 the guard iterates a bash array and refuses an empty list (no process-substitution status gap)",
+    )
+
+    # Control FIRST: with a valid configuration the entrypoint gets PAST the
+    # validators and reaches stop (the stubs then fail preflight, which is
+    # fine). Without this, every negative case below could pass for the
+    # wrong reason (a guard that refuses everything).
+    control(h, "B3 control: valid restart passes the gate and reaches stop on both ranks")
+
+    def fails_closed(label: str, **env: str) -> None:
+        r = h.run("restart", **env)
+        calls = h.host_touching_calls()
+        last = r.stderr.strip().splitlines()[-1] if r.stderr.strip() else ""
+        check(
+            r.returncode == 2 and not calls,
+            f"{label}: rc={r.returncode}, host-touching calls={len(calls)} ({last[:90]!r})",
+        )
+
+    if wires_swa():
+        fails_closed(f"B3 restart with {SWA}=3000 exits 2 with nothing stopped", **{SWA: "3000"})
+        fails_closed(f"B3 restart with {SWA}=1003520 exits 2 with nothing stopped", **{SWA: "1003520"})
+    if wires_fg():
+        fails_closed(f"B3 restart with {FG}=yes exits 2 with nothing stopped", **{FG: "yes"})
+    if wires_ns():
+        fails_closed(f"B3 restart with {NS}=yes exits 2 with nothing stopped", **{NS: "yes"})
+        fails_closed(f"B3 restart with {NS}= (explicitly empty) exits 2 with nothing stopped", **{NS: ""})
+
+    broken = h.tmp / "broken_patch.py"
+    broken.write_text("def (:\n    pass\n")
+    empty = h.tmp / "empty_patch.py"
+    empty.write_text("")
+    video = h.repo / "overlay" / "patch_glm_video_placeholders.py"
+    hybrid = h.repo / "overlay" / "patch_hybrid_prefix_hit.py"
+    for var, base in vars_.items():
+        wrong = hybrid if base == video.name else video
+        fails_closed(f"B4 {var} missing ({base})", **{var: str(h.tmp / "does-not-exist.py")})
+        fails_closed(f"B4 {var} pointed at a different overlay ({wrong.name})", **{var: str(wrong)})
+    blank = h.tmp / "whitespace_only.py"
+    blank.write_text("\n   \n\t\n")
+    for var, base in shipped.items():
+        fails_closed(f"B4 {var} empty file ({base})", **{var: str(empty)})
+        fails_closed(f"B4 {var} whitespace-only file ({base}; pipefail-safe rc=2 diagnostic)", **{var: str(blank)})
+        fails_closed(f"B4 {var} unparseable file ({base})", **{var: str(broken)})
+    # Truncation: for EVERY guarded Python artifact, the longest strict prefix
+    # (by lines) that still parses. It carries the identity string and is
+    # valid Python, so only the EOF-sentinel check can refuse it -- and must.
+    guarded = {var: h.repo / "overlay" / base for var, base in vars_.items()}
+    guarded["overlay/patch_ablit.py"] = h.repo / "overlay" / "patch_ablit.py"
+    guarded["overlay/ablit_runtime.py"] = h.repo / "overlay" / "ablit_runtime.py"
+    for var, path in guarded.items():
+        prefix_text = longest_parseable_prefix(path.read_text())
+        check(prefix_text is not None and parses(prefix_text), f"B4 {path.name}: a strict prefix that still parses exists ({len(prefix_text.splitlines()) if prefix_text else 0} lines)")
+        if prefix_text is None:
+            continue
+        if var.startswith("overlay/"):
+            original = path.read_text()
+            path.write_text(prefix_text)
+            try:
+                fails_closed(f"B4 {path.name} truncated to its longest parseable prefix (fixed-path artifact)")
+            finally:
+                path.write_text(original)
+        else:
+            prefix = h.tmp / f"truncated_{path.name}"
+            prefix.write_text(prefix_text)
+            fails_closed(f"B4 {var} truncated to its longest parseable prefix ({path.name})", **{var: str(prefix)})
+    fails_closed("B4 CHAT_TEMPLATE_HOST missing", CHAT_TEMPLATE_HOST=str(h.tmp / "no-template.jinja"))
+    (h.tmp / "template-dir").mkdir(exist_ok=True)
+    (h.tmp / "template-dir" / "x").write_text("x")
+    fails_closed("B4 CHAT_TEMPLATE_HOST is a (non-empty) directory", CHAT_TEMPLATE_HOST=str(h.tmp / "template-dir"))
+    layer_map = h.repo / "ablit" / "LAYER_MAP.json"
+    saved = layer_map.read_text()
+    layer_map.write_text("{ not json")
+    try:
+        fails_closed("B4 ablit/LAYER_MAP.json not JSON")
+    finally:
+        layer_map.write_text(saved)
+
+    control(h, "B5 control after the negative cases (the harness copy is intact)")
+
+
+# ------------------------------------------------------------------ part C --
+
+
+def overlay_order() -> list[str]:
+    m = re.search(r"^GLM53_OVERLAY_ORDER=\(\n(.*?)^\)\n", source(), re.S | re.M)
+    assert m, "GLM53_OVERLAY_ORDER=( ... ) not found in start.sh"
+    return [ln.strip().split()[0] for ln in m.group(1).splitlines() if ln.strip() and not ln.strip().startswith("#")]
+
+
+def apply_sequence(script: Path) -> list[str]:
+    return re.findall(r"^\s*python3 /opt/glm53/(patch_[a-z0-9_]+\.py)$", script.read_text(), re.M)
+
+
+def part_c(h: Harness) -> None:
+    print("Part C: overlay order pinned once, emitted to both ranks")
+    text = source()
+    order = overlay_order()
+    idx = {name: order.index(name) for name in PINNED if name in order}
+    check(len(idx) == 3, f"C1 all three prefix-cache overlays are listed: {sorted(idx)}")
+    check(
+        len(idx) == 3 and idx[PINNED[0]] < idx[PINNED[1]] < idx[PINNED[2]],
+        "C1 pinned order hybrid -> per-group -> fine-grained",
+    )
+    if wires_ns() or NO_STORE in order:
+        check(
+            NO_STORE in order and len(idx) == 3 and order.index(NO_STORE) > idx[PINNED[2]],
+            "C1 no-store is listed after fine-grained (no shared anchors, but one pinned order)",
+        )
+    check(
+        'emit_overlay_block >> "$HEAD_SCRIPT"' in text and 'emit_overlay_block >> "$WORKER_SCRIPT"' in text,
+        "C2 both inner scripts take the block from emit_overlay_block",
+    )
+    check("python3 /opt/glm53/patch_" not in text, "C2 no literal per-rank patch ladder remains in start.sh")
+
+    r = h.run("write_inner_scripts", entry="start.fn.sh")
+    head = h.repo / ".glm53-exl3-head.inner.sh"
+    worker = h.repo / ".glm53-exl3-worker.inner.sh"
+    check(
+        r.returncode == 0 and head.is_file() and worker.is_file(),
+        f"C3 write_inner_scripts produced both inner scripts (rc={r.returncode} {r.stderr.strip()[:80]!r})",
+    )
+    if head.is_file() and worker.is_file():
+        hs, ws = apply_sequence(head), apply_sequence(worker)
+        check(hs == order, f"C3 head applies exactly GLM53_OVERLAY_ORDER ({len(hs)} entries)")
+        check(ws == order, f"C3 worker applies exactly GLM53_OVERLAY_ORDER ({len(ws)} entries)")
+        check(hs == ws, "C3 head and worker apply sequences are identical")
+        for s in (head, worker):
+            body = s.read_text()
+            check(
+                body.index("/opt/glm53/patch_hybrid_prefix_hit.py")
+                < body.index("/opt/glm53/patch_apc_per_group_retention.py")
+                < body.index("/opt/glm53/patch_apc_fine_grained_hits.py"),
+                f"C3 {s.name}: hybrid -> per-group -> fine-grained in the generated script",
+            )
+            check(
+                "python3 /opt/glm53/patch_ablit.py" in body
+                and body.index("patch_kpool_tail_slotmap.py") < body.index("python3 /opt/glm53/patch_ablit.py"),
+                f"C3 {s.name}: ablit still applies last",
+            )
+            if NO_STORE in order:
+                check(
+                    body.index("/opt/glm53/patch_apc_fine_grained_hits.py") < body.index(f"/opt/glm53/{NO_STORE}") < body.index("/opt/glm53/patch_xgrammar_termination.py"),
+                    f"C3 {s.name}: fine-grained -> no-store -> xgrammar in the generated script",
+                )
+            check(
+                re.search(r"if \[ -f /opt/glm53/patch_apc_per_group_retention\.py \]; then\n\s+python3", body) is not None,
+                f"C3 {s.name}: every slot is `[ -f ]`-guarded (unmounted sibling slot is a no-op)",
+            )
+
+
+# ------------------------------------------------------------------ part D --
+
+
+class Rank:
+    def __init__(self, argv: list[str]) -> None:
+        self.env: dict[str, str] = {}
+        self.mounts: dict[str, str] = {}  # container path -> source path
+        i = 0
+        while i < len(argv):
+            tok = argv[i]
+            if tok == "-e" and i + 1 < len(argv):
+                k, _, v = argv[i + 1].partition("=")
+                self.env[k] = v
+                i += 2
+                continue
+            if tok == "-v" and i + 1 < len(argv):
+                parts = argv[i + 1].split(":")
+                if len(parts) >= 2 and parts[1].startswith("/opt/glm53/") and parts[1].endswith(".py"):
+                    self.mounts[parts[1]] = parts[0]
+                i += 2
+                continue
+            i += 1
+
+
+def parity_issues(head: Rank, worker: Rank, scp: dict[str, str], required: dict[str, str]) -> list[str]:
+    """Everything that would make the two ranks differ. `scp` maps the
+    worker-side /tmp file to the host file it was copied from; `required`
+    maps container env names the launcher wires to the value expected."""
+    issues = []
+    for name in CONTAINER_NAMES:
+        if head.env.get(name) != worker.env.get(name):
+            issues.append(f"env {name}: head={head.env.get(name)!r} worker={worker.env.get(name)!r}")
+    for name, value in required.items():
+        if head.env.get(name) != value or worker.env.get(name) != value:
+            issues.append(f"env {name} expected {value!r} on both ranks: head={head.env.get(name)!r} worker={worker.env.get(name)!r}")
+    if set(head.mounts) != set(worker.mounts):
+        issues.append(f"mount set differs: head-only={sorted(set(head.mounts) - set(worker.mounts))} worker-only={sorted(set(worker.mounts) - set(head.mounts))}")
+    for dest, head_src in head.mounts.items():
+        worker_tmp = worker.mounts.get(dest)
+        worker_src = scp.get(worker_tmp or "")
+        if worker_src != head_src:
+            issues.append(f"{dest}: head mounts {head_src}, worker mounts {worker_tmp} which scp fed from {worker_src}")
+    return issues
+
+
+def rank_runs(h: Harness, **env: str) -> tuple[Rank, Rank, dict[str, str]] | None:
+    r = h.run("launch_cluster", entry="start.fn.sh", MODEL_DIR="/root/.cache/huggingface/x", **env)
+    if r.returncode != 0:
+        print(f"    launch_cluster rc={r.returncode}: {r.stderr.strip()[-300:]}")
+        return None
+    head = worker = None
+    scp: dict[str, str] = {}
+    for c in h.calls():
+        if c[:2] == ["docker", "run"]:
+            head = Rank(c[2:])
+        elif c[0] == "ssh" and c[-1].lstrip().startswith("docker run"):
+            worker = Rank(shlex.split(c[-1])[2:])
+        elif c[0] == "scp" and len(c) >= 3 and ":" in c[-1]:
+            scp[c[-1].split(":", 1)[1]] = c[-2]
+    if head is None or worker is None:
+        print(f"    could not find both docker run lines (head={head is not None} worker={worker is not None})")
+        return None
+    return head, worker, scp
+
+
+def part_d(h: Harness) -> None:
+    print("Part D: both ranks mount the same host artifacts and get identical effective values")
+    shipped = shipped_apc_vars()
+    order = overlay_order()
+
+    scenarios: list[tuple[str, dict[str, str]]] = [("defaults", {})]
+    if wires_swa():
+        scenarios += [("SWA=14336", {SWA: "14336"}), ("SWA=0", {SWA: "0"}), ("SWA unset (auto)", {})]
+    if wires_fg():
+        scenarios += [("FINEGRAINED=0", {FG: "0"}), ("FINEGRAINED=1", {FG: "1"})]
+    if wires_swa() and wires_fg():
+        scenarios.append(("SWA=14336 + FINEGRAINED=0", {SWA: "14336", FG: "0"}))
+    if wires_ns():
+        scenarios += [("NO_STORE=0", {NS: "0"}), ("NO_STORE=1", {NS: "1"}), ("NO_STORE unset (default 1)", {})]
+
+    first = None
+    for label, env in scenarios:
+        got = rank_runs(h, **env)
+        check(got is not None, f"D1 [{label}] launch_cluster dry-run captured both docker run lines")
+        if got is None:
+            continue
+        head, worker, scp = got
+        first = first or got
+        required: dict[str, str] = {}
+        if wires_swa() and env.get(SWA, ""):
+            required["VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA"] = env[SWA]
+        if wires_fg():
+            required[FG] = env.get(FG, "1")
+        if wires_ns():
+            required[NS] = env.get(NS, "1")
+        issues = parity_issues(head, worker, scp, required)
+        check(not issues, f"D2 [{label}] rank parity: " + ("; ".join(issues) if issues else "no differences"))
+        for name in CONTAINER_NAMES:
+            hv, wv = head.env.get(name), worker.env.get(name)
+            print(f"         {name}: head={hv!r} worker={wv!r}" + ("  (not wired by this launcher)" if hv is None and wv is None else ""))
+        if wires_swa() and not env.get(SWA, ""):
+            check(
+                "VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA" not in head.env and "VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA" not in worker.env,
+                f"D2 [{label}] empty SWA (auto) is forwarded to neither rank",
+            )
+        mounted = {Path(p).name for p in head.mounts}
+        check(len(head.mounts) >= 9, f"D3 [{label}] {len(head.mounts)} /opt/glm53 patch mounts, identical chain head-mount = scp source = worker-mount")
+        # Expected source -> destination map for EVERY *_PATCH_HOST: the head
+        # mount, the scp source and the worker mount must all be that file.
+        wrong_map = []
+        for var, base in host_vars().items():
+            dest = f"/opt/glm53/{base}"
+            src = head.mounts.get(dest, "")
+            if Path(src).resolve() != (h.repo / "overlay" / base).resolve() or dest not in worker.mounts:
+                wrong_map.append(f"{var}: {dest} <- {src or 'unmounted'}")
+        check(not wrong_map, f"D3 [{label}] every *_PATCH_HOST maps to its own /opt/glm53 destination on both ranks (wrong={wrong_map})")
+        for var, base in shipped.items():
+            src = head.mounts.get(f"/opt/glm53/{base}", "")
+            check(
+                base in mounted and Path(src).resolve() == (h.repo / "overlay" / base).resolve(),
+                f"D3 [{label}] {base} ({var}) mounted on both ranks from the checkout's overlay/ copy ({src})",
+            )
+        unlisted = sorted(m for m in mounted if m.startswith("patch_") and m not in order)
+        check(not unlisted, f"D3 [{label}] every mounted patch_*.py is in GLM53_OVERLAY_ORDER (unlisted={unlisted})")
+
+    # Negative self-check: the comparison must notice a one-rank difference.
+    if first is not None:
+        head, worker, scp = first
+        tampered = Rank([])
+        tampered.env = dict(worker.env)
+        tampered.mounts = dict(worker.mounts)
+        knob = FG if FG in tampered.env else (NS if NS in tampered.env else "GLM53_MIXED_PREFILL_CHUNK")
+        tampered.env[knob] = "0" if tampered.env.get(knob) != "0" else "1"
+        dest = next(iter(sorted(tampered.mounts)))
+        del tampered.mounts[dest]
+        issues = parity_issues(head, tampered, scp, {})
+        check(
+            any(f"env {knob}" in i for i in issues) and any("mount set differs" in i for i in issues),
+            f"D4 synthetic one-rank mismatch is reported ({len(issues)} issues: {issues[:2]})",
+        )
+        bad_scp = dict(scp)
+        wdest = sorted(worker.mounts)[0]
+        bad_scp[worker.mounts[wdest]] = "/somewhere/else.py"
+        issues = parity_issues(head, worker, bad_scp, {})
+        check(any(wdest in i for i in issues), f"D4 a worker scp fed from a different host file is reported ({issues[:1]})")
+
+
+# ------------------------------------------------------------------- main --
+
+
+def main() -> int:
+    if not START.is_file():
+        raise SystemExit(f"missing {START}")
+    print(f"launcher: {START}")
+    print(f"ships: {', '.join(f'{v}={b}' for v, b in shipped_apc_vars().items())}; forwards SWA={wires_swa()} FINEGRAINED={wires_fg()} NO_STORE={wires_ns()}")
+    part_a()
+    with tempfile.TemporaryDirectory() as raw:
+        h = Harness(Path(raw))
+        part_b(h)
+        part_c(h)
+        part_d(h)
+    print()
+    if FAILURES:
+        print(f"FAILED ({len(FAILURES)}): " + "; ".join(FAILURES))
+        return 1
+    print("launcher rank-parity / order / pre-stop gate OK")
+    return 0
+
+
+def test_launcher_rank_parity() -> None:
+    """pytest entry point (the script form above is what the README documents)."""
+    FAILURES.clear()
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_xgrammar_termination.py
+++ b/tests/test_xgrammar_termination.py
@@ -385,7 +385,12 @@ def test_recipe_wiring_if_present() -> None:
     launcher = start.read_text()
     image = dockerfile.read_text()
     assert 'XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-' in launcher
-    assert launcher.count("python3 /opt/glm53/patch_xgrammar_termination.py") == 2
+    # Both ranks apply the one pinned list (GLM53_OVERLAY_ORDER) that
+    # write_inner_scripts emits into the head and worker inner scripts.
+    order = launcher[launcher.index("GLM53_OVERLAY_ORDER=(") : launcher.index(")", launcher.index("GLM53_OVERLAY_ORDER=("))]
+    assert "\n    patch_xgrammar_termination.py\n" in order
+    assert 'emit_overlay_block >> "$HEAD_SCRIPT"' in launcher
+    assert 'emit_overlay_block >> "$WORKER_SCRIPT"' in launcher
     assert (
         "-v '/tmp/patch_xgrammar_termination.py:"
         "/opt/glm53/patch_xgrammar_termination.py:ro'" in launcher


### PR DESCRIPTION
## Per-request GPU prefix-cache no-store: `skip_writing_prefix_cache` / `vllm_xargs` (`GLM53_APC_NO_STORE`)

### Problem (verified in the fork source)
`BlockPool.free_blocks` appends **hashed** blocks to the back of the free queue (LRU) and prepends unhashed ones
(LIFO); `get_new_blocks` pops from the front. A one-off batch/eval request therefore stores its blocks *behind* the
owner's idle 80K conversation, and the owner's blocks are what gets evicted next — the batch job re-orders the LRU
in its own favour. On this hybrid model every cached segment costs one block id per group (MLA + 4 mamba + drafter
SWA) out of one shared pool, which amplifies it. vLLM has a read-side opt-out (`skip_reading_prefix_cache`) but no
write-side one; `cache_salt` namespaces and still stores; `delay_cache_blocks` is a one-step P/D defer.

### Change
Overlay `patch_apc_no_store.py` (three files, 8 anchors; every anchor preflighted before any write, atomic temp-file
+ `os.replace` writes, an already-marked file must carry every generated snippet verbatim and parse or it is refused;
no coordinator anchors, so it composes with `patch_hybrid_prefix_hit.py` / #83 / #84 and is pinned after them in
`GLM53_OVERLAY_ORDER`):
- `SamplingParams.skip_writing_prefix_cache: bool | None` (typed) and `vllm_xargs: {"skip_writing_prefix_cache": 1}`
  on `/v1/chat/completions`, `/v1/completions`, `/v1/responses` (already forwarded to `extra_args` by the fork —
  zero entrypoint edits). **Strict** values (bool, int 0/1, str "0"/"1"; pydantic coerces a JSON boolean in
  `vllm_xargs` to 1/0 — verified on pydantic 2.13 — so `true` works with the intended meaning); anything else
  (`1.0`, `"yes"`, `2`, …) is rejected in `SamplingParams.__post_init__`, which runs in the API-server process, so
  the client gets an HTTP 400 naming the field (`Request` is materialised in the engine-core input thread — its
  resolver never raises).
- Guards at the two request-driven `_insert_block_hash` sites in `BlockPool` (`cache_full_blocks`,
  `cache_partial_block`) — **not** the `allocate_slots` one-liner, because skipping `coordinator.cache_blocks`
  skips the `num_cached_block` update that doubles as the running-request sentinel for SWA/drafter allocation
  (`get_num_blocks_to_allocate` fast path, `allocate_new_computed_blocks`). All bookkeeping proceeds as for a normal
  request; the mamba partial-tail *producer* registration self-suppresses (gated on a non-`None` partial hash); the
  *reader*-side CoW is untouched; `move_block_hashes` stays unguarded and is shown unreachable for a no-store request.
- Semantics: write-only, GPU prefix cache only. Lookups stay enabled (reads touch blocks, i.e. refresh LRU position —
  stated, not hidden); a preempted no-store request resumes from whatever it could *read*. KV connectors / CPU offload
  and pooling requests are out of scope (none on this kit; documented).
- Kill switch `GLM53_APC_NO_STORE` (exactly 0/1, default 1 = honour the flag; requests never opt in on their own, so
  the default deployment behaviour is unchanged). Malformed values are rejected before the switch is consulted.
- Receipts in the server log, once per process: `[glm53-apc-no-store] first request resolved
  skip_writing_prefix_cache=1` (flag reached the engine) and `[glm53-apc-no-store] suppressing prefix-cache store
  (full site)` / `(partial site)` (a store was cut).
- Launcher: set-ness aware caller capture (an explicitly empty export is captured and rejected), 0/1 validator, the
  same fail-closed overlay-artifact gate as #83/#84 (existence / identity string / EOF sentinel / `ast.parse` before
  `restart` stops anything), `GLM53_OVERLAY_ORDER` emitted verbatim into both rank scripts, mount + scp on both
  ranks, `-e GLM53_APC_NO_STORE` in `nccl_common`. Dockerfile COPY / test-before-patch / RUN. README section
  "Opting a request out of the prefix cache", knob row, `.env.example`, `docs/DESIGN-apc-no-store.md`.

### Host tests (Mac, python 3.14 + a CPU vLLM venv on upstream `22df3a3`, whose `block_pool.py` carries the same anchors)
- `tests/test_apc_no_store.py` — **195 checks** (114 with replicas only, no vLLM): Part A patch mechanics on pristine copies (and on vendored
  anchor-context replicas when no source is present): 8 anchors, parse, idempotent byte-identical re-apply, every
  anchor drifted one at a time → non-zero exit and *nothing written*, partially-marked / marked-but-altered /
  truncated files refused, no temp litter, off-limits files not targets, guards precede `_insert_block_hash`,
  `move_block_hashes` unguarded. Part B resolver matrix (6 accepted / 17 rejected values, pydantic coercion of the
  `vllm_xargs` type — `true`→1, `false`→0, `1.0` stays float and is rejected — typed > `extra_args` precedence,
  kill-switch matrix, unparseable-in-engine → False + warning).
  Part C on a real vLLM (patched copies injected via `sys.modules`; mandatory in the image): `BlockPool` LIFO-front
  vs LRU-back with isolated legs; `KVCacheManager` chunked prefill — a no-store request and a normal twin have
  identical per-group `num_cached_block` traces at every step, zero hashes / zero partial entry vs a 14-token hit for
  the twin, freed blocks are the next ids recycled; hybrid Full + mamba(align): no-store *producer* (no
  `_partial_hit_reqs` / `_producer_partial_tail_reqs`, two decode steps, no CoW sourced from its blocks), no-store
  *reader* with and without `delay_cache_blocks` (CoW into a private block, source keeps its hash, private block
  unhashed, freed to the front) plus normal controls; the live shape MLA + 4 mamba(align) + EAGLE-SWA (plus
  `KpoolTailSpec` when the fork exposes it, i.e. in-image): no hash in any group after prefill + decode, per-group
  sentinel parity, `cached_blocks_this_step` empty; preemption both cases (cold → resumes from 0; read-hit → resumes
  from what it read); `skip_reading` + `skip_writing` = zero interaction; real `SamplingParams` rejection; receipts
  exactly once. Part D launcher 0/1 guard (3 accepted, 11 rejected incl. empty, `01`, `1\r`).
- `tests/test_launcher_rank_parity.py` (shared with #83/#84, extended additively): restart with
  `GLM53_APC_NO_STORE=yes` or explicitly empty exits 2 before any docker/ssh call; every artifact missing /
  mis-pointed / empty / whitespace / unparseable / truncated-to-longest-parseable-prefix refused; order pinned
  hybrid → per-group → fine-grained → no-store in both generated rank scripts; both ranks mount the same host
  artifacts and receive identical `GLM53_APC_NO_STORE` (0 / 1 / unset→1 scenarios).
- Full suite on the Mac: `test_apc_no_store`, `test_launcher_rank_parity`, `test_bringup_robustness`,
  `test_hybrid_prefix_hit`, `test_kpool_tail_slotmap`, `test_numeric_config`, `test_start_overrides`,
  `test_suppress_stops`, `test_warm_restart_stdout`, `test_xgrammar_termination` PASS; `test_ablit`,
  `test_chat_template`, `test_exl3_overlay`, `test_mixed_prefill_decode`, `test_scheduler_decode_floor` need the
  image (torch / jinja / vLLM), same as on #83/#84.

### Receipts (captured live, 2026-09-01; boot 04:27:31→04:35 UTC, one boot for every receipt below)

Environment: deploy branch `deploy/dogfood-next2` @ c90fe5c (= production `deploy/dogfood-next` 338366b + this branch
+ `pr/kv-capacity-log`; launcher hunks re-derived by scripted insertion), production `.env` byte-identical to the
previous production checkout's (MAX_MODEL_LEN=1,000,000, MAX_NUM_SEQS=16, MAX_NUM_BATCHED_TOKENS=2048,
GPU_MEM_UTIL=0.87, rightsize workspace, dense retention + SWA=0, fine-grained hits on, DFlash2 k=7; this boot:
804 block ids / 803 usable). **Measurement note, applies to every cached-token figure**: this deployment does not
enable `--enable-prompt-tokens-details`, so `usage.prompt_tokens_details` is never present in responses; cached
tokens are measured as the `vllm:prefix_cache_hits_total` (and `_queries_total`) delta around the lone request on an
idle server, which is the same signal `usage.cached_tokens` reports. An internet outage cut the driving session
~04:50–06:50 UTC; the on-kit run continued detached, and every receipt is re-attributed from the timestamped on-kit
logs — all on this same boot. Full logs: `receipts-next2` on the kit.

0. **In-fork host test** — before the restart, in the then-serving container (sources pristine for this overlay;
   repo-shaped test tree; `VLLM_PREFIX_CACHE_RETENTION_INTERVAL[_SWA]` unset for the test process, since the serving
   container exports them for the engine and the test's synthetic coordinators must not inherit engine retention
   knobs): `docker exec -e GLM53_REQUIRE_VLLM=1 … env -u … python3 /tmp/glm53-next2/tests/test_apc_no_store.py` →
   **`no-store overlay OK (195 checks)`**. After the restart (sources patched → Part A on the vendored replicas,
   Part C on the fork's patched modules incl. the KpoolTailSpec group): **`no-store overlay OK (195 checks)`**.
   The first pre-restart run FAILED on one harness bug this receipt step exists to catch: sub-check C2r used
   `dataclasses.replace(cfg, prefix_cache_retention_interval=…)`, a field upstream 22df3a3 has but the fork's
   in-image `KVCacheConfig` does not (retention is env-driven here) — fixed on the branch by feature-detecting the
   field (commit aab56de, the only change since f8a5efe; the upstream field-based path stays covered by the Mac run).

1. **Boot**: launcher log `per-request prefix-cache no-store flag: GLM53_APC_NO_STORE=1 (both ranks)`;
   `docker exec glm53-exl3-head env` and the worker both show `GLM53_APC_NO_STORE=1`; overlay apply line
   (`patched no-store overlay (per-request GPU prefix-cache no-store …)`) in both ranks' container logs;
   `docker logs glm53-exl3-head | grep -c '[glm53-apc-no-store]'` = **0** before the first flagged request
   (checked 04:40 UTC). Negative, against the live pair: `GLM53_APC_NO_STORE=yes ./start.sh restart` →
   `GLM53_APC_NO_STORE must be exactly 0 or 1 (got: yes)`, **rc=2**, head and worker `StartedAt` unchanged,
   `/health` 200 throughout (the fail-closed gate runs before `restart` stops anything).

2. **Wire** (04:44–04:45 UTC; stimulus EXACTLY 8192 rendered tokens = a 64-multiple that is not a 3584-multiple, so
   one flagged request reaches both store sites):
   ```
[wire] baseline log counts: resolved=0 full=0 partial=0
[wire] lane prompt EXACTLY 8192 tokens (8192 % 64 = 0, 8192 % 3584 = 1024)
[wire] owner prompt ~7895 tokens
[wire] 1 flagged lane request (vllm_xargs skip_writing_prefix_cache=1, cache_salt set): {'status': 200, 'wall': 14.141, 'ttft': None, 'prompt': 8186, 'cached': None, 'raw': None}
[wire] head log after the first flagged request:
418:(EngineCore pid=1892) INFO 09-01 04:44:58 [sampling_params.py:323] [glm53-apc-no-store] first request resolved skip_writing_prefix_cache=1 (lookups unaffected, prefix-cache stores suppressed; later occurrences not logged)
419:(EngineCore pid=1892) INFO 09-01 04:44:59 [block_pool.py:153] [glm53-apc-no-store] suppressing prefix-cache store (full site); lookups still enabled; later occurrences not logged
420:(EngineCore pid=1892) INFO 09-01 04:45:10 [block_pool.py:153] [glm53-apc-no-store] suppressing prefix-cache store (partial site); lookups still enabled; later occurrences not logged
[wire] counts: resolved=1 full=1 partial=1   (expected exactly 1 each: once-per-process receipts; the 8192-token stimulus reaches both store sites; partial-site NOT exercised if partial=0)
[wire] 2nd flagged request sharing the flagged lane's prefix (same salt): {'status': 200, 'wall': 10.245, 'ttft': None, 'prompt': 8188, 'cached': None, 'raw': None} -> expect cached_tokens == 0
[wire] owner request (unflagged, stores normally): {'status': 200, 'wall': 10.312, 'ttft': None, 'prompt': 7889, 'cached': None, 'raw': None}
[wire] flagged request sharing the OWNER's prefix (same salt): {'status': 200, 'wall': 0.319, 'ttft': None, 'prompt': 7891, 'cached': None, 'raw': None} -> expect cached_tokens > 0 (reads enabled)
[wire] skip_writing_prefix_cache='yes': {'status': 400, 'wall': 0.082, 'ttft': None, 'prompt': None, 'cached': None, 'raw': {'error': '{"error":{"message":"vllm_xargs[\\"skip_writing_prefix_cache\\"] must be 0 or 1 (int), \\"0\\"/\\"1\\" (str) or a JSON boolean; got \'yes\'.","type":"BadRequestError","param":null,"code":400}}'}} -> expect HTTP 400 naming the field
[wire] JSON true: {'status': 200, 'wall': 0.266, 'ttft': None, 'prompt': 9, 'cached': None, 'raw': None} -> expect 200 (pydantic coerces to 1)
[wire] final counts: resolved=1 (once per process) full=1 partial=1
[wire] sub-checks: flagged200=True resolved_once=True full_once=True partial_once=True lane_second_cached0=False owner_prefix_read=False junk400=True true200=True
[wire] VERDICT: FAIL
   ```
   All three once-per-process receipts appeared exactly once (`first request resolved skip_writing_prefix_cache=1`,
   `suppressing prefix-cache store (full site)`, `(partial site)`); `"yes"` → HTTP 400 naming the field; JSON `true`
   → 200 (pydantic coerces to 1). The cached-token sub-checks were re-measured with fresh salts on the same boot
   (the once-per-process lines above belong to the 04:44 run and are counted once, not re-counted):
   ```
[wire2] cached tokens = vllm:prefix_cache_hits_total delta around each lone request (usage.prompt_tokens_details is off on this deployment)
[wire2] flagged lane prompt ~7882 tokens, salt wire2-lane-0b18e3
[wire2] owner prompt ~7932 tokens, salt wire2-owner-0b18e3
[wire2] 1 flagged lane (cold): status=200 cached_m=0/7876
[wire2] 2nd flagged sharing the flagged lane's prefix: cached_m=0/7878 -> expect 0 (nothing was stored)
[wire2] owner (unflagged, stores): cached_m=0/7926
[wire2] flagged sharing the OWNER's prefix: cached_m=7872/7928 -> expect > 0 (reads enabled)
[wire2] sub-checks: flagged_cold0=True second_flagged0=True owner_prefix_read=7872>7135=True
[wire2] VERDICT: PASS
   ```

3. **A/B, identical owner turn in every arm** (each arm ×2, order A0 A1 A2 A3 A0 A1 A2 A3). Protocol deviations from
   the plan above, stated: `/reset_prefix_cache` is vLLM's dev-only router and is NOT mounted on this build (404) —
   arms are isolated by fresh `cache_salt` namespaces instead, which prevents logical cross-arm hits but does not
   clear physical blocks or LRU order (a non-equivalent substitute; residual state from earlier arms is carried);
   the lanes rendered at ~54.4K tokens instead of the planned ≈30K (a words→tokens scaling slip in the receipt
   harness — identical in A1/A2/A3, so it raises eviction pressure symmetrically); A3's lanes share C's system
   prompt AND C's cache_salt (review correction — same-salt is what makes the read-touch real). 16/16 lanes returned
   HTTP 200 in every rep; scheduler traces showed max 4 running / 15 waiting, zero preemptions, in every arm.
   ```
[ab] measurement: turn-1..4 cached tokens = vllm:prefix_cache_hits_total delta around the lone request (server idle before/after; --enable-prompt-tokens-details is off on this deployment so usage.prompt_tokens_details is absent); ratio = cached_m / usage.prompt_tokens
[ab] owner C: turn-1 prompt ~78542 tokens, turn-4 prompt ~80390 tokens, salt owner-C-ba7b85-<arm><rep>
[ab] lane template ~30315 tokens x 16 lanes
[ab] POST /reset_prefix_cache -> 404 '{"detail":"Not Found"}'  (NOT mounted on this build - vLLM dev-only router). NO RESET between arms: arms use fresh cache_salt namespaces, which prevents logical prefix hits across arms but does NOT clear physical blocks or the LRU order; residual state from earlier arms is carried into later arms (order A0 A1 A2 A3 A0 A1 A2 A3). This is a non-equivalent substitute and is reported as such.
[ab] A0r1: C turns 1-3: t1 prompt=78536 cached_m=0/78536 wall=88.862s | t2 prompt=79141 cached_m=78528/79141 wall=1.45s | t3 prompt=79767 cached_m=79104/79767 wall=1.622s
[ab] A0r1: 
[ab] A0r1: C turn 4: prompt=80384 cached_m=79744 queried_m=80384 ratio=0.992 TTFT=1.273s preemptions(arm)=0 kv_usage_after_lanes=0.000
[ab] A1r1: C turns 1-3: t1 prompt=78536 cached_m=0/78536 wall=88.649s | t2 prompt=79141 cached_m=78528/79141 wall=1.437s | t3 prompt=79767 cached_m=79104/79767 wall=1.519s
[ab] A1r1: lanes: 16/16 HTTP 200, prompt~54416, cached=[None,None,None,None,None,None,None,None,None,None,None,None,None,None,None,None], wall=976.2s; scheduler: samples=486 max_running=4 max_waiting=15 max_kv_usage=0.390 preempt_delta=0 running_trace=[0, 1, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 2, 1]
[ab] A1r1: C turn 4: prompt=80384 cached_m=0 queried_m=80384 ratio=0.000 TTFT=90.94s preemptions(arm)=0 kv_usage_after_lanes=0.000
[ab] A2r1: C turns 1-3: t1 prompt=78536 cached_m=0/78536 wall=89.032s | t2 prompt=79141 cached_m=78528/79141 wall=1.443s | t3 prompt=79767 cached_m=79104/79767 wall=1.501s
[ab] A2r1: lanes: 16/16 HTTP 200, prompt~54416, cached=[None,None,None,None,None,None,None,None,None,None,None,None,None,None,None,None], wall=977.7s; scheduler: samples=487 max_running=4 max_waiting=15 max_kv_usage=0.390 preempt_delta=0 running_trace=[0, 1, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 2, 1]
[ab] A2r1: C turn 4: prompt=80384 cached_m=79744 queried_m=80384 ratio=0.992 TTFT=1.304s preemptions(arm)=0 kv_usage_after_lanes=0.000
[ab] A3r1: C turns 1-3: t1 prompt=78536 cached_m=0/78536 wall=88.946s | t2 prompt=79141 cached_m=78528/79141 wall=1.459s | t3 prompt=79767 cached_m=79104/79767 wall=1.525s
[ab] A3r1: lanes: 16/16 HTTP 200, prompt~54936, cached=[None,None,None,None,None,None,None,None,None,None,None,None,None,None,None,None], wall=988.0s; scheduler: samples=492 max_running=4 max_waiting=15 max_kv_usage=0.384 preempt_delta=0 running_trace=[0, 1, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 3, 2, 1]
[ab] A3r1: C turn 4: prompt=80384 cached_m=79744 queried_m=80384 ratio=0.992 TTFT=1.29s preemptions(arm)=0 kv_usage_after_lanes=0.000
[ab] A0r2: C turns 1-3: t1 prompt=78536 cached_m=0/78536 wall=88.901s | t2 prompt=79141 cached_m=78528/79141 wall=1.444s | t3 prompt=79767 cached_m=79104/79767 wall=1.508s
[ab] A0r2: 
[ab] A0r2: C turn 4: prompt=80384 cached_m=79744 queried_m=80384 ratio=0.992 TTFT=1.289s preemptions(arm)=0 kv_usage_after_lanes=0.000
[ab] A1r2: C turns 1-3: t1 prompt=78536 cached_m=0/78536 wall=88.743s | t2 prompt=79141 cached_m=78528/79141 wall=1.45s | t3 prompt=79767 cached_m=79104/79767 wall=1.493s
[ab] A1r2: lanes: 16/16 HTTP 200, prompt~54416, cached=[None,None,None,None,None,None,None,None,None,None,None,None,None,None,None,None], wall=975.5s; scheduler: samples=486 max_running=4 max_waiting=15 max_kv_usage=0.390 preempt_delta=0 running_trace=[0, 1, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 2, 1]
[ab] A1r2: C turn 4: prompt=80384 cached_m=0 queried_m=80384 ratio=0.000 TTFT=90.959s preemptions(arm)=0 kv_usage_after_lanes=0.000
[ab] A2r2: C turns 1-3: t1 prompt=78536 cached_m=0/78536 wall=88.85s | t2 prompt=79141 cached_m=78528/79141 wall=1.434s | t3 prompt=79767 cached_m=79104/79767 wall=1.513s
[ab] A2r2: lanes: 16/16 HTTP 200, prompt~54416, cached=[None,None,None,None,None,None,None,None,None,None,None,None,None,None,None,None], wall=977.2s; scheduler: samples=487 max_running=4 max_waiting=15 max_kv_usage=0.389 preempt_delta=0 running_trace=[0, 1, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 2, 1]
[ab] A2r2: C turn 4: prompt=80384 cached_m=79744 queried_m=80384 ratio=0.992 TTFT=1.287s preemptions(arm)=0 kv_usage_after_lanes=0.000
[ab] A3r2: C turns 1-3: t1 prompt=78536 cached_m=0/78536 wall=88.895s | t2 prompt=79141 cached_m=78528/79141 wall=1.452s | t3 prompt=79767 cached_m=79104/79767 wall=1.515s
[ab] A3r2: lanes: 16/16 HTTP 200, prompt~54936, cached=[None,None,None,None,None,None,None,None,None,None,None,None,None,None,None,None], wall=988.0s; scheduler: samples=492 max_running=4 max_waiting=15 max_kv_usage=0.385 preempt_delta=0 running_trace=[0, 1, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 3, 2, 1]
[ab] A3r2: C turn 4: prompt=80384 cached_m=79744 queried_m=80384 ratio=0.992 TTFT=1.299s preemptions(arm)=0 kv_usage_after_lanes=0.000
[ab] per-arm turn-4 cached/prompt: {'A0': [0.992, 0.992], 'A1': [0.0, 0.0], 'A2': [0.992, 0.992], 'A3': [0.992, 0.992]}
[ab] per-arm TTFT s: {'A0': [1.273, 1.289], 'A1': [90.94, 90.959], 'A2': [1.304, 1.287], 'A3': [1.29, 1.299]}
[ab] per-arm preemptions: {'A0': [0.0, 0.0], 'A1': [0.0, 0.0], 'A2': [0.0, 0.0], 'A3': [0.0, 0.0]}
[ab] means: {'A0': 0.992, 'A1': 0.0, 'A2': 0.992, 'A3': 0.992}
[ab] pass criteria: A2 >= 0.9*A0 -> True (0.992 vs 0.893); A2 - A1 >= 0.3*A0 -> True (0.992 vs 0.298); premise (A1 clearly below A0) -> True
[ab] informational A3 (lanes share C's system prompt, flagged): 0.992
[ab] VERDICT: PASS
[ab] invalid reps (a lane did not return 200): none; preemption counts are engine-wide (not C-specific)
   ```
   **Both pre-registered criteria pass: A2 ≥ 0.9×A0 (0.992 vs 0.893) and A2 − A1 ≥ 0.3×A0 (0.992 vs 0.298).**
   Sixteen ~54K unflagged lanes evict the owner's 80K turn-4 prefix completely (A1 hit 0.000, TTFT 91 s = full
   recompute); the same lanes flagged leave it untouched (A2 hit 0.992, TTFT 1.29–1.30 s, identical to A0); lanes
   that additionally share C's salt + system prompt (A3, read-touch) also leave it at 0.992. A first, unmeasured run
   of the same protocol on this boot (before the cached-token instrumentation was fixed) showed the same TTFT
   pattern: A0 1.45/1.5 s, A1 92.0/92.0 s, A2 1.43/1.45 s, A3 1.44/1.45 s.

4. **Equivalence** (receipt, not part of the pass criterion; probe byte-identical to the one shipped on #79
   `pr/apc-retention-knob` 07c780a, sha256 `c050e5e2…09cd`):
   (a) unmodified → **PASS**, warm hit 0.999, cold-vs-cold floor 0.2736:
   ```
[nostore] warm runs prefix-cache hit ratio 0.999
[nostore] cold1: 64.7s len=367 logprob positions=64
[nostore] cold2: 60.1s len=376 logprob positions=64
[nostore] cold3: 59.5s len=390 logprob positions=64
[nostore] warm1: 3.5s len=362 logprob positions=64
[nostore] warm2: 3.9s len=400 logprob positions=64
[nostore] text first-divergence: cold-vs-cold @42 | cold-vs-warm @99 | warm-vs-warm @42
[nostore] max|dlogprob|: cold-vs-cold floor 0.2736 (pairs 0.0460/0.0868/0.2736, 7 pos, pos-0 same=True) | cold-vs-warm 0.3033 (14 pos) | pos-0 token same=True
[nostore] cold1 pos0: ('An', -0.196726992726326, ('#', '##', '**', 'An', 'Audit'))
[nostore] cold2 pos0: ('An', -0.15073776245117188, ('#', '##', '**', 'An', 'Audit'))
[nostore] warm1 pos0: ('An', -0.18366527557373047, ('#', '##', '**', 'An', 'Audit'))
[nostore] warm2 pos0: ('An', -0.24148382246494293, ('#', '##', '**', 'An', 'Audit'))
[nostore] PASS: cold-vs-warm max|dlogprob| 0.3033 <= 3 x cold-vs-cold floor (0.8208); pos-0 chosen token identical=True
   ```
   (b) one local edit adding `"vllm_xargs": {"skip_writing_prefix_cache": 1}` to the two warm runs → **PASS**,
   warm hit 0.999 (reads unaffected by the flag; the exact diff is recorded in the run log):
   ```
[nostore-flaggedwarm] warm runs prefix-cache hit ratio 0.999
[nostore-flaggedwarm] cold1: 58.6s len=350 logprob positions=64
[nostore-flaggedwarm] cold2: 60.2s len=373 logprob positions=64
[nostore-flaggedwarm] cold3: 58.8s len=354 logprob positions=64
[nostore-flaggedwarm] warm1: 4.1s len=364 logprob positions=64
[nostore-flaggedwarm] warm2: 4.6s len=374 logprob positions=64
[nostore-flaggedwarm] text first-divergence: cold-vs-cold @42 | cold-vs-warm @42 | warm-vs-warm @160
[nostore-flaggedwarm] max|dlogprob|: cold-vs-cold floor 0.1783 (pairs 0.1441/0.1783/0.0342, 7 pos, pos-0 same=True) | cold-vs-warm 0.1894 (7 pos) | pos-0 token same=True
[nostore-flaggedwarm] cold1 pos0: ('An', -0.26278120279312134, ('#', '##', '**', 'An', 'Audit'))
[nostore-flaggedwarm] cold2 pos0: ('An', -0.261768639087677, ('#', '##', '**', 'An', 'Audit'))
[nostore-flaggedwarm] warm1 pos0: ('An', -0.20656128227710724, ('#', '##', '**', 'An', 'Audit'))
[nostore-flaggedwarm] warm2 pos0: ('An', -0.2692779004573822, ('#', '##', '**', 'An', 'Audit'))
[nostore-flaggedwarm] PASS: cold-vs-warm max|dlogprob| 0.1894 <= 3 x cold-vs-cold floor (0.5349); pos-0 chosen token identical=True
   ```
   (c) three-request pair, cached via metrics delta:
   ```
[pair] cached tokens = vllm:prefix_cache_hits_total delta around each lone request (usage.prompt_tokens_details is off on this deployment)
[pair] 1 flagged cold: prompt=50480 cached_m=0
[pair] 2 unflagged same salt: prompt=50480 cached_m=0 -> expect 0 (nothing was stored)
[pair] 3 unflagged again: prompt=50480 cached_m=50432 -> expect >= 47956 (the 2nd send stored normally)
[pair] pos-0 token same=True ('An' vs 'An'); max|dlogprob| over 12 agreeing positions = 0.2095; strict 3 x floor(0.1500) = 0.4500 -> ok; probe gate 3 x max(floor,0.15) = 0.4500 -> ok
[pair] VERDICT: PASS
   ```
   Note on wrapper status, for the record: the captured pair run used a fallback floor of 0.15 instead of the
   measured 0.2736 — the harness's floor-parse grep also matched the probe's PASS line and came up empty (the grep
   was fixed in the harness only AFTER this capture; the captured run is the one shown). 0.15 is the STRICTER gate
   (3×0.15 = 0.45 < 3×0.2736 = 0.82) and the pair passes under both. Because that parse check is itself a harness
   assertion, the stage wrappers recorded non-zero status around semantically passing runs: `stage pair FAILS=1` /
   `rc=1` (the one FAIL is the floor-parse assertion; the pair itself is `VERDICT: PASS`) and, in the earlier
   pre-instrumentation attempt, `stage equiv FAILS=2` / `rc=1` (same parse assertion + the pair's cached_tokens
   read as None before the metrics-delta measurement existed — superseded by the runs shown above). Every other
   stage wrapper exited 0.

### Merge note
Branch is cut from `main` 493cb88 like #83/#84. `git merge-tree` against those two: `start.sh` and
`tests/test_launcher_rank_parity.py` auto-merge; `Dockerfile` and `README.md` conflict textually only (adjacent
COPY/RUN lines and adjacent table rows — keep both sides). The artifact-guard block, `GLM53_OVERLAY_ORDER` list and
`_glm53_validate_bool_flag` body are byte-identical to #83/#84 apart from each PR's own entry, so a merge dedups
rather than double-defines.

### Audit log
Codex gpt-5.6-luna design advisory (research train, 12 findings) → BlockPool placement kept; strict value parsing,
explicit read semantics, connector scope, same-turn A/B, hybrid/CoW/preemption tests adopted. Codex build-plan
advisory (build-with-changes, 9 findings) → all adopted except one rebutted with evidence (`move_block_hashes`
unreachable for a no-store request; tests C3a/C3b are the executable argument); finding 5 (a `ValueError` from
`Request.__init__` is not a 400) matched an independent read of `EngineCore.preprocess_add_request` and moved the
validation to `SamplingParams.__post_init__`. Codex adversarial review of the final diff (ship-with-changes, 4
findings): JSON-boolean claim corrected (pydantic coerces `true`→1 — accepted with the intended meaning; the
suggested pre-validation in the three API models is not adopted: it would add entrypoint anchors for a case that is
already semantically exact); equivalence probe origin/invocation stated and demoted to a receipt; partial-site
stimulus corrected; patcher hardened (verbatim-snippet verification on marked files, atomic writes). The
`move_block_hashes` rebuttal was accepted as sound. Confirm pass (CODEX-PR4-CONFIRM.md): F1–F4 RESOLVED, one stale
check-count wording fixed → ready to open pending the live receipts.
 Receipts phase (2026-09-01): combined-deploy receipts plan + script took a Codex advisory (NO-GO on the harness v1 — repo-shaped in-container test tree, restart/rc enforcement, honest no-reset reporting, A3 salt fix, exact 8192-token stimulus, strict pair tolerance — all adopted) and a confirm pass (GO-WITH-CHANGES — ab criteria-fail exit, provenance assertion, sampler/trim fixes — adopted); the in-fork step-0 run caught the C2r field skew fixed in aab56de; final pre-open pass: CODEX-PR4-OPEN.md.

---
Submitted by nood-co1 on behalf of Blockbrain Labs (https://x.com/blockbrain_labs, GitHub org blockbrain-ai). Measured on our 2× NVIDIA DGX Spark deployment.
