### PR TITLE
Add numeric spinwait configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -156,6 +156,9 @@ GLM53_MIXED_PREFILL_CHUNK=skip
 #   rightsize = the legal per-step maximum, ~+26% KV cache. Opt-in.
 # See docs/DESIGN-indexer-workspace.md. Anything else is rejected at launch.
 GLM53_INDEXER_WORKSPACE=stock
+# SpinCondition reader busy-loop window: stock keeps vLLM's 1 s default;
+# 1..1000 selects milliseconds. This deployment's frozen sweep selected 16.
+GLM53_SPINWAIT_MS=stock
 # EngineCore execute timeout (seconds). Stock 300 is short for a cold JIT.
 # VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -454,6 +454,8 @@ COPY overlay/patch_xgrammar_termination.py /opt/glm53/patch_xgrammar_termination
 COPY tests/test_xgrammar_termination.py /opt/glm53/test_xgrammar_termination.py
 COPY overlay/patch_kpool_tail_slotmap.py /opt/glm53/patch_kpool_tail_slotmap.py
 COPY tests/test_kpool_tail_slotmap.py /opt/glm53/test_kpool_tail_slotmap.py
+COPY overlay/patch_spinwait.py /opt/glm53/patch_spinwait.py
+COPY tests/test_spinwait_patch.py /opt/glm53/test_spinwait_patch.py
 COPY overlay/patch_indexer_workspace.py /opt/glm53/patch_indexer_workspace.py
 COPY tests/test_indexer_workspace.py /opt/glm53/test_indexer_workspace.py
 COPY overlay/ablit_runtime.py /opt/glm53/ablit_runtime.py
@@ -472,6 +474,7 @@ RUN python3 /opt/glm53/patch_kpool_tail_slotmap.py
 # Applied unconditionally; the injected sizing reads GLM53_INDEXER_WORKSPACE
 # at runtime and returns the stock expression unless it is "rightsize".
 RUN python3 /opt/glm53/patch_indexer_workspace.py
+RUN python3 /opt/glm53/patch_spinwait.py --preflight
 RUN python3 /opt/glm53/patch_ablit.py
 
 RUN EXL3_SELFCHECK_GPU=0 python3 /opt/glm53/test_exl3_overlay.py \
@@ -480,6 +483,7 @@ RUN EXL3_SELFCHECK_GPU=0 python3 /opt/glm53/test_exl3_overlay.py \
     && python3 /opt/glm53/test_hybrid_prefix_hit.py \
     && python3 /opt/glm53/test_xgrammar_termination.py \
     && python3 /opt/glm53/test_kpool_tail_slotmap.py \
+    && python3 /opt/glm53/test_spinwait_patch.py \
     && python3 /opt/glm53/test_indexer_workspace.py \
     && python3 /opt/glm53/test_ablit.py
 

--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ that are now documented/enforced:
 | `GLM53_MIXED_PREFILL_CHUNK` | `skip` | do not mix a peer prefill into a decode step (issue #6). `N>0` = cap tokens; `0` = off. Solo prefill stays MNBT (7168) |
 | `GLM53_SUPPRESS_STOPS_IN_REASONING` | `1` | ignore client `stop` strings until `</think>` (thinking-on default) |
 | `GLM53_INDEXER_WORKSPACE` | `stock` | sparse-indexer prefill gather workspace. `stock` = `max_model_len * 40` entries (**5036.40 MB** locked at 1M — measured, `VLLM_DEBUG_WORKSPACE=1`). `rightsize` = the legal per-step maximum `min(MAX_NUM_SEQS, MNBT) * cdiv(MAX_MODEL_LEN + k, index_kpool)` = 126 MB at `MAX_NUM_SEQS=4` / 504 MB at 16, so **~+26–28% KV**. Opt-in; see [docs/DESIGN-indexer-workspace.md](docs/DESIGN-indexer-workspace.md) |
+| `GLM53_SPINWAIT_MS` | `stock` | SpinCondition reader busy-loop window. `stock` preserves vLLM's 1 s default; `1..1000` selects milliseconds. A frozen TP=2 sweep selected `16` (+0.95% median decode vs stock, 85.3% less active EngineCore CPU) |
 | `GLM53_BOOT_SHAPE_WARMUP` | `1` | after `/health`, burn DFlash2 BLOCK / sampler / kpool shapes (nonfatal) |
 | `TRITON_HOST_CACHE` / `TILELANG_HOST_CACHE` | `$CACHE_ROOT/triton` / `tilelang` | persist JIT caches across container recreate |
 | `LANGUAGE_MODEL_ONLY` | `0` | load vision tower (image + video) |
@@ -539,6 +540,8 @@ After CUDA compile, Python overlay edits (`overlay/exl3.py`, tests) are a cheap 
 | `tests/test_kpool_tail_slotmap.py` | circular addressing math, exact kernel patch, idempotence, fail-closed drift, launcher wiring |
 | `overlay/patch_indexer_workspace.py` | opt-in `GLM53_INDEXER_WORKSPACE=rightsize`: size the sparse-indexer prefill workspace to the legal per-step maximum instead of `max_model_len * 40`; boot-time compress-ratio cross-check |
 | `tests/test_indexer_workspace.py` | sizing formula (MNBT/`max_num_seqs`/spec-token edge cases, stock clamp), chunk-list equivalence vs stock by exhaustion, exact three-site patch, idempotence, fail-closed drift, launcher wiring |
+| `overlay/patch_spinwait.py` | opt-in numeric `GLM53_SPINWAIT_MS`: fail-closed runtime patch of SpinCondition's reader busy-loop window on both ranks |
+| `tests/test_spinwait_patch.py` | numeric contract, exact patch, idempotence, drift rejection, mode preservation, pyc cleanup, and launcher/build wiring |
 | `overlay/ablit_runtime.py` | load-time o_proj transplant / projection (`ABLIT=1`); no-op when off |
 | `overlay/patch_ablit.py` | install the load_weights hook; bind-mounted and run on both ranks |
 | `ablit/` | direction vectors + `LAYER_MAP.json` from drowzeys' published recipe; `fetch_transplant.py` + `transplant/` for the donor o_proj byte-copy |

--- a/overlay/patch_spinwait.py
+++ b/overlay/patch_spinwait.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Configure vLLM SpinCondition's reader spin window in milliseconds.
+
+``GLM53_SPINWAIT_MS=stock`` (or an unset variable) preserves vLLM's one-second
+default. A positive integer from 1 through 1000 selects that many milliseconds.
+The launcher validates and canonicalizes the value before stopping a running
+cluster; this patch validates again inside each container and fails closed on
+source drift.
+
+The deployment value 16 was selected by a frozen TP=2 sweep at MNBT=2048:
+median decode was +0.95% versus stock while active EngineCore CPU fell 85.3%.
+The 2 ms candidate lost 1.68% decode in its paired test; 32 and 64 ms both lost
+about 1.8% while consuming more CPU than 16 ms.
+"""
+from __future__ import annotations
+
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+
+ENV_NAME = "GLM53_SPINWAIT_MS"
+MAX_MS = 1000
+TARGET = Path(
+    os.environ.get(
+        "GLM53_SPINWAIT_TARGET",
+        "/usr/local/lib/python3.12/dist-packages/vllm/distributed/"
+        "device_communicators/shm_broadcast.py",
+    )
+)
+STOCK_LINE = "        busy_loop_s: float = 1,\n"
+
+
+def parse_spinwait_ms(raw: str | None) -> int | None:
+    """Return milliseconds, or ``None`` for stock behavior."""
+    if raw is None or raw == "stock":
+        return None
+    if re.fullmatch(r"[0-9]+", raw) is None:
+        raise ValueError(
+            f"{ENV_NAME} must be 'stock' or a base-10 integer from 1 to "
+            f"{MAX_MS} (got: {raw!r})"
+        )
+    value = int(raw, 10)
+    if not 1 <= value <= MAX_MS:
+        raise ValueError(
+            f"{ENV_NAME} must be between 1 and {MAX_MS} milliseconds "
+            f"(got: {raw!r})"
+        )
+    return value
+
+
+def seconds_literal(milliseconds: int) -> str:
+    if milliseconds == 1000:
+        return "1"
+    return f"0.{milliseconds:03d}".rstrip("0")
+
+
+def configured_line(milliseconds: int) -> str:
+    return f"        busy_loop_s: float = {seconds_literal(milliseconds)},\n"
+
+
+def prepare(source: str, milliseconds: int | None) -> tuple[str, str]:
+    """Return patched source and an action; reject ambiguous source states."""
+    stock_count = source.count(STOCK_LINE)
+    if milliseconds is None:
+        if stock_count != 1:
+            raise ValueError(
+                f"stock anchor found {stock_count} times (expected exactly 1)"
+            )
+        return source, "stock"
+
+    replacement = configured_line(milliseconds)
+    if replacement == STOCK_LINE:
+        if stock_count != 1:
+            raise ValueError(
+                f"stock anchor found {stock_count} times (expected exactly 1)"
+            )
+        return source, "already stock-equivalent (1000 ms)"
+
+    replacement_count = source.count(replacement)
+    if stock_count == 1 and replacement_count == 0:
+        return source.replace(STOCK_LINE, replacement, 1), "patched"
+    if stock_count == 0 and replacement_count == 1:
+        return source, "already present"
+    raise ValueError(
+        "spinwait source is ambiguous or drifted: "
+        f"stock={stock_count}, configured={replacement_count}"
+    )
+
+
+def replace_file(target: Path, source: str) -> None:
+    temp = target.with_name(f".{target.name}.glm53-spinwait.tmp")
+    try:
+        temp.write_text(source)
+        os.chmod(temp, stat.S_IMODE(target.stat().st_mode))
+        os.replace(temp, target)
+    finally:
+        if temp.exists():
+            temp.unlink()
+
+
+def clear_pyc(target: Path) -> None:
+    cache = target.parent / "__pycache__"
+    if cache.is_dir():
+        for pyc in cache.glob(f"{target.stem}*.pyc"):
+            pyc.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv if argv is None else argv
+    unknown = [arg for arg in argv[1:] if arg != "--preflight"]
+    if unknown:
+        raise SystemExit(f"unknown arguments: {' '.join(unknown)}")
+    preflight_only = "--preflight" in argv[1:]
+
+    if not TARGET.is_file():
+        raise SystemExit(f"missing {TARGET}")
+    try:
+        milliseconds = parse_spinwait_ms(os.environ.get(ENV_NAME))
+        source = TARGET.read_text()
+        patched, action = prepare(source, milliseconds)
+        compile(patched, str(TARGET), "exec")
+    except ValueError as exc:
+        raise SystemExit(f"spinwait preflight failed: {exc}") from exc
+
+    selected = "stock" if milliseconds is None else f"{milliseconds} ms"
+    if preflight_only:
+        print(f"{TARGET.name}: spinwait preflight OK ({selected}; {action})")
+        return 0
+    if patched != source:
+        replace_file(TARGET, patched)
+        clear_pyc(TARGET)
+    print(f"{TARGET.name}: spinwait {selected} ({action})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/start.sh
+++ b/start.sh
@@ -82,6 +82,8 @@ _cli_ablit_mtp="${ABLIT_INCLUDE_MTP-}"
 # must reach validate_numeric_config, not be swallowed by a .env value.
 _cli_indexer_workspace_set="${GLM53_INDEXER_WORKSPACE+1}"
 _cli_indexer_workspace="${GLM53_INDEXER_WORKSPACE-}"
+_cli_spinwait_ms_set="${GLM53_SPINWAIT_MS+1}"
+_cli_spinwait_ms="${GLM53_SPINWAIT_MS-}"
 set -a
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/.env"
@@ -107,6 +109,7 @@ set +a
 [ -n "${_cli_ablit_alpha}" ] && ABLIT_ALPHA="$_cli_ablit_alpha"
 [ -n "${_cli_ablit_mtp}" ] && ABLIT_INCLUDE_MTP="$_cli_ablit_mtp"
 [ -n "${_cli_indexer_workspace_set}" ] && GLM53_INDEXER_WORKSPACE="$_cli_indexer_workspace"
+[ -n "${_cli_spinwait_ms_set}" ] && GLM53_SPINWAIT_MS="$_cli_spinwait_ms"
 
 # ----------------------------- configuration -------------------------------
 MODEL="${MODEL:-Mia-AiLab/GLM-5.3-Flash-EXL3-TR3-4bpw}"
@@ -188,6 +191,7 @@ DRAFTER_PATCH_HOST="${DRAFTER_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm5_drafter
 APC_PATCH_HOST="${APC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_hybrid_prefix_hit.py}"
 XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_xgrammar_termination.py}"
 KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kpool_tail_slotmap.py}"
+SPINWAIT_PATCH_HOST="${SPINWAIT_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_spinwait.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
 QUANTIZATION="${QUANTIZATION:-exl3}"
 LANGUAGE_MODEL_ONLY="${LANGUAGE_MODEL_ONLY:-0}"
@@ -254,6 +258,9 @@ GLM53_MIXED_PREFILL_CHUNK="${GLM53_MIXED_PREFILL_CHUNK:-skip}"
 # when UNSET: an explicitly empty value is an operator error and
 # validate_numeric_config rejects it rather than guessing a serving mode.
 GLM53_INDEXER_WORKSPACE="${GLM53_INDEXER_WORKSPACE-stock}"
+# SpinCondition reader busy-loop window. "stock" preserves vLLM's 1 s default;
+# 1..1000 selects milliseconds. The frozen TP=2 sweep selected 16 ms.
+GLM53_SPINWAIT_MS="${GLM53_SPINWAIT_MS-stock}"
 # EngineCore stock timeout is 300s; mid-serve Triton/TileLang JIT on TP=2 can
 # exceed that without being a true hang. NCCL watchdog is still 600s.
 VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS="${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-1800}"
@@ -313,7 +320,7 @@ _glm53_canonical_positive_int() {
         return 2
     fi
     printf -v "$name" '%s' "$canonical"
-    # $name is one of three fixed names below.
+    # $name is a validated integer configuration variable.
     # shellcheck disable=SC2163
     export "$name"
 }
@@ -336,6 +343,15 @@ _glm53_validate_enum() {
     return 2
 }
 
+_glm53_validate_spinwait_ms() {
+    if [ "$GLM53_SPINWAIT_MS" = "stock" ]; then
+        export GLM53_SPINWAIT_MS
+        return 0
+    fi
+    _glm53_canonical_positive_int \
+        GLM53_SPINWAIT_MS "$GLM53_SPINWAIT_MS" 1000
+}
+
 validate_numeric_config() {
     if ! [[ "$GPU_MEM_UTIL" =~ ^(0([.][0-9]+)?|[.][0-9]+|1([.]0+)?)$ ]] \
        || ! awk -v u="$GPU_MEM_UTIL" 'BEGIN { exit !(u > 0 && u <= 1) }'; then
@@ -347,6 +363,7 @@ validate_numeric_config() {
     _glm53_canonical_positive_int MAX_NUM_BATCHED_TOKENS "$MAX_NUM_BATCHED_TOKENS" 8388608 || return
     _glm53_validate_enum GLM53_INDEXER_WORKSPACE "${GLM53_INDEXER_WORKSPACE-stock}" \
         stock rightsize || return
+    _glm53_validate_spinwait_ms || return
 }
 # GLM53 numeric config guard (end)
 
@@ -484,6 +501,7 @@ preflight() {
     [ -f "$APC_PATCH_HOST" ] || die "$APC_PATCH_HOST missing"
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "$XGRAMMAR_PATCH_HOST missing"
     [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "$KPOOL_TAIL_PATCH_HOST missing"
+    [ -f "$SPINWAIT_PATCH_HOST" ] || die "$SPINWAIT_PATCH_HOST missing"
     [ -f "$SCRIPT_DIR/overlay/patch_ablit.py" ] || die "$SCRIPT_DIR/overlay/patch_ablit.py missing"
     [ -f "$SCRIPT_DIR/overlay/ablit_runtime.py" ] || die "$SCRIPT_DIR/overlay/ablit_runtime.py missing"
     [ -f "$SCRIPT_DIR/ablit/LAYER_MAP.json" ] || die "$SCRIPT_DIR/ablit/LAYER_MAP.json missing"
@@ -987,6 +1005,9 @@ fi
 if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
     python3 /opt/glm53/patch_kpool_tail_slotmap.py
 fi
+if [ -f /opt/glm53/patch_spinwait.py ]; then
+    python3 /opt/glm53/patch_spinwait.py
+fi
 if [ -f /opt/glm53/patch_indexer_workspace.py ]; then
     python3 /opt/glm53/patch_indexer_workspace.py
 fi
@@ -1080,6 +1101,9 @@ fi
 if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
     python3 /opt/glm53/patch_kpool_tail_slotmap.py
 fi
+if [ -f /opt/glm53/patch_spinwait.py ]; then
+    python3 /opt/glm53/patch_spinwait.py
+fi
 if [ -f /opt/glm53/patch_indexer_workspace.py ]; then
     python3 /opt/glm53/patch_indexer_workspace.py
 fi
@@ -1121,6 +1145,8 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$XGRAMMAR_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_xgrammar_termination.py"
     [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "missing $KPOOL_TAIL_PATCH_HOST"
     scp -q -o BatchMode=yes "$KPOOL_TAIL_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kpool_tail_slotmap.py"
+    [ -f "$SPINWAIT_PATCH_HOST" ] || die "missing $SPINWAIT_PATCH_HOST"
+    scp -q -o BatchMode=yes "$SPINWAIT_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_spinwait.py"
 
     worker_ssh "rm -rf /tmp/glm53-ablit"
     scp -q -r -o BatchMode=yes "$SCRIPT_DIR/ablit" "${WORKER_SSH}:/tmp/glm53-ablit"
@@ -1145,6 +1171,7 @@ launch_cluster() {
         -e "GLM53_SUPPRESS_STOPS_IN_REASONING=$GLM53_SUPPRESS_STOPS_IN_REASONING"
         -e "GLM53_MIXED_PREFILL_CHUNK=$GLM53_MIXED_PREFILL_CHUNK"
         -e "GLM53_INDEXER_WORKSPACE=$GLM53_INDEXER_WORKSPACE"
+        -e "GLM53_SPINWAIT_MS=$GLM53_SPINWAIT_MS"
         -e "TRITON_CACHE_DIR=$TRITON_CACHE_DIR"
         -e "TILELANG_CACHE_DIR=$TILELANG_CACHE_DIR"
         -e "VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=$VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS"
@@ -1217,6 +1244,7 @@ launch_cluster() {
         -v '/tmp/patch_hybrid_prefix_hit.py:/opt/glm53/patch_hybrid_prefix_hit.py:ro' \
         -v '/tmp/patch_xgrammar_termination.py:/opt/glm53/patch_xgrammar_termination.py:ro' \
         -v '/tmp/patch_kpool_tail_slotmap.py:/opt/glm53/patch_kpool_tail_slotmap.py:ro' \
+        -v '/tmp/patch_spinwait.py:/opt/glm53/patch_spinwait.py:ro' \
         -v '/tmp/glm53-ablit:/opt/glm53/ablit:ro' \
         -v '/tmp/glm53-ablit_runtime.py:/opt/glm53/ablit_runtime.py:ro' \
         -v '/tmp/patch_ablit.py:/opt/glm53/patch_ablit.py:ro' \
@@ -1248,6 +1276,7 @@ launch_cluster() {
         -v "$APC_PATCH_HOST:/opt/glm53/patch_hybrid_prefix_hit.py:ro" \
         -v "$XGRAMMAR_PATCH_HOST:/opt/glm53/patch_xgrammar_termination.py:ro" \
         -v "$KPOOL_TAIL_PATCH_HOST:/opt/glm53/patch_kpool_tail_slotmap.py:ro" \
+        -v "$SPINWAIT_PATCH_HOST:/opt/glm53/patch_spinwait.py:ro" \
         -v "$SCRIPT_DIR/ablit:/opt/glm53/ablit:ro" \
         -v "$SCRIPT_DIR/overlay/ablit_runtime.py:/opt/glm53/ablit_runtime.py:ro" \
         -v "$SCRIPT_DIR/overlay/patch_ablit.py:/opt/glm53/patch_ablit.py:ro" \

--- a/tests/test_numeric_config.py
+++ b/tests/test_numeric_config.py
@@ -24,7 +24,7 @@ def validate(util: str, model: str, seqs: str, batch: str) -> subprocess.Complet
     script = (
         guard_source()
         + '\nGPU_MEM_UTIL="$1"; MAX_MODEL_LEN="$2"; MAX_NUM_SEQS="$3"; '
-        + 'MAX_NUM_BATCHED_TOKENS="$4"\n'
+        + 'MAX_NUM_BATCHED_TOKENS="$4"; GLM53_SPINWAIT_MS=stock\n'
         + 'validate_numeric_config || exit $?\n'
         + 'printf "%s|%s|%s|%s\\n" "$GPU_MEM_UTIL" "$MAX_MODEL_LEN" '
         + '"$MAX_NUM_SEQS" "$MAX_NUM_BATCHED_TOKENS"\n'
@@ -69,7 +69,7 @@ def validate_enum(value: str | None) -> subprocess.CompletedProcess[str]:
     script = (
         guard_source()
         + '\nGPU_MEM_UTIL=0.87; MAX_MODEL_LEN=1000000; MAX_NUM_SEQS=4; '
-        + 'MAX_NUM_BATCHED_TOKENS=1024\n'
+        + 'MAX_NUM_BATCHED_TOKENS=1024; GLM53_SPINWAIT_MS=stock\n'
         + 'validate_numeric_config || exit $?\n'
         + 'printf "%s\\n" "${GLM53_INDEXER_WORKSPACE-unset}"\n'
     )
@@ -99,6 +99,36 @@ def test_indexer_workspace_enum() -> None:
         assert "GLM53_INDEXER_WORKSPACE must be one of" in result.stderr, bad
 
 
+def validate_spinwait(value: str | None) -> subprocess.CompletedProcess[str]:
+    script = (
+        guard_source()
+        + '\nGPU_MEM_UTIL=0.87; MAX_MODEL_LEN=1000000; MAX_NUM_SEQS=4; '
+        + 'MAX_NUM_BATCHED_TOKENS=1024; GLM53_INDEXER_WORKSPACE=stock\n'
+        + 'validate_numeric_config || exit $?\n'
+        + 'printf "%s\\n" "${GLM53_SPINWAIT_MS-unset}"\n'
+    )
+    env = {k: v for k, v in os.environ.items() if k != "GLM53_SPINWAIT_MS"}
+    env["LC_ALL"] = "C"
+    if value is not None:
+        env["GLM53_SPINWAIT_MS"] = value
+    else:
+        env["GLM53_SPINWAIT_MS"] = "stock"
+    return subprocess.run(
+        ["bash", "-c", script], text=True, capture_output=True, check=False, env=env
+    )
+
+
+def test_spinwait_numeric_contract() -> None:
+    for raw, canonical in (("stock", "stock"), ("1", "1"), ("016", "16"), ("1000", "1000")):
+        result = validate_spinwait(raw)
+        assert result.returncode == 0, (raw, result.stderr)
+        assert result.stdout.strip() == canonical, (raw, result.stdout)
+    for bad in ("", "0", "1001", "-1", "1.5", "nan", " 16", "16 ", "STOCK"):
+        result = validate_spinwait(bad)
+        assert result.returncode == 2, (bad, result.returncode, result.stdout)
+        assert "GLM53_SPINWAIT_MS must" in result.stderr, bad
+
+
 def test_restart_validates_before_stop() -> None:
     source = START.read_text()
     main = source.index("main() {")
@@ -111,5 +141,6 @@ if __name__ == "__main__":
     test_matrix()
     test_decimal_normalization()
     test_indexer_workspace_enum()
+    test_spinwait_numeric_contract()
     test_restart_validates_before_stop()
     print("numeric config tests: PASS")

--- a/tests/test_spinwait_patch.py
+++ b/tests/test_spinwait_patch.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Focused host checks for the numeric SpinCondition patch."""
+from __future__ import annotations
+
+import importlib.util
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+PATCH_PATH = next(
+    path
+    for path in (ROOT / "overlay" / "patch_spinwait.py", HERE / "patch_spinwait.py")
+    if path.is_file()
+)
+spec = importlib.util.spec_from_file_location("patch_spinwait", PATCH_PATH)
+assert spec and spec.loader
+patch = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(patch)
+
+FIXTURE = (
+    "class SpinCondition:\n"
+    "    def __init__(\n"
+    "        self,\n"
+    "        busy_loop_s: float = 1,\n"
+    "    ):\n"
+    "        self.busy_loop_s = busy_loop_s\n"
+)
+
+
+def test_parse_contract() -> None:
+    assert patch.parse_spinwait_ms(None) is None
+    assert patch.parse_spinwait_ms("stock") is None
+    for raw, expected in (("1", 1), ("016", 16), ("16", 16), ("1000", 1000)):
+        assert patch.parse_spinwait_ms(raw) == expected
+    for raw in ("", "0", "1001", "-1", "1.5", "nan", " 16", "16 ", "STOCK"):
+        try:
+            patch.parse_spinwait_ms(raw)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"accepted invalid value {raw!r}")
+
+
+def test_seconds_literals() -> None:
+    assert patch.seconds_literal(1) == "0.001"
+    assert patch.seconds_literal(16) == "0.016"
+    assert patch.seconds_literal(100) == "0.1"
+    assert patch.seconds_literal(999) == "0.999"
+    assert patch.seconds_literal(1000) == "1"
+
+
+def test_stock_is_exact_noop() -> None:
+    out, action = patch.prepare(FIXTURE, None)
+    assert out == FIXTURE
+    assert action == "stock"
+    out, action = patch.prepare(FIXTURE, 1000)
+    assert out == FIXTURE
+    assert "stock-equivalent" in action
+
+
+def test_numeric_patch_and_idempotence() -> None:
+    out, action = patch.prepare(FIXTURE, 16)
+    assert action == "patched"
+    assert "busy_loop_s: float = 0.016," in out
+    assert patch.STOCK_LINE not in out
+    again, action = patch.prepare(out, 16)
+    assert again == out
+    assert action == "already present"
+    compile(out, "fixture.py", "exec")
+
+
+def test_drift_and_ambiguity_fail_closed() -> None:
+    for source in (
+        FIXTURE.replace("float = 1", "float = 0.002"),
+        FIXTURE + FIXTURE,
+        FIXTURE.replace(patch.STOCK_LINE, ""),
+    ):
+        try:
+            patch.prepare(source, 16)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("drifted source was accepted")
+
+
+def _run(target: Path, value: str | None, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["GLM53_SPINWAIT_TARGET"] = str(target)
+    env.pop(patch.ENV_NAME, None)
+    if value is not None:
+        env[patch.ENV_NAME] = value
+    return subprocess.run(
+        [sys.executable, str(PATCH_PATH), *args],
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+
+
+def test_cli_preflight_apply_mode_and_pyc_cleanup() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        target = root / "shm_broadcast.py"
+        target.write_text(FIXTURE)
+        target.chmod(0o640)
+        cache = root / "__pycache__"
+        cache.mkdir()
+        pyc = cache / "shm_broadcast.cpython-312.pyc"
+        pyc.write_bytes(b"stale")
+
+        preflight = _run(target, "16", "--preflight")
+        assert preflight.returncode == 0, preflight.stderr
+        assert target.read_text() == FIXTURE
+        applied = _run(target, "16")
+        assert applied.returncode == 0, applied.stderr
+        assert "0.016" in target.read_text()
+        assert stat.S_IMODE(target.stat().st_mode) == 0o640
+        assert not pyc.exists()
+        repeated = _run(target, "16")
+        assert repeated.returncode == 0, repeated.stderr
+        assert "already present" in repeated.stdout
+
+
+def test_invalid_cli_never_writes() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        target = Path(raw) / "shm_broadcast.py"
+        target.write_text(FIXTURE)
+        for value in ("", "0", "1001", "2ms"):
+            result = _run(target, value)
+            assert result.returncode != 0, (value, result.stdout, result.stderr)
+            assert target.read_text() == FIXTURE
+
+
+def test_live_source_if_enabled() -> None:
+    live = os.environ.get("GLM53_SPINWAIT_LIVE_SOURCE")
+    if not live:
+        return
+    source = Path(live).read_text()
+    out, action = patch.prepare(source, 16)
+    assert action in ("patched", "already present")
+    compile(out, live, "exec")
+
+
+def test_recipe_wiring() -> None:
+    if not all(
+        (ROOT / name).is_file() for name in ("start.sh", "Dockerfile", ".env.example")
+    ):
+        return
+    start = (ROOT / "start.sh").read_text()
+    dockerfile = (ROOT / "Dockerfile").read_text()
+    env_example = (ROOT / ".env.example").read_text()
+    required_start = (
+        'SPINWAIT_PATCH_HOST="${SPINWAIT_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_spinwait.py}"',
+        'GLM53_SPINWAIT_MS="${GLM53_SPINWAIT_MS-stock}"',
+        "_glm53_validate_spinwait_ms",
+        'python3 /opt/glm53/patch_spinwait.py',
+        '"GLM53_SPINWAIT_MS=$GLM53_SPINWAIT_MS"',
+        '/opt/glm53/patch_spinwait.py:ro',
+    )
+    for needle in required_start:
+        assert needle in start, needle
+    assert start.count("python3 /opt/glm53/patch_spinwait.py") == 2
+    assert start.count("/opt/glm53/patch_spinwait.py:ro") == 2
+    assert "COPY overlay/patch_spinwait.py /opt/glm53/patch_spinwait.py" in dockerfile
+    assert "tests/test_spinwait_patch.py" in dockerfile
+    assert "GLM53_SPINWAIT_MS=stock" in env_example
+    assert "GLM53_SPINWAIT_2MS" not in start + dockerfile + env_example
+
+
+def main() -> int:
+    tests = [value for name, value in sorted(globals().items()) if name.startswith("test_")]
+    for test in tests:
+        test()
+    print(f"numeric spinwait patch OK ({len(tests)} tests)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_start_overrides.py
+++ b/tests/test_start_overrides.py
@@ -55,7 +55,7 @@ def _run_preamble(env_file: str, caller: dict[str, str], probe: str) -> str:
         (tmp / ".env").write_text(env_file)
 
         env = {k: v for k, v in os.environ.items()
-               if k not in ("GLM53_INDEXER_WORKSPACE",)}
+               if k not in ("GLM53_INDEXER_WORKSPACE", "GLM53_SPINWAIT_MS")}
         env.update(caller)
         result = subprocess.run(
             ["bash", str(script)], check=True, capture_output=True, text=True, env=env
@@ -89,7 +89,23 @@ def test_indexer_workspace_caller_capture_is_setness_aware() -> None:
     assert _run_preamble("", {}, probe) == "V=[UNSET]"
 
 
+def test_spinwait_caller_capture_is_setness_aware() -> None:
+    probe = '\nprintf "V=[%s]\\n" "${GLM53_SPINWAIT_MS-UNSET}"\n'
+    env_file = "GLM53_SPINWAIT_MS=16\n"
+
+    assert _run_preamble(env_file, {}, probe) == "V=[16]"
+    assert _run_preamble(
+        env_file, {"GLM53_SPINWAIT_MS": "stock"}, probe
+    ) == "V=[stock]"
+    assert _run_preamble(
+        env_file, {"GLM53_SPINWAIT_MS": ""}, probe
+    ) == "V=[]"
+    assert _run_preamble("", {"GLM53_SPINWAIT_MS": ""}, probe) == "V=[]"
+    assert _run_preamble("", {}, probe) == "V=[UNSET]"
+
+
 if __name__ == "__main__":
     test_max_num_seqs_inline_override_wins()
     test_indexer_workspace_caller_capture_is_setness_aware()
+    test_spinwait_caller_capture_is_setness_aware()
     print("start.sh caller override regression OK")


### PR DESCRIPTION
Supersedes #69 with the validated numeric design.

- `GLM53_SPINWAIT_MS=stock` preserves vLLM's 1 s default.
- Integer `1..1000` selects milliseconds; this deployment selected `16` in a frozen TP=2 sweep.
- Explicit empty/invalid values fail before restart and again inside each container.
- Both ranks receive the same value and fail closed on source drift.
- The patch and focused test are included in the image as well as runtime-mounted.

Validation at exact head `8fcc9507e43e27c84526999284077d609388b3b0`:
- `bash -n start.sh`
- numeric spinwait patch: 9 checks
- numeric config tests
- caller override tests
- indexer right-sizing: 21 checks
- chat-template tests: 7 checks
- Docker-flat `/opt/glm53` test layout
- preflight/apply/idempotence against the actual stock image `shm_broadcast.py`

Independent HELP/Kimi review completed before publication. No hosted checks are configured.