### PR TITLE
Stage-1 store-only disk KV tier: eligible-group scoping + worker-local per-rank store (GLM53_KV_OFFLOAD, default off)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,6 +140,17 @@ GLM53_SUPPRESS_STOPS_IN_REASONING=1
 # When a decode seq is running, do not mix a peer prefill into that step
 # (issue #6). skip = decode-only steps; N>0 = cap mixed prefill tokens; 0 = off.
 GLM53_MIXED_PREFILL_CHUNK=skip
+# Disk KV-offload store tier, stage 1 (store-only; overlays
+# patch_kv_offload_scope.py + patch_kv_offload_store_local.py). 1 = enable the
+# OffloadingConnector: CPU staging bounce + worker-local per-rank headered
+# chunk files on each Spark's NVMe. 0 (default) = OFF, byte-identical serving.
+# Restore stays 0 in stage 1 (the launcher refuses 1). Exactly 0 or 1 each.
+GLM53_KV_OFFLOAD=0
+# GLM53_KV_OFFLOAD_DIR=$HOME/glm53-kv-offload
+# GLM53_KV_OFFLOAD_CPU_GB=4
+# GLM53_KV_OFFLOAD_RESTORE=0
+# GLM53_KV_OFFLOAD_DRAFTER=0
+# GLM53_KV_OFFLOAD_KEEP_BOUNDARIES=2
 # EngineCore execute timeout (seconds). Stock 300 is short for a cold JIT.
 # VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -446,6 +446,11 @@ COPY overlay/patch_scheduler_decode_floor.py /opt/glm53/patch_scheduler_decode_f
 COPY tests/test_scheduler_decode_floor.py /opt/glm53/test_scheduler_decode_floor.py
 COPY overlay/patch_hybrid_prefix_hit.py /opt/glm53/patch_hybrid_prefix_hit.py
 COPY tests/test_hybrid_prefix_hit.py /opt/glm53/test_hybrid_prefix_hit.py
+COPY overlay/patch_kv_offload_scope.py /opt/glm53/patch_kv_offload_scope.py
+COPY overlay/patch_kv_offload_store_local.py /opt/glm53/patch_kv_offload_store_local.py
+COPY overlay/kv_offload_store_gc.py /opt/glm53/kv_offload_store_gc.py
+COPY tests/test_kv_offload_scope.py /opt/glm53/test_kv_offload_scope.py
+COPY tests/test_kv_offload_store_local.py /opt/glm53/test_kv_offload_store_local.py
 COPY overlay/patch_xgrammar_termination.py /opt/glm53/patch_xgrammar_termination.py
 COPY tests/test_xgrammar_termination.py /opt/glm53/test_xgrammar_termination.py
 COPY overlay/patch_kpool_tail_slotmap.py /opt/glm53/patch_kpool_tail_slotmap.py
@@ -461,6 +466,14 @@ RUN python3 /opt/glm53/patch_glm5_drafter_group.py
 RUN python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
 RUN python3 /opt/glm53/patch_scheduler_decode_floor.py
 RUN python3 /opt/glm53/patch_hybrid_prefix_hit.py
+# Order-dependent pair: scope rewrites the offloading connector group
+# pairing; store_local anchors on scope's scheduler output. Host tests run
+# against the REAL in-image tree first (preflight + patched-runtime drive),
+# then the patchers bake the overlays in.
+RUN GLM53_REQUIRE_TARGET=1 python3 /opt/glm53/test_kv_offload_scope.py
+RUN python3 /opt/glm53/patch_kv_offload_scope.py
+RUN python3 /opt/glm53/patch_kv_offload_store_local.py
+RUN python3 /opt/glm53/test_kv_offload_store_local.py
 RUN python3 /opt/glm53/patch_xgrammar_termination.py
 RUN python3 /opt/glm53/patch_kpool_tail_slotmap.py
 RUN python3 /opt/glm53/patch_ablit.py

--- a/README.md
+++ b/README.md
@@ -533,6 +533,12 @@ this Dockerfile instead. After CUDA compile, Python overlay edits
 | `tests/test_xgrammar_termination.py` | exact two-file patch, idempotence, cross-file fail-closed drift, termination/rollback/reset and post-reasoning draft behavior, launcher wiring |
 | `overlay/patch_kpool_tail_slotmap.py` | clamp KpoolTail one-block circular slot mapping; identity for other KV groups |
 | `tests/test_kpool_tail_slotmap.py` | circular addressing math, exact kernel patch, idempotence, fail-closed drift, launcher wiring |
+| `overlay/patch_kv_offload_scope.py` | offloading-connector eligible-group scoping (port of vllm#54743 onto this image): prefix-cacheable groups minus the drafter policy exclusion, original indices preserved, full-length worker layout; unblocks the connector on the hybrid layout (KpoolTail scratch crashed it at boot) |
+| `overlay/patch_kv_offload_store_local.py` | stage-1 store-only disk KV tier (`GLM53_KV_OFFLOAD=1`): worker-local per-rank chunk files with versioned headers + segment tables, boundary manifests, inline keep-K retention; restore hard-off (`GLM53_KV_OFFLOAD_RESTORE` refused at 1); see `docs/DESIGN-kv-offload-store-only.md` |
+| `overlay/kv_offload_store_gc.py` | store verifier/GC: header+CRC checks, orphan/corrupt reporting (dry-run default), manifest-mediated keep-K sweep |
+| `tests/test_kv_offload_scope.py` | patcher preflight/idempotence/drift on pinned image fixtures; eligibility predicate; patched-runtime drive under a stubbed vllm (eligible {0,2,3,4,5}, original-index keys, full-length group_sizes, store-only lookup short-circuit) |
+| `tests/test_kv_offload_store_local.py` | header codec + torn-file rejection, store-job meta alignment + pickle, writer real-bytes/segment-table/manifest-ordering/retention/ENOSPC/rank-guard/delayed-ack, GC tool |
+| `tests/test_launcher_kv_offload.py` | knob guard matrix, fail-closed pre-stop gate, knob=0 no-mount parity, knob=1 both-rank env/mount/scp/JSON parity, overlay order pin |
 | `overlay/ablit_runtime.py` | load-time o_proj transplant / projection (`ABLIT=1`); no-op when off |
 | `overlay/patch_ablit.py` | install the load_weights hook; bind-mounted and run on both ranks |
 | `ablit/` | direction vectors + `LAYER_MAP.json` from drowzeys' published recipe; `fetch_transplant.py` + `transplant/` for the donor o_proj byte-copy |

--- a/docs/DESIGN-kv-offload-store-only.md
+++ b/docs/DESIGN-kv-offload-store-only.md
@@ -1,0 +1,135 @@
+# Stage-1 store-only disk KV tier (`GLM53_KV_OFFLOAD`)
+
+Design record for `overlay/patch_kv_offload_scope.py` +
+`overlay/patch_kv_offload_store_local.py` + the `start.sh` wiring. Stage 1 of
+the disk KV-offload research plan: the tier **writes**; nothing reads it back
+(`GLM53_KV_OFFLOAD_RESTORE` is refused at 1 by the launcher). Restore plumbing
+is stage 2.
+
+## Why
+
+A session whose KV has left the ~455K-token resident GPU envelope reprefills
+from zero (174 s measured at 120K). The plan's endgame is
+park-to-disk/restore-on-touch; stage 1 lands the write side with zero blast
+radius: knob off ⇒ no connector, byte-identical serving.
+
+## The two boot blockers this image has
+
+1. **Scratch-group divisibility crash.** `build_offloading_config` builds an
+   offload group config for every KV-cache group and asserts
+   `tokens_per_block % tokens_per_hash == 0` — the KpoolTailSpec scratch group
+   (block 4, hash grid 64) crashes the connector at boot. Our upstream PR
+   vllm-project/vllm#54743 scopes the group list to prefix-cacheable groups;
+   the scope overlay ports that onto this image's older tree.
+2. **Wrapped group specs.** This image hands the connector
+   `UniformTypeKVCacheSpecs` wrappers (subclass of `KVCacheSpec` only), which
+   the connector's isinstance dispatch cannot classify: the full-attention
+   assert would crash on group 0, and mamba groups would silently lose their
+   alignment/CoW semantics. The scope overlay adds a fail-closed single-type
+   unwrap (`_glm53_kvo_inner_spec`), and reads cacheability through the
+   image's `participates_in_prefix_caching` name.
+
+Eligible set on this deployment: **{0, 2, 3, 4, 5}** — g1 (kpool scratch) out
+by the upstream predicate, g6 (DFlash2 drafter) out by fork policy
+(min-exempt, retention 0: its window is rebuilt by the remainder's prefill;
+`GLM53_KV_OFFLOAD_DRAFTER=1` re-includes it for experiments). All eligible
+groups sit on the 3584 grid, so `blocks_per_chunk=1` gives one 3584-token
+chunk per group per boundary.
+
+## Why the store is worker-local (risk R0)
+
+`TieringOffloadingSpec.get_manager()` constructs the CPU primary tier AND all
+secondary tiers on the scheduler and hands the fs tier the *scheduler node's*
+staging memoryview. On this 2-node TP=2 kit, rank 1's staging mmap lives on
+the other Spark: the scheduler-side view's rank-1 slots are never written,
+and the stock fs tier would persist rank-0 bytes + uninitialised garbage as
+rank-1 halves — corruption that only surfaces at restore. So:
+
+- the connector JSON configures **CPU staging only** (no `secondary_tiers`);
+- store jobs carry a metadata side-channel (`TransferJob.glm53_store_meta`):
+  ordered `(hash, group_idx, chunk_idx)` aligned with the job's block order,
+  plus boundary-manifest candidates (cumulative chunk-hash chains);
+- each worker, after its GPU→CPU DMA completes, writes **its own bytes** from
+  **its own mmap** to **its own NVMe** under
+  `GLM53_KV_OFFLOAD_DIR/glm53kv_<model>_<ns>_r<rank>/…`, and only then acks
+  the store job (staging stays pinned until every worker acks, so bytes
+  cannot be evicted under the writer);
+- rank is the initialized TP rank cross-checked against the connector
+  config's rank — disagreement disables the writer rather than risking
+  cross-rank mixing.
+
+## On-disk format (v1)
+
+`GLM53KV1` magic | u32 header_len | canonical-JSON header | u32 header-crc32
+| payload. Header: format_version, namespace_hash, ORIGINAL group_idx,
+spec_kind, layers, block_size_tokens, n_tokens_valid, boundary_token_index,
+tp_rank/tp_world, per-layer segment table (KDA layers: conv/temporal split
+with shape/dtype/derived-contiguous stride), state-ABI tag +
+num_speculative_tokens for mamba groups, payload_len, payload_crc32
+(zlib crc32; the header names the algorithm). Payload = **real (unpadded)
+bytes only** — the CanonicalKVCacheRef layout the DMA uses already carries
+unpadded page sizes, so the mamba slot-share padding never reaches disk.
+
+Namespace hash: sha256[:12] over model, vllm version, build id, TP/world, KV
+dtype, prefix-cache hash algo, tokens_per_hash, blocks_per_chunk,
+num_speculative_tokens (baked into the KDA conv width), per-eligible-group
+(original idx, block size, layers, real page sizes), the KDA state-ABI
+descriptor, format_version. Any change forks the directory. Retention K is
+recorded in the namespace file but does NOT fence the hash.
+
+**Boundary manifests**: per (chain, boundary), keyed by the boundary hash,
+published only after all four mamba payloads AND the cumulative full-attn
+chunks are durable on that rank (fsync file+dir, tmp+rename). No manifest ⇒
+the boundary does not exist for stage-2 lookup. Cross-rank rule (stage 2): a
+boundary is restore-eligible iff BOTH ranks hold a valid manifest.
+
+**Retention** (`GLM53_KV_OFFLOAD_KEEP_BOUNDARIES`, default 2): inline, per
+publish — a manifest is superseded (manifest deleted, its mamba payloads
+unlinked) once it is beyond the K most recent boundaries of every chain
+containing it; full-attention chunks stay dense (cheap, and cumulative
+references from any live manifest keep shallower boundaries restorable).
+Cross-boot leftovers: `overlay/kv_offload_store_gc.py` (dry-run default).
+
+## Failure semantics (everything degrades to reprefill)
+
+| failure | behaviour |
+|---|---|
+| write fails | tmp unlinked, one log line, key enters the failed ledger (never manifested this boot), job acked — lost store only |
+| ENOSPC | writer pauses (all further writes dropped, one log); serving unaffected |
+| crash between group writes | orphan payloads, no live manifest; GC reports/sweeps |
+| torn/truncated file | header+CRC verification rejects at read (stage 2 / GC) |
+| rank mismatch, wrong layout, blocks_per_chunk≠1 | writer disabled at init with a named reason; jobs flow normally |
+
+Known stage-1 limit (recorded): the worker→scheduler ack protocol has no
+per-job failure bit, so the CPU tier believes a failed key stored and will
+not retry it this boot. Safe while restore is off (an incomplete boundary is
+simply invisible); the failure bit lands with stage 2's T4 invalidation work.
+
+## Knobs
+
+| knob | default | meaning |
+|---|---|---|
+| `GLM53_KV_OFFLOAD` | 0 | 1 = enable the connector + store tier. 0 = byte-identical serving (no argv, no mounts) |
+| `GLM53_KV_OFFLOAD_DIR` | `~/glm53-kv-offload` | host dir on EACH Spark's local NVMe; mounted rw at `/data/glm53-kv-offload` on both ranks |
+| `GLM53_KV_OFFLOAD_CPU_GB` | 4 | CPU staging bounce (`cpu_bytes_to_use`); never a capacity tier |
+| `GLM53_KV_OFFLOAD_RESTORE` | 0 | stage-1 hard rule: 1 is refused by the launcher |
+| `GLM53_KV_OFFLOAD_DRAFTER` | 0 | 1 = include the drafter group (stage-4 experiment) |
+| `GLM53_KV_OFFLOAD_KEEP_BOUNDARIES` | 2 | inline manifest retention (0 = dense) |
+
+## Deviations from the research plan (recorded)
+
+- `blocks_per_chunk=1` uniformly (plan wanted 16 for MLA): the image has one
+  global chunk size and all eligible groups share block 3584.
+- CRC is zlib crc32, not crc32c (stdlib; algorithm named in the header).
+- The stock fs secondary tier is not configured (Codex advisory finding 3 /
+  Q1): scheduler-side byte I/O is exactly the R0 hazard; the worker-local
+  writer is the disk tier.
+
+## Receipts
+
+Live receipts (knob=0 byte-parity, knob=1 boot + store-cascade evidence on
+both Sparks, store overhead within noise, fail-closed negatives) are captured
+in the PR body before the PR opens; host-side coverage is
+`tests/test_kv_offload_scope.py`, `tests/test_kv_offload_store_local.py`,
+`tests/test_launcher_kv_offload.py` against the pinned image fixtures
+(`tests/fixtures/`, sha256s in its README).

--- a/docs/DESIGN-kv-offload-store-only.md
+++ b/docs/DESIGN-kv-offload-store-only.md
@@ -45,15 +45,22 @@ the other Spark: the scheduler-side view's rank-1 slots are never written,
 and the stock fs tier would persist rank-0 bytes + uninitialised garbage as
 rank-1 halves — corruption that only surfaces at restore. So:
 
-- the connector JSON configures **CPU staging only** (no `secondary_tiers`);
+- the connector JSON configures **CPU staging only** (no `secondary_tiers`)
+  and sets `offload_prompt_only: false` — the upstream default (true) would
+  silently skip decoded tokens, and a parked session must cover its
+  responses too;
 - store jobs carry a metadata side-channel (`TransferJob.glm53_store_meta`):
   ordered `(hash, group_idx, chunk_idx)` aligned with the job's block order,
   plus boundary-manifest candidates (cumulative chunk-hash chains);
-- each worker, after its GPU→CPU DMA completes, writes **its own bytes** from
-  **its own mmap** to **its own NVMe** under
-  `GLM53_KV_OFFLOAD_DIR/glm53kv_<model>_<ns>_r<rank>/…`, and only then acks
-  the store job (staging stays pinned until every worker acks, so bytes
-  cannot be evicted under the writer);
+- each worker SNAPSHOTS the job's bytes out of its own staging mmap
+  synchronously at DMA completion (capture-then-write; adversarial-review
+  finding 1: `reset_cache()` frees staging rows regardless of pending disk
+  work, so async reads from the mmap could tear) — at `get_finished` before
+  its ack, or right after `worker.wait()` on the flush/reset path — then a
+  2-thread pool writes the private buffers (512 MB budget, over-budget
+  captures dropped as lost stores) to **its own NVMe** under
+  `GLM53_KV_OFFLOAD_DIR/glm53kv_<model>_<ns>_r<rank>/…`; acks are never
+  deferred;
 - rank is the initialized TP rank cross-checked against the connector
   config's rank — disagreement disables the writer rather than risking
   cross-rank mixing.
@@ -78,8 +85,11 @@ descriptor, format_version. Any change forks the directory. Retention K is
 recorded in the namespace file but does NOT fence the hash.
 
 **Boundary manifests**: per (chain, boundary), keyed by the boundary hash,
-published only after all four mamba payloads AND the cumulative full-attn
-chunks are durable on that rank (fsync file+dir, tmp+rename). No manifest ⇒
+published only after all four mamba payloads AND every cumulative full-attn
+chunk are durable AND header-verified on that rank (namespace + hash + group
+identity; per-chunk `[hash, len, crc]` recorded for full groups too; dedup of
+an existing file likewise requires a verifying header, else it is rewritten).
+fsync file+dir, tmp+rename. No manifest ⇒
 the boundary does not exist for stage-2 lookup. Cross-rank rule (stage 2): a
 boundary is restore-eligible iff BOTH ranks hold a valid manifest.
 
@@ -94,7 +104,8 @@ Cross-boot leftovers: `overlay/kv_offload_store_gc.py` (dry-run default).
 
 | failure | behaviour |
 |---|---|
-| write fails | tmp unlinked, one log line, key enters the failed ledger (never manifested this boot), job acked — lost store only |
+| write fails | tmp unlinked, one log line, key enters the failed ledger (never manifested this boot) — lost store only |
+| capture over budget | write dropped (lost store), key stays manifest-eligible for a later re-store |
 | ENOSPC | writer pauses (all further writes dropped, one log); serving unaffected |
 | crash between group writes | orphan payloads, no live manifest; GC reports/sweeps |
 | torn/truncated file | header+CRC verification rejects at read (stage 2 / GC) |

--- a/overlay/kv_offload_store_gc.py
+++ b/overlay/kv_offload_store_gc.py
@@ -44,10 +44,16 @@ from patch_kv_offload_store_local import read_chunk_header  # noqa: E402
 
 
 def find_stale_temps(base: Path):
-    """Yield every leftover ``*.tmp.*`` under the base (payloads, manifests,
-    namespace records). Any temp is stale by definition: publication is
-    tmp+rename, so a temp only survives a crash mid-write."""
+    """Yield every leftover ``*.tmp.*`` under the base (payloads, manifests)
+    plus namespace-record temps, which live BESIDE the per-rank base in the
+    store root (non-recursive). Any temp is stale by definition: publication
+    is tmp+rename, so a temp only survives a crash mid-write."""
     yield from base.rglob("*.tmp.*")
+    root = base.parent
+    if root.is_dir():
+        for p in root.glob("glm53kv_*.json.tmp.*"):
+            if p.is_file():
+                yield p
 
 
 def find_chunk_files(base: Path):

--- a/overlay/kv_offload_store_gc.py
+++ b/overlay/kv_offload_store_gc.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Verify / garbage-collect a GLM53 KV-offload store (stage-1 companion tool).
+
+Walks one per-rank store base directory (``glm53kv_<model>_<ns>_r<rank>``, as
+written by ``patch_kv_offload_store_local.py``), header-verifies every chunk
+file, cross-references boundary manifests, and reports:
+
+- corrupt/torn files (bad magic, truncated header/payload, CRC mismatch);
+- orphan payloads: mamba-group chunks referenced by NO live manifest (a crash
+  between group writes and manifest publish leaves exactly these);
+- manifest health: per manifest, whether every referenced payload (the four
+  mamba chunks at the boundary and the CUMULATIVE g0 chunk chain — plan §4
+  C1) exists and matches its recorded size/CRC.
+
+DRY-RUN by default: nothing is deleted or modified unless flags say so.
+
+- ``--sweep``          delete corrupt files and orphan mamba payloads
+- ``--keep-boundaries K``  manifest-mediated retention (plan §7): per chain,
+                       keep the K most recent boundary manifests (by
+                       boundary_token_index), mark the rest superseded
+                       (delete the manifest file), then sweep payloads no
+                       live manifest references. Full-attention chunks are
+                       liveness-protected by ANY live manifest of any chain
+                       (cumulative references), so superseding a boundary
+                       never strands a shallower restorable boundary.
+- ``--verify-crc``     full payload CRC verification (reads every byte)
+
+Chains are identified by their deepest manifest's chunk-hash chain: manifest
+A belongs to chain C when A's chunk_hashes is a prefix of C's. Runs on the
+host against the mounted store dir or inside the container; stdlib only.
+
+Exit code: 0 clean, 1 findings (corrupt/orphans), 2 usage/IO error.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# The header codec lives in the store overlay (single implementation).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from patch_kv_offload_store_local import read_chunk_header  # noqa: E402
+
+
+def find_chunk_files(base: Path):
+    """Yield (path, hash_hex, group_idx) for every .bin under the base."""
+    for sub1 in sorted(base.iterdir()):
+        if not sub1.is_dir() or sub1.name == "manifests":
+            continue
+        for sub2 in sorted(sub1.iterdir()):
+            if not sub2.is_dir() or "_g" not in sub2.name:
+                continue
+            try:
+                group_idx = int(sub2.name.rsplit("_g", 1)[1])
+            except ValueError:
+                continue
+            for f in sorted(sub2.glob("*.bin")):
+                yield f, f.stem, group_idx
+
+
+def load_manifests(base: Path):
+    import json
+
+    manifests = []
+    mdir = base / "manifests"
+    if not mdir.is_dir():
+        return manifests
+    for sub in sorted(mdir.iterdir()):
+        if not sub.is_dir():
+            continue
+        for f in sorted(sub.glob("*.json")):
+            try:
+                with open(f, encoding="utf-8") as fh:
+                    m = json.load(fh)
+            except (OSError, ValueError) as exc:
+                manifests.append({"_path": f, "_error": str(exc)})
+                continue
+            m["_path"] = f
+            manifests.append(m)
+    return manifests
+
+
+def assign_chains(manifests):
+    """Group manifests into chains: A joins C's chain when A.chunk_hashes is a
+    prefix of C.chunk_hashes (C the deepest)."""
+    valid = [m for m in manifests if "_error" not in m and m.get("chunk_hashes")]
+    valid.sort(key=lambda m: len(m["chunk_hashes"]), reverse=True)
+    chains: list[list[dict]] = []
+    for m in valid:
+        placed = False
+        for chain in chains:
+            deepest = chain[0]["chunk_hashes"]
+            mine = m["chunk_hashes"]
+            if deepest[: len(mine)] == mine:
+                chain.append(m)
+                placed = True
+                break
+        if not placed:
+            chains.append([m])
+    return chains
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("base", help="per-rank store base dir (…_r<rank>)")
+    ap.add_argument("--sweep", action="store_true", help="delete corrupt files and orphan mamba payloads")
+    ap.add_argument("--keep-boundaries", type=int, default=0, metavar="K", help="keep only the K most recent boundary manifests per chain (0 = keep all)")
+    ap.add_argument("--verify-crc", action="store_true", help="full payload CRC verification")
+    args = ap.parse_args(argv)
+
+    base = Path(args.base)
+    if not base.is_dir():
+        print(f"ERROR: not a directory: {base}", file=sys.stderr)
+        return 2
+    dry = not args.sweep
+
+    corrupt: list[Path] = []
+    headers: dict[tuple[str, int], dict] = {}
+    total_bytes = 0
+    n_files = 0
+    for path, hash_hex, group_idx in find_chunk_files(base):
+        n_files += 1
+        total_bytes += path.stat().st_size
+        try:
+            h = read_chunk_header(str(path), verify_payload=args.verify_crc)
+        except (OSError, ValueError) as exc:
+            corrupt.append(path)
+            print(f"CORRUPT {path}: {exc}")
+            continue
+        if h.get("hash") != hash_hex or h.get("group_idx") != group_idx:
+            corrupt.append(path)
+            print(f"CORRUPT {path}: header identity mismatch (hash/group)")
+            continue
+        headers[(hash_hex, group_idx)] = h
+
+    manifests = load_manifests(base)
+    broken_manifests = [m for m in manifests if "_error" in m]
+    for m in broken_manifests:
+        print(f"BAD-MANIFEST {m['_path']}: {m['_error']}")
+
+    # Retention: keep K most recent per chain (by boundary_token_index).
+    superseded: list[dict] = []
+    chains = assign_chains(manifests)
+    if args.keep_boundaries > 0:
+        for chain in chains:
+            chain.sort(key=lambda m: m.get("boundary_token_index", 0), reverse=True)
+            for m in chain[args.keep_boundaries :]:
+                superseded.append(m)
+        for m in superseded:
+            print(f"SUPERSEDE {m['_path']} (boundary {m.get('boundary_token_index')})")
+            if not dry:
+                m["_path"].unlink(missing_ok=True)
+        live = [
+            m
+            for m in manifests
+            if "_error" not in m and m not in superseded
+        ]
+    else:
+        live = [m for m in manifests if "_error" not in m]
+
+    # Liveness: any chunk referenced by any live manifest.
+    live_keys: set[tuple[str, int]] = set()
+    incomplete_manifests = 0
+    for m in live:
+        ok = True
+        chunk_hashes = m.get("chunk_hashes") or []
+        for gidx_s, entry in (m.get("cow_groups") or {}).items():
+            key = (entry.get("hash"), int(gidx_s))
+            live_keys.add(key)
+            h = headers.get(key)
+            if h is None:
+                print(f"MANIFEST-MISSING-PAYLOAD {m['_path']}: g{gidx_s} {entry.get('hash', '?')[:12]}")
+                ok = False
+            elif (
+                h.get("payload_len") != entry.get("payload_len")
+                or h.get("payload_crc32") != entry.get("payload_crc32")
+            ):
+                print(f"MANIFEST-PAYLOAD-MISMATCH {m['_path']}: g{gidx_s}")
+                ok = False
+        for gidx_s in (m.get("full_groups") or {}):
+            for hh in chunk_hashes:
+                key = (hh, int(gidx_s))
+                live_keys.add(key)
+                if key not in headers:
+                    print(f"MANIFEST-MISSING-PAYLOAD {m['_path']}: g{gidx_s} {hh[:12]}")
+                    ok = False
+        if not ok:
+            incomplete_manifests += 1
+
+    # Orphans: mamba-group payloads no live manifest references. Full-attn
+    # chunks without a manifest are NOT orphans by default (a boundary may
+    # legitimately be mid-store); report them only under retention mode.
+    mamba_groups = {
+        int(g) for m in live for g in (m.get("cow_groups") or {})
+    }
+    orphans = [
+        (key, h)
+        for key, h in headers.items()
+        if key not in live_keys
+        and (key[1] in mamba_groups or (args.keep_boundaries > 0))
+    ]
+    for (hash_hex, gidx), _h in orphans:
+        print(f"ORPHAN {hash_hex} g{gidx}")
+
+    if not dry:
+        for path in corrupt:
+            path.unlink(missing_ok=True)
+            print(f"DELETED {path}")
+        for (hash_hex, gidx), _h in orphans:
+            p = base / hash_hex[:3] / f"{hash_hex[3:5]}_g{gidx}" / f"{hash_hex}.bin"
+            p.unlink(missing_ok=True)
+            print(f"DELETED {p}")
+
+    print(
+        f"SUMMARY files={n_files} bytes={total_bytes} manifests={len(manifests)} "
+        f"chains={len(chains)} corrupt={len(corrupt)} orphans={len(orphans)} "
+        f"superseded={len(superseded)} incomplete_manifests={incomplete_manifests} "
+        f"broken_manifests={len(broken_manifests)} mode={'DRY-RUN' if dry else 'SWEEP'}"
+    )
+    return 1 if (corrupt or orphans or broken_manifests or incomplete_manifests) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/overlay/kv_offload_store_gc.py
+++ b/overlay/kv_offload_store_gc.py
@@ -43,6 +43,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from patch_kv_offload_store_local import read_chunk_header  # noqa: E402
 
 
+def find_stale_temps(base: Path):
+    """Yield every leftover ``*.tmp.*`` under the base (payloads, manifests,
+    namespace records). Any temp is stale by definition: publication is
+    tmp+rename, so a temp only survives a crash mid-write."""
+    yield from base.rglob("*.tmp.*")
+
+
 def find_chunk_files(base: Path):
     """Yield (path, hash_hex, group_idx) for every .bin under the base."""
     for sub1 in sorted(base.iterdir()):
@@ -134,28 +141,51 @@ def main(argv=None) -> int:
             continue
         headers[(hash_hex, group_idx)] = h
 
+    stale_temps = list(find_stale_temps(base))
+    for t in stale_temps:
+        print(f"STALE-TEMP {t}")
+    if not dry:
+        for t in stale_temps:
+            t.unlink(missing_ok=True)
+            print(f"DELETED {t}")
+
     manifests = load_manifests(base)
     broken_manifests = [m for m in manifests if "_error" in m]
     for m in broken_manifests:
         print(f"BAD-MANIFEST {m['_path']}: {m['_error']}")
 
-    # Retention: keep K most recent per chain (by boundary_token_index).
+    # Retention: the same keep-set rule as the writer's inline retention — a
+    # manifest survives while it is within the K most recent boundaries of
+    # ANY chain containing it. Chains are parent-linked via chunk_hashes
+    # (parent = chunk_hashes[-2]); walking up from every leaf keeps shared
+    # divergence-point ancestors alive as long as any branch needs them.
     superseded: list[dict] = []
-    chains = assign_chains(manifests)
-    if args.keep_boundaries > 0:
-        for chain in chains:
-            chain.sort(key=lambda m: m.get("boundary_token_index", 0), reverse=True)
-            for m in chain[args.keep_boundaries :]:
-                superseded.append(m)
+    chains = assign_chains(manifests)  # reporting only
+    valid = [m for m in manifests if "_error" not in m and m.get("chunk_hashes")]
+    if args.keep_boundaries > 0 and valid:
+        by_hash = {m["chunk_hashes"][-1]: m for m in valid}
+        parents = {
+            h: (m["chunk_hashes"][-2] if len(m["chunk_hashes"]) > 1 else None)
+            for h, m in by_hash.items()
+        }
+        child_count = {h: 0 for h in by_hash}
+        for h, parent in parents.items():
+            if parent in child_count:
+                child_count[parent] += 1
+        keep: set[str] = set()
+        for leaf in [h for h, c in child_count.items() if c == 0]:
+            node, kept = leaf, 0
+            while node is not None and kept < args.keep_boundaries:
+                if node in by_hash:
+                    keep.add(node)
+                    kept += 1
+                node = parents.get(node)
+        superseded = [m for h, m in by_hash.items() if h not in keep]
         for m in superseded:
             print(f"SUPERSEDE {m['_path']} (boundary {m.get('boundary_token_index')})")
             if not dry:
                 m["_path"].unlink(missing_ok=True)
-        live = [
-            m
-            for m in manifests
-            if "_error" not in m and m not in superseded
-        ]
+        live = [m for m in valid if m not in superseded]
     else:
         live = [m for m in manifests if "_error" not in m]
 
@@ -178,22 +208,37 @@ def main(argv=None) -> int:
             ):
                 print(f"MANIFEST-PAYLOAD-MISMATCH {m['_path']}: g{gidx_s}")
                 ok = False
-        for gidx_s in (m.get("full_groups") or {}):
+        for gidx_s, entry in (m.get("full_groups") or {}).items():
+            # entry: [[hash, payload_len, payload_crc32], ...] (current) or a
+            # bare chunk count (early format) — hashes come from chunk_hashes.
+            expected = {
+                e[0]: (e[1], e[2]) for e in entry
+            } if isinstance(entry, list) else {}
             for hh in chunk_hashes:
                 key = (hh, int(gidx_s))
                 live_keys.add(key)
-                if key not in headers:
+                h = headers.get(key)
+                if h is None:
                     print(f"MANIFEST-MISSING-PAYLOAD {m['_path']}: g{gidx_s} {hh[:12]}")
+                    ok = False
+                elif hh in expected and (
+                    h.get("payload_len"), h.get("payload_crc32")
+                ) != expected[hh]:
+                    print(f"MANIFEST-PAYLOAD-MISMATCH {m['_path']}: g{gidx_s} {hh[:12]}")
                     ok = False
         if not ok:
             incomplete_manifests += 1
 
-    # Orphans: mamba-group payloads no live manifest references. Full-attn
+    # Orphans: mamba-group payloads no live manifest references. Mamba-ness
+    # comes from the chunk HEADERS (spec_kind == MambaSpec), so a store whose
+    # crash predates its first manifest still reports its orphans. Full-attn
     # chunks without a manifest are NOT orphans by default (a boundary may
-    # legitimately be mid-store); report them only under retention mode.
+    # legitimately be mid-store); they count only under retention mode.
     mamba_groups = {
-        int(g) for m in live for g in (m.get("cow_groups") or {})
+        gidx for (_h, gidx), hdr in headers.items()
+        if hdr.get("spec_kind") == "MambaSpec"
     }
+    mamba_groups |= {int(g) for m in live for g in (m.get("cow_groups") or {})}
     orphans = [
         (key, h)
         for key, h in headers.items()
@@ -216,9 +261,20 @@ def main(argv=None) -> int:
         f"SUMMARY files={n_files} bytes={total_bytes} manifests={len(manifests)} "
         f"chains={len(chains)} corrupt={len(corrupt)} orphans={len(orphans)} "
         f"superseded={len(superseded)} incomplete_manifests={incomplete_manifests} "
+        f"stale_temps={len(stale_temps)} "
         f"broken_manifests={len(broken_manifests)} mode={'DRY-RUN' if dry else 'SWEEP'}"
     )
-    return 1 if (corrupt or orphans or broken_manifests or incomplete_manifests) else 0
+    return (
+        1
+        if (
+            corrupt
+            or orphans
+            or broken_manifests
+            or incomplete_manifests
+            or stale_temps
+        )
+        else 0
+    )
 
 
 if __name__ == "__main__":

--- a/overlay/patch_kv_offload_scope.py
+++ b/overlay/patch_kv_offload_scope.py
@@ -924,6 +924,16 @@ def main(argv: list[str] | None = None) -> int:
     argv = sys.argv if argv is None else argv
     preflight_only = "--preflight" in argv[1:]
 
+    if "--check-injected" in argv[1:]:
+        # Host-side gate mode: compile the injected helper source standalone
+        # (no target access needed) so a truncated/corrupted string literal
+        # inside this file fails BEFORE the launcher stops a healthy pair.
+        compile(HELPERS_SRC, "<glm53-kv-offload-scope helpers>", "exec")
+        compile(S0_HELPER, "<glm53-kv-offload-scope unwrap>", "exec")
+        load_helpers()
+        print("patch_kv_offload_scope.py: injected sources compile OK")
+        return 0
+
     # Preflight EVERY target before writing ANY (fail-closed: a drifted
     # scheduler must not leave a patched config.py behind).
     prepared: list[tuple[Path, str, str, str]] = []

--- a/overlay/patch_kv_offload_scope.py
+++ b/overlay/patch_kv_offload_scope.py
@@ -1,0 +1,955 @@
+#!/usr/bin/env python3
+"""Eligible-group scoping for the KV-offloading connector (port of vllm#54743).
+
+The problem
+-----------
+``build_offloading_config`` (``vllm/distributed/kv_transfer/kv_connector/v1/
+offloading/config.py``) builds an ``OffloadingGroupConfig`` for EVERY KV-cache
+group and asserts ``tokens_per_block % tokens_per_hash == 0`` across all of
+them, while ``resolve_kv_cache_block_sizes`` derives ``tokens_per_hash`` from
+prefix-cacheable groups only. On this deployment the KpoolTailSpec scratch
+group (group 1: block_size 4, ``prefix_cacheable=False``) fails the assert
+(4 % 64) the moment the OffloadingConnector is enabled — the connector cannot
+even boot on the hybrid layout.
+
+Our upstream PR vllm-project/vllm#54743 (branch
+fix/offloading-config-scope-prefix-cacheable, commit 899699c) fixes this at
+HEAD by scoping the offload group list to prefix-cacheable groups while
+preserving ORIGINAL group indices. This overlay ports that scoping onto the
+image's older tree (vllm 0.1.dev20051+g487ecf187), which sits between the PR's
+base and HEAD: the scheduler-side ``GroupOffloadConfig`` already carries
+``group_idx``, but the config boundary does not, and every scheduler pairing
+still assumes ``index == group_idx`` identity.
+
+What this overlay does (three files)
+------------------------------------
+1. ``vllm/v1/kv_offload/config.py`` — ``OffloadingGroupConfig`` gains
+   ``group_idx`` (original index into ``KVCacheConfig.kv_cache_groups``;
+   trailing default ``-1`` keeps existing constructors valid, and the
+   connector path always sets it).
+2. ``.../offloading/config.py`` — the groups tuple is scoped to the eligible
+   set: prefix-cacheable groups (upstream predicate) MINUS the fork policy
+   exclusion (exact-``SlidingWindowSpec`` drafter groups, unless
+   ``GLM53_KV_OFFLOAD_DRAFTER=1`` — plan §3.2/§11-C5: the DFlash2 drafter is
+   min-exempt with retention 0, so restoring it is pointless and storing it is
+   pure waste). Original indices ride in ``group_idx``; the divisibility
+   assert still guards every eligible group; one boot log line names the
+   eligible set. Final eligible set on this deployment: {0, 2, 3, 4, 5}.
+3. ``.../offloading/scheduler.py`` — the group_idx pairing port, [I]-adapted
+   from 899699c:
+   - ``resolve_mamba_align_size`` / the full-attn alignment scan / the
+     kv_group_configs build loop iterate ``spec.config.groups`` (group_idx +
+     tokens_per_block from the entry) instead of ``enumerate(
+     spec.tokens_per_block)``;
+   - ``SchedulerOffloadConfig`` gains ``num_kv_cache_groups`` (the FULL group
+     count) and ``from_spec`` fills it;
+   - ``RequestOffloadState.group_states`` is sized by the full group count —
+     block-id bookkeeping spans all groups (``update_block_id_groups`` asserts
+     one entry per KV-cache group), while offload keys are only generated for
+     eligible groups;
+   - every ``zip(kv_group_configs, group_states)`` pairing indexes
+     ``group_states[group_config.group_idx]`` instead;
+   - the two ``kv_group_configs[group_idx]`` subscripts go through a new
+     ``_group_config_by_idx`` dict;
+   - ``update_state_after_alloc`` builds FULL-LENGTH ``group_sizes`` /
+     ``block_indices`` (zeros for ineligible groups) and reads
+     ``blocks.blocks[group_config.group_idx]`` — the worker's
+     ``GPULoadStoreSpec`` layout is built from ALL kv-cache groups
+     (``register_kv_caches`` iterates ``kv_cache_config.kv_cache_groups``), so
+     ineligible groups keep zero-size entries and the worker layout is
+     unchanged;
+   - ``_build_store_jobs`` and ``_build_partial_tail_store_jobs`` write their
+     group_sizes/block_indices at ``group_idx`` into full-length lists;
+   - ``supports_partial_tail`` additionally requires every KV-cache group to
+     be eligible (conservative opt-out, exactly HEAD's rule; on this layout it
+     is already False via the EAGLE drafter).
+
+Behaviour for models without scratch/policy-excluded groups is unchanged: the
+eligible set is then every group and all the new indexing degenerates to the
+old identity pairing.
+
+Adaptation notes vs 899699c (per-anchor honesty)
+------------------------------------------------
+- [I] already has ``group_idx``/``is_eagle_group``/``requires_cow_source`` in
+  the scheduler NamedTuple; only the PAIRING is ported, not the fields.
+- HEAD's ``kv_connector_extra_config['block_size']`` assert-message reword is
+  NOT ported: the branch is unused by this deployment and the semantics are
+  already rescoped by the filtered ``groups`` tuple it reads.
+- HEAD hoists the ``_current_batch_allocated_block_ids`` sweep over all
+  groups in ``update_state_after_alloc``; [I]'s loop is shaped differently but
+  the port keeps HEAD's semantics (sweep ALL groups' allocated ids, then walk
+  only eligible groups).
+- The fork policy exclusion (drafter) is fork-only and NOT part of #54743;
+  upstream's predicate alone yields {0,2,3,4,5,6} here.
+
+Conventions follow ``overlay/patch_kv_capacity_log.py``: pinned ANCHORs, MARK
+sentinels, ``verified_state``, ``prepare``, idempotent, atomic replace, pyc
+clear, drift => nonzero exit. ALL anchors in ALL three files are preflighted
+before ANY file is written. Must run BEFORE ``patch_kv_offload_store_local.py``
+(that overlay anchors on this one's output in scheduler.py). No anchors are
+shared with any other overlay (none touch the kv_offload/connector tree).
+
+Usage::
+
+    python3 patch_kv_offload_scope.py              # apply
+    python3 patch_kv_offload_scope.py --preflight  # validate anchors only
+"""
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+VLLM_ROOT = os.environ.get(
+    "GLM53_VLLM_ROOT", "/usr/local/lib/python3.12/dist-packages/vllm"
+)
+
+TARGET_KVO_CONFIG = Path(
+    os.environ.get("GLM53_KVO_CONFIG_PY", f"{VLLM_ROOT}/v1/kv_offload/config.py")
+)
+TARGET_CONN_CONFIG = Path(
+    os.environ.get(
+        "GLM53_KVO_CONN_CONFIG_PY",
+        f"{VLLM_ROOT}/distributed/kv_transfer/kv_connector/v1/offloading/config.py",
+    )
+)
+TARGET_SCHED = Path(
+    os.environ.get(
+        "GLM53_KVO_SCHED_PY",
+        f"{VLLM_ROOT}/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py",
+    )
+)
+
+TAG = "[glm53-kv-offload-scope]"
+ENV_DRAFTER = "GLM53_KV_OFFLOAD_DRAFTER"
+
+
+# ---------------------------------------------------------------------------
+# Shared helper source: the eligibility predicate.
+#
+# Injected into offloading/config.py AND exec'd below so host tests drive the
+# exact shipped predicate (one implementation, no drifting replica).
+# ---------------------------------------------------------------------------
+HELPERS_SRC = '''# [glm53-kv-offload-scope] helpers -- see overlay/patch_kv_offload_scope.py
+_GLM53_KVO_SCOPE_TAG = "[glm53-kv-offload-scope]"
+_GLM53_KVO_DRAFTER_ENV = "GLM53_KV_OFFLOAD_DRAFTER"
+
+
+def _glm53_kvo_drafter_included() -> bool:
+    """Exactly "0" or "1"; unset means "0" (exclude the drafter group).
+
+    Same contract as the launcher's ``_glm53_validate_bool_flag``: "" is a
+    value, not an absence; a typo'd knob raises rather than silently choosing
+    which groups hit the disk tier.
+    """
+    import os as _os
+
+    raw = _os.environ.get(_GLM53_KVO_DRAFTER_ENV)
+    if raw is None or raw == "0":
+        return False
+    if raw == "1":
+        return True
+    raise ValueError(
+        f"{_GLM53_KVO_DRAFTER_ENV} must be exactly 0 or 1 (got: {raw!r})"
+    )
+
+
+def _glm53_kvo_unwrap_spec(spec):
+    """Unwrap a UniformTypeKVCacheSpecs so the group's real spec class is named."""
+    specs = getattr(spec, "kv_cache_specs", None)
+    if isinstance(specs, dict) and specs:
+        return next(iter(specs.values()))
+    return spec
+
+
+def _glm53_kvo_group_eligible(
+    kv_cache_group, drafter_included: bool, use_eagle: bool
+) -> bool:
+    """Upstream predicate (prefix_cacheable) minus the fork policy exclusion.
+
+    - Non-prefix-cacheable groups (KpoolTailSpec scratch) are never offloaded:
+      block hashes only cover prefix-cacheable groups, so a scratch group has
+      no valid hash granularity (vllm#54743's predicate).
+    - Fork policy: DRAFT-model attention groups are excluded unless
+      GLM53_KV_OFFLOAD_DRAFTER=1 — the drafter is min-exempt with retention 0
+      (#83), so its window is rebuilt by the remainder's prefill and storing
+      it is waste (plan §3.2). A group is a drafter group when it carries
+      ``is_eagle_group`` OR — only under an EAGLE-like speculative config
+      (``use_eagle``) — when its unwrapped spec is EXACTLY SlidingWindowSpec
+      (the same exact-class rule as patch_hybrid_prefix_hit's
+      ``_glm53_is_draft_swa_spec``; without EAGLE context a SlidingWindowSpec
+      group is genuine model SWA and stays eligible).
+    """
+    spec = kv_cache_group.kv_cache_spec
+    # [I] names the flag participates_in_prefix_caching (a property, and on
+    # UniformTypeKVCacheSpecs an all-members aggregate); newer trees say
+    # prefix_cacheable. Check both, fork name first (same dual-name rule as
+    # patch_kv_capacity_log). A spec with neither name caches (legacy).
+    for name in ("participates_in_prefix_caching", "prefix_cacheable"):
+        value = getattr(spec, name, None)
+        if callable(value):
+            value = value()
+        if isinstance(value, bool):
+            if not value:
+                return False
+            break
+    if not drafter_included:
+        if bool(getattr(kv_cache_group, "is_eagle_group", False)):
+            return False
+        if use_eagle:
+            inner = _glm53_kvo_unwrap_spec(spec)
+            if type(inner).__name__ == "SlidingWindowSpec":
+                return False
+    return True
+
+
+def _glm53_kvo_use_eagle(vllm_config) -> bool:
+    spec_cfg = getattr(vllm_config, "speculative_config", None)
+    if spec_cfg is None:
+        return False
+    use_eagle = getattr(spec_cfg, "use_eagle", None)
+    if callable(use_eagle):
+        return bool(use_eagle())
+    return bool(use_eagle)
+
+
+'''
+
+
+def load_helpers() -> dict:
+    """Exec HELPERS_SRC into a fresh namespace (what the host tests drive)."""
+    ns: dict = {}
+    exec(compile(HELPERS_SRC, "<glm53-kv-offload-scope helpers>", "exec"), ns)
+    return ns
+
+
+_HELPERS = load_helpers()
+kvo_drafter_included = _HELPERS["_glm53_kvo_drafter_included"]
+kvo_unwrap_spec = _HELPERS["_glm53_kvo_unwrap_spec"]
+kvo_group_eligible = _HELPERS["_glm53_kvo_group_eligible"]
+
+
+# ===========================================================================
+# File 1: vllm/v1/kv_offload/config.py — OffloadingGroupConfig.group_idx
+# ===========================================================================
+MARK_GROUPCFG = "    # [glm53-kv-offload-scope] original index into KVCacheConfig.kv_cache_groups\n"
+
+ANCHOR_GROUPCFG = """@dataclass(frozen=True)
+class OffloadingGroupConfig:
+    # Total token span covered by one block across all workers
+    # (accounts for context parallelism).
+    tokens_per_block: int
+    # Layer names belonging to this group.
+    layer_names: tuple[str, ...]
+"""
+
+PATCHED_GROUPCFG = """@dataclass(frozen=True)
+class OffloadingGroupConfig:
+    # Total token span covered by one block across all workers
+    # (accounts for context parallelism).
+    tokens_per_block: int
+    # Layer names belonging to this group.
+    layer_names: tuple[str, ...]
+    # [glm53-kv-offload-scope] original index into KVCacheConfig.kv_cache_groups
+    # (offload groups are scoped to eligible groups; keys/layouts keep original
+    # indices). Required, matching upstream 899699c: the only constructor is
+    # build_offloading_config, which always sets it.
+    group_idx: int
+"""
+
+SITES_KVO_CONFIG = (
+    ("OffloadingGroupConfig.group_idx", MARK_GROUPCFG, ANCHOR_GROUPCFG, PATCHED_GROUPCFG),
+)
+
+
+# ===========================================================================
+# File 2: offloading/config.py — eligible-group scoping at the boundary
+# ===========================================================================
+MARK_CONN_HELPERS = "# [glm53-kv-offload-scope] helpers -- see overlay/patch_kv_offload_scope.py\n"
+
+ANCHOR_CONN_HELPERS = """def is_kv_cache_tensor_packed(kv_cache_tensor: "KVCacheTensor") -> bool:
+"""
+
+PATCHED_CONN_HELPERS = HELPERS_SRC + ANCHOR_CONN_HELPERS
+
+MARK_CONN_GROUPS = "    # [glm53-kv-offload-scope] scope to eligible groups, keep original indices\n"
+
+ANCHOR_CONN_GROUPS = """    parallel_config = vllm_config.parallel_config
+    groups = tuple(
+        OffloadingGroupConfig(
+            tokens_per_block=(
+                group.kv_cache_spec.block_size
+                * (
+                    parallel_config.decode_context_parallel_size
+                    if isinstance(group.kv_cache_spec, AttentionSpec)
+                    else 1
+                )
+            ),
+            layer_names=tuple(group.layer_names),
+        )
+        for group in kv_cache_config.kv_cache_groups
+    )
+"""
+
+PATCHED_CONN_GROUPS = """    parallel_config = vllm_config.parallel_config
+    # [glm53-kv-offload-scope] scope to eligible groups, keep original indices
+    # (port of vllm#54743): only prefix-cacheable groups can serve offload
+    # hits -- block hashes are computed over prefix-cacheable groups only
+    # (resolve_kv_cache_block_sizes), so scratch groups (KpoolTailSpec) have
+    # no valid hash granularity and must not be offloaded. The fork policy
+    # additionally excludes the exact-SlidingWindowSpec drafter group unless
+    # GLM53_KV_OFFLOAD_DRAFTER=1. Original group indices ride in group_idx.
+    _glm53_drafter_included = _glm53_kvo_drafter_included()
+    _glm53_use_eagle = _glm53_kvo_use_eagle(vllm_config)
+    _glm53_eligible = [
+        group_idx
+        for group_idx, group in enumerate(kv_cache_config.kv_cache_groups)
+        if _glm53_kvo_group_eligible(
+            group, _glm53_drafter_included, _glm53_use_eagle
+        )
+    ]
+    from vllm.logger import init_logger as _glm53_init_logger
+
+    _glm53_init_logger(__name__).info(
+        "%s eligible groups: %s of %d (drafter_included=%s)",
+        _GLM53_KVO_SCOPE_TAG,
+        _glm53_eligible,
+        len(kv_cache_config.kv_cache_groups),
+        _glm53_drafter_included,
+    )
+    groups = tuple(
+        OffloadingGroupConfig(
+            tokens_per_block=(
+                group.kv_cache_spec.block_size
+                * (
+                    parallel_config.decode_context_parallel_size
+                    # Unwrap: [I] wraps per-layer specs in
+                    # UniformTypeKVCacheSpecs (KVCacheSpec subclass only), so
+                    # the stock isinstance would miss attention groups.
+                    if isinstance(
+                        _glm53_kvo_unwrap_spec(group.kv_cache_spec), AttentionSpec
+                    )
+                    else 1
+                )
+            ),
+            layer_names=tuple(group.layer_names),
+            group_idx=group_idx,
+        )
+        for group_idx, group in enumerate(kv_cache_config.kv_cache_groups)
+        if group_idx in _glm53_eligible
+    )
+"""
+
+SITES_CONN_CONFIG = (
+    ("connector config helpers", MARK_CONN_HELPERS, ANCHOR_CONN_HELPERS, PATCHED_CONN_HELPERS),
+    ("eligible-group scoping", MARK_CONN_GROUPS, ANCHOR_CONN_GROUPS, PATCHED_CONN_GROUPS),
+)
+
+
+# ===========================================================================
+# File 3: offloading/scheduler.py — group_idx pairing port
+# ===========================================================================
+
+# --- site S0: spec-unwrap helper (an [I]-specific adaptation) ---------------
+# [I]'s kv-cache groups wrap per-layer specs in UniformTypeKVCacheSpecs
+# (subclass of KVCacheSpec only): the module's isinstance dispatch
+# (get_sliding_window_size_in_chunks' FullAttentionSpec assert, the MambaSpec
+# checks) would crash or silently misclassify every wrapped group. Not part
+# of upstream 899699c (HEAD's group specs reach the connector unwrapped).
+MARK_S0 = "# [glm53-kv-offload-scope] spec unwrap helper\n"
+
+ANCHOR_S0 = """def get_sliding_window_size_in_chunks(
+"""
+
+S0_HELPER = '''# [glm53-kv-offload-scope] spec unwrap helper
+def _glm53_kvo_inner_spec(spec):
+    """Return the single-type member spec of a UniformTypeKVCacheSpecs.
+
+    [I]'s kv-cache groups wrap their per-layer specs (mixed page sizes) in
+    UniformTypeKVCacheSpecs, which subclasses only KVCacheSpec -- the stock
+    isinstance() dispatch in this module would assert on it. Unwrap to the
+    first member when every member is the same class; otherwise return the
+    wrapper unchanged, so the caller's FullAttentionSpec assert fails LOUDLY
+    at boot instead of misclassifying a mixed group.
+    """
+    specs = getattr(spec, "kv_cache_specs", None)
+    if isinstance(specs, dict) and specs:
+        members = list(specs.values())
+        first_cls = type(members[0])
+        if all(type(m) is first_cls for m in members):
+            return members[0]
+    return spec
+
+
+'''
+
+PATCHED_S0 = S0_HELPER + ANCHOR_S0
+
+# --- site S1: resolve_mamba_align_size iterates config.groups ---------------
+MARK_S1 = "    # [glm53-kv-offload-scope] iterate eligible groups (original indices)\n"
+
+ANCHOR_S1 = """    mamba_align_size: int | None = None
+    for idx, tokens_per_block in enumerate(spec.tokens_per_block):
+        kv_spec = kv_cache_config.kv_cache_groups[idx].kv_cache_spec
+        if isinstance(kv_spec, MambaSpec) and kv_spec.mamba_cache_mode in (
+            "align",
+            "all",
+        ):
+            tokens_per_chunk = tokens_per_block * spec.blocks_per_chunk
+            assert mamba_align_size is None or mamba_align_size == tokens_per_chunk
+            mamba_align_size = tokens_per_chunk
+    return mamba_align_size
+"""
+
+PATCHED_S1 = """    mamba_align_size: int | None = None
+    # [glm53-kv-offload-scope] iterate eligible groups (original indices)
+    for group in spec.config.groups:
+        kv_spec = _glm53_kvo_inner_spec(
+            kv_cache_config.kv_cache_groups[group.group_idx].kv_cache_spec
+        )
+        if isinstance(kv_spec, MambaSpec) and kv_spec.mamba_cache_mode in (
+            "align",
+            "all",
+        ):
+            tokens_per_chunk = group.tokens_per_block * spec.blocks_per_chunk
+            assert mamba_align_size is None or mamba_align_size == tokens_per_chunk
+            mamba_align_size = tokens_per_chunk
+    return mamba_align_size
+"""
+
+# --- site S2: SchedulerOffloadConfig fields --------------------------------
+MARK_S2 = "    # [glm53-kv-offload-scope] total number of KV cache groups\n"
+
+ANCHOR_S2 = """class SchedulerOffloadConfig(NamedTuple):
+    kv_group_configs: tuple[GroupOffloadConfig, ...]
+    blocks_per_chunk: int
+"""
+
+PATCHED_S2 = """class SchedulerOffloadConfig(NamedTuple):
+    # One entry per ELIGIBLE KV cache group; group_idx keeps the original
+    # index into KVCacheConfig.kv_cache_groups. Ineligible groups (scratch,
+    # policy-excluded drafter) are never offloaded and get no entry here.
+    kv_group_configs: tuple[GroupOffloadConfig, ...]
+    # [glm53-kv-offload-scope] total number of KV cache groups
+    # (including ineligible ones); sizes per-group structures shared with the
+    # scheduler core and the worker.
+    num_kv_cache_groups: int
+    blocks_per_chunk: int
+"""
+
+# --- site S3: from_spec full-attn alignment scan ---------------------------
+MARK_S3 = "        # [glm53-kv-offload-scope] alignment scan over eligible groups\n"
+
+ANCHOR_S3 = """        full_attn_tokens_per_chunk: set[int] = set()
+        for idx, tokens_per_block in enumerate(spec.tokens_per_block):
+            kv_spec = kv_cache_config.kv_cache_groups[idx].kv_cache_spec
+            sw = get_sliding_window_size_in_chunks(
+                kv_spec, tokens_per_block * spec.blocks_per_chunk
+            )
+            if sw is None:
+                full_attn_tokens_per_chunk.add(tokens_per_block * spec.blocks_per_chunk)
+"""
+
+PATCHED_S3 = """        full_attn_tokens_per_chunk: set[int] = set()
+        # [glm53-kv-offload-scope] alignment scan over eligible groups
+        for group in spec.config.groups:
+            kv_spec = _glm53_kvo_inner_spec(
+                kv_cache_config.kv_cache_groups[group.group_idx].kv_cache_spec
+            )
+            sw = get_sliding_window_size_in_chunks(
+                kv_spec, group.tokens_per_block * spec.blocks_per_chunk
+            )
+            if sw is None:
+                full_attn_tokens_per_chunk.add(
+                    group.tokens_per_block * spec.blocks_per_chunk
+                )
+"""
+
+# --- site S4: from_spec kv_group_configs build loop ------------------------
+MARK_S4 = "        # [glm53-kv-offload-scope] build configs for eligible groups only\n"
+
+ANCHOR_S4 = """        kv_group_configs_list: list[GroupOffloadConfig] = []
+        for idx, tokens_per_block in enumerate(spec.tokens_per_block):
+            kv_cache_group = kv_cache_config.kv_cache_groups[idx]
+            kv_spec = kv_cache_group.kv_cache_spec
+"""
+
+PATCHED_S4 = """        kv_group_configs_list: list[GroupOffloadConfig] = []
+        # [glm53-kv-offload-scope] build configs for eligible groups only
+        for group in spec.config.groups:
+            idx = group.group_idx
+            tokens_per_block = group.tokens_per_block
+            kv_cache_group = kv_cache_config.kv_cache_groups[idx]
+            kv_spec = _glm53_kvo_inner_spec(kv_cache_group.kv_cache_spec)
+"""
+
+# --- site S5: supports_partial_tail + num_kv_cache_groups ------------------
+MARK_S5 = "        # [glm53-kv-offload-scope] partial tails need every group eligible\n"
+
+ANCHOR_S5 = """        kv_group_configs = tuple(kv_group_configs_list)
+        group_block_sizes = {config.tokens_per_block for config in kv_group_configs}
+"""
+
+PATCHED_S5 = """        kv_group_configs = tuple(kv_group_configs_list)
+        # [glm53-kv-offload-scope] partial tails need every group eligible
+        num_kv_cache_groups = len(kv_cache_config.kv_cache_groups)
+        group_block_sizes = {config.tokens_per_block for config in kv_group_configs}
+"""
+
+MARK_S5B = "            and len(kv_group_configs) == num_kv_cache_groups  # [glm53-kv-offload-scope]\n"
+
+ANCHOR_S5B = """        supports_partial_tail = (
+            spec.blocks_per_chunk == 1
+            and len(group_block_sizes) == 1
+            and has_partial_recurrent_group
+"""
+
+PATCHED_S5B = """        supports_partial_tail = (
+            spec.blocks_per_chunk == 1
+            and len(group_block_sizes) == 1
+            and len(kv_group_configs) == num_kv_cache_groups  # [glm53-kv-offload-scope]
+            and has_partial_recurrent_group
+"""
+
+MARK_S5C = "            num_kv_cache_groups=num_kv_cache_groups,  # [glm53-kv-offload-scope]\n"
+
+ANCHOR_S5C = """        return cls(
+            num_workers=vllm_config.parallel_config.world_size,
+            kv_group_configs=kv_group_configs,
+            blocks_per_chunk=spec.blocks_per_chunk,
+"""
+
+PATCHED_S5C = """        return cls(
+            num_workers=vllm_config.parallel_config.world_size,
+            kv_group_configs=kv_group_configs,
+            num_kv_cache_groups=num_kv_cache_groups,  # [glm53-kv-offload-scope]
+            blocks_per_chunk=spec.blocks_per_chunk,
+"""
+
+# --- site S6: RequestOffloadState.group_states full-length -----------------
+MARK_S6 = "        # [glm53-kv-offload-scope] one state per KV cache group (original index)\n"
+
+ANCHOR_S6 = """    def __post_init__(self) -> None:
+        self.group_states = tuple(
+            RequestGroupState() for _ in self.config.kv_group_configs
+        )
+"""
+
+PATCHED_S6 = """    def __post_init__(self) -> None:
+        # [glm53-kv-offload-scope] one state per KV cache group (original index)
+        # -- block-id bookkeeping spans ALL groups (update_block_id_groups gets
+        # one entry per KV cache group from the core), while offload keys are
+        # only ever generated for the eligible kv_group_configs.
+        self.group_states = tuple(
+            RequestGroupState() for _ in range(self.config.num_kv_cache_groups)
+        )
+"""
+
+# --- site S7: update_offload_keys pairing ----------------------------------
+MARK_S7 = "        for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S7\n"
+
+ANCHOR_S7 = """    def update_offload_keys(self) -> None:
+        for group_config, group_state in zip(
+            self.config.kv_group_configs, self.group_states
+        ):
+"""
+
+PATCHED_S7 = """    def update_offload_keys(self) -> None:
+        for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S7
+            group_state = self.group_states[group_config.group_idx]
+"""
+
+# --- site S8: advance_stored_idx pairing -----------------------------------
+MARK_S8 = "        for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S8\n"
+
+ANCHOR_S8 = """        for group_config, group_state in zip(
+            self.config.kv_group_configs, self.group_states
+        ):
+            group_state.next_stored_chunk_idx = max(
+"""
+
+PATCHED_S8 = """        for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S8
+            group_state = self.group_states[group_config.group_idx]
+            group_state.next_stored_chunk_idx = max(
+"""
+
+# --- site S9: update_num_hit_chunks pairing --------------------------------
+MARK_S9 = "        for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S9\n"
+
+ANCHOR_S9 = """        for group_config, group_state in zip(
+            self.config.kv_group_configs, self.group_states
+        ):
+            group_state.num_hit_chunks = (
+"""
+
+PATCHED_S9 = """        for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S9
+            group_state = self.group_states[group_config.group_idx]
+            group_state.num_hit_chunks = (
+"""
+
+# --- site S10: scheduler __init__ dict + sort key --------------------------
+MARK_S10 = "        # [glm53-kv-offload-scope] original group index -> eligible group config\n"
+
+ANCHOR_S10 = """        full_attention_groups: list[int] = []
+        sliding_window_groups: list[int] = []
+        for group_config in self.config.kv_group_configs:
+            if group_config.sliding_window_size_in_chunks is None:
+                full_attention_groups.append(group_config.group_idx)
+            else:
+                sliding_window_groups.append(group_config.group_idx)
+
+        # sort sliding window groups by window size in decreasing order
+        def _sliding_window_sort_key(i: int) -> int:
+            val = self.config.kv_group_configs[i].sliding_window_size_in_chunks
+            assert val is not None
+            return val
+"""
+
+PATCHED_S10 = """        # [glm53-kv-offload-scope] original group index -> eligible group config
+        self._group_config_by_idx: dict[int, GroupOffloadConfig] = {
+            group_config.group_idx: group_config
+            for group_config in self.config.kv_group_configs
+        }
+
+        full_attention_groups: list[int] = []
+        sliding_window_groups: list[int] = []
+        for group_config in self.config.kv_group_configs:
+            if group_config.sliding_window_size_in_chunks is None:
+                full_attention_groups.append(group_config.group_idx)
+            else:
+                sliding_window_groups.append(group_config.group_idx)
+
+        # sort sliding window groups by window size in decreasing order
+        def _sliding_window_sort_key(i: int) -> int:
+            val = self._group_config_by_idx[i].sliding_window_size_in_chunks
+            assert val is not None
+            return val
+"""
+
+# --- site S11: _touch pairing ----------------------------------------------
+MARK_S11 = "        for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S11\n"
+
+ANCHOR_S11 = """    def _touch(self, req_status: RequestOffloadState):
+        for group_config, group_state in zip(
+            self.config.kv_group_configs, req_status.group_states
+        ):
+"""
+
+PATCHED_S11 = """    def _touch(self, req_status: RequestOffloadState):
+        for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S11
+            group_state = req_status.group_states[group_config.group_idx]
+"""
+
+# --- site S12: _lookup_complete_chunks subscript ---------------------------
+MARK_S12 = "                group_config: GroupOffloadConfig = self._group_config_by_idx[  # [glm53-kv-offload-scope]\n"
+
+ANCHOR_S12 = """            for group_idx in groups_iter:
+                group_config: GroupOffloadConfig = self.config.kv_group_configs[
+                    group_idx
+                ]
+"""
+
+PATCHED_S12 = """            for group_idx in groups_iter:
+                group_config: GroupOffloadConfig = self._group_config_by_idx[  # [glm53-kv-offload-scope]
+                    group_idx
+                ]
+"""
+
+# --- site S13: _chunks_being_loaded pairing --------------------------------
+MARK_S13 = "            for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S13\n"
+
+ANCHOR_S13 = """        if self._chunks_being_loaded:
+            for group_config, group_state in zip(
+                self.config.kv_group_configs, req_status.group_states
+            ):
+"""
+
+PATCHED_S13 = """        if self._chunks_being_loaded:
+            for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S13
+                group_state = req_status.group_states[group_config.group_idx]
+"""
+
+# --- site S14: update_state_after_alloc ------------------------------------
+MARK_S14 = "        # [glm53-kv-offload-scope] full-length per-group layout, eligible walk\n"
+
+ANCHOR_S14 = """        keys_to_load: list[OffloadKey] = []
+        dst_block_ids: list[int] = []
+        # per group
+        group_sizes: list[int] = []
+        block_indices: list[int] = []
+        for group_config, group_state, group_blocks in zip(
+            self.config.kv_group_configs,
+            req_status.group_states,
+            blocks.blocks,
+        ):
+            self._current_batch_allocated_block_ids.update(
+                block.block_id for block in group_blocks if block.block_id != 0
+            )
+
+            tokens_per_block = group_config.tokens_per_block
+"""
+
+PATCHED_S14 = """        # [glm53-kv-offload-scope] full-length per-group layout, eligible walk
+        # (GPULoadStoreSpec group_sizes/block_indices are indexed by ORIGINAL
+        # group index; ineligible groups never load, so their entries stay 0).
+        for group_blocks in blocks.blocks:
+            self._current_batch_allocated_block_ids.update(
+                block.block_id for block in group_blocks if block.block_id != 0
+            )
+
+        keys_to_load: list[OffloadKey] = []
+        dst_block_ids: list[int] = []
+        # per group (indexed by original group index)
+        group_sizes: list[int] = [0] * self.config.num_kv_cache_groups
+        block_indices: list[int] = [0] * self.config.num_kv_cache_groups
+        for group_config in self.config.kv_group_configs:
+            group_state = req_status.group_states[group_config.group_idx]
+            group_blocks = blocks.blocks[group_config.group_idx]
+
+            tokens_per_block = group_config.tokens_per_block
+"""
+
+MARK_S14B = "            group_sizes[group_config.group_idx] = num_pending_gpu_blocks  # [glm53-kv-offload-scope]\n"
+
+ANCHOR_S14B = """            group_sizes.append(num_pending_gpu_blocks)
+            block_indices.append(num_locally_computed_gpu_blocks)
+"""
+
+PATCHED_S14B = """            group_sizes[group_config.group_idx] = num_pending_gpu_blocks  # [glm53-kv-offload-scope]
+            block_indices[group_config.group_idx] = num_locally_computed_gpu_blocks
+"""
+
+# --- site S15: _build_partial_tail_store_jobs ------------------------------
+MARK_S15 = "            group_by_key = {  # [glm53-kv-offload-scope] original-index keyed\n"
+
+ANCHOR_S15 = """            group_by_key = {key: idx for idx, key in enumerate(keys)}
+            accepted_groups = [group_by_key[key] for key in store_output.keys_to_store]
+            group_sizes = [0] * len(self.config.kv_group_configs)
+            block_indices = [0] * len(self.config.kv_group_configs)
+"""
+
+PATCHED_S15 = """            group_by_key = {  # [glm53-kv-offload-scope] original-index keyed
+                key: group.group_idx
+                for group, key in zip(self.config.kv_group_configs, keys)
+            }
+            # GPULoadStoreSpec expects blocks ordered by group index.
+            accepted_groups = sorted(
+                group_by_key[key] for key in store_output.keys_to_store
+            )
+            group_sizes = [0] * self.config.num_kv_cache_groups
+            block_indices = [0] * self.config.num_kv_cache_groups
+"""
+
+MARK_S15B = "            source_blocks = [  # [glm53-kv-offload-scope] via block_id_by_group\n"
+
+ANCHOR_S15B = """            source_blocks = [block_ids[group_idx] for group_idx in accepted_groups]
+"""
+
+PATCHED_S15B = """            source_blocks = [  # [glm53-kv-offload-scope] via block_id_by_group
+                _glm53_block_id_by_group[group_idx] for group_idx in accepted_groups
+            ]
+"""
+
+MARK_S15C = "            _glm53_block_id_by_group = {  # [glm53-kv-offload-scope]\n"
+
+ANCHOR_S15C = """            block_ids = [
+                cow_blocks[group.group_idx]
+                if group.group_idx in self._cow_source_groups
+                else req_status.group_states[group.group_idx].block_ids[block_idx]
+                for group in self.config.kv_group_configs
+            ]
+            assert all(block_id != 0 for block_id in block_ids)
+"""
+
+PATCHED_S15C = """            _glm53_block_id_by_group = {  # [glm53-kv-offload-scope]
+                group.group_idx: (
+                    cow_blocks[group.group_idx]
+                    if group.group_idx in self._cow_source_groups
+                    else req_status.group_states[group.group_idx].block_ids[block_idx]
+                )
+                for group in self.config.kv_group_configs
+            }
+            assert all(
+                block_id != 0 for block_id in _glm53_block_id_by_group.values()
+            )
+"""
+
+# --- site S16: _build_store_jobs first pairing (key filter loop) -----------
+MARK_S16 = "            for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S16\n"
+
+ANCHOR_S16 = """            new_offload_keys: list[OffloadKey] = []
+            for group_config, group_state in zip(
+                self.config.kv_group_configs, req_status.group_states
+            ):
+"""
+
+PATCHED_S16 = """            new_offload_keys: list[OffloadKey] = []
+            for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S16
+                group_state = req_status.group_states[group_config.group_idx]
+"""
+
+# --- site S17: _build_store_jobs source-block walk -------------------------
+MARK_S17 = "            group_sizes = [0] * self.config.num_kv_cache_groups  # [glm53-kv-offload-scope]\n"
+
+ANCHOR_S17 = """            group_sizes: list[int] = []
+            block_indices: list[int] = []
+            src_block_ids: list[int] = []
+            fenced_block_ids: list[int] = []
+            deferred_fence_block_ids: list[int] = []
+            for group_config, group_state in zip(
+                self.config.kv_group_configs, req_status.group_states
+            ):
+"""
+
+PATCHED_S17 = """            group_sizes = [0] * self.config.num_kv_cache_groups  # [glm53-kv-offload-scope]
+            block_indices = [0] * self.config.num_kv_cache_groups
+            src_block_ids: list[int] = []
+            fenced_block_ids: list[int] = []
+            deferred_fence_block_ids: list[int] = []
+            for group_config in self.config.kv_group_configs:
+                group_state = req_status.group_states[group_config.group_idx]
+"""
+
+MARK_S17B = "                group_sizes[group_config.group_idx] = num_group_blocks  # [glm53-kv-offload-scope]\n"
+
+ANCHOR_S17B = """                group_sizes.append(num_group_blocks)
+                block_indices.append(start_gpu_block_idx or 0)
+"""
+
+PATCHED_S17B = """                group_sizes[group_config.group_idx] = num_group_blocks  # [glm53-kv-offload-scope]
+                block_indices[group_config.group_idx] = start_gpu_block_idx or 0
+"""
+
+SITES_SCHED = (
+    ("S0 spec unwrap helper", MARK_S0, ANCHOR_S0, PATCHED_S0),
+    ("S1 resolve_mamba_align_size", MARK_S1, ANCHOR_S1, PATCHED_S1),
+    ("S2 SchedulerOffloadConfig fields", MARK_S2, ANCHOR_S2, PATCHED_S2),
+    ("S3 full-attn alignment scan", MARK_S3, ANCHOR_S3, PATCHED_S3),
+    ("S4 kv_group_configs build loop", MARK_S4, ANCHOR_S4, PATCHED_S4),
+    ("S5 num_kv_cache_groups", MARK_S5, ANCHOR_S5, PATCHED_S5),
+    ("S5B supports_partial_tail", MARK_S5B, ANCHOR_S5B, PATCHED_S5B),
+    ("S5C from_spec return", MARK_S5C, ANCHOR_S5C, PATCHED_S5C),
+    ("S6 group_states sizing", MARK_S6, ANCHOR_S6, PATCHED_S6),
+    ("S7 update_offload_keys", MARK_S7, ANCHOR_S7, PATCHED_S7),
+    ("S8 advance_stored_idx", MARK_S8, ANCHOR_S8, PATCHED_S8),
+    ("S9 update_num_hit_chunks", MARK_S9, ANCHOR_S9, PATCHED_S9),
+    ("S10 scheduler init dict", MARK_S10, ANCHOR_S10, PATCHED_S10),
+    ("S11 _touch", MARK_S11, ANCHOR_S11, PATCHED_S11),
+    ("S12 lookup subscript", MARK_S12, ANCHOR_S12, PATCHED_S12),
+    ("S13 chunks_being_loaded", MARK_S13, ANCHOR_S13, PATCHED_S13),
+    ("S14 update_state_after_alloc", MARK_S14, ANCHOR_S14, PATCHED_S14),
+    ("S14B alloc group sizes", MARK_S14B, ANCHOR_S14B, PATCHED_S14B),
+    ("S15C partial-tail block ids", MARK_S15C, ANCHOR_S15C, PATCHED_S15C),
+    ("S15 partial-tail group_by_key", MARK_S15, ANCHOR_S15, PATCHED_S15),
+    ("S15B partial-tail source blocks", MARK_S15B, ANCHOR_S15B, PATCHED_S15B),
+    ("S16 store-jobs key filter", MARK_S16, ANCHOR_S16, PATCHED_S16),
+    ("S17 store-jobs block walk", MARK_S17, ANCHOR_S17, PATCHED_S17),
+    ("S17B store-jobs group sizes", MARK_S17B, ANCHOR_S17B, PATCHED_S17B),
+)
+
+
+TARGETS = (
+    ("kv_offload/config.py", TARGET_KVO_CONFIG, SITES_KVO_CONFIG),
+    ("offloading/config.py", TARGET_CONN_CONFIG, SITES_CONN_CONFIG),
+    ("offloading/scheduler.py", TARGET_SCHED, SITES_SCHED),
+)
+
+
+def verified_state(text: str, sites) -> bool:
+    """Exact post-state: one mark per site, one patched block per site, and
+    anchors survive only where the replacement itself contains them."""
+    return all(
+        text.count(mark) == 1
+        and text.count(patched) == 1
+        and text.count(anchor) == patched.count(anchor)
+        for _name, mark, anchor, patched in sites
+    )
+
+
+def prepare(source: str, sites, label: str) -> tuple[str, str]:
+    """Idempotent, fail-closed. Returns (text, action). Nothing written here.
+
+    The already-present check counts MARK sentinels only (each exactly once):
+    patch_kv_offload_store_local.py legitimately edits inside this overlay's
+    patched scheduler regions afterwards, so full patched-block equality only
+    holds between the two applications (and is still enforced post-patch)."""
+    marks = sum(source.count(mark) for _n, mark, _a, _p in sites)
+    if marks:
+        if marks != len(sites) or any(
+            source.count(mark) != 1 for _n, mark, _a, _p in sites
+        ):
+            raise ValueError(
+                f"partial/inconsistent kv-offload-scope patch in {label} "
+                f"(marks={marks}, expected {len(sites)}) -- refusing to touch "
+                "a half-patched file"
+            )
+        return source, "already present"
+
+    for name, _mark, anchor, _patched in sites:
+        n = source.count(anchor)
+        if n != 1:
+            raise ValueError(
+                f"pinned kv-offload-scope anchor '{name}' drifted in {label} "
+                f"(found {n}, expected 1)"
+            )
+    out = source
+    for _name, _mark, anchor, patched in sites:
+        out = out.replace(anchor, patched, 1)
+    if not verified_state(out, sites):
+        raise ValueError(f"kv-offload-scope post-patch verification failed in {label}")
+    return out, "patched"
+
+
+def replace_file(target: Path, source: str) -> None:
+    tmp = target.with_name(f".{target.name}.glm53-kv-offload-scope.tmp")
+    try:
+        tmp.write_text(source)
+        os.chmod(tmp, stat.S_IMODE(target.stat().st_mode))
+        os.replace(tmp, target)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def clear_pyc(target: Path) -> None:
+    cache = target.parent / "__pycache__"
+    if not cache.is_dir():
+        return
+    for pyc in cache.glob(f"{target.stem}*.pyc"):
+        pyc.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv if argv is None else argv
+    preflight_only = "--preflight" in argv[1:]
+
+    # Preflight EVERY target before writing ANY (fail-closed: a drifted
+    # scheduler must not leave a patched config.py behind).
+    prepared: list[tuple[Path, str, str, str]] = []
+    for label, target, sites in TARGETS:
+        if not target.is_file():
+            raise SystemExit(f"missing {target}")
+        source = target.read_text()
+        try:
+            patched, action = prepare(source, sites, label)
+        except ValueError as exc:
+            raise SystemExit(f"kv-offload-scope preflight failed: {exc}") from exc
+        compile(patched, str(target), "exec")
+        prepared.append((target, source, patched, action))
+        if preflight_only:
+            print(f"{target.name}: kv-offload-scope preflight OK ({action})")
+
+    if preflight_only:
+        return 0
+
+    for target, source, patched, action in prepared:
+        if patched != source:
+            replace_file(target, patched)
+            clear_pyc(target)
+        print(f"{target.name}: kv-offload-scope {action}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/overlay/patch_kv_offload_store_local.py
+++ b/overlay/patch_kv_offload_store_local.py
@@ -1,0 +1,1364 @@
+#!/usr/bin/env python3
+"""Store-only worker-local disk KV tier with chunk headers (GLM53_KV_OFFLOAD).
+
+Stage 1 of the disk KV-offload plan (PLAN-KV-OFFLOAD.md §11): the tier WRITES;
+nothing reads it back (restore stays off behind GLM53_KV_OFFLOAD_RESTORE=0).
+
+Why worker-local (plan risk R0)
+-------------------------------
+``TieringOffloadingSpec.get_manager()`` builds the CPU primary tier AND every
+secondary tier on the SCHEDULER side and hands ``FileSystemTierManager`` the
+scheduler node's staging memoryview. On this 2-node TP=2 deployment
+(``--nnodes 2``) rank 1's staging mmap lives on the other Spark: the
+scheduler-side view's rank-1 page slots are never written, so the stock fs
+tier would persist rank-0 bytes plus uninitialised garbage as the rank-1 half
+of every file — corruption that only surfaces at restore time. The CPU
+primary tier itself is multi-node-correct (GPU<->CPU DMA is worker-local
+against each node's own mmap), so this overlay keeps the CPU staging path
+stock and moves the DISK write to the workers: each rank writes its own bytes
+from its own staging mmap to its own local NVMe under a per-rank root.
+
+What this overlay does (three files)
+------------------------------------
+The stock fs secondary tier is NOT configured at all (Codex advisory
+CODEX-OFFLOAD1-PLAN.md, finding 3 / Q1): the launcher's connector JSON is
+``TieringOffloadingSpec`` with CPU staging only, and THIS overlay's
+worker-local writer is the disk tier. The in-image
+``FileSystemTierManager`` stays untouched and unused; stage 2's per-rank
+manifest-aggregating lookup replaces it on the read side.
+
+1. ``offloading/common.py`` — ``TransferJob`` gains an optional
+   ``glm53_store_meta`` field (versioned picklable dict; rides the existing
+   scheduler->worker metadata channel; a plain dict is deliberate — pickled
+   custom classes would couple scheduler/worker code versions on the wire).
+2. ``offloading/scheduler.py`` (AFTER patch_kv_offload_scope.py — two of the
+   anchors below pin that overlay's output) —
+   - store jobs collect an ordered (key, group_idx, chunk_idx) list aligned
+     with the job's src/dst block order and attach it, plus boundary-manifest
+     candidates (chunk-hash chains from ``req.block_hashes``), as
+     ``glm53_store_meta``;
+   - under ``GLM53_KV_OFFLOAD_RESTORE=0`` (default) the external lookup in
+     ``get_num_new_matched_tokens`` is short-circuited to 0 hits: no loads,
+     no promotions, no WAITING_FOR_REMOTE_KVS — store-only, zero restore
+     machinery active.
+3. ``offloading/worker.py`` — the worker-local writer:
+   - store-job metadata is captured per job (both the ``prepare_store_kv``
+     and the ``handle_preemptions`` flush path);
+   - when a store job's GPU->CPU DMA completes, the job is NOT acked to the
+     scheduler yet; a small writer pool (2 threads) writes one file per
+     (block-hash, group): real (unpadded) bytes only, gathered from the
+     worker's own CPU staging tensors via the same CanonicalKVCacheRef layout
+     the DMA used, with a §4 chunk header (format v1: magic, versioned JSON
+     header with namespace hash, ORIGINAL group index, per-layer segment
+     table incl. the KDA conv/temporal split, payload CRC, header CRC);
+   - the job is acked only after its writes finish — staging blocks stay
+     pinned by the store protocol until every worker acks, so the bytes
+     cannot be evicted or rewritten under the disk writer;
+   - after a job's payloads are durable (write+fsync+rename+parent-dir
+     fsync, unique pid-suffixed temp names), boundary manifests are
+     published (existence-verified cumulative references, tmp+rename with
+     file+dir fsync) — a crash between group writes leaves orphan payloads,
+     never a live half-boundary; a key whose write failed this boot can
+     never enter a manifest (failed-key ledger + on-disk header check);
+   - K-boundary retention INLINE (plan §7, ``GLM53_KV_OFFLOAD_KEEP_BOUNDARIES``,
+     default 2): after each publish, a manifest is superseded (deleted, its
+     mamba payloads unlinked) once it is beyond the K most recent boundaries
+     of EVERY chain containing it — chains are prefix-related manifest
+     chains, so a shared divergence-point boundary survives as long as any
+     chain still keeps it; full-attention chunks stay dense (cheap; plan §7).
+     Cross-boot leftovers are the GC tool's job (kv_offload_store_gc.py);
+   - failure semantics (plan §8): a failed write unlinks its tmp and logs
+     (lost store = future reprefill; restore is off, nothing can serve wrong
+     bytes); ENOSPC pauses the writer (all further writes dropped, one log);
+     the job is acked either way so serving is never blocked on the tier.
+     KNOWN stage-1 limit (Codex finding 2, partially rebutted): the ack
+     protocol has no per-job failure bit, so the CPU tier will believe a
+     failed key stored and not retry it this boot — safe while restore is
+     off (a boundary with a missing payload simply never gets a manifest and
+     stays invisible); the protocol failure bit lands with stage 2's T4
+     invalidation work, where it is load-bearing.
+
+File format v1 (see also overlay/kv_offload_store_gc.py, which reads it)
+------------------------------------------------------------------------
+``GLM53KV1`` magic (8 B) | u32 header_len | canonical-JSON header |
+u32 crc32(header) | payload. The header carries format_version,
+namespace_hash, group_idx, spec_kind, layers, block_size_tokens,
+n_tokens_valid, tp_rank/tp_world, an explicit per-layer segment table
+(``(layer, kind, offset, length)``; two segments (conv/temporal, with shapes
+and dtypes) per KDA layer when the spec exposes them), the state-ABI tag +
+``num_speculative_tokens`` for mamba groups, boundary_token_index,
+payload_len and payload_crc32 (zlib crc32 — stdlib has no crc32c; the header
+names its algorithm so a crc32c bump is a format-version change, not silent
+corruption). Any field mismatch at read => reject.
+
+The namespace hash (§6) covers model path, vllm version, TP/world, KV dtype,
+tokens_per_hash, blocks_per_chunk, per-eligible-group (group_idx, block size,
+layer count, real per-layer page sizes), the KDA state-ABI descriptor and
+``num_speculative_tokens`` (stage-0 receipt A2: num_spec is baked into the
+conv width), and format_version. Any change forks the directory.
+
+Preconditions enforced by the writer (fail-closed: refuse to write, never
+write garbage; serving unaffected): ``blocks_per_chunk == 1``, a sane
+``parallel.rank``, and the direct (non-canonical) staging layout.
+
+Conventions follow ``overlay/patch_kv_capacity_log.py``: pinned ANCHORs, MARK
+sentinels, ``verified_state``, ``prepare``, idempotent, atomic replace, pyc
+clear, drift => nonzero. ALL anchors in ALL three files preflight before ANY
+write. MUST run AFTER ``patch_kv_offload_scope.py``.
+
+Usage::
+
+    python3 patch_kv_offload_store_local.py              # apply
+    python3 patch_kv_offload_store_local.py --preflight  # validate anchors only
+"""
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+VLLM_ROOT = os.environ.get(
+    "GLM53_VLLM_ROOT", "/usr/local/lib/python3.12/dist-packages/vllm"
+)
+_CONN = "distributed/kv_transfer/kv_connector/v1/offloading"
+
+TARGET_COMMON = Path(
+    os.environ.get("GLM53_KVO_COMMON_PY", f"{VLLM_ROOT}/{_CONN}/common.py")
+)
+TARGET_SCHED = Path(
+    os.environ.get("GLM53_KVO_SCHED_PY", f"{VLLM_ROOT}/{_CONN}/scheduler.py")
+)
+TARGET_WORKER = Path(
+    os.environ.get("GLM53_KVO_WORKER_PY", f"{VLLM_ROOT}/{_CONN}/worker.py")
+)
+
+TAG = "[glm53-kv-offload-store]"
+ENV_ENABLE = "GLM53_KV_OFFLOAD"
+ENV_RESTORE = "GLM53_KV_OFFLOAD_RESTORE"
+ENV_DIR = "GLM53_KV_OFFLOAD_DIR"
+
+MAGIC = b"GLM53KV1"
+FORMAT_VERSION = 1
+STATE_ABI_VERSION = "v0-kda-r13"
+
+
+# ---------------------------------------------------------------------------
+# Shared mode helpers (exec'd for host tests AND injected into three files).
+# ---------------------------------------------------------------------------
+MODE_HELPERS_SRC = '''# [glm53-kv-offload-store] mode helpers -- see overlay/patch_kv_offload_store_local.py
+_GLM53_KVO_STORE_TAG = "[glm53-kv-offload-store]"
+
+
+def _glm53_kvo_bool_env(name: str, default: str) -> bool:
+    """Exactly "0" or "1"; unset means the given default. "" is a value and
+    an error: a typo'd knob must not silently pick a storage mode."""
+    import os as _os
+
+    raw = _os.environ.get(name)
+    if raw is None:
+        raw = default
+    if raw == "0":
+        return False
+    if raw == "1":
+        return True
+    raise ValueError(f"{name} must be exactly 0 or 1 (got: {raw!r})")
+
+
+def _glm53_kvo_store_local_enabled() -> bool:
+    return _glm53_kvo_bool_env("GLM53_KV_OFFLOAD", "0")
+
+
+def _glm53_kvo_restore_enabled() -> bool:
+    return _glm53_kvo_bool_env("GLM53_KV_OFFLOAD_RESTORE", "0")
+
+
+'''
+
+# ---------------------------------------------------------------------------
+# Chunk-header codec + store-meta builder + worker-local writer.
+#
+# One source string, exec'd below into module scope (tests + the GC tool
+# import the codec from THIS overlay module) and injected verbatim into
+# offloading/worker.py; the meta-builder part is also injected into
+# scheduler.py. Stdlib-only imports: the payload gathering uses only tensor
+# methods (`.numpy().tobytes()`), so no torch/numpy import is needed.
+# ---------------------------------------------------------------------------
+CODEC_SRC = '''# [glm53-kv-offload-store] chunk-header codec (format v1)
+import json as _glm53_json
+import struct as _glm53_struct
+import zlib as _glm53_zlib
+
+_GLM53_KVO_MAGIC = b"GLM53KV1"
+_GLM53_KVO_FORMAT_VERSION = 1
+_GLM53_KVO_STATE_ABI = "v0-kda-r13"
+_GLM53_KVO_MAX_HEADER = 1 << 20
+
+
+def glm53_encode_chunk(header: dict, payload: bytes) -> bytes:
+    """Serialize header+payload into the v1 on-disk chunk format."""
+    h = dict(header)
+    h["format_version"] = _GLM53_KVO_FORMAT_VERSION
+    h["crc_algo"] = "crc32-zlib"
+    h["payload_len"] = len(payload)
+    h["payload_crc32"] = _glm53_zlib.crc32(payload) & 0xFFFFFFFF
+    hjson = _glm53_json.dumps(h, sort_keys=True, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    if len(hjson) > _GLM53_KVO_MAX_HEADER:
+        raise ValueError("chunk header too large")
+    hcrc = _glm53_zlib.crc32(hjson) & 0xFFFFFFFF
+    return (
+        _GLM53_KVO_MAGIC
+        + _glm53_struct.pack("<I", len(hjson))
+        + hjson
+        + _glm53_struct.pack("<I", hcrc)
+        + payload
+    )
+
+
+def glm53_read_chunk_header(path: str, verify_payload: bool = False) -> dict:
+    """Read+validate a v1 chunk header; raises ValueError on ANY mismatch.
+
+    With verify_payload=True the payload is read fully and CRC-checked.
+    """
+    with open(path, "rb") as f:
+        magic = f.read(8)
+        if magic != _GLM53_KVO_MAGIC:
+            raise ValueError(f"bad magic in {path!r}")
+        raw_len = f.read(4)
+        if len(raw_len) != 4:
+            raise ValueError(f"truncated header length in {path!r}")
+        (hlen,) = _glm53_struct.unpack("<I", raw_len)
+        if not 0 < hlen <= _GLM53_KVO_MAX_HEADER:
+            raise ValueError(f"implausible header length {hlen} in {path!r}")
+        hjson = f.read(hlen)
+        if len(hjson) != hlen:
+            raise ValueError(f"truncated header in {path!r}")
+        raw_crc = f.read(4)
+        if len(raw_crc) != 4:
+            raise ValueError(f"truncated header crc in {path!r}")
+        (hcrc,) = _glm53_struct.unpack("<I", raw_crc)
+        if (_glm53_zlib.crc32(hjson) & 0xFFFFFFFF) != hcrc:
+            raise ValueError(f"header crc mismatch in {path!r}")
+        try:
+            header = _glm53_json.loads(hjson.decode("utf-8"))
+        except Exception as exc:
+            raise ValueError(f"header not JSON in {path!r}: {exc}") from exc
+        if header.get("format_version") != _GLM53_KVO_FORMAT_VERSION:
+            raise ValueError(
+                f"format_version {header.get('format_version')!r} in {path!r}"
+            )
+        expected = header.get("payload_len")
+        if not isinstance(expected, int) or expected < 0:
+            raise ValueError(f"bad payload_len in {path!r}")
+        if verify_payload:
+            payload = f.read(expected + 1)
+            if len(payload) != expected:
+                raise ValueError(
+                    f"payload length {len(payload)} != {expected} in {path!r}"
+                )
+            if (_glm53_zlib.crc32(payload) & 0xFFFFFFFF) != header.get(
+                "payload_crc32"
+            ):
+                raise ValueError(f"payload crc mismatch in {path!r}")
+        else:
+            import os as _os
+
+            actual = _os.fstat(f.fileno()).st_size - 8 - 4 - hlen - 4
+            if actual != expected:
+                raise ValueError(
+                    f"payload length {actual} != {expected} in {path!r}"
+                )
+    return header
+
+
+'''
+
+META_BUILDER_SRC = '''# [glm53-kv-offload-store] store-meta builder (scheduler side)
+def _glm53_build_store_meta(config, req, entries):
+    """Build the picklable per-job store metadata.
+
+    ``entries`` is the ordered list of (offload_key, group_idx, chunk_idx)
+    aligned 1:1 with the job's src GPU / dst CPU block order. Returns None
+    when store-local mode is off or the job carries nothing.
+    """
+    if not entries or not _glm53_kvo_store_local_enabled():
+        return None
+    from vllm.v1.kv_offload.base import get_offload_block_hash
+
+    cow_groups = [
+        g.group_idx for g in config.kv_group_configs if g.requires_cow_source
+    ]
+    full_groups = [
+        g.group_idx
+        for g in config.kv_group_configs
+        if g.sliding_window_size_in_chunks is None and not g.requires_cow_source
+    ]
+    tokens_per_chunk = {
+        g.group_idx: g.tokens_per_chunk for g in config.kv_group_configs
+    }
+    hashes_per_chunk = {
+        g.group_idx: g.hashes_per_chunk for g in config.kv_group_configs
+    }
+
+    keys = []
+    mamba_chunk_idxs = set()
+    for key, group_idx, chunk_idx in entries:
+        keys.append(
+            (
+                bytes(get_offload_block_hash(key)).hex(),
+                group_idx,
+                chunk_idx,
+                tokens_per_chunk[group_idx],
+            )
+        )
+        if group_idx in cow_groups:
+            mamba_chunk_idxs.add(chunk_idx)
+
+    # Boundary-manifest candidates need one uniform chunk grid across the
+    # eligible groups (true here: every eligible group is block 3584 with
+    # blocks_per_chunk 1). On a non-uniform layout payloads still land;
+    # manifests are skipped (stage-2 lookup then sees no boundaries).
+    manifests = []
+    if (
+        cow_groups
+        and full_groups
+        and len(set(tokens_per_chunk.values())) == 1
+        and len(set(hashes_per_chunk.values())) == 1
+    ):
+        stride = next(iter(hashes_per_chunk.values()))
+        tokens = next(iter(tokens_per_chunk.values()))
+        for k in sorted(mamba_chunk_idxs):
+            if (k + 1) * stride > len(req.block_hashes):
+                continue
+            chunk_hashes = [
+                bytes(req.block_hashes[(j + 1) * stride - 1]).hex()
+                for j in range(k + 1)
+            ]
+            manifests.append(
+                {
+                    "boundary_token_index": (k + 1) * tokens,
+                    "chunk_hashes": chunk_hashes,
+                }
+            )
+    return {
+        "v": 1,
+        "keys": keys,
+        "cow_groups": cow_groups,
+        "full_groups": full_groups,
+        "manifests": manifests,
+    }
+
+
+'''
+
+WRITER_SRC = '''# [glm53-kv-offload-store] worker-local store writer
+import hashlib as _glm53_hashlib
+import queue as _glm53_queue
+import threading as _glm53_threading
+import time as _glm53_time
+
+
+def _glm53_unwrap_kv_spec(spec):
+    specs = getattr(spec, "kv_cache_specs", None)
+    if isinstance(specs, dict) and specs:
+        return next(iter(specs.values()))
+    return spec
+
+
+def _glm53_dtype_itemsize(dtype) -> int | None:
+    itemsize = getattr(dtype, "itemsize", None)
+    if isinstance(itemsize, int):
+        return itemsize
+    name = str(dtype)
+    sizes = {
+        "torch.float32": 4, "torch.float": 4, "torch.bfloat16": 2,
+        "torch.float16": 2, "torch.half": 2, "torch.uint8": 1,
+        "torch.int8": 1, "torch.float8_e4m3fn": 1,
+    }
+    return sizes.get(name)
+
+
+class Glm53LocalStoreWriter:
+    """Per-worker disk writer: real bytes from the local staging mmap to the
+    local NVMe, one headered file per (block hash, group), plus boundary
+    manifests. Fail-closed: any precondition violation disables the writer
+    (jobs still ack; nothing is ever written half-right)."""
+
+    def __init__(self, connector_worker, logger):
+        self._log = logger
+        self._paused_reason = None
+        self._disabled_reason = None
+        self._pending_jobs = {}
+        self._done_queue = _glm53_queue.Queue()
+        self._task_queue = _glm53_queue.Queue()
+        self._threads = []
+        self._lock = _glm53_threading.Lock()
+        self._files_written = 0
+        self._files_dropped = 0
+        # Keys whose write failed THIS boot: a manifest must never reference
+        # them even if a stale file appears on disk later (plan §8).
+        self._failed_keys: set = set()
+        # In-memory manifest index for inline K-boundary retention:
+        # boundary_hash -> {"parent": hash|None, "boundary": int,
+        #                   "mamba_keys": [(hash, gidx)...]}
+        self._manifest_index: dict = {}
+        try:
+            self._init_layout(connector_worker)
+        except Exception as exc:  # noqa: BLE001 - fail closed, keep serving
+            self._disabled_reason = f"{type(exc).__name__}: {exc}"
+            self._log.error(
+                "%s writer DISABLED (store tier inactive, serving unaffected): %s",
+                _GLM53_KVO_STORE_TAG,
+                self._disabled_reason,
+            )
+
+    # ---- layout / namespace -------------------------------------------
+    def _init_layout(self, cw) -> None:
+        import os as _os
+
+        spec = cw.spec
+        worker = cw.worker
+        assert worker is not None, "writer initialised before register_kv_caches"
+        if spec.blocks_per_chunk != 1:
+            raise ValueError(
+                f"store-local requires blocks_per_chunk == 1 "
+                f"(got {spec.blocks_per_chunk})"
+            )
+        handler = worker._store_handler
+        if getattr(handler, "_canonical_copy_plans", None) is not None:
+            raise ValueError("store-local requires the direct staging layout")
+        parallel = spec.config.parallel
+        world = parallel.world_size
+        # Rank routing (plan R0; Codex OFFLOAD1 finding 1): the initialized
+        # TP rank of THIS worker process is authoritative -- NEVER a local
+        # device index (both one-GPU nodes report device 0). The connector
+        # config's parallel.rank must agree; disagreement disables the
+        # writer rather than risking cross-rank mixing.
+        rank = None
+        try:
+            from vllm.distributed.parallel_state import (
+                get_tensor_model_parallel_rank as _glm53_tp_rank,
+            )
+
+            rank = int(_glm53_tp_rank())
+        except Exception:  # noqa: BLE001 - group not initialized: fall back
+            rank = None
+        cfg_rank = parallel.rank
+        if rank is None:
+            rank = cfg_rank
+        elif isinstance(cfg_rank, int) and cfg_rank != rank:
+            raise ValueError(
+                f"TP rank {rank} disagrees with OffloadingParallelConfig.rank "
+                f"{cfg_rank} -- refusing to pick a per-rank directory"
+            )
+        if not (isinstance(rank, int) and 0 <= rank < world):
+            raise ValueError(f"implausible parallel rank {rank!r} of {world!r}")
+        root = _os.environ.get("GLM53_KV_OFFLOAD_DIR")
+        if not root:
+            raise ValueError("GLM53_KV_OFFLOAD_DIR is not set")
+        keep_raw = _os.environ.get("GLM53_KV_OFFLOAD_KEEP_BOUNDARIES", "2")
+        if not keep_raw.isdigit():
+            raise ValueError(
+                "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES must be a non-negative "
+                f"base-10 integer (got: {keep_raw!r})"
+            )
+        self._keep_boundaries = int(keep_raw)
+
+        self._rank = rank
+        self._world = world
+        self._cpu_tensors = handler.dst_tensors
+        self._refs_per_group = handler.layer_refs_per_group
+        kv_groups = cw.kv_cache_config.kv_cache_groups
+        if len(self._refs_per_group) != len(kv_groups):
+            raise ValueError(
+                f"group refs ({len(self._refs_per_group)}) != kv cache groups "
+                f"({len(kv_groups)})"
+            )
+        self._kv_groups = kv_groups
+        vllm_config = cw.vllm_config
+        spec_cfg = getattr(vllm_config, "speculative_config", None)
+        self._num_spec = int(
+            getattr(spec_cfg, "num_speculative_tokens", 0) or 0
+        )
+        import vllm as _vllm
+
+        eligible = []
+        for g in spec.config.groups:
+            refs = self._refs_per_group[g.group_idx]
+            eligible.append(
+                {
+                    "group_idx": g.group_idx,
+                    "tokens_per_block": g.tokens_per_block,
+                    "layers": len(g.layer_names),
+                    "real_page_sizes": [r.page_size_bytes for r in refs],
+                }
+            )
+        self._eligible_groups = {e["group_idx"] for e in eligible}
+        cache_cfg = getattr(vllm_config, "cache_config", None)
+        namespace_fields = {
+            "format_version": _GLM53_KVO_FORMAT_VERSION,
+            "state_abi_version": _GLM53_KVO_STATE_ABI,
+            "model": spec.config.model.name,
+            "kv_dtype": spec.config.model.dtype,
+            "vllm_version": getattr(_vllm, "__version__", "unknown"),
+            # Fork/overlay build identity (operator-pinned; empty = unpinned).
+            "build_id": _os.environ.get("GLM53_KV_OFFLOAD_BUILD_ID", ""),
+            # Prefix-cache hash algo + seed policy fence (plan §6): sha256 is
+            # content-stable; anything else (process-seeded builtin) must fork
+            # the namespace so cross-boot keys can never collide.
+            "prefix_caching_hash_algo": str(
+                getattr(cache_cfg, "prefix_caching_hash_algo", "unknown")
+            ),
+            "tp_size": parallel.tp_size,
+            "world_size": world,
+            "tokens_per_hash": spec.tokens_per_hash,
+            "blocks_per_chunk": spec.blocks_per_chunk,
+            "num_speculative_tokens": self._num_spec,
+            "groups": eligible,
+            "state_abi": self._state_abi_descriptor(),
+        }
+        canonical = _glm53_json.dumps(
+            namespace_fields, sort_keys=True, separators=(",", ":")
+        )
+        self._namespace_hash = _glm53_hashlib.sha256(
+            canonical.encode("utf-8")
+        ).hexdigest()[:12]
+        # keep_boundaries is retention POLICY, not byte semantics: it rides
+        # the on-disk namespace record for operators but must NOT fence the
+        # namespace hash (changing K must not orphan the whole store).
+        namespace_fields["keep_boundaries"] = self._keep_boundaries
+        canonical = _glm53_json.dumps(
+            namespace_fields, sort_keys=True, separators=(",", ":")
+        )
+        safe_model = spec.config.model.name.replace("/", "_")
+        self._base = (
+            f"{root}/glm53kv_{safe_model}_{self._namespace_hash}_r{rank}"
+        )
+        _os.makedirs(self._base, exist_ok=True)
+        ns_path = f"{root}/glm53kv_{safe_model}_{self._namespace_hash}.json"
+        if not _os.path.exists(ns_path):
+            tmp = ns_path + f".tmp.r{rank}.{_os.getpid()}"
+            with open(tmp, "w", encoding="utf-8") as f:
+                f.write(canonical)
+            _os.replace(tmp, ns_path)
+        for _ in range(2):
+            t = _glm53_threading.Thread(
+                target=self._writer_loop,
+                name="glm53-kv-offload-store",
+                daemon=True,
+            )
+            t.start()
+            self._threads.append(t)
+        self._log.info(
+            "%s writer up: rank %d/%d base=%s eligible=%s",
+            _GLM53_KVO_STORE_TAG,
+            rank,
+            world,
+            self._base,
+            sorted(self._eligible_groups),
+        )
+
+    def _state_abi_descriptor(self):
+        abi = {}
+        for gidx, group in enumerate(self._kv_groups):
+            inner = _glm53_unwrap_kv_spec(group.kv_cache_spec)
+            if type(inner).__name__ != "MambaSpec":
+                continue
+            shapes = getattr(inner, "shapes", None)
+            dtypes = getattr(inner, "dtypes", None)
+            abi[str(gidx)] = {
+                "shapes": [list(s) for s in shapes] if shapes else None,
+                "dtypes": [str(d) for d in dtypes] if dtypes else None,
+                "num_spec": self._num_spec,
+            }
+        return abi
+
+    # ---- job intake ----------------------------------------------------
+    def submit_job(self, job_id: int, meta: dict, dst_block_ids) -> bool:
+        """Queue a completed-DMA store job for disk writing. Returns True when
+        the ack must be deferred until the writes finish."""
+        if self._disabled_reason is not None:
+            return False
+        keys = meta.get("keys") or []
+        rows = [int(b) for b in dst_block_ids]
+        if len(keys) != len(rows):
+            self._log.error(
+                "%s job %d: %d keys vs %d dst blocks -- dropping write "
+                "(lost store only)",
+                _GLM53_KVO_STORE_TAG,
+                job_id,
+                len(keys),
+                len(rows),
+            )
+            return False
+        job = {
+            "job_id": job_id,
+            "meta": meta,
+            "remaining": len(keys),
+            "written": [],
+        }
+        with self._lock:
+            self._pending_jobs[job_id] = job
+        for (hash_hex, group_idx, chunk_idx, n_tokens), row in zip(keys, rows):
+            self._task_queue.put(
+                (job, hash_hex, int(group_idx), int(chunk_idx), int(n_tokens), row)
+            )
+        if not keys:
+            self._finish_job(job)
+        return True
+
+    def drain_done(self):
+        done = []
+        while True:
+            try:
+                done.append(self._done_queue.get_nowait())
+            except _glm53_queue.Empty:
+                return done
+
+    def shutdown(self, timeout: float = 30.0) -> None:
+        deadline = _glm53_time.monotonic() + timeout
+        while _glm53_time.monotonic() < deadline:
+            with self._lock:
+                if not self._pending_jobs:
+                    return
+            _glm53_time.sleep(0.05)
+
+    # ---- write path ----------------------------------------------------
+    def _file_path(self, hash_hex: str, group_idx: int) -> str:
+        return (
+            f"{self._base}/{hash_hex[:3]}/{hash_hex[3:5]}_g{group_idx}"
+            f"/{hash_hex}.bin"
+        )
+
+    def _manifest_path(self, boundary_hash: str) -> str:
+        return f"{self._base}/manifests/{boundary_hash[:3]}/{boundary_hash}.json"
+
+    def _writer_loop(self) -> None:
+        while True:
+            job, hash_hex, group_idx, chunk_idx, n_tokens, row = (
+                self._task_queue.get()
+            )
+            try:
+                self._write_one(job, hash_hex, group_idx, chunk_idx, n_tokens, row)
+            except Exception as exc:  # noqa: BLE001 - lost store only
+                self._on_write_error(hash_hex, group_idx, exc)
+            finally:
+                with self._lock:
+                    job["remaining"] -= 1
+                    finished = job["remaining"] <= 0
+                if finished:
+                    self._finish_job(job)
+
+    def _on_write_error(self, hash_hex, group_idx, exc) -> None:
+        import errno as _errno
+
+        self._files_dropped += 1
+        with self._lock:
+            self._failed_keys.add((hash_hex, group_idx))
+        if isinstance(exc, OSError) and exc.errno == _errno.ENOSPC:
+            if self._paused_reason is None:
+                self._paused_reason = "ENOSPC"
+                self._log.error(
+                    "%s store tier PAUSED (ENOSPC): all further writes are "
+                    "dropped; serving unaffected",
+                    _GLM53_KVO_STORE_TAG,
+                )
+            return
+        self._log.warning(
+            "%s write failed for %s g%d (lost store only): %s: %s",
+            _GLM53_KVO_STORE_TAG,
+            hash_hex[:12],
+            group_idx,
+            type(exc).__name__,
+            exc,
+        )
+
+    def _write_one(self, job, hash_hex, group_idx, chunk_idx, n_tokens, row):
+        import os as _os
+
+        if self._paused_reason is not None or self._disabled_reason is not None:
+            self._files_dropped += 1
+            return
+        if group_idx not in self._eligible_groups:
+            raise ValueError(f"ineligible group {group_idx} reached the writer")
+        path = self._file_path(hash_hex, group_idx)
+        if _os.path.exists(path):
+            _os.utime(path)  # dedup refresh, mtime stays meaningful
+            with self._lock:
+                job["written"].append((hash_hex, group_idx))
+            return
+
+        refs = self._refs_per_group[group_idx]
+        group = self._kv_groups[group_idx]
+        layer_names = list(group.layer_names)
+        segments = []
+        parts = []
+        offset = 0
+        for i, ref in enumerate(refs):
+            tensor = self._cpu_tensors[ref.tensor_idx]
+            chunk = tensor[row, : ref.page_size_bytes]
+            parts.append(chunk.numpy().tobytes())
+            layer = layer_names[i] if i < len(layer_names) else f"ref{i}"
+            segments.extend(
+                self._layer_segments(group, layer, offset, ref.page_size_bytes)
+            )
+            offset += ref.page_size_bytes
+        payload = b"".join(parts)
+
+        inner = _glm53_unwrap_kv_spec(group.kv_cache_spec)
+        header = {
+            "namespace_hash": self._namespace_hash,
+            "group_idx": group_idx,
+            "spec_kind": type(inner).__name__,
+            "layers": len(refs),
+            "block_size_tokens": getattr(inner, "block_size", None),
+            "n_tokens_valid": n_tokens,
+            "boundary_token_index": (chunk_idx + 1) * n_tokens,
+            "tp_rank": self._rank,
+            "tp_world": self._world,
+            "segment_table": segments,
+            "hash": hash_hex,
+        }
+        if type(inner).__name__ == "MambaSpec":
+            header["state_abi_version"] = _GLM53_KVO_STATE_ABI
+            header["num_speculative_tokens"] = self._num_spec
+        blob = glm53_encode_chunk(header, payload)
+
+        _os.makedirs(_os.path.dirname(path), exist_ok=True)
+        tmp = f"{path}.tmp.r{self._rank}.{_os.getpid()}"
+        try:
+            with open(tmp, "wb") as f:
+                f.write(blob)
+                f.flush()
+                _os.fsync(f.fileno())
+            _os.replace(tmp, path)
+            dfd = _os.open(_os.path.dirname(path), _os.O_RDONLY)
+            try:
+                _os.fsync(dfd)
+            finally:
+                _os.close(dfd)
+        except BaseException:
+            try:
+                _os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+        self._files_written += 1
+        with self._lock:
+            job["written"].append((hash_hex, group_idx))
+
+    def _layer_segments(self, group, layer, offset, length):
+        inner = _glm53_unwrap_kv_spec(group.kv_cache_spec)
+        if type(inner).__name__ == "MambaSpec":
+            shapes = getattr(inner, "shapes", None)
+            dtypes = getattr(inner, "dtypes", None)
+            if shapes and dtypes and len(shapes) == len(dtypes):
+                sizes = []
+                for shape, dtype in zip(shapes, dtypes):
+                    n = 1
+                    for d in shape:
+                        n *= int(d)
+                    itemsize = _glm53_dtype_itemsize(dtype)
+                    if itemsize is None:
+                        sizes = None
+                        break
+                    sizes.append((list(shape), str(dtype), n * itemsize))
+                if sizes is not None and sum(s[2] for s in sizes) == length:
+                    segs = []
+                    kinds = ("conv_state", "temporal_state")
+                    run = offset
+                    for i, (shape, dtype, size) in enumerate(sizes):
+                        # Row-major contiguous element strides, DERIVED (not
+                        # observed live -- stage-0 receipt R13 caveat rides
+                        # in "stride_provenance" so a reader cannot mistake
+                        # them for a measured layout).
+                        strides = []
+                        acc = 1
+                        for d in reversed(shape):
+                            strides.append(acc)
+                            acc *= int(d)
+                        strides.reverse()
+                        segs.append(
+                            {
+                                "layer": layer,
+                                "kind": kinds[i] if i < 2 else f"state{i}",
+                                "shape": shape,
+                                "dtype": dtype,
+                                "stride": strides,
+                                "stride_provenance": "derived-contiguous",
+                                "offset": run,
+                                "length": size,
+                            }
+                        )
+                        run += size
+                    return segs
+        return [
+            {
+                "layer": layer,
+                "kind": "raw",
+                "shape": [length],
+                "dtype": "uint8",
+                "stride": [1],
+                "stride_provenance": "derived-contiguous",
+                "offset": offset,
+                "length": length,
+            }
+        ]
+
+    # ---- manifests ------------------------------------------------------
+    def _finish_job(self, job) -> None:
+        try:
+            if self._paused_reason is None and self._disabled_reason is None:
+                self._publish_manifests(job["meta"])
+        except Exception as exc:  # noqa: BLE001 - manifests are best-effort
+            self._log.warning(
+                "%s manifest publish failed (boundary stays invisible): %s: %s",
+                _GLM53_KVO_STORE_TAG,
+                type(exc).__name__,
+                exc,
+            )
+        finally:
+            with self._lock:
+                self._pending_jobs.pop(job["job_id"], None)
+            self._done_queue.put(job["job_id"])
+
+    def _publish_manifests(self, meta) -> None:
+        import os as _os
+
+        cow_groups = meta.get("cow_groups") or []
+        full_groups = meta.get("full_groups") or []
+        for cand in meta.get("manifests") or []:
+            chunk_hashes = cand["chunk_hashes"]
+            boundary_hash = chunk_hashes[-1]
+            mpath = self._manifest_path(boundary_hash)
+            if _os.path.exists(mpath):
+                self._register_manifest(cand, cow_groups)
+                continue
+            # A key that failed to write THIS boot must never be referenced,
+            # even if a stale on-disk file would pass the header check.
+            with self._lock:
+                failed = set(self._failed_keys)
+            groups_entry = {}
+            complete = True
+            for gidx in cow_groups:
+                if (boundary_hash, gidx) in failed:
+                    complete = False
+                    break
+                fpath = self._file_path(boundary_hash, gidx)
+                try:
+                    fheader = glm53_read_chunk_header(fpath)
+                except (OSError, ValueError):
+                    complete = False
+                    break
+                groups_entry[str(gidx)] = {
+                    "hash": boundary_hash,
+                    "payload_len": fheader["payload_len"],
+                    "payload_crc32": fheader["payload_crc32"],
+                }
+            if not complete:
+                continue
+            for gidx in full_groups:
+                for h in chunk_hashes:
+                    if (h, gidx) in failed or not _os.path.exists(
+                        self._file_path(h, gidx)
+                    ):
+                        complete = False
+                        break
+                if not complete:
+                    break
+            if not complete:
+                continue
+            manifest = {
+                "format_version": _GLM53_KVO_FORMAT_VERSION,
+                "namespace_hash": self._namespace_hash,
+                "boundary_token_index": cand["boundary_token_index"],
+                "chunk_hashes": chunk_hashes,
+                "cow_groups": groups_entry,
+                "full_groups": {str(g): len(chunk_hashes) for g in full_groups},
+                "rank": self._rank,
+                "created_at": _glm53_time.time(),
+            }
+            _os.makedirs(_os.path.dirname(mpath), exist_ok=True)
+            tmp = f"{mpath}.tmp.r{self._rank}.{_os.getpid()}"
+            try:
+                with open(tmp, "w", encoding="utf-8") as f:
+                    _glm53_json.dump(manifest, f, sort_keys=True)
+                    f.flush()
+                    _os.fsync(f.fileno())
+                _os.replace(tmp, mpath)
+                dfd = _os.open(_os.path.dirname(mpath), _os.O_RDONLY)
+                try:
+                    _os.fsync(dfd)
+                finally:
+                    _os.close(dfd)
+            except BaseException:
+                try:
+                    _os.unlink(tmp)
+                except OSError:
+                    pass
+                raise
+            self._register_manifest(cand, cow_groups)
+            self._apply_retention()
+
+    # ---- inline K-boundary retention (plan §7; Codex OFFLOAD1 finding 4) --
+    def _register_manifest(self, cand, cow_groups) -> None:
+        chunk_hashes = cand["chunk_hashes"]
+        boundary_hash = chunk_hashes[-1]
+        with self._lock:
+            self._manifest_index[boundary_hash] = {
+                "parent": chunk_hashes[-2] if len(chunk_hashes) > 1 else None,
+                "boundary": cand["boundary_token_index"],
+                "mamba_keys": [(boundary_hash, g) for g in cow_groups],
+            }
+
+    def _apply_retention(self) -> None:
+        """Supersede manifests beyond the K most recent boundaries of EVERY
+        chain containing them (chains = parent-linked manifest chains; a
+        shared divergence-point boundary survives while any chain keeps it).
+        Only manifests published/observed this boot are considered; cross-boot
+        leftovers belong to the GC tool. Mamba payloads of a superseded
+        boundary are unlinked; full-attention chunks stay dense (plan §7)."""
+        import os as _os
+
+        if self._keep_boundaries <= 0:
+            return
+        with self._lock:
+            index = {k: dict(v) for k, v in self._manifest_index.items()}
+        if not index:
+            return
+        parents = {h: v["parent"] for h, v in index.items()}
+        child_count = {h: 0 for h in index}
+        for h, p in parents.items():
+            if p in child_count:
+                child_count[p] += 1
+        leaves = [h for h, c in child_count.items() if c == 0]
+        keep: set = set()
+        for leaf in leaves:
+            node, kept = leaf, 0
+            while node is not None and kept < self._keep_boundaries:
+                if node in index:
+                    keep.add(node)
+                    kept += 1
+                node = parents.get(node)
+        drop = [h for h in index if h not in keep]
+        for boundary_hash in drop:
+            entry = index[boundary_hash]
+            mpath = self._manifest_path(boundary_hash)
+            try:
+                _os.unlink(mpath)
+            except OSError:
+                pass
+            for hash_hex, gidx in entry["mamba_keys"]:
+                try:
+                    _os.unlink(self._file_path(hash_hex, gidx))
+                except OSError:
+                    pass
+            with self._lock:
+                self._manifest_index.pop(boundary_hash, None)
+            self._log.info(
+                "%s superseded boundary %d (%s) under keep_boundaries=%d",
+                _GLM53_KVO_STORE_TAG,
+                entry["boundary"],
+                boundary_hash[:12],
+                self._keep_boundaries,
+            )
+
+
+def _glm53_get_store_writer(connector_worker):
+    writer = connector_worker._glm53_store_writer
+    if writer is None:
+        writer = Glm53LocalStoreWriter(connector_worker, logger)
+        connector_worker._glm53_store_writer = writer
+    return writer
+
+
+def _glm53_drain_finished_disk_writes(connector_worker) -> None:
+    writer = connector_worker._glm53_store_writer
+    if writer is None:
+        return
+    for job_id in writer.drain_done():
+        connector_worker._connector_worker_meta.mark_completed(job_id)
+
+
+def _glm53_intercept_store_completion(connector_worker, job_id: int) -> bool:
+    """Route a DMA-complete store job into the local disk writer. Returns True
+    when the ack is deferred until the disk write finishes."""
+    captured = connector_worker._glm53_job_meta.pop(job_id, None)
+    if captured is None:
+        return False
+    meta, dst_spec = captured
+    try:
+        writer = _glm53_get_store_writer(connector_worker)
+        return writer.submit_job(job_id, meta, dst_spec.block_ids)
+    except Exception as exc:  # noqa: BLE001 - never block serving on the tier
+        logger.error(
+            "%s store interception failed (job acked, store lost): %s: %s",
+            _GLM53_KVO_STORE_TAG,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+
+'''
+
+
+def load_helpers() -> dict:
+    """Exec the shared sources into a namespace (host tests + GC tool)."""
+    ns: dict = {}
+    src = MODE_HELPERS_SRC + CODEC_SRC + META_BUILDER_SRC
+    exec(compile(src, "<glm53-kv-offload-store helpers>", "exec"), ns)
+    return ns
+
+
+_HELPERS = load_helpers()
+kvo_store_local_enabled = _HELPERS["_glm53_kvo_store_local_enabled"]
+kvo_restore_enabled = _HELPERS["_glm53_kvo_restore_enabled"]
+encode_chunk = _HELPERS["glm53_encode_chunk"]
+read_chunk_header = _HELPERS["glm53_read_chunk_header"]
+build_store_meta = _HELPERS["_glm53_build_store_meta"]
+
+
+def load_writer_helpers(logger) -> dict:
+    """Exec the FULL injected worker source with a host-supplied logger."""
+    ns: dict = {"logger": logger}
+    src = MODE_HELPERS_SRC + CODEC_SRC + WRITER_SRC
+    exec(compile(src, "<glm53-kv-offload-store writer>", "exec"), ns)
+    return ns
+
+
+# ===========================================================================
+# File 1: offloading/common.py — TransferJob.glm53_store_meta
+# ===========================================================================
+MARK_C1 = "    # [glm53-kv-offload-store] optional store-side metadata\n"
+
+ANCHOR_C1 = """    req_id: ReqId
+    src_spec: LoadStoreSpec
+    dst_spec: LoadStoreSpec
+"""
+
+PATCHED_C1 = """    req_id: ReqId
+    src_spec: LoadStoreSpec
+    dst_spec: LoadStoreSpec
+    # [glm53-kv-offload-store] optional store-side metadata
+    # (keys/manifests for the worker-local disk writer; None for loads and
+    # when GLM53_KV_OFFLOAD store-local mode is off). Plain dict: picklable
+    # across the scheduler->worker metadata channel.
+    glm53_store_meta: object | None = None
+"""
+
+SITES_COMMON = (("TransferJob.glm53_store_meta", MARK_C1, ANCHOR_C1, PATCHED_C1),)
+
+
+# ===========================================================================
+# File 2: offloading/scheduler.py (anchored on the SCOPE-patched text)
+# ===========================================================================
+MARK_L1 = "# [glm53-kv-offload-store] mode helpers -- see overlay/patch_kv_offload_store_local.py\n"
+
+ANCHOR_L1 = """def get_sliding_window_size_in_chunks(
+"""
+
+PATCHED_L1 = MODE_HELPERS_SRC + META_BUILDER_SRC + ANCHOR_L1
+
+MARK_L2 = "        if request.skip_reading_prefix_cache or not _glm53_kvo_restore_enabled():  # [glm53-kv-offload-store]\n"
+
+ANCHOR_L2 = """        num_hit_tokens: int | None
+        if request.skip_reading_prefix_cache:
+            num_hit_tokens = 0
+        else:
+"""
+
+PATCHED_L2 = """        num_hit_tokens: int | None
+        if request.skip_reading_prefix_cache or not _glm53_kvo_restore_enabled():  # [glm53-kv-offload-store]
+            # Store-only stage 1: never report external hits, so no loads,
+            # no promotions and no WAITING_FOR_REMOTE_KVS can occur. Stores
+            # (below in build_connector_meta) are unaffected.
+            num_hit_tokens = 0
+        else:
+"""
+
+# L3 anchors on scope-patched S17 output.
+MARK_L3 = "            _glm53_store_meta_entries: list = []  # [glm53-kv-offload-store]\n"
+
+ANCHOR_L3 = """            group_sizes = [0] * self.config.num_kv_cache_groups  # [glm53-kv-offload-scope]
+            block_indices = [0] * self.config.num_kv_cache_groups
+"""
+
+PATCHED_L3 = """            group_sizes = [0] * self.config.num_kv_cache_groups  # [glm53-kv-offload-scope]
+            block_indices = [0] * self.config.num_kv_cache_groups
+            _glm53_store_meta_entries: list = []  # [glm53-kv-offload-store]
+"""
+
+MARK_L4 = "                        _glm53_store_meta_entries.append(  # [glm53-kv-offload-store]\n"
+
+ANCHOR_L4 = """                        if start_gpu_block_idx is None:
+                            start_gpu_block_idx = gpu_block_idx + i
+                        src_block_ids.append(block_id)
+                        num_group_blocks += 1
+"""
+
+PATCHED_L4 = """                        if start_gpu_block_idx is None:
+                            start_gpu_block_idx = gpu_block_idx + i
+                        src_block_ids.append(block_id)
+                        _glm53_store_meta_entries.append(  # [glm53-kv-offload-store]
+                            (offload_key, group_config.group_idx, chunk_idx)
+                        )
+                        num_group_blocks += 1
+"""
+
+MARK_L5 = "                glm53_store_meta=_glm53_build_store_meta(  # [glm53-kv-offload-store]\n"
+
+ANCHOR_L5 = """            store_jobs[job_id] = TransferJob(
+                req_id=req_id, src_spec=src_spec, dst_spec=dst_spec
+            )
+"""
+
+PATCHED_L5 = """            store_jobs[job_id] = TransferJob(
+                req_id=req_id,
+                src_spec=src_spec,
+                dst_spec=dst_spec,
+                glm53_store_meta=_glm53_build_store_meta(  # [glm53-kv-offload-store]
+                    self.config, req, _glm53_store_meta_entries
+                ),
+            )
+"""
+
+SITES_SCHED = (
+    ("L1 scheduler helpers", MARK_L1, ANCHOR_L1, PATCHED_L1),
+    ("L2 restore-off short-circuit", MARK_L2, ANCHOR_L2, PATCHED_L2),
+    ("L3 store-meta list init", MARK_L3, ANCHOR_L3, PATCHED_L3),
+    ("L4 store-meta entry append", MARK_L4, ANCHOR_L4, PATCHED_L4),
+    ("L5 TransferJob store meta", MARK_L5, ANCHOR_L5, PATCHED_L5),
+)
+
+
+# ===========================================================================
+# File 3: offloading/worker.py — capture, delay acks, write locally
+# ===========================================================================
+MARK_W1 = "# [glm53-kv-offload-store] worker-local store writer\n"
+
+ANCHOR_W1 = """class OffloadingConnectorWorker:
+"""
+
+PATCHED_W1 = MODE_HELPERS_SRC + CODEC_SRC + WRITER_SRC + ANCHOR_W1
+
+MARK_W2 = "        self._glm53_store_writer = None  # [glm53-kv-offload-store] lazy\n"
+
+ANCHOR_W2 = """        self._unsubmitted_store_jobs: list[
+            tuple[int, GPULoadStoreSpec, LoadStoreSpec]
+        ] = []
+        self._connector_worker_meta = OffloadingWorkerMetadata()
+"""
+
+PATCHED_W2 = """        self._unsubmitted_store_jobs: list[
+            tuple[int, GPULoadStoreSpec, LoadStoreSpec]
+        ] = []
+        self._connector_worker_meta = OffloadingWorkerMetadata()
+        self._glm53_store_writer = None  # [glm53-kv-offload-store] lazy
+        self._glm53_job_meta: dict[int, tuple] = {}
+"""
+
+MARK_W3 = "                    _glm53_meta = getattr(entry, \"glm53_store_meta\", None)  # [glm53-kv-offload-store] flush path\n"
+
+ANCHOR_W3 = """                entry = kv_connector_metadata.store_jobs.pop(job_id, None)
+                if entry is not None:
+                    if not self._is_store_writer:
+                        self._connector_worker_meta.mark_completed(job_id)
+                        continue
+                    assert isinstance(entry.src_spec, GPULoadStoreSpec)
+"""
+
+PATCHED_W3 = """                entry = kv_connector_metadata.store_jobs.pop(job_id, None)
+                if entry is not None:
+                    if not self._is_store_writer:
+                        self._connector_worker_meta.mark_completed(job_id)
+                        continue
+                    _glm53_meta = getattr(entry, \"glm53_store_meta\", None)  # [glm53-kv-offload-store] flush path
+                    if _glm53_meta is not None:
+                        self._glm53_job_meta[job_id] = (_glm53_meta, entry.dst_spec)
+                    assert isinstance(entry.src_spec, GPULoadStoreSpec)
+"""
+
+MARK_W4 = "            _glm53_meta = getattr(entry, \"glm53_store_meta\", None)  # [glm53-kv-offload-store]\n"
+
+ANCHOR_W4 = """        for job_id, entry in metadata.store_jobs.items():
+            if not self._is_store_writer:
+                # Gate before queueing: no _unsubmitted_store_jobs entry.
+                self._connector_worker_meta.mark_completed(job_id)
+                continue
+"""
+
+PATCHED_W4 = """        for job_id, entry in metadata.store_jobs.items():
+            if not self._is_store_writer:
+                # Gate before queueing: no _unsubmitted_store_jobs entry.
+                self._connector_worker_meta.mark_completed(job_id)
+                continue
+            _glm53_meta = getattr(entry, \"glm53_store_meta\", None)  # [glm53-kv-offload-store]
+            if _glm53_meta is not None:
+                self._glm53_job_meta[job_id] = (_glm53_meta, entry.dst_spec)
+"""
+
+MARK_W5 = "        _glm53_drain_finished_disk_writes(self)  # [glm53-kv-offload-store]\n"
+
+ANCHOR_W5 = """        assert self.worker is not None
+        finished_recving: set[str] = set()
+        for transfer_result in self.worker.get_finished():
+"""
+
+PATCHED_W5 = """        assert self.worker is not None
+        finished_recving: set[str] = set()
+        _glm53_drain_finished_disk_writes(self)  # [glm53-kv-offload-store]
+        for transfer_result in self.worker.get_finished():
+"""
+
+MARK_W5B = "            if _glm53_intercept_store_completion(self, job_id):  # [glm53-kv-offload-store]\n"
+
+ANCHOR_W5B = """            self._connector_worker_meta.mark_completed(job_id)
+            req_id = self._load_jobs.pop(job_id, None)
+"""
+
+PATCHED_W5B = """            if _glm53_intercept_store_completion(self, job_id):  # [glm53-kv-offload-store]
+                # DMA done; the ack is deferred until this rank's disk write
+                # finishes (staging stays pinned by the store protocol, so
+                # the bytes cannot be evicted under the writer).
+                continue
+            self._connector_worker_meta.mark_completed(job_id)
+            req_id = self._load_jobs.pop(job_id, None)
+"""
+
+MARK_W6 = "        if self._glm53_store_writer is not None:  # [glm53-kv-offload-store]\n"
+
+ANCHOR_W6 = """    def shutdown(self) -> None:
+        self._unsubmitted_store_jobs.clear()
+"""
+
+PATCHED_W6 = """    def shutdown(self) -> None:
+        if self._glm53_store_writer is not None:  # [glm53-kv-offload-store]
+            self._glm53_store_writer.shutdown()
+        self._unsubmitted_store_jobs.clear()
+"""
+
+SITES_WORKER = (
+    ("W1 writer classes", MARK_W1, ANCHOR_W1, PATCHED_W1),
+    ("W2 worker state", MARK_W2, ANCHOR_W2, PATCHED_W2),
+    ("W3 flush-path meta capture", MARK_W3, ANCHOR_W3, PATCHED_W3),
+    ("W4 store meta capture", MARK_W4, ANCHOR_W4, PATCHED_W4),
+    ("W5 drain finished writes", MARK_W5, ANCHOR_W5, PATCHED_W5),
+    ("W5B intercept completion", MARK_W5B, ANCHOR_W5B, PATCHED_W5B),
+    ("W6 shutdown drain", MARK_W6, ANCHOR_W6, PATCHED_W6),
+)
+
+
+TARGETS = (
+    ("offloading/common.py", TARGET_COMMON, SITES_COMMON),
+    ("offloading/scheduler.py", TARGET_SCHED, SITES_SCHED),
+    ("offloading/worker.py", TARGET_WORKER, SITES_WORKER),
+)
+
+# The scheduler anchors L3/L5 pin patch_kv_offload_scope.py output; refuse to
+# run against an unscoped tree with a clear message instead of anchor drift.
+SCOPE_MARK = "[glm53-kv-offload-scope]"
+
+
+def verified_state(text: str, sites) -> bool:
+    return all(
+        text.count(mark) == 1
+        and text.count(patched) == 1
+        and text.count(anchor) == patched.count(anchor)
+        for _name, mark, anchor, patched in sites
+    )
+
+
+def prepare(source: str, sites, label: str) -> tuple[str, str]:
+    marks = sum(source.count(mark) for _n, mark, _a, _p in sites)
+    if marks:
+        # Marks-only already-present check (same rationale as the scope
+        # patcher: a later overlay may edit inside patched regions; full
+        # verification is enforced on this patcher's own output below).
+        if marks != len(sites) or any(
+            source.count(mark) != 1 for _n, mark, _a, _p in sites
+        ):
+            raise ValueError(
+                f"partial/inconsistent kv-offload-store patch in {label} "
+                f"(marks={marks}, expected {len(sites)}) -- refusing to touch "
+                "a half-patched file"
+            )
+        return source, "already present"
+    for name, _mark, anchor, _patched in sites:
+        n = source.count(anchor)
+        if n != 1:
+            raise ValueError(
+                f"pinned kv-offload-store anchor '{name}' drifted in {label} "
+                f"(found {n}, expected 1)"
+            )
+    out = source
+    for _name, _mark, anchor, patched in sites:
+        out = out.replace(anchor, patched, 1)
+    if not verified_state(out, sites):
+        raise ValueError(f"kv-offload-store post-patch verification failed in {label}")
+    return out, "patched"
+
+
+def replace_file(target: Path, source: str) -> None:
+    tmp = target.with_name(f".{target.name}.glm53-kv-offload-store.tmp")
+    try:
+        tmp.write_text(source)
+        os.chmod(tmp, stat.S_IMODE(target.stat().st_mode))
+        os.replace(tmp, target)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def clear_pyc(target: Path) -> None:
+    cache = target.parent / "__pycache__"
+    if not cache.is_dir():
+        return
+    for pyc in cache.glob(f"{target.stem}*.pyc"):
+        pyc.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv if argv is None else argv
+    preflight_only = "--preflight" in argv[1:]
+
+    sched_source = TARGET_SCHED.read_text() if TARGET_SCHED.is_file() else ""
+    if SCOPE_MARK not in sched_source:
+        raise SystemExit(
+            "kv-offload-store preflight failed: scheduler.py is not "
+            "scope-patched -- run patch_kv_offload_scope.py first "
+            "(GLM53_OVERLAY_ORDER pins this)"
+        )
+
+    prepared: list[tuple[Path, str, str, str]] = []
+    for label, target, sites in TARGETS:
+        if not target.is_file():
+            raise SystemExit(f"missing {target}")
+        source = target.read_text()
+        try:
+            patched, action = prepare(source, sites, label)
+        except ValueError as exc:
+            raise SystemExit(f"kv-offload-store preflight failed: {exc}") from exc
+        compile(patched, str(target), "exec")
+        prepared.append((target, source, patched, action))
+        if preflight_only:
+            print(f"{target.name}: kv-offload-store preflight OK ({action})")
+
+    if preflight_only:
+        return 0
+
+    for target, source, patched, action in prepared:
+        if patched != source:
+            replace_file(target, patched)
+            clear_pyc(target)
+    print(
+        f"kv-offload-store {prepared[0][3]} "
+        f"({ENV_ENABLE}={os.environ.get(ENV_ENABLE, '0 (unset)')!r})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/overlay/patch_kv_offload_store_local.py
+++ b/overlay/patch_kv_offload_store_local.py
@@ -539,13 +539,20 @@ class Glm53LocalStoreWriter:
         self._namespace_hash = _glm53_hashlib.sha256(
             canonical.encode("utf-8")
         ).hexdigest()[:12]
-        # keep_boundaries is retention POLICY, not byte semantics: it rides
-        # the on-disk namespace record for operators but must NOT fence the
-        # namespace hash (changing K must not orphan the whole store).
-        namespace_fields["keep_boundaries"] = self._keep_boundaries
-        namespace_fields["rank_source"] = rank_source
-        canonical = _glm53_json.dumps(
-            namespace_fields, sort_keys=True, separators=(",", ":")
+        # The on-disk record separates the FENCED fields (exact-compared and
+        # hashed) from informational ones: retention K and rank provenance are
+        # policy/diagnostics, not byte semantics -- changing them must neither
+        # fork the namespace nor disable the writer on the next boot.
+        record = _glm53_json.dumps(
+            {
+                "fenced": namespace_fields,
+                "info": {
+                    "keep_boundaries": self._keep_boundaries,
+                    "rank_source": rank_source,
+                },
+            },
+            sort_keys=True,
+            separators=(",", ":"),
         )
         safe_model = spec.config.model.name.replace("/", "_")
         self._base = (
@@ -554,12 +561,21 @@ class Glm53LocalStoreWriter:
         _os.makedirs(self._base, exist_ok=True)
         ns_path = f"{root}/glm53kv_{safe_model}_{self._namespace_hash}.json"
         if _os.path.exists(ns_path):
-            with open(ns_path, encoding="utf-8") as f:
-                existing = f.read()
-            if existing != canonical:
-                # Same 12-hex namespace, different canonical record: either a
-                # truncated write or a hash collision -- both disqualify the
-                # store (fail closed rather than mixing semantics).
+            # Compare the FENCED portion only (info fields may legitimately
+            # differ across boots). An unparseable or mismatched record is a
+            # truncated write or hash collision: fail closed.
+            try:
+                with open(ns_path, encoding="utf-8") as f:
+                    existing = _glm53_json.load(f)
+                existing_fenced = _glm53_json.dumps(
+                    existing["fenced"], sort_keys=True, separators=(",", ":")
+                )
+            except (OSError, ValueError, KeyError, TypeError) as exc:
+                raise ValueError(
+                    f"namespace record unreadable at {ns_path} ({exc}) -- "
+                    "refusing to write into an unverifiable store"
+                ) from exc
+            if existing_fenced != canonical:
                 raise ValueError(
                     f"namespace record mismatch at {ns_path} -- refusing to "
                     "write into a store whose recorded config differs"
@@ -567,7 +583,7 @@ class Glm53LocalStoreWriter:
         else:
             tmp = ns_path + f".tmp.r{rank}.{_os.getpid()}"
             with open(tmp, "w", encoding="utf-8") as f:
-                f.write(canonical)
+                f.write(record)
                 f.flush()
                 _os.fsync(f.fileno())
             _os.replace(tmp, ns_path)

--- a/overlay/patch_kv_offload_store_local.py
+++ b/overlay/patch_kv_offload_store_local.py
@@ -44,16 +44,19 @@ manifest-aggregating lookup replaces it on the read side.
 3. ``offloading/worker.py`` — the worker-local writer:
    - store-job metadata is captured per job (both the ``prepare_store_kv``
      and the ``handle_preemptions`` flush path);
-   - when a store job's GPU->CPU DMA completes, the job is NOT acked to the
-     scheduler yet; a small writer pool (2 threads) writes one file per
-     (block-hash, group): real (unpadded) bytes only, gathered from the
-     worker's own CPU staging tensors via the same CanonicalKVCacheRef layout
-     the DMA used, with a §4 chunk header (format v1: magic, versioned JSON
-     header with namespace hash, ORIGINAL group index, per-layer segment
-     table incl. the KDA conv/temporal split, payload CRC, header CRC);
-   - the job is acked only after its writes finish — staging blocks stay
-     pinned by the store protocol until every worker acks, so the bytes
-     cannot be evicted or rewritten under the disk writer;
+   - when a store job's GPU->CPU DMA completes, the job's bytes are
+     SNAPSHOTTED synchronously out of the staging mmap (capture-then-write;
+     Codex OFFLOAD1-REVIEW finding 1) — at get_finished before this rank's
+     ack (rows pinned until complete_store) or right after worker.wait() on
+     the flush/reset path, before any new DMA can reuse the rows: staging
+     reuse after reset_cache()/preemption/shutdown can never tear a payload.
+     A small writer pool (2 threads) then writes one file per (block-hash,
+     group) from PRIVATE buffers (budget-capped, drop-over-budget = lost
+     store): real (unpadded) bytes only, via the same CanonicalKVCacheRef
+     layout the DMA used, with a §4 chunk header (format v1: magic,
+     versioned JSON header with namespace hash, ORIGINAL group index,
+     per-layer segment table incl. the KDA conv/temporal split, payload
+     CRC, header CRC); acks are never deferred;
    - after a job's payloads are durable (write+fsync+rename+parent-dir
      fsync, unique pid-suffixed temp names), boundary manifests are
      published (existence-verified cumulative references, tmp+rename with
@@ -397,6 +400,7 @@ class Glm53LocalStoreWriter:
         self._lock = _glm53_threading.Lock()
         self._files_written = 0
         self._files_dropped = 0
+        self._outstanding_bytes = 0
         # Keys whose write failed THIS boot: a manifest must never reference
         # them even if a stale file appears on disk later (plan §8).
         self._failed_keys: set = set()
@@ -437,14 +441,23 @@ class Glm53LocalStoreWriter:
         # config's parallel.rank must agree; disagreement disables the
         # writer rather than risking cross-rank mixing.
         rank = None
+        rank_source = "tp-group"
         try:
             from vllm.distributed.parallel_state import (
                 get_tensor_model_parallel_rank as _glm53_tp_rank,
             )
 
             rank = int(_glm53_tp_rank())
-        except Exception:  # noqa: BLE001 - group not initialized: fall back
+        except Exception as exc:  # noqa: BLE001 - group not initialized
             rank = None
+            rank_source = f"config-fallback ({type(exc).__name__})"
+            self._log.warning(
+                "%s TP rank unavailable (%s); falling back to "
+                "OffloadingParallelConfig.rank -- the two-node R0 receipt is "
+                "the live check for this path",
+                _GLM53_KVO_STORE_TAG,
+                exc,
+            )
         cfg_rank = parallel.rank
         if rank is None:
             rank = cfg_rank
@@ -467,6 +480,7 @@ class Glm53LocalStoreWriter:
         self._keep_boundaries = int(keep_raw)
 
         self._rank = rank
+        self._rank_source = rank_source
         self._world = world
         self._cpu_tensors = handler.dst_tensors
         self._refs_per_group = handler.layer_refs_per_group
@@ -529,6 +543,7 @@ class Glm53LocalStoreWriter:
         # the on-disk namespace record for operators but must NOT fence the
         # namespace hash (changing K must not orphan the whole store).
         namespace_fields["keep_boundaries"] = self._keep_boundaries
+        namespace_fields["rank_source"] = rank_source
         canonical = _glm53_json.dumps(
             namespace_fields, sort_keys=True, separators=(",", ":")
         )
@@ -538,10 +553,23 @@ class Glm53LocalStoreWriter:
         )
         _os.makedirs(self._base, exist_ok=True)
         ns_path = f"{root}/glm53kv_{safe_model}_{self._namespace_hash}.json"
-        if not _os.path.exists(ns_path):
+        if _os.path.exists(ns_path):
+            with open(ns_path, encoding="utf-8") as f:
+                existing = f.read()
+            if existing != canonical:
+                # Same 12-hex namespace, different canonical record: either a
+                # truncated write or a hash collision -- both disqualify the
+                # store (fail closed rather than mixing semantics).
+                raise ValueError(
+                    f"namespace record mismatch at {ns_path} -- refusing to "
+                    "write into a store whose recorded config differs"
+                )
+        else:
             tmp = ns_path + f".tmp.r{rank}.{_os.getpid()}"
             with open(tmp, "w", encoding="utf-8") as f:
                 f.write(canonical)
+                f.flush()
+                _os.fsync(f.fileno())
             _os.replace(tmp, ns_path)
         for _ in range(2):
             t = _glm53_threading.Thread(
@@ -576,11 +604,27 @@ class Glm53LocalStoreWriter:
         return abi
 
     # ---- job intake ----------------------------------------------------
-    def submit_job(self, job_id: int, meta: dict, dst_block_ids) -> bool:
-        """Queue a completed-DMA store job for disk writing. Returns True when
-        the ack must be deferred until the writes finish."""
+    # CAPTURE-THEN-WRITE (Codex OFFLOAD1-REVIEW finding 1, BLOCKER): payload
+    # bytes are SNAPSHOTTED OUT of the staging mmap synchronously at capture
+    # time -- while the job's rows are still guaranteed live (normal path:
+    # before this rank's ack, rows pinned until complete_store; flush/reset
+    # path: immediately after worker.wait(), before any new DMA is submitted).
+    # The async writer threads then work on private buffers only, so staging
+    # reuse after reset_cache(), preemption fencing, or shutdown/mmap cleanup
+    # can never tear a payload. Bounded by _BUFFER_BUDGET (drop-oldest-style:
+    # new captures over budget are dropped as lost stores, plan §7).
+    _BUFFER_BUDGET_BYTES = 512 * 1024 * 1024
+
+    def capture_job(self, job_id: int, meta: dict, dst_block_ids) -> None:
+        """Snapshot a completed-DMA store job's bytes and queue disk writes.
+
+        Synchronous copy, asynchronous write. Idempotent per job_id. Never
+        defers the job's ack: correctness no longer depends on ack timing."""
         if self._disabled_reason is not None:
-            return False
+            return
+        with self._lock:
+            if job_id in self._pending_jobs:
+                return
         keys = meta.get("keys") or []
         rows = [int(b) for b in dst_block_ids]
         if len(keys) != len(rows):
@@ -592,22 +636,60 @@ class Glm53LocalStoreWriter:
                 len(keys),
                 len(rows),
             )
-            return False
+            return
         job = {
             "job_id": job_id,
             "meta": meta,
-            "remaining": len(keys),
+            "remaining": 0,
             "written": [],
         }
+        tasks = []
+        for (hash_hex, group_idx, chunk_idx, n_tokens), row in zip(keys, rows):
+            group_idx = int(group_idx)
+            if self._paused_reason is not None:
+                self._files_dropped += 1
+                continue
+            try:
+                if group_idx not in self._eligible_groups:
+                    raise ValueError(
+                        f"ineligible group {group_idx} reached the writer"
+                    )
+                payload, segments = self._gather_payload(group_idx, row)
+            except Exception as exc:  # noqa: BLE001 - lost store only
+                self._on_write_error(hash_hex, group_idx, exc)
+                continue
+            with self._lock:
+                if (
+                    self._outstanding_bytes + len(payload)
+                    > self._BUFFER_BUDGET_BYTES
+                ):
+                    over_budget = True
+                else:
+                    over_budget = False
+                    self._outstanding_bytes += len(payload)
+            if over_budget:
+                # Lost store, not a failure: the key may be re-stored later
+                # and stays manifest-eligible if a durable file appears.
+                self._files_dropped += 1
+                continue
+            tasks.append(
+                (
+                    job,
+                    hash_hex,
+                    group_idx,
+                    int(chunk_idx),
+                    int(n_tokens),
+                    payload,
+                    segments,
+                )
+            )
+        job["remaining"] = len(tasks)
         with self._lock:
             self._pending_jobs[job_id] = job
-        for (hash_hex, group_idx, chunk_idx, n_tokens), row in zip(keys, rows):
-            self._task_queue.put(
-                (job, hash_hex, int(group_idx), int(chunk_idx), int(n_tokens), row)
-            )
-        if not keys:
+        for task in tasks:
+            self._task_queue.put(task)
+        if not tasks:
             self._finish_job(job)
-        return True
 
     def drain_done(self):
         done = []
@@ -637,15 +719,18 @@ class Glm53LocalStoreWriter:
 
     def _writer_loop(self) -> None:
         while True:
-            job, hash_hex, group_idx, chunk_idx, n_tokens, row = (
+            job, hash_hex, group_idx, chunk_idx, n_tokens, payload, segments = (
                 self._task_queue.get()
             )
             try:
-                self._write_one(job, hash_hex, group_idx, chunk_idx, n_tokens, row)
+                self._write_one(
+                    job, hash_hex, group_idx, chunk_idx, n_tokens, payload, segments
+                )
             except Exception as exc:  # noqa: BLE001 - lost store only
                 self._on_write_error(hash_hex, group_idx, exc)
             finally:
                 with self._lock:
+                    self._outstanding_bytes -= len(payload)
                     job["remaining"] -= 1
                     finished = job["remaining"] <= 0
                 if finished:
@@ -675,21 +760,10 @@ class Glm53LocalStoreWriter:
             exc,
         )
 
-    def _write_one(self, job, hash_hex, group_idx, chunk_idx, n_tokens, row):
-        import os as _os
-
-        if self._paused_reason is not None or self._disabled_reason is not None:
-            self._files_dropped += 1
-            return
-        if group_idx not in self._eligible_groups:
-            raise ValueError(f"ineligible group {group_idx} reached the writer")
-        path = self._file_path(hash_hex, group_idx)
-        if _os.path.exists(path):
-            _os.utime(path)  # dedup refresh, mtime stays meaningful
-            with self._lock:
-                job["written"].append((hash_hex, group_idx))
-            return
-
+    def _gather_payload(self, group_idx: int, row: int):
+        """Copy one (group, staging-row) chunk OUT of the mmap: real bytes
+        per CanonicalKVCacheRef, in group layer order. Runs synchronously at
+        capture time (rows guaranteed live); returns (payload, segments)."""
         refs = self._refs_per_group[group_idx]
         group = self._kv_groups[group_idx]
         layer_names = list(group.layer_names)
@@ -705,8 +779,50 @@ class Glm53LocalStoreWriter:
                 self._layer_segments(group, layer, offset, ref.page_size_bytes)
             )
             offset += ref.page_size_bytes
-        payload = b"".join(parts)
+        return b"".join(parts), segments
 
+    def _write_one(
+        self, job, hash_hex, group_idx, chunk_idx, n_tokens, payload, segments
+    ):
+        import os as _os
+
+        if self._paused_reason is not None or self._disabled_reason is not None:
+            self._files_dropped += 1
+            return
+        path = self._file_path(hash_hex, group_idx)
+        if _os.path.exists(path):
+            # Dedup ONLY when the existing file verifies as ours (header
+            # identity: namespace + hash + group). A corrupt or foreign file
+            # under our name is unlinked and rewritten (Codex OFFLOAD1-REVIEW
+            # finding 3: existence alone must not certify).
+            try:
+                h = glm53_read_chunk_header(path)
+                if (
+                    h.get("namespace_hash") == self._namespace_hash
+                    and h.get("hash") == hash_hex
+                    and h.get("group_idx") == group_idx
+                ):
+                    _os.utime(path)  # dedup refresh, mtime stays meaningful
+                    with self._lock:
+                        job["written"].append((hash_hex, group_idx))
+                    return
+                raise ValueError("header identity mismatch")
+            except (OSError, ValueError) as exc:
+                self._log.warning(
+                    "%s existing chunk %s g%d failed verification (%s) -- "
+                    "rewriting",
+                    _GLM53_KVO_STORE_TAG,
+                    hash_hex[:12],
+                    group_idx,
+                    exc,
+                )
+                try:
+                    _os.unlink(path)
+                except OSError:
+                    pass
+
+        group = self._kv_groups[group_idx]
+        refs = self._refs_per_group[group_idx]
         inner = _glm53_unwrap_kv_spec(group.kv_cache_spec)
         header = {
             "namespace_hash": self._namespace_hash,
@@ -727,7 +843,10 @@ class Glm53LocalStoreWriter:
         blob = glm53_encode_chunk(header, payload)
 
         _os.makedirs(_os.path.dirname(path), exist_ok=True)
-        tmp = f"{path}.tmp.r{self._rank}.{_os.getpid()}"
+        tmp = (
+            f"{path}.tmp.r{self._rank}.{_os.getpid()}"
+            f".{_glm53_threading.get_ident()}"
+        )
         try:
             with open(tmp, "wb") as f:
                 f.write(blob)
@@ -852,6 +971,13 @@ class Glm53LocalStoreWriter:
                 except (OSError, ValueError):
                     complete = False
                     break
+                if (
+                    fheader.get("namespace_hash") != self._namespace_hash
+                    or fheader.get("hash") != boundary_hash
+                    or fheader.get("group_idx") != gidx
+                ):
+                    complete = False
+                    break
                 groups_entry[str(gidx)] = {
                     "hash": boundary_hash,
                     "payload_len": fheader["payload_len"],
@@ -859,15 +985,29 @@ class Glm53LocalStoreWriter:
                 }
             if not complete:
                 continue
+            full_entry = {}
             for gidx in full_groups:
+                chunks = []
                 for h in chunk_hashes:
-                    if (h, gidx) in failed or not _os.path.exists(
-                        self._file_path(h, gidx)
+                    if (h, gidx) in failed:
+                        complete = False
+                        break
+                    try:
+                        fh = glm53_read_chunk_header(self._file_path(h, gidx))
+                    except (OSError, ValueError):
+                        complete = False
+                        break
+                    if (
+                        fh.get("namespace_hash") != self._namespace_hash
+                        or fh.get("hash") != h
+                        or fh.get("group_idx") != gidx
                     ):
                         complete = False
                         break
+                    chunks.append([h, fh["payload_len"], fh["payload_crc32"]])
                 if not complete:
                     break
+                full_entry[str(gidx)] = chunks
             if not complete:
                 continue
             manifest = {
@@ -876,12 +1016,17 @@ class Glm53LocalStoreWriter:
                 "boundary_token_index": cand["boundary_token_index"],
                 "chunk_hashes": chunk_hashes,
                 "cow_groups": groups_entry,
-                "full_groups": {str(g): len(chunk_hashes) for g in full_groups},
+                # Per-chunk [hash, payload_len, payload_crc32], cumulative
+                # 0..boundary (plan §4: hashes + sizes + crcs per group).
+                "full_groups": full_entry,
                 "rank": self._rank,
                 "created_at": _glm53_time.time(),
             }
             _os.makedirs(_os.path.dirname(mpath), exist_ok=True)
-            tmp = f"{mpath}.tmp.r{self._rank}.{_os.getpid()}"
+            tmp = (
+                f"{mpath}.tmp.r{self._rank}.{_os.getpid()}"
+                f".{_glm53_threading.get_ident()}"
+            )
             try:
                 with open(tmp, "w", encoding="utf-8") as f:
                     _glm53_json.dump(manifest, f, sort_keys=True)
@@ -974,32 +1119,33 @@ def _glm53_get_store_writer(connector_worker):
     return writer
 
 
-def _glm53_drain_finished_disk_writes(connector_worker) -> None:
-    writer = connector_worker._glm53_store_writer
-    if writer is None:
-        return
-    for job_id in writer.drain_done():
-        connector_worker._connector_worker_meta.mark_completed(job_id)
+def _glm53_capture_store_job(connector_worker, job_id: int) -> None:
+    """Snapshot a DMA-complete store job's bytes out of the staging mmap.
 
-
-def _glm53_intercept_store_completion(connector_worker, job_id: int) -> bool:
-    """Route a DMA-complete store job into the local disk writer. Returns True
-    when the ack is deferred until the disk write finishes."""
+    Called at the two points where the job's rows are guaranteed still live:
+    get_finished (before this rank's ack -- staging pinned until
+    complete_store) and immediately after worker.wait() on the flush/reset
+    path (before any new DMA can reuse the rows). Never defers the ack; the
+    disk write proceeds on private buffers."""
     captured = connector_worker._glm53_job_meta.pop(job_id, None)
     if captured is None:
-        return False
+        return
     meta, dst_spec = captured
     try:
         writer = _glm53_get_store_writer(connector_worker)
-        return writer.submit_job(job_id, meta, dst_spec.block_ids)
+        writer.capture_job(job_id, meta, dst_spec.block_ids)
     except Exception as exc:  # noqa: BLE001 - never block serving on the tier
         logger.error(
-            "%s store interception failed (job acked, store lost): %s: %s",
+            "%s store capture failed (store lost, serving unaffected): %s: %s",
             _GLM53_KVO_STORE_TAG,
             type(exc).__name__,
             exc,
         )
-        return False
+
+
+def _glm53_capture_flushed_store_jobs(connector_worker, job_ids) -> None:
+    for job_id in list(job_ids or ()):
+        _glm53_capture_store_job(connector_worker, job_id)
 
 
 '''
@@ -1200,32 +1346,31 @@ PATCHED_W4 = """        for job_id, entry in metadata.store_jobs.items():
                 self._glm53_job_meta[job_id] = (_glm53_meta, entry.dst_spec)
 """
 
-MARK_W5 = "        _glm53_drain_finished_disk_writes(self)  # [glm53-kv-offload-store]\n"
-
-ANCHOR_W5 = """        assert self.worker is not None
-        finished_recving: set[str] = set()
-        for transfer_result in self.worker.get_finished():
-"""
-
-PATCHED_W5 = """        assert self.worker is not None
-        finished_recving: set[str] = set()
-        _glm53_drain_finished_disk_writes(self)  # [glm53-kv-offload-store]
-        for transfer_result in self.worker.get_finished():
-"""
-
-MARK_W5B = "            if _glm53_intercept_store_completion(self, job_id):  # [glm53-kv-offload-store]\n"
+MARK_W5B = "            _glm53_capture_store_job(self, job_id)  # [glm53-kv-offload-store]\n"
 
 ANCHOR_W5B = """            self._connector_worker_meta.mark_completed(job_id)
             req_id = self._load_jobs.pop(job_id, None)
 """
 
-PATCHED_W5B = """            if _glm53_intercept_store_completion(self, job_id):  # [glm53-kv-offload-store]
-                # DMA done; the ack is deferred until this rank's disk write
-                # finishes (staging stays pinned by the store protocol, so
-                # the bytes cannot be evicted under the writer).
-                continue
+PATCHED_W5B = """            _glm53_capture_store_job(self, job_id)  # [glm53-kv-offload-store]
             self._connector_worker_meta.mark_completed(job_id)
             req_id = self._load_jobs.pop(job_id, None)
+"""
+
+# Flush/reset path: reset_cache() frees ALL staging rows and the very next
+# step may DMA new stores into them -- capture the flushed jobs' bytes
+# synchronously right after their DMA wait, before returning to the step.
+MARK_W5C = "            _glm53_capture_flushed_store_jobs(  # [glm53-kv-offload-store]\n"
+
+ANCHOR_W5C = """        if kv_connector_metadata.jobs_to_flush:
+            self.worker.wait(kv_connector_metadata.jobs_to_flush)
+"""
+
+PATCHED_W5C = """        if kv_connector_metadata.jobs_to_flush:
+            self.worker.wait(kv_connector_metadata.jobs_to_flush)
+            _glm53_capture_flushed_store_jobs(  # [glm53-kv-offload-store]
+                self, kv_connector_metadata.jobs_to_flush
+            )
 """
 
 MARK_W6 = "        if self._glm53_store_writer is not None:  # [glm53-kv-offload-store]\n"
@@ -1245,8 +1390,8 @@ SITES_WORKER = (
     ("W2 worker state", MARK_W2, ANCHOR_W2, PATCHED_W2),
     ("W3 flush-path meta capture", MARK_W3, ANCHOR_W3, PATCHED_W3),
     ("W4 store meta capture", MARK_W4, ANCHOR_W4, PATCHED_W4),
-    ("W5 drain finished writes", MARK_W5, ANCHOR_W5, PATCHED_W5),
-    ("W5B intercept completion", MARK_W5B, ANCHOR_W5B, PATCHED_W5B),
+    ("W5B capture at completion", MARK_W5B, ANCHOR_W5B, PATCHED_W5B),
+    ("W5C capture at flush", MARK_W5C, ANCHOR_W5C, PATCHED_W5C),
     ("W6 shutdown drain", MARK_W6, ANCHOR_W6, PATCHED_W6),
 )
 
@@ -1323,6 +1468,21 @@ def clear_pyc(target: Path) -> None:
 def main(argv: list[str] | None = None) -> int:
     argv = sys.argv if argv is None else argv
     preflight_only = "--preflight" in argv[1:]
+
+    if "--check-injected" in argv[1:]:
+        # Host-side gate mode: compile every injected source standalone (no
+        # target access) so a truncated/corrupted string literal inside this
+        # file fails BEFORE the launcher stops a healthy pair.
+        for name, src in (
+            ("mode helpers", MODE_HELPERS_SRC),
+            ("codec", CODEC_SRC),
+            ("meta builder", META_BUILDER_SRC),
+            ("writer", WRITER_SRC),
+        ):
+            compile(src, f"<glm53-kv-offload-store {name}>", "exec")
+        load_helpers()
+        print("patch_kv_offload_store_local.py: injected sources compile OK")
+        return 0
 
     sched_source = TARGET_SCHED.read_text() if TARGET_SCHED.is_file() else ""
     if SCOPE_MARK not in sched_source:

--- a/start.sh
+++ b/start.sh
@@ -73,11 +73,26 @@ _cli_ablit_direction="${ABLIT_DIRECTION-}"
 _cli_ablit_layers="${ABLIT_LAYERS-}"
 _cli_ablit_alpha="${ABLIT_ALPHA-}"
 _cli_ablit_mtp="${ABLIT_INCLUDE_MTP-}"
+_cli_kvoffload_set="${GLM53_KV_OFFLOAD+1}"
+_cli_kvoffload="${GLM53_KV_OFFLOAD-}"
+_cli_kvoffload_dir_set="${GLM53_KV_OFFLOAD_DIR+1}"
+_cli_kvoffload_dir="${GLM53_KV_OFFLOAD_DIR-}"
+_cli_kvoffload_cpu_set="${GLM53_KV_OFFLOAD_CPU_GB+1}"
+_cli_kvoffload_cpu="${GLM53_KV_OFFLOAD_CPU_GB-}"
+_cli_kvoffload_restore_set="${GLM53_KV_OFFLOAD_RESTORE+1}"
+_cli_kvoffload_restore="${GLM53_KV_OFFLOAD_RESTORE-}"
+_cli_kvoffload_drafter_set="${GLM53_KV_OFFLOAD_DRAFTER+1}"
+_cli_kvoffload_drafter="${GLM53_KV_OFFLOAD_DRAFTER-}"
 set -a
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/.env"
 set +a
 [ -n "${_cli_mtp}" ] && MTP_TOKENS="$_cli_mtp"
+[ -n "${_cli_kvoffload_set}" ] && GLM53_KV_OFFLOAD="$_cli_kvoffload"
+[ -n "${_cli_kvoffload_dir_set}" ] && GLM53_KV_OFFLOAD_DIR="$_cli_kvoffload_dir"
+[ -n "${_cli_kvoffload_cpu_set}" ] && GLM53_KV_OFFLOAD_CPU_GB="$_cli_kvoffload_cpu"
+[ -n "${_cli_kvoffload_restore_set}" ] && GLM53_KV_OFFLOAD_RESTORE="$_cli_kvoffload_restore"
+[ -n "${_cli_kvoffload_drafter_set}" ] && GLM53_KV_OFFLOAD_DRAFTER="$_cli_kvoffload_drafter"
 [ -n "${_cli_spec}" ] && SPEC_METHOD="$_cli_spec"
 [ -n "${_cli_eager}" ] && ENFORCE_EAGER="$_cli_eager"
 [ -n "${_cli_fused}" ] && EXL3_FUSED_MOE="$_cli_fused"
@@ -173,6 +188,8 @@ STOP_PATCH_HOST="${STOP_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_suppress_stops_in_
 SCHED_PATCH_HOST="${SCHED_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_scheduler_decode_floor.py}"
 DRAFTER_PATCH_HOST="${DRAFTER_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm5_drafter_group.py}"
 APC_PATCH_HOST="${APC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_hybrid_prefix_hit.py}"
+KVOFFLOAD_SCOPE_PATCH_HOST="${KVOFFLOAD_SCOPE_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kv_offload_scope.py}"
+KVOFFLOAD_STORE_PATCH_HOST="${KVOFFLOAD_STORE_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kv_offload_store_local.py}"
 XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_xgrammar_termination.py}"
 KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kpool_tail_slotmap.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
@@ -227,6 +244,29 @@ GLM53_SUPPRESS_STOPS_IN_REASONING="${GLM53_SUPPRESS_STOPS_IN_REASONING:-1}"
 # Mixed-step prefill policy when a peer is already decoding (issue #6).
 # skip = do not mix; N>0 = cap tokens; 0 = off.
 GLM53_MIXED_PREFILL_CHUNK="${GLM53_MIXED_PREFILL_CHUNK:-skip}"
+# --- disk KV-offload store tier (stage 1: store-only) -----------------------
+# 1 = enable the OffloadingConnector (CPU staging + worker-local per-rank disk
+# writes under overlay patch_kv_offload_scope.py + patch_kv_offload_store_local.py).
+# 0 (default) = OFF: no --kv-transfer-config, no store mount — serving is
+# byte-identical to a build without the tier. Exactly 0 or 1.
+GLM53_KV_OFFLOAD="${GLM53_KV_OFFLOAD-0}"
+# Host directory for the store (local NVMe on EACH Spark; same path on both;
+# per-rank namespaced subdirs are created by the writer). Mounted rw at
+# $GLM53_KV_OFFLOAD_DIR_CTR in both containers when the knob is 1.
+GLM53_KV_OFFLOAD_DIR="${GLM53_KV_OFFLOAD_DIR:-$HOME/glm53-kv-offload}"
+GLM53_KV_OFFLOAD_DIR_CTR="/data/glm53-kv-offload"
+# CPU staging bounce-buffer size in GiB (cpu_bytes_to_use). Staging only —
+# never a capacity tier (plan non-goal); 4 GiB ≈ 15 aligned boundaries.
+GLM53_KV_OFFLOAD_CPU_GB="${GLM53_KV_OFFLOAD_CPU_GB:-4}"
+# Stage-1 hard rule: restore stays OFF. The launcher REFUSES 1 (stage 2
+# flips this default after the restore plumbing lands + receipts).
+GLM53_KV_OFFLOAD_RESTORE="${GLM53_KV_OFFLOAD_RESTORE-0}"
+# 1 = include the DFlash2 drafter group in the offload eligible set
+# (stage-4 experiment); 0 (default) = policy-excluded (plan §3.2).
+GLM53_KV_OFFLOAD_DRAFTER="${GLM53_KV_OFFLOAD_DRAFTER-0}"
+# Inline manifest retention: keep the K most recent boundary manifests per
+# chain (plan §7; 0 = dense, no inline supersede).
+GLM53_KV_OFFLOAD_KEEP_BOUNDARIES="${GLM53_KV_OFFLOAD_KEEP_BOUNDARIES:-2}"
 # EngineCore stock timeout is 300s; mid-serve Triton/TileLang JIT on TP=2 can
 # exceed that without being a true hang. NCCL watchdog is still 600s.
 VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS="${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-1800}"
@@ -291,6 +331,19 @@ _glm53_canonical_positive_int() {
     export "$name"
 }
 
+# Kill switches are exactly 0 or 1. Not "non-empty means on", not `[ "$v" = 0 ]`
+# with everything else treated as on: a typo'd knob must not silently pick a
+# serving/storage mode. The overlays re-validate in-container
+# (_glm53_kvo_bool_env), so catching it here turns a container boot failure
+# into a launcher error with the healthy pair left serving.
+_glm53_validate_bool_flag() {
+    local name="$1" value="$2"
+    if [ "$value" != 0 ] && [ "$value" != 1 ]; then
+        echo "$name must be exactly 0 or 1 (got: $value)" >&2
+        return 2
+    fi
+}
+
 validate_numeric_config() {
     if ! [[ "$GPU_MEM_UTIL" =~ ^(0([.][0-9]+)?|[.][0-9]+|1([.]0+)?)$ ]] \
        || ! awk -v u="$GPU_MEM_UTIL" 'BEGIN { exit !(u > 0 && u <= 1) }'; then
@@ -300,8 +353,87 @@ validate_numeric_config() {
     _glm53_canonical_positive_int MAX_MODEL_LEN "$MAX_MODEL_LEN" 1000000 || return
     _glm53_canonical_positive_int MAX_NUM_SEQS "$MAX_NUM_SEQS" 4096 || return
     _glm53_canonical_positive_int MAX_NUM_BATCHED_TOKENS "$MAX_NUM_BATCHED_TOKENS" 8388608 || return
+    _glm53_validate_bool_flag GLM53_KV_OFFLOAD "${GLM53_KV_OFFLOAD-0}" || return
+    _glm53_validate_bool_flag GLM53_KV_OFFLOAD_RESTORE "${GLM53_KV_OFFLOAD_RESTORE-0}" || return
+    _glm53_validate_bool_flag GLM53_KV_OFFLOAD_DRAFTER "${GLM53_KV_OFFLOAD_DRAFTER-0}" || return
+    # Stage-1 hard rule: the restore path is not built yet; refusing here is
+    # fail-closed (the flag exists so stage 2 flips exactly one default).
+    if [ "${GLM53_KV_OFFLOAD_RESTORE-0}" = 1 ]; then
+        echo "GLM53_KV_OFFLOAD_RESTORE=1 is refused: stage 1 is store-only (restore lands in stage 2)" >&2
+        return 2
+    fi
+    if [ "${GLM53_KV_OFFLOAD-0}" = 1 ]; then
+        _glm53_canonical_positive_int GLM53_KV_OFFLOAD_CPU_GB "${GLM53_KV_OFFLOAD_CPU_GB-}" 64 || return
+        if ! [[ "${GLM53_KV_OFFLOAD_KEEP_BOUNDARIES-}" =~ ^[0-9]+$ ]] \
+           || [ "${GLM53_KV_OFFLOAD_KEEP_BOUNDARIES-}" -gt 1024 ]; then
+            echo "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES must be an integer 0..1024 (got: ${GLM53_KV_OFFLOAD_KEEP_BOUNDARIES-})" >&2
+            return 2
+        fi
+        case "${GLM53_KV_OFFLOAD_DIR-}" in
+            /*) ;;
+            *)
+                echo "GLM53_KV_OFFLOAD_DIR must be an absolute path (got: ${GLM53_KV_OFFLOAD_DIR-})" >&2
+                return 2
+                ;;
+        esac
+        case "${GLM53_KV_OFFLOAD_DIR-}" in
+            *"'"*|*'"'*|*[$' \t\n']*)
+                echo "GLM53_KV_OFFLOAD_DIR must not contain quotes or whitespace (got: $GLM53_KV_OFFLOAD_DIR)" >&2
+                return 2
+                ;;
+        esac
+    fi
 }
 # GLM53 numeric config guard (end)
+
+# GLM53 kv-offload artifact guard (begin)
+# The two kv-offload overlays + the GC tool, validated BEFORE `restart` stops
+# anything: a missing, empty, mis-pointed, truncated or syntactically broken
+# artifact is a launcher error with the healthy pair left serving, not a
+# container that dies at boot after the old one is gone. Identity string +
+# exact last non-blank line + ast.parse, per artifact (same technique as the
+# overlay artifact guard on the capacity-log branch; scoped to this PR's
+# artifacts so the two guards merge cleanly).
+validate_kv_offload_artifacts() {
+    local main_guard='    sys.exit(main())'
+    local gc_guard='    sys.exit(main())'
+    local -a artifacts=(
+        "$KVOFFLOAD_SCOPE_PATCH_HOST|[glm53-kv-offload-scope]|$main_guard"
+        "$KVOFFLOAD_STORE_PATCH_HOST|[glm53-kv-offload-store]|$main_guard"
+        "$SCRIPT_DIR/overlay/kv_offload_store_gc.py|glm53kv_<model>_<ns>_r<rank>|$gc_guard"
+    )
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "python3 is required on the head to verify kv-offload artifacts before launch" >&2
+        return 2
+    fi
+    local entry path rest tag tail last
+    for entry in "${artifacts[@]}"; do
+        path="${entry%%|*}"
+        rest="${entry#*|}"
+        tag="${rest%%|*}"
+        tail="${rest#*|}"
+        if [ ! -f "$path" ] || [ ! -r "$path" ] || [ ! -s "$path" ]; then
+            echo "kv-offload artifact missing, unreadable or empty: $path" >&2
+            return 2
+        fi
+        if ! grep -qF -- "$tag" "$path"; then
+            echo "kv-offload artifact $path does not carry its identity string '$tag' (wrong file?)" >&2
+            return 2
+        fi
+        # `|| true`: under pipefail a whitespace-only file makes grep exit 1,
+        # which must surface as the rc=2 diagnostic below, not a bare exit 1.
+        last="$(grep -v '^[[:space:]]*$' "$path" | tail -n 1 || true)"
+        if [ "$last" != "$tail" ]; then
+            echo "kv-offload artifact $path does not end with '$tail' (truncated copy? last line: '$last')" >&2
+            return 2
+        fi
+        if ! python3 -c 'import ast, sys; ast.parse(open(sys.argv[1], encoding="utf-8").read(), sys.argv[1])' "$path" 2>/dev/null; then
+            echo "kv-offload artifact does not parse as Python: $path" >&2
+            return 2
+        fi
+    done
+}
+# GLM53 kv-offload artifact guard (end)
 
 banner() {
     local label="${1:-start.sh}"
@@ -435,6 +567,8 @@ preflight() {
     [ -f "$SCHED_PATCH_HOST" ] || die "$SCHED_PATCH_HOST missing"
     [ -f "$DRAFTER_PATCH_HOST" ] || die "$DRAFTER_PATCH_HOST missing"
     [ -f "$APC_PATCH_HOST" ] || die "$APC_PATCH_HOST missing"
+    [ -f "$KVOFFLOAD_SCOPE_PATCH_HOST" ] || die "$KVOFFLOAD_SCOPE_PATCH_HOST missing"
+    [ -f "$KVOFFLOAD_STORE_PATCH_HOST" ] || die "$KVOFFLOAD_STORE_PATCH_HOST missing"
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "$XGRAMMAR_PATCH_HOST missing"
     [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "$KPOOL_TAIL_PATCH_HOST missing"
     [ -f "$SCRIPT_DIR/overlay/patch_ablit.py" ] || die "$SCRIPT_DIR/overlay/patch_ablit.py missing"
@@ -822,6 +956,43 @@ sync_weights() {
 }
 
 # ------------------------ inner container scripts --------------------------
+# Overlay application order inside BOTH rank containers. write_inner_scripts
+# emits this one list verbatim into the head and the worker inner script, so
+# the two ranks cannot drift apart. Pinned segments:
+#   - the prefix-cache overlays share the kv_cache_coordinator.py helper
+#     insert point: patch_hybrid_prefix_hit -> patch_apc_per_group_retention
+#     -> patch_apc_fine_grained_hits (per-group = PR #83, fine-grained =
+#     PR #84 — [ -f ]-guarded no-ops unless those branches' artifacts are
+#     mounted);
+#   - the kv-offload pair is order-dependent: patch_kv_offload_scope MUST
+#     precede patch_kv_offload_store_local (the store overlay anchors on the
+#     scope overlay's scheduler output and refuses an unscoped tree).
+# Entries that are not mounted are skipped in-container (`[ -f ]`); which ones
+# MUST exist is decided by the artifact guards above, not here.
+GLM53_OVERLAY_ORDER=(
+    patch_glm_video_placeholders.py
+    patch_suppress_stops_in_reasoning.py
+    patch_scheduler_decode_floor.py
+    patch_glm5_drafter_group.py
+    patch_hybrid_prefix_hit.py
+    patch_apc_per_group_retention.py
+    patch_apc_fine_grained_hits.py
+    patch_kv_offload_scope.py
+    patch_kv_offload_store_local.py
+    patch_xgrammar_termination.py
+    patch_kpool_tail_slotmap.py
+    patch_ablit.py
+)
+
+# Emits the in-container apply block for GLM53_OVERLAY_ORDER (same bytes for
+# both ranks).
+emit_overlay_block() {
+    local p
+    for p in "${GLM53_OVERLAY_ORDER[@]}"; do
+        printf 'if [ -f /opt/glm53/%s ]; then\n    python3 /opt/glm53/%s\nfi\n' "$p" "$p"
+    done
+}
+
 write_inner_scripts() {
     cat > "$HEAD_SCRIPT" <<'EOF'
 #!/bin/bash
@@ -851,6 +1022,16 @@ ARGS=(
 [ -n "${MAX_NUM_SEQS:-}" ] && ARGS+=(--max-num-seqs "${MAX_NUM_SEQS}")
 [ -n "${MAX_NUM_BATCHED_TOKENS:-}" ] && ARGS+=(--max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}")
 [ -n "${KV_CACHE_DTYPE:-}" ] && ARGS+=(--kv-cache-dtype "${KV_CACHE_DTYPE}")
+if [ "${GLM53_KV_OFFLOAD:-0}" = "1" ]; then
+    # Stage-1 store tier: CPU staging only (TieringOffloadingSpec, NO
+    # secondary tiers -- the worker-local writer in
+    # patch_kv_offload_store_local.py is the disk tier; the scheduler-side fs
+    # tier is byte-invalid on 2-node TP, see the overlay header).
+    ARGS+=(--kv-transfer-config "$(python3 -S -c 'import json,os
+gb=int(os.environ["GLM53_KV_OFFLOAD_CPU_GB"])
+cfg={"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":gb*(1<<30),"blocks_per_chunk":1}}
+print(json.dumps(cfg,separators=(",",":")))')")
+fi
 if [ "${SPEC_METHOD:-mtp}" = "dflash" ]; then
     ARGS+=(--speculative-config "$(python3 -S -c 'import json,os
 spec={"method":"dflash","model":os.environ["DFLASH_MODEL_DIR"],"num_speculative_tokens":int(os.environ.get("DFLASH_TOKENS","7")),"kv_cache_dtype":"auto","draft_sample_method":"probabilistic","rejection_sample_method":"standard"}
@@ -881,30 +1062,9 @@ if [ -n "${EXTRA_ARGS:-}" ]; then
 fi
 
 [ -f "${MODEL_DIR}/config.json" ] || { say "FATAL: ${MODEL_DIR}/config.json missing"; ls -la "${MODEL_DIR}" | head; exit 1; }
-if [ -f /opt/glm53/patch_glm_video_placeholders.py ]; then
-    python3 /opt/glm53/patch_glm_video_placeholders.py
-fi
-if [ -f /opt/glm53/patch_suppress_stops_in_reasoning.py ]; then
-    python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
-fi
-if [ -f /opt/glm53/patch_scheduler_decode_floor.py ]; then
-    python3 /opt/glm53/patch_scheduler_decode_floor.py
-fi
-if [ -f /opt/glm53/patch_glm5_drafter_group.py ]; then
-    python3 /opt/glm53/patch_glm5_drafter_group.py
-fi
-if [ -f /opt/glm53/patch_hybrid_prefix_hit.py ]; then
-    python3 /opt/glm53/patch_hybrid_prefix_hit.py
-fi
-if [ -f /opt/glm53/patch_xgrammar_termination.py ]; then
-    python3 /opt/glm53/patch_xgrammar_termination.py
-fi
-if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
-    python3 /opt/glm53/patch_kpool_tail_slotmap.py
-fi
-if [ -f /opt/glm53/patch_ablit.py ]; then
-    python3 /opt/glm53/patch_ablit.py
-fi
+EOF
+    emit_overlay_block >> "$HEAD_SCRIPT"
+    cat >> "$HEAD_SCRIPT" <<'EOF'
 if [ "${ABLIT:-0}" = "1" ]; then
     say "ablit: o_proj orthogonalization ON (method=${ABLIT_METHOD:-auto} direction=${ABLIT_DIRECTION:-dealign} layers=${ABLIT_LAYERS:-15-45} alpha=${ABLIT_ALPHA:-3.0})"
 else
@@ -943,6 +1103,16 @@ ARGS=(
 [ -n "${MAX_NUM_SEQS:-}" ] && ARGS+=(--max-num-seqs "${MAX_NUM_SEQS}")
 [ -n "${MAX_NUM_BATCHED_TOKENS:-}" ] && ARGS+=(--max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}")
 [ -n "${KV_CACHE_DTYPE:-}" ] && ARGS+=(--kv-cache-dtype "${KV_CACHE_DTYPE}")
+if [ "${GLM53_KV_OFFLOAD:-0}" = "1" ]; then
+    # Stage-1 store tier: CPU staging only (TieringOffloadingSpec, NO
+    # secondary tiers -- the worker-local writer in
+    # patch_kv_offload_store_local.py is the disk tier; the scheduler-side fs
+    # tier is byte-invalid on 2-node TP, see the overlay header).
+    ARGS+=(--kv-transfer-config "$(python3 -S -c 'import json,os
+gb=int(os.environ["GLM53_KV_OFFLOAD_CPU_GB"])
+cfg={"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":gb*(1<<30),"blocks_per_chunk":1}}
+print(json.dumps(cfg,separators=(",",":")))')")
+fi
 if [ "${SPEC_METHOD:-mtp}" = "dflash" ]; then
     ARGS+=(--speculative-config "$(python3 -S -c 'import json,os
 spec={"method":"dflash","model":os.environ["DFLASH_MODEL_DIR"],"num_speculative_tokens":int(os.environ.get("DFLASH_TOKENS","7")),"kv_cache_dtype":"auto","draft_sample_method":"probabilistic","rejection_sample_method":"standard"}
@@ -971,30 +1141,9 @@ if [ -n "${EXTRA_ARGS:-}" ]; then
 fi
 
 [ -f "${MODEL_DIR}/config.json" ] || { say "FATAL: ${MODEL_DIR}/config.json missing"; ls -la "${MODEL_DIR}" | head; exit 1; }
-if [ -f /opt/glm53/patch_glm_video_placeholders.py ]; then
-    python3 /opt/glm53/patch_glm_video_placeholders.py
-fi
-if [ -f /opt/glm53/patch_suppress_stops_in_reasoning.py ]; then
-    python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
-fi
-if [ -f /opt/glm53/patch_scheduler_decode_floor.py ]; then
-    python3 /opt/glm53/patch_scheduler_decode_floor.py
-fi
-if [ -f /opt/glm53/patch_glm5_drafter_group.py ]; then
-    python3 /opt/glm53/patch_glm5_drafter_group.py
-fi
-if [ -f /opt/glm53/patch_hybrid_prefix_hit.py ]; then
-    python3 /opt/glm53/patch_hybrid_prefix_hit.py
-fi
-if [ -f /opt/glm53/patch_xgrammar_termination.py ]; then
-    python3 /opt/glm53/patch_xgrammar_termination.py
-fi
-if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
-    python3 /opt/glm53/patch_kpool_tail_slotmap.py
-fi
-if [ -f /opt/glm53/patch_ablit.py ]; then
-    python3 /opt/glm53/patch_ablit.py
-fi
+EOF
+    emit_overlay_block >> "$WORKER_SCRIPT"
+    cat >> "$WORKER_SCRIPT" <<'EOF'
 if [ "${ABLIT:-0}" = "1" ]; then
     say "ablit: o_proj orthogonalization ON (method=${ABLIT_METHOD:-auto} direction=${ABLIT_DIRECTION:-dealign} layers=${ABLIT_LAYERS:-15-45} alpha=${ABLIT_ALPHA:-3.0})"
 else
@@ -1013,6 +1162,18 @@ launch_cluster() {
 
     mkdir -p "$CACHE_ROOT" "$TRITON_HOST_CACHE" "$TILELANG_HOST_CACHE"
     worker_ssh "mkdir -p '$WORKER_VLLM_CACHE' '$WORKER_TRITON_CACHE' '$WORKER_TILELANG_CACHE'"
+
+    # Disk KV-offload store: mount + dir only when the knob is 1 (knob=0 adds
+    # NOTHING to the containers beyond the replayed env — byte-identical boot).
+    local -a head_offload_mount=()
+    local worker_offload_mount=""
+    if [ "$GLM53_KV_OFFLOAD" = 1 ]; then
+        mkdir -p "$GLM53_KV_OFFLOAD_DIR"
+        worker_ssh "mkdir -p '$GLM53_KV_OFFLOAD_DIR'"
+        head_offload_mount=(-v "$GLM53_KV_OFFLOAD_DIR:$GLM53_KV_OFFLOAD_DIR_CTR")
+        worker_offload_mount="-v '$GLM53_KV_OFFLOAD_DIR:$GLM53_KV_OFFLOAD_DIR_CTR'"
+        log "kv-offload store tier ON: $GLM53_KV_OFFLOAD_DIR (both ranks, rw) staging=${GLM53_KV_OFFLOAD_CPU_GB}GiB keep_boundaries=$GLM53_KV_OFFLOAD_KEEP_BOUNDARIES restore=$GLM53_KV_OFFLOAD_RESTORE"
+    fi
     scp -q -o BatchMode=yes "$WORKER_SCRIPT" "${WORKER_SSH}:/tmp/${CONTAINER_WORKER}.sh"
     [ -f "$CHAT_TEMPLATE_HOST" ] || die "missing chat template: $CHAT_TEMPLATE_HOST"
     scp -q -o BatchMode=yes "$CHAT_TEMPLATE_HOST" "${WORKER_SSH}:/tmp/glm53-chat_template.jinja"
@@ -1026,6 +1187,10 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$DRAFTER_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_glm5_drafter_group.py"
     [ -f "$APC_PATCH_HOST" ] || die "missing $APC_PATCH_HOST"
     scp -q -o BatchMode=yes "$APC_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_hybrid_prefix_hit.py"
+    [ -f "$KVOFFLOAD_SCOPE_PATCH_HOST" ] || die "missing $KVOFFLOAD_SCOPE_PATCH_HOST"
+    scp -q -o BatchMode=yes "$KVOFFLOAD_SCOPE_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kv_offload_scope.py"
+    [ -f "$KVOFFLOAD_STORE_PATCH_HOST" ] || die "missing $KVOFFLOAD_STORE_PATCH_HOST"
+    scp -q -o BatchMode=yes "$KVOFFLOAD_STORE_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kv_offload_store_local.py"
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "missing $XGRAMMAR_PATCH_HOST"
     scp -q -o BatchMode=yes "$XGRAMMAR_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_xgrammar_termination.py"
     [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "missing $KPOOL_TAIL_PATCH_HOST"
@@ -1053,6 +1218,12 @@ launch_cluster() {
         -e VLLM_CACHE_ROOT=/root/.cache/vllm
         -e "GLM53_SUPPRESS_STOPS_IN_REASONING=$GLM53_SUPPRESS_STOPS_IN_REASONING"
         -e "GLM53_MIXED_PREFILL_CHUNK=$GLM53_MIXED_PREFILL_CHUNK"
+        -e "GLM53_KV_OFFLOAD=$GLM53_KV_OFFLOAD"
+        -e "GLM53_KV_OFFLOAD_DIR=$GLM53_KV_OFFLOAD_DIR_CTR"
+        -e "GLM53_KV_OFFLOAD_CPU_GB=$GLM53_KV_OFFLOAD_CPU_GB"
+        -e "GLM53_KV_OFFLOAD_RESTORE=$GLM53_KV_OFFLOAD_RESTORE"
+        -e "GLM53_KV_OFFLOAD_DRAFTER=$GLM53_KV_OFFLOAD_DRAFTER"
+        -e "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES=$GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"
         -e "TRITON_CACHE_DIR=$TRITON_CACHE_DIR"
         -e "TILELANG_CACHE_DIR=$TILELANG_CACHE_DIR"
         -e "VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=$VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS"
@@ -1123,11 +1294,14 @@ launch_cluster() {
         -v '/tmp/patch_scheduler_decode_floor.py:/opt/glm53/patch_scheduler_decode_floor.py:ro' \
         -v '/tmp/patch_glm5_drafter_group.py:/opt/glm53/patch_glm5_drafter_group.py:ro' \
         -v '/tmp/patch_hybrid_prefix_hit.py:/opt/glm53/patch_hybrid_prefix_hit.py:ro' \
+        -v '/tmp/patch_kv_offload_scope.py:/opt/glm53/patch_kv_offload_scope.py:ro' \
+        -v '/tmp/patch_kv_offload_store_local.py:/opt/glm53/patch_kv_offload_store_local.py:ro' \
         -v '/tmp/patch_xgrammar_termination.py:/opt/glm53/patch_xgrammar_termination.py:ro' \
         -v '/tmp/patch_kpool_tail_slotmap.py:/opt/glm53/patch_kpool_tail_slotmap.py:ro' \
         -v '/tmp/glm53-ablit:/opt/glm53/ablit:ro' \
         -v '/tmp/glm53-ablit_runtime.py:/opt/glm53/ablit_runtime.py:ro' \
         -v '/tmp/patch_ablit.py:/opt/glm53/patch_ablit.py:ro' \
+        ${worker_offload_mount} \
         ${worker_preload} \
         ${worker_nccl} \
         -e NCCL_SOCKET_IFNAME='$WORKER_CX7_IF' \
@@ -1154,11 +1328,14 @@ launch_cluster() {
         -v "$SCHED_PATCH_HOST:/opt/glm53/patch_scheduler_decode_floor.py:ro" \
         -v "$DRAFTER_PATCH_HOST:/opt/glm53/patch_glm5_drafter_group.py:ro" \
         -v "$APC_PATCH_HOST:/opt/glm53/patch_hybrid_prefix_hit.py:ro" \
+        -v "$KVOFFLOAD_SCOPE_PATCH_HOST:/opt/glm53/patch_kv_offload_scope.py:ro" \
+        -v "$KVOFFLOAD_STORE_PATCH_HOST:/opt/glm53/patch_kv_offload_store_local.py:ro" \
         -v "$XGRAMMAR_PATCH_HOST:/opt/glm53/patch_xgrammar_termination.py:ro" \
         -v "$KPOOL_TAIL_PATCH_HOST:/opt/glm53/patch_kpool_tail_slotmap.py:ro" \
         -v "$SCRIPT_DIR/ablit:/opt/glm53/ablit:ro" \
         -v "$SCRIPT_DIR/overlay/ablit_runtime.py:/opt/glm53/ablit_runtime.py:ro" \
         -v "$SCRIPT_DIR/overlay/patch_ablit.py:/opt/glm53/patch_ablit.py:ro" \
+        ${head_offload_mount[@]+"${head_offload_mount[@]}"} \
         "${head_preload[@]}" \
         "${nccl_common[@]}" \
         -e NCCL_SOCKET_IFNAME="$HEAD_CX7_IF" \
@@ -1391,7 +1568,7 @@ logs() {
 main() {
     local cmd="${1:-start}"
     case "$cmd" in
-        start|restart) validate_numeric_config ;;
+        start|restart) validate_numeric_config; validate_kv_offload_artifacts ;;
     esac
     case "$cmd" in
         stop)     banner stop.sh ;;

--- a/start.sh
+++ b/start.sh
@@ -1214,18 +1214,20 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$SCRIPT_DIR/overlay/ablit_runtime.py" "${WORKER_SSH}:/tmp/glm53-ablit_runtime.py"
     scp -q -o BatchMode=yes "$SCRIPT_DIR/overlay/patch_ablit.py" "${WORKER_SSH}:/tmp/patch_ablit.py"
 
-    # OffloadingConnector (GLM53_KV_OFFLOAD=1) is refused by vLLM when
-    # PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True: the VMM allocator can
-    # remap KV-cache virtual addresses onto different physical pages under
-    # pinned/registered KV memory (VllmConfig validation refuses the pair at
-    # boot; found live in the #99 receipt window — the check is unreachable
-    # from host stubs). knob=1 boots therefore DROP the env on both ranks
+    # OffloadingConnector (GLM53_KV_OFFLOAD=1) is refused by vLLM under
+    # PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True unless
+    # enable_cumem_allocator is also on (not on this deployment): the VMM
+    # allocator can remap KV-cache virtual addresses onto different physical
+    # pages under pinned/registered KV memory (VllmConfig rejects the pair on
+    # the non-CuMem path at boot; found live in the #99 receipt window — the
+    # check is unreachable from host stubs). knob=1 boots therefore DROP the
+    # env on both ranks
     # (torch default allocator); knob=0 boots keep the stock entry, container
     # env byte-identical to a build without the tier.
     local -a alloc_conf_env=(-e PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True)
     if [ "${GLM53_KV_OFFLOAD-0}" = 1 ]; then
         alloc_conf_env=()
-        log "kv-offload: PYTORCH_CUDA_ALLOC_CONF (expandable_segments:True) dropped on both ranks (OffloadingConnector incompatibility, vllm config validation)"
+        log "kv-offload: PYTORCH_CUDA_ALLOC_CONF (expandable_segments:True) dropped on both ranks (vllm rejects OffloadingConnector with it unless CuMem allocator is enabled)"
     fi
     local -a nccl_common=(
         -e NCCL_IB_DISABLE=0

--- a/start.sh
+++ b/start.sh
@@ -267,6 +267,10 @@ GLM53_KV_OFFLOAD_DRAFTER="${GLM53_KV_OFFLOAD_DRAFTER-0}"
 # Inline manifest retention: keep the K most recent boundary manifests per
 # chain (plan §7; 0 = dense, no inline supersede).
 GLM53_KV_OFFLOAD_KEEP_BOUNDARIES="${GLM53_KV_OFFLOAD_KEEP_BOUNDARIES:-2}"
+# Build identity for the store namespace fence: the recipe checkout SHA (an
+# overlay change that alters byte semantics forks the store). "unpinned"
+# when the checkout is not a git repo.
+GLM53_KV_OFFLOAD_BUILD_ID="${GLM53_KV_OFFLOAD_BUILD_ID:-$(git -C "$SCRIPT_DIR" rev-parse --short=12 HEAD 2>/dev/null || echo unpinned)}"
 # EngineCore stock timeout is 300s; mid-serve Triton/TileLang JIT on TP=2 can
 # exceed that without being a true hang. NCCL watchdog is still 600s.
 VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS="${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-1800}"
@@ -429,6 +433,15 @@ validate_kv_offload_artifacts() {
         fi
         if ! python3 -c 'import ast, sys; ast.parse(open(sys.argv[1], encoding="utf-8").read(), sys.argv[1])' "$path" 2>/dev/null; then
             echo "kv-offload artifact does not parse as Python: $path" >&2
+            return 2
+        fi
+    done
+    # The two patchers embed their in-container code as string literals; a
+    # file that parses can still carry a truncated literal. --check-injected
+    # compiles every injected source standalone (no image access needed).
+    for entry in "$KVOFFLOAD_SCOPE_PATCH_HOST" "$KVOFFLOAD_STORE_PATCH_HOST"; do
+        if ! python3 "$entry" --check-injected >/dev/null 2>&1; then
+            echo "kv-offload artifact failed its injected-source self-check: $entry" >&2
             return 2
         fi
     done
@@ -1029,7 +1042,7 @@ if [ "${GLM53_KV_OFFLOAD:-0}" = "1" ]; then
     # tier is byte-invalid on 2-node TP, see the overlay header).
     ARGS+=(--kv-transfer-config "$(python3 -S -c 'import json,os
 gb=int(os.environ["GLM53_KV_OFFLOAD_CPU_GB"])
-cfg={"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":gb*(1<<30),"blocks_per_chunk":1}}
+cfg={"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":gb*(1<<30),"blocks_per_chunk":1,"offload_prompt_only":False}}
 print(json.dumps(cfg,separators=(",",":")))')")
 fi
 if [ "${SPEC_METHOD:-mtp}" = "dflash" ]; then
@@ -1110,7 +1123,7 @@ if [ "${GLM53_KV_OFFLOAD:-0}" = "1" ]; then
     # tier is byte-invalid on 2-node TP, see the overlay header).
     ARGS+=(--kv-transfer-config "$(python3 -S -c 'import json,os
 gb=int(os.environ["GLM53_KV_OFFLOAD_CPU_GB"])
-cfg={"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":gb*(1<<30),"blocks_per_chunk":1}}
+cfg={"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":gb*(1<<30),"blocks_per_chunk":1,"offload_prompt_only":False}}
 print(json.dumps(cfg,separators=(",",":")))')")
 fi
 if [ "${SPEC_METHOD:-mtp}" = "dflash" ]; then
@@ -1224,6 +1237,7 @@ launch_cluster() {
         -e "GLM53_KV_OFFLOAD_RESTORE=$GLM53_KV_OFFLOAD_RESTORE"
         -e "GLM53_KV_OFFLOAD_DRAFTER=$GLM53_KV_OFFLOAD_DRAFTER"
         -e "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES=$GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"
+        -e "GLM53_KV_OFFLOAD_BUILD_ID=$GLM53_KV_OFFLOAD_BUILD_ID"
         -e "TRITON_CACHE_DIR=$TRITON_CACHE_DIR"
         -e "TILELANG_CACHE_DIR=$TILELANG_CACHE_DIR"
         -e "VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=$VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS"

--- a/start.sh
+++ b/start.sh
@@ -1214,6 +1214,19 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$SCRIPT_DIR/overlay/ablit_runtime.py" "${WORKER_SSH}:/tmp/glm53-ablit_runtime.py"
     scp -q -o BatchMode=yes "$SCRIPT_DIR/overlay/patch_ablit.py" "${WORKER_SSH}:/tmp/patch_ablit.py"
 
+    # OffloadingConnector (GLM53_KV_OFFLOAD=1) is refused by vLLM when
+    # PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True: the VMM allocator can
+    # remap KV-cache virtual addresses onto different physical pages under
+    # pinned/registered KV memory (VllmConfig validation refuses the pair at
+    # boot; found live in the #99 receipt window — the check is unreachable
+    # from host stubs). knob=1 boots therefore DROP the env on both ranks
+    # (torch default allocator); knob=0 boots keep the stock entry, container
+    # env byte-identical to a build without the tier.
+    local -a alloc_conf_env=(-e PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True)
+    if [ "${GLM53_KV_OFFLOAD-0}" = 1 ]; then
+        alloc_conf_env=()
+        log "kv-offload: PYTORCH_CUDA_ALLOC_CONF (expandable_segments:True) dropped on both ranks (OffloadingConnector incompatibility, vllm config validation)"
+    fi
     local -a nccl_common=(
         -e NCCL_IB_DISABLE=0
         -e NCCL_IB_ROCE_VERSION_NUM=2
@@ -1244,7 +1257,7 @@ launch_cluster() {
         -e "TORCH_CUDA_ARCH_LIST=$TORCH_CUDA_ARCH_LIST"
         -e "FLASHINFER_CUDA_ARCH_LIST=$FLASHINFER_CUDA_ARCH_LIST"
         -e FLASHINFER_DISABLE_VERSION_CHECK=1
-        -e PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+        ${alloc_conf_env[@]+"${alloc_conf_env[@]}"}
         -e "VLLM_ENGINE_READY_TIMEOUT_S=$READY_TIMEOUT"
         # py-cpuinfo JSON-parses empty output on Grace/aarch64; the usage
         # thread then dumps JSONDecodeError. Stats are off on this private kit.

--- a/tests/_kv_offload_stub_env.py
+++ b/tests/_kv_offload_stub_env.py
@@ -1,0 +1,683 @@
+#!/usr/bin/env python3
+"""Stubbed-vllm exec environment for the kv-offload overlay tests.
+
+Applies the overlay patchers to the pinned image fixtures
+(tests/fixtures/image_487ecf187_*.py) and executes the PATCHED module text
+under a minimal fake ``vllm`` namespace, so the tests drive the exact code the
+container will run — not a replica (Codex OFFLOAD1 finding 6).
+
+Only what the patched modules import is stubbed; everything else raises on
+first touch. The 7-group GLM-5.3-Flash boot layout (stage-0 receipts) is the
+canonical fake config: g0 mixed MLA+indexer (block 3584), g1 KpoolTail scratch
+(block 4, not prefix-cacheable), g2-5 MambaSpec align (block 3584), g6 exact
+SlidingWindowSpec drafter (block 64, EAGLE).
+"""
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass, field
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+FIXTURES = HERE / "fixtures"
+
+sys.path.insert(0, str(ROOT / "overlay"))
+
+import patch_kv_offload_scope as scope_mod  # noqa: E402
+import patch_kv_offload_store_local as store_mod  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Patched module text
+# ---------------------------------------------------------------------------
+def patched_texts(with_store: bool = True) -> dict[str, str]:
+    """Apply the patchers (prepare only, no writes) to the pinned fixtures."""
+    kvo_cfg = (FIXTURES / "image_487ecf187_kv_offload_config.py").read_text()
+    conn_cfg = (FIXTURES / "image_487ecf187_offloading_config.py").read_text()
+    sched = (FIXTURES / "image_487ecf187_offloading_scheduler.py").read_text()
+    common = (FIXTURES / "image_487ecf187_offloading_common.py").read_text()
+    worker = (FIXTURES / "image_487ecf187_offloading_worker.py").read_text()
+
+    kvo_cfg, _ = scope_mod.prepare(kvo_cfg, scope_mod.SITES_KVO_CONFIG, "t")
+    conn_cfg, _ = scope_mod.prepare(conn_cfg, scope_mod.SITES_CONN_CONFIG, "t")
+    sched, _ = scope_mod.prepare(sched, scope_mod.SITES_SCHED, "t")
+    if with_store:
+        common, _ = store_mod.prepare(common, store_mod.SITES_COMMON, "t")
+        sched, _ = store_mod.prepare(sched, store_mod.SITES_SCHED, "t")
+        worker, _ = store_mod.prepare(worker, store_mod.SITES_WORKER, "t")
+    return {
+        "kv_offload_config": kvo_cfg,
+        "offloading_config": conn_cfg,
+        "scheduler": sched,
+        "common": common,
+        "worker": worker,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fake spec classes (names are load-bearing: the overlays key on them)
+# ---------------------------------------------------------------------------
+class KVCacheSpec:
+    """[I] naming: the cacheability flag is the participates_in_prefix_caching
+    PROPERTY (no prefix_cacheable attribute exists) — the stub mirrors that so
+    the overlays' dual-name check is exercised against the fork name."""
+
+    def __init__(self, block_size, prefix_cacheable=True):
+        self.block_size = block_size
+        self._cacheable = prefix_cacheable
+
+    @property
+    def participates_in_prefix_caching(self) -> bool:
+        return self._cacheable
+
+
+class AttentionSpec(KVCacheSpec):
+    pass
+
+
+class FullAttentionSpec(AttentionSpec):
+    pass
+
+
+class MLAAttentionSpec(FullAttentionSpec):
+    pass
+
+
+class ChunkedLocalAttentionSpec(AttentionSpec):
+    pass
+
+
+class SlidingWindowSpec(AttentionSpec):
+    def __init__(self, block_size, sliding_window, **kw):
+        super().__init__(block_size, **kw)
+        self.sliding_window = sliding_window
+
+
+class MambaSpec(KVCacheSpec):
+    def __init__(self, block_size, mamba_cache_mode="align", shapes=None, dtypes=None):
+        super().__init__(block_size)
+        self.mamba_cache_mode = mamba_cache_mode
+        # Stage-0 R13 KDA ABI at num_spec=7, TP=2.
+        self.shapes = shapes if shapes is not None else ((10, 12288), (32, 128, 128))
+        self.dtypes = (
+            dtypes if dtypes is not None else ("torch.bfloat16", "torch.float32")
+        )
+
+
+class KpoolTailSpec(AttentionSpec):
+    pass
+
+
+class UniformTypeKVCacheSpecs(KVCacheSpec):
+    """[I]'s wrapper: subclasses KVCacheSpec ONLY (not FullAttentionSpec),
+    aggregates member cacheability — kv_cache_interface.py:920-937."""
+
+    def __init__(self, block_size, kv_cache_specs):
+        super().__init__(block_size)
+        self.kv_cache_specs = kv_cache_specs
+
+    @property
+    def participates_in_prefix_caching(self) -> bool:
+        return all(
+            s.participates_in_prefix_caching for s in self.kv_cache_specs.values()
+        )
+
+
+@dataclass
+class FakeKVCacheGroup:
+    kv_cache_spec: object
+    layer_names: tuple
+    is_eagle_group: bool = False
+
+
+@dataclass
+class FakeKVCacheConfig:
+    kv_cache_groups: list
+    num_blocks: int = 804
+
+
+def boot_layout() -> FakeKVCacheConfig:
+    """The 7-group GLM-5.3-Flash layout (stage-0 receipts §C)."""
+    g0_layers = tuple(f"mla.{i}" for i in range(11)) + tuple(
+        f"idx.{i}" for i in range(11)
+    )
+    g0 = FakeKVCacheGroup(
+        UniformTypeKVCacheSpecs(
+            3584, {n: MLAAttentionSpec(3584) for n in g0_layers}
+        ),
+        g0_layers,
+    )
+    g1_layers = tuple(f"kpool.{i}" for i in range(11))
+    g1 = FakeKVCacheGroup(
+        UniformTypeKVCacheSpecs(
+            4, {n: KpoolTailSpec(4, prefix_cacheable=False) for n in g1_layers}
+        ),
+        g1_layers,
+    )
+    mamba_groups = []
+    for g, n in ((2, 9), (3, 9), (4, 8), (5, 8)):
+        names = tuple(f"kda{g}.{i}" for i in range(n))
+        mamba_groups.append(
+            FakeKVCacheGroup(
+                UniformTypeKVCacheSpecs(3584, {nm: MambaSpec(3584) for nm in names}),
+                names,
+            )
+        )
+    g6_layers = tuple(f"draft.{i}" for i in range(5))
+    g6 = FakeKVCacheGroup(
+        UniformTypeKVCacheSpecs(
+            64, {n: SlidingWindowSpec(64, 2048) for n in g6_layers}
+        ),
+        g6_layers,
+    )
+    return FakeKVCacheConfig([g0, g1] + mamba_groups + [g6])
+
+
+@dataclass
+class FakeSpeculativeConfig:
+    num_speculative_tokens: int = 7
+
+    def use_eagle(self) -> bool:
+        return True
+
+
+@dataclass
+class FakeParallelConfig:
+    rank: int = 0
+    world_size: int = 2
+    tensor_parallel_size: int = 2
+    pipeline_parallel_size: int = 1
+    prefill_context_parallel_size: int = 1
+    decode_context_parallel_size: int = 1
+    data_parallel_index: int = 0
+    data_parallel_size: int = 1
+    data_parallel_rank_local: int | None = 0
+    nnodes_within_dp: int = 2
+    distributed_executor_backend: str = "mp"
+
+
+@dataclass
+class FakeCacheConfig:
+    enable_prefix_caching: bool = True
+    prefix_caching_hash_algo: str = "sha256"
+    cache_dtype: str = "fp8"
+
+
+@dataclass
+class FakeModelConfig:
+    model: str = "Mia-AiLab/GLM-5.3-Flash-EXL3-TR3-4bpw"
+    dtype: str = "bfloat16"
+    use_mla: bool = True
+
+    def get_total_num_kv_heads(self) -> int:
+        return 1
+
+
+@dataclass
+class FakeVllmConfig:
+    parallel_config: FakeParallelConfig = field(default_factory=FakeParallelConfig)
+    speculative_config: FakeSpeculativeConfig | None = field(
+        default_factory=FakeSpeculativeConfig
+    )
+    cache_config: FakeCacheConfig = field(default_factory=FakeCacheConfig)
+    model_config: FakeModelConfig = field(default_factory=FakeModelConfig)
+    kv_transfer_config: object | None = None
+    kv_events_config: object | None = None
+    use_v2_model_runner: bool = False
+
+
+# ---------------------------------------------------------------------------
+# The fake vllm module tree
+# ---------------------------------------------------------------------------
+class _RecordingLogger:
+    def __init__(self):
+        self.lines: list[str] = []
+
+    def _fmt(self, msg, *args):
+        try:
+            self.lines.append(msg % args if args else str(msg))
+        except TypeError:
+            self.lines.append(str(msg))
+
+    info = info_once = debug = warning = warning_once = error = exception = _fmt
+
+
+def _mod(name: str) -> types.ModuleType:
+    m = types.ModuleType(name)
+    sys.modules[name] = m
+    return m
+
+
+def install_fake_vllm() -> dict:
+    """Install a minimal fake vllm namespace; returns handles for tests."""
+    logger = _RecordingLogger()
+
+    vllm = _mod("vllm")
+    vllm.__version__ = "0.1.dev20051+g487ecf187"
+
+    m = _mod("vllm.config")
+    m.VllmConfig = FakeVllmConfig
+
+    m = _mod("vllm.logger")
+    m.init_logger = lambda name: logger
+
+    m = _mod("vllm.utils.math_utils")
+    m.cdiv = lambda a, b: -(-a // b)
+    m.round_down = lambda x, y: (x // y) * y
+    sys.modules["vllm.utils"] = types.ModuleType("vllm.utils")
+
+    m = _mod("vllm.distributed.kv_events")
+    m.KVCacheEvent = object
+
+    m = _mod("vllm.distributed.parallel_state")
+
+    def _tp_rank():
+        raise RuntimeError("TP group not initialized in the stub env")
+
+    m.get_tensor_model_parallel_rank = _tp_rank
+
+    m = _mod("vllm.distributed.kv_transfer.kv_connector.utils")
+
+    def yield_req_data(scheduler_output):
+        for req_id, (blocks, preempted) in scheduler_output.req_data.items():
+            yield req_id, blocks, preempted
+
+    m.yield_req_data = yield_req_data
+
+    m = _mod("vllm.distributed.kv_transfer.kv_connector.v1.base")
+
+    class KVConnectorMetadata:
+        pass
+
+    class KVConnectorWorkerMetadata:
+        pass
+
+    m.KVConnectorMetadata = KVConnectorMetadata
+    m.KVConnectorWorkerMetadata = KVConnectorWorkerMetadata
+
+    m = _mod("vllm.v1.kv_cache_interface")
+    for cls in (
+        AttentionSpec,
+        FullAttentionSpec,
+        MLAAttentionSpec,
+        ChunkedLocalAttentionSpec,
+        SlidingWindowSpec,
+        MambaSpec,
+        KVCacheSpec,
+        UniformTypeKVCacheSpecs,
+    ):
+        setattr(m, cls.__name__, cls)
+    m.KVCacheConfig = FakeKVCacheConfig
+    m.KVCacheTensor = object
+
+    m = _mod("vllm.v1.core.kv_cache_manager")
+
+    @dataclass
+    class KVCacheBlocks:
+        blocks: tuple
+
+    m.KVCacheBlocks = KVCacheBlocks
+
+    m = _mod("vllm.v1.core.sched.output")
+    m.SchedulerOutput = object
+
+    m = _mod("vllm.v1.core.kv_cache_utils")
+    m.resolve_kv_cache_block_sizes = lambda kv_cache_config, vllm_config: (
+        [3584],
+        64,
+    )
+
+    m = _mod("vllm.v1.outputs")
+
+    @dataclass
+    class KVConnectorOutput:
+        kv_connector_stats: object = None
+        invalid_block_ids: frozenset = frozenset()
+        finished_sending: set | None = None
+        finished_recving: set | None = None
+
+    m.KVConnectorOutput = KVConnectorOutput
+
+    m = _mod("vllm.v1.request")
+
+    class RequestStatus:
+        FINISHED_ABORTED = "aborted"
+
+    class Request:
+        pass
+
+    m.RequestStatus = RequestStatus
+    m.Request = Request
+
+    m = _mod("vllm.v1.attention.backend")
+    m.AttentionBackend = object
+
+    # --- vllm.v1.kv_offload.base: real key packing, minimal everything else
+    m = _mod("vllm.v1.kv_offload.base")
+
+    def make_offload_key(block_hash: bytes, group_idx: int):
+        return block_hash + group_idx.to_bytes(4, "big", signed=False)
+
+    m.make_offload_key = make_offload_key
+    m.get_offload_block_hash = lambda key: key[:-4]
+    m.get_offload_group_idx = lambda key: int.from_bytes(key[-4:], "big")
+    m.OffloadKey = bytes
+
+    import enum
+
+    class Medium(enum.Enum):
+        CPU = "CPU"
+        STORAGE = "STORAGE"
+
+    class Locality(enum.Enum):
+        LOCAL = "LOCAL"
+        REMOTE = "REMOTE"
+
+    class LookupResult(enum.Enum):
+        HIT = 1
+        HIT_PENDING = 2
+        RETRY = 3
+        MISS = 4
+
+    class OffloadPolicy(enum.Enum):
+        BLOCK_LEVEL = 1
+        REQUEST_LEVEL = 2
+
+    @dataclass
+    class TierMatcher:
+        medium: object = None
+        locality: object = None
+
+    class TierFilter:
+        ALL = None
+
+        def __init__(self, matchers=()):
+            self.matchers = matchers
+
+    TierFilter.ALL = TierFilter()
+
+    @dataclass
+    class ReqContext:
+        req_id: str
+        kv_transfer_params: dict | None = None
+        load_tier_filter: object = None
+
+    @dataclass
+    class RequestOffloadingContext:
+        policy: object = OffloadPolicy.BLOCK_LEVEL
+
+    @dataclass
+    class ScheduleEndContext:
+        pass
+
+    import numpy as np
+
+    class LoadStoreSpec:
+        pass
+
+    class BlockIDsLoadStoreSpec(LoadStoreSpec):
+        def __init__(self, block_ids):
+            self.block_ids = np.array(block_ids, dtype=np.int64)
+
+    class GPULoadStoreSpec(BlockIDsLoadStoreSpec):
+        def __init__(self, block_ids, group_sizes, block_indices):
+            super().__init__(block_ids)
+            assert sum(group_sizes) == len(block_ids)
+            assert len(block_indices) == len(group_sizes)
+            self.group_sizes = group_sizes
+            self.block_indices = block_indices
+
+    class CPULoadStoreSpec(BlockIDsLoadStoreSpec):
+        pass
+
+    class OffloadingManager:
+        pass
+
+    class OffloadingWorker:
+        pass
+
+    class OffloadingSpec:
+        def __init__(self, config):
+            self.config = config
+            self.extra_config = config.extra_config
+            self.tokens_per_block = tuple(
+                g.tokens_per_block for g in config.groups
+            )
+            self.tokens_per_hash = config.cache.tokens_per_hash
+            self.blocks_per_chunk = config.cache.blocks_per_chunk
+            self.offload_prompt_only = False
+
+    for name, obj in dict(
+        Medium=Medium,
+        Locality=Locality,
+        LookupResult=LookupResult,
+        OffloadPolicy=OffloadPolicy,
+        TierMatcher=TierMatcher,
+        TierFilter=TierFilter,
+        ReqContext=ReqContext,
+        RequestOffloadingContext=RequestOffloadingContext,
+        ScheduleEndContext=ScheduleEndContext,
+        LoadStoreSpec=LoadStoreSpec,
+        BlockIDsLoadStoreSpec=BlockIDsLoadStoreSpec,
+        GPULoadStoreSpec=GPULoadStoreSpec,
+        CPULoadStoreSpec=CPULoadStoreSpec,
+        OffloadingManager=OffloadingManager,
+        OffloadingWorker=OffloadingWorker,
+        OffloadingSpec=OffloadingSpec,
+        CanonicalKVCaches=object,
+        CanonicalKVCacheRef=object,
+        CanonicalKVCacheTensor=object,
+        OffloadingCounterMetadata=object,
+        OffloadingGaugeMetadata=object,
+        OffloadingHistogramMetadata=object,
+        OffloadingMetricMetadata=object,
+    ).items():
+        setattr(m, name, obj)
+
+    # --- offloading sibling modules the scheduler/worker import
+    m = _mod("vllm.distributed.kv_transfer.kv_connector.v1.offloading.events")
+
+    @dataclass
+    class OffloadingEventGroupSpec:
+        name: str = "g"
+
+    class OffloadingEventsTracker:
+        def __init__(self, kv_events_config):
+            self.records = []
+
+        def record_lookup(self, *a, **k):
+            self.records.append(("lookup", a))
+
+        def record_partial_lookup(self, *a, **k):
+            self.records.append(("partial_lookup", a))
+
+        def record_store(self, *a, **k):
+            self.records.append(("store", a))
+
+        def record_partial_store(self, *a, **k):
+            self.records.append(("partial_store", a))
+
+        def take_events(self):
+            return ()
+
+    m.OffloadingEventGroupSpec = OffloadingEventGroupSpec
+    m.OffloadingEventsTracker = OffloadingEventsTracker
+    m.get_offloading_event_group_spec = lambda group: OffloadingEventGroupSpec()
+
+    m = _mod("vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics")
+
+    class OffloadingConnectorStats:
+        def __init__(self):
+            self.hist = []
+
+        def observe_histogram(self, *a, **k):
+            self.hist.append(a)
+
+        def increase_counter(self, *a, **k):
+            pass
+
+    class _ConnectorMetricName:
+        LOOKUP_ASYNC_DELAY = "lookup_async"
+        LOOKUP_SYNC_DELAY = "lookup_sync"
+        ALLOCATION_FAILURE = "alloc_failure"
+
+    class _TransferMetricName:
+        pass
+
+    m.OffloadingConnectorStats = OffloadingConnectorStats
+    m._ConnectorMetricName = _ConnectorMetricName
+    m._TransferMetricName = _TransferMetricName
+
+    m = _mod(
+        "vllm.distributed.kv_transfer.kv_connector.v1.offloading.canonical_mapping"
+    )
+    m.derive_canonical_mappings = lambda *a, **k: {}
+    m.canonical_format_id = lambda: "v1-nhd"
+
+    # --- exec the PATCHED overlay outputs as the real module names
+    texts = patched_texts(with_store=True)
+
+    kvo_cfg = _mod("vllm.v1.kv_offload.config")
+    exec(compile(texts["kv_offload_config"], "kv_offload/config.py", "exec"), kvo_cfg.__dict__)
+
+    common = _mod("vllm.distributed.kv_transfer.kv_connector.v1.offloading.common")
+    exec(compile(texts["common"], "offloading/common.py", "exec"), common.__dict__)
+
+    conn_cfg = _mod("vllm.distributed.kv_transfer.kv_connector.v1.offloading.config")
+    exec(compile(texts["offloading_config"], "offloading/config.py", "exec"), conn_cfg.__dict__)
+
+    sched = _mod("vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler")
+    exec(compile(texts["scheduler"], "offloading/scheduler.py", "exec"), sched.__dict__)
+
+    # worker.py imports torch at module level; provide a named stub only if
+    # torch is genuinely absent (the writer path never touches it).
+    if "torch" not in sys.modules:
+        try:
+            import torch  # noqa: F401
+        except ImportError:
+            t = _mod("torch")
+            t.Tensor = object
+            t.Event = object
+
+    worker = _mod("vllm.distributed.kv_transfer.kv_connector.v1.offloading.worker")
+    exec(compile(texts["worker"], "offloading/worker.py", "exec"), worker.__dict__)
+
+    return {
+        "logger": logger,
+        "kv_offload_config": kvo_cfg,
+        "offloading_config": conn_cfg,
+        "scheduler": sched,
+        "common": common,
+        "worker": worker,
+        "base": sys.modules["vllm.v1.kv_offload.base"],
+        "kv_cache_manager": sys.modules["vllm.v1.core.kv_cache_manager"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Convenience builders on top of the fake tree
+# ---------------------------------------------------------------------------
+@dataclass
+class FakeKVTransferConfig:
+    engine_id: str = "engine0"
+    kv_connector_extra_config: dict = field(default_factory=dict)
+
+
+def build_offloading_config(mods, vllm_config=None, kv_cache_config=None):
+    vllm_config = vllm_config or FakeVllmConfig(
+        kv_transfer_config=FakeKVTransferConfig()
+    )
+    kv_cache_config = kv_cache_config or boot_layout()
+    # worker_kv_bytes_per_block path needs kv_cache_tensors; keep it inert.
+    kv_cache_config.kv_cache_tensors = []
+    kv_cache_config.num_blocks = 0
+    return mods["offloading_config"].build_offloading_config(
+        vllm_config, kv_cache_config
+    )
+
+
+class FakeManager:
+    """Scheduler-side OffloadingManager stub that accepts every store."""
+
+    def __init__(self, mods):
+        self.base = mods["base"]
+        self.lookup_calls = []
+        self.prepare_load_calls = []
+        self.touched = []
+
+    def on_new_request(self, req_context):
+        return self.base.RequestOffloadingContext()
+
+    def lookup(self, key, req_context):
+        self.lookup_calls.append(key)
+        return self.base.LookupResult.MISS
+
+    def touch(self, keys, req_context):
+        self.touched.append(tuple(keys))
+
+    def prepare_load(self, keys, req_context):
+        self.prepare_load_calls.append(tuple(keys))
+        return self.base.CPULoadStoreSpec(list(range(len(list(keys)))))
+
+    def prepare_store(self, keys, req_context):
+        keys = list(keys)
+
+        class StoreOutput:
+            pass
+
+        out = StoreOutput()
+        out.keys_to_store = list(keys)
+        out.store_spec = self.base.CPULoadStoreSpec(
+            list(range(100, 100 + len(keys)))
+        )
+        return out
+
+    def on_request_finished(self, req_context):
+        pass
+
+    def take_events(self):
+        return ()
+
+    def get_stats(self):
+        return None
+
+
+class FakeSchedSpec:
+    """Duck-typed OffloadingSpec for the scheduler side."""
+
+    def __init__(self, mods, offloading_config, manager=None):
+        self.config = offloading_config
+        self.tokens_per_block = tuple(
+            g.tokens_per_block for g in offloading_config.groups
+        )
+        self.tokens_per_hash = offloading_config.cache.tokens_per_hash
+        self.blocks_per_chunk = offloading_config.cache.blocks_per_chunk
+        self.offload_prompt_only = False
+        self.kv_events_config = None
+        self._manager = manager or FakeManager(mods)
+
+    def get_manager(self):
+        return self._manager
+
+
+class FakeRequest:
+    def __init__(self, num_tokens, tokens_per_hash=64, req_id="req0", salt=b"s"):
+        import hashlib
+
+        self.request_id = req_id
+        self.num_tokens = num_tokens
+        self.num_prompt_tokens = num_tokens
+        self.num_computed_tokens = 0
+        self.kv_transfer_params = None
+        self.skip_reading_prefix_cache = False
+        self.status = None
+        n_hashes = num_tokens // tokens_per_hash
+        self.block_hashes = [
+            hashlib.sha256(salt + i.to_bytes(4, "big")).digest()
+            for i in range(n_hashes)
+        ]
+
+    def is_finished(self):
+        return False

--- a/tests/_kv_offload_stub_env.py
+++ b/tests/_kv_offload_stub_env.py
@@ -447,7 +447,11 @@ def install_fake_vllm() -> dict:
             )
             self.tokens_per_hash = config.cache.tokens_per_hash
             self.blocks_per_chunk = config.cache.blocks_per_chunk
-            self.offload_prompt_only = False
+            # Mirror upstream: DEFAULT TRUE — the launcher must explicitly
+            # pass offload_prompt_only=false or decoded tokens are not stored.
+            self.offload_prompt_only = bool(
+                config.extra_config.get("offload_prompt_only", True)
+            )
 
     for name, obj in dict(
         Medium=Medium,
@@ -654,7 +658,9 @@ class FakeSchedSpec:
         )
         self.tokens_per_hash = offloading_config.cache.tokens_per_hash
         self.blocks_per_chunk = offloading_config.cache.blocks_per_chunk
-        self.offload_prompt_only = False
+        self.offload_prompt_only = bool(
+            offloading_config.extra_config.get("offload_prompt_only", True)
+        )
         self.kv_events_config = None
         self._manager = manager or FakeManager(mods)
 

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,12 @@
+# Pinned image fixtures (vllm 0.1.dev20051+g487ecf187, image ad0cdd86)
+
+Byte-exact copies of the in-image vLLM sources the kv-offload overlays patch,
+captured read-only from the deployed container on 2026-09-01 (Apache-2.0,
+SPDX headers retained). The kv-offload patcher tests preflight/apply against
+these and exec the patched result under a stubbed vllm namespace, so anchor
+drift or a broken port fails on the host before any server is touched.
+
+sha256 (as captured; `shasum -a 256` these files to compare against a future
+image):
+- offloading/config.py    d400d0b0fadc06f2ad60a1356a6fee730a187dbcc4e48656da523de813419ec9
+- offloading/scheduler.py 616e7fd4cb0d09064cbc4d5735f607b37964c6be3b81e26de00d5913e0a9a3e3

--- a/tests/fixtures/image_487ecf187_kv_offload_config.py
+++ b/tests/fixtures/image_487ecf187_kv_offload_config.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Normalized configuration consumed by native offloading backends."""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class OffloadingGroupConfig:
+    # Total token span covered by one block across all workers
+    # (accounts for context parallelism).
+    tokens_per_block: int
+    # Layer names belonging to this group.
+    layer_names: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class OffloadingModelConfig:
+    # Model identifier (e.g. HuggingFace model path).
+    name: str
+    # KV cache data type (e.g. "float16").
+    dtype: str
+
+
+@dataclass(frozen=True)
+class OffloadingCacheConfig:
+    # Tokens per block hash.
+    tokens_per_hash: int
+    # Blocks coalesced into one offload chunk.
+    blocks_per_chunk: int
+
+
+@dataclass(frozen=True)
+class OffloadingParallelConfig:
+    # Worker index in [0, world_size). 0 on the scheduler side.
+    rank: int
+    # Total number of workers.
+    world_size: int
+    # Tensor parallel size.
+    tp_size: int
+    # Pipeline parallel size.
+    pp_size: int
+    # Prefill context parallel size.
+    pcp_size: int
+    # Decode context parallel size.
+    dcp_size: int
+    # Data parallel replica index of this engine.
+    data_parallel_index: int
+    # Number of data parallel replicas.
+    data_parallel_size: int
+    # Local rank of the data parallel group, set only in SPMD mode.
+    data_parallel_rank_local: int | None
+    # True when the bytes that will be persisted for a block are portable
+    # across parallelism configurations: for the direct layout, concatenating
+    # the block's data across all workers in rank order yields the same bytes
+    # under any topology; for the canonical layout, the canonical page itself
+    # is topology-free.
+    is_parallelism_agnostic: bool
+
+
+@dataclass(frozen=True)
+class OffloadingConfig:
+    groups: tuple[OffloadingGroupConfig, ...]
+    # KV bytes stored by one worker per block.
+    worker_kv_bytes_per_block: int
+    # Whether the scheduler emits KV cache events. When true,
+    # the offloading backend should emit events as well.
+    enable_kv_cache_events: bool
+    # Offloading-specific configuration from kv_connector_extra_config.
+    extra_config: Mapping[str, Any]
+    # Unique identifier for this engine, distinct per DP rank.
+    engine_id: str
+    model: OffloadingModelConfig
+    cache: OffloadingCacheConfig
+    parallel: OffloadingParallelConfig
+    # True when the offloaded bytes of every worker are expected to be
+    # byte-identical per block (pure-MLA model, single-node TP-only
+    # parallelism), enabling a single-copy host layout in backends that
+    # support it. Aggregate layout decision; per-layer replication metadata
+    # is planned for CanonicalKVCacheRef (#48408).
+    replicated_layout: bool = False
+    # True when the canonical per-layer host byte layout was requested via
+    # kv_connector_extra_config; certified per-layer at worker registration.
+    canonical_layout: bool = False

--- a/tests/fixtures/image_487ecf187_offloading_common.py
+++ b/tests/fixtures/image_487ecf187_offloading_common.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from dataclasses import dataclass, field
+
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorMetadata,
+    KVConnectorWorkerMetadata,
+)
+from vllm.v1.kv_offload.base import LoadStoreSpec
+
+ReqId = str
+
+
+@dataclass(slots=True)
+class DirectionalTransferStats:
+    bytes: int = 0
+    time: float = 0.0
+    sizes: list[int | float] = field(default_factory=list)
+
+    def aggregate(
+        self, other: "DirectionalTransferStats"
+    ) -> "DirectionalTransferStats":
+        return DirectionalTransferStats(
+            bytes=self.bytes + other.bytes,
+            time=self.time + other.time,
+            sizes=[*self.sizes, *other.sizes],
+        )
+
+    def record(self, num_bytes: int, time: float) -> None:
+        self.bytes += num_bytes
+        self.time += time
+        self.sizes.append(num_bytes)
+
+    def is_empty(self) -> bool:
+        return self.bytes == 0 and self.time == 0.0 and not self.sizes
+
+
+@dataclass(slots=True)
+class TransferStats:
+    load: DirectionalTransferStats = field(default_factory=DirectionalTransferStats)
+    store: DirectionalTransferStats = field(default_factory=DirectionalTransferStats)
+
+    def aggregate(self, other: "TransferStats") -> "TransferStats":
+        return TransferStats(
+            load=self.load.aggregate(other.load),
+            store=self.store.aggregate(other.store),
+        )
+
+    def is_empty(self) -> bool:
+        return self.load.is_empty() and self.store.is_empty()
+
+
+@dataclass
+class TransferJob:
+    """A transfer job bundling request context with transfer spec.
+
+    Used for both loads and stores, keyed by scheduler-assigned job ID.
+    The worker reports the job ID back when the transfer finishes,
+    and the scheduler processes the completion.
+    """
+
+    req_id: ReqId
+    src_spec: LoadStoreSpec
+    dst_spec: LoadStoreSpec
+
+
+@dataclass
+class OffloadingConnectorMetadata(KVConnectorMetadata):
+    # Keyed by scheduler-assigned job IDs.
+    load_jobs: dict[int, TransferJob]
+    store_jobs: dict[int, TransferJob]
+    jobs_to_flush: set[int] | None = None
+
+
+@dataclass
+class OffloadingWorkerMetadata(KVConnectorWorkerMetadata):
+    """Worker -> Scheduler metadata for completed transfer jobs.
+
+    Each worker reports {job_id: 1} for newly completed transfer jobs
+    (load or store). aggregate() sums counts across workers within a step.
+    The scheduler accumulates across steps and processes
+    a transfer completion only when count reaches num_workers.
+    """
+
+    completed_jobs: dict[int, int] = field(default_factory=dict)
+    transfer_stats: TransferStats = field(default_factory=TransferStats)
+
+    def mark_completed(self, job_id: int) -> None:
+        """Record a transfer job completion from this worker."""
+        self.completed_jobs[job_id] = 1
+
+    def aggregate(
+        self, other: "KVConnectorWorkerMetadata"
+    ) -> "KVConnectorWorkerMetadata":
+        assert isinstance(other, OffloadingWorkerMetadata)
+
+        merged = dict(self.completed_jobs)
+        for job_id, v in other.completed_jobs.items():
+            merged[job_id] = merged.get(job_id, 0) + v
+
+        return OffloadingWorkerMetadata(
+            completed_jobs=merged,
+            transfer_stats=self.transfer_stats.aggregate(other.transfer_stats),
+        )

--- a/tests/fixtures/image_487ecf187_offloading_config.py
+++ b/tests/fixtures/image_487ecf187_offloading_config.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Translate vLLM KV cache metadata for native offloading backends."""
+
+from typing import TYPE_CHECKING
+
+from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    FullAttentionSpec,
+    MLAAttentionSpec,
+)
+from vllm.v1.kv_offload.config import (
+    OffloadingCacheConfig,
+    OffloadingConfig,
+    OffloadingGroupConfig,
+    OffloadingModelConfig,
+    OffloadingParallelConfig,
+)
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheTensor
+
+
+def is_kv_cache_tensor_packed(kv_cache_tensor: "KVCacheTensor") -> bool:
+    """Return whether a KV cache tensor uses a packed block stride."""
+    return bool(kv_cache_tensor.block_stride)
+
+
+def build_offloading_config(
+    vllm_config: "VllmConfig",
+    kv_cache_config: "KVCacheConfig",
+) -> OffloadingConfig:
+    """Translate vLLM configuration into the native offloading boundary."""
+    kv_transfer_config = vllm_config.kv_transfer_config
+    assert kv_transfer_config is not None
+    extra_config = kv_transfer_config.kv_connector_extra_config
+    assert kv_transfer_config.engine_id is not None
+    engine_id = kv_transfer_config.engine_id
+
+    parallel_config = vllm_config.parallel_config
+    groups = tuple(
+        OffloadingGroupConfig(
+            tokens_per_block=(
+                group.kv_cache_spec.block_size
+                * (
+                    parallel_config.decode_context_parallel_size
+                    if isinstance(group.kv_cache_spec, AttentionSpec)
+                    else 1
+                )
+            ),
+            layer_names=tuple(group.layer_names),
+        )
+        for group in kv_cache_config.kv_cache_groups
+    )
+
+    _, tokens_per_hash = resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)
+    for group in groups:
+        assert group.tokens_per_block % tokens_per_hash == 0, (
+            f"tokens_per_block={group.tokens_per_block} not divisible by "
+            f"tokens_per_hash={tokens_per_hash}. "
+            f"Hybrid models (e.g. Mamba+Attention) need "
+            f"--enable-prefix-caching to align block sizes."
+        )
+
+    blocks_per_chunk = 1
+    blocks_per_chunk_config = extra_config.get("blocks_per_chunk")
+    tokens_per_chunk = extra_config.get("block_size")
+
+    if blocks_per_chunk_config is not None and tokens_per_chunk is not None:
+        raise ValueError(
+            "Specify only one of 'block_size' or 'blocks_per_chunk' "
+            "in kv_connector_extra_config."
+        )
+
+    if blocks_per_chunk_config is not None:
+        blocks_per_chunk = int(blocks_per_chunk_config)
+
+        if blocks_per_chunk <= 0:
+            raise ValueError("'blocks_per_chunk' must be greater than 0.")
+
+    elif tokens_per_chunk is not None:
+        tokens_per_chunk_int = int(tokens_per_chunk)
+
+        unique_tokens_per_block = {group.tokens_per_block for group in groups}
+
+        assert len(unique_tokens_per_block) == 1, (
+            "If 'block_size' is specified in kv_connector_extra_config, "
+            "there must be at least one KV cache group, "
+            "and all groups must have the same block size."
+        )
+
+        tokens_per_block = unique_tokens_per_block.pop()
+        assert tokens_per_chunk_int % tokens_per_block == 0
+        blocks_per_chunk = tokens_per_chunk_int // tokens_per_block
+
+    worker_kv_bytes_per_block = 0
+    if kv_cache_config.num_blocks > 0:
+        packed_tensors = tuple(
+            is_kv_cache_tensor_packed(tensor)
+            for tensor in kv_cache_config.kv_cache_tensors
+        )
+        is_packed = any(packed_tensors)
+        assert not is_packed or all(packed_tensors)
+        total_gpu_kv_bytes = (
+            kv_cache_config.kv_cache_tensors[0].size
+            if is_packed
+            else sum(tensor.size for tensor in kv_cache_config.kv_cache_tensors)
+        )
+        worker_kv_bytes_per_block = total_gpu_kv_bytes // kv_cache_config.num_blocks
+
+    single_group_spec = (
+        kv_cache_config.kv_cache_groups[0].kv_cache_spec
+        if len(kv_cache_config.kv_cache_groups) == 1
+        else None
+    )
+    replicated_layout = (
+        vllm_config.model_config.use_mla
+        # Exact type: fail closed on wrappers and sliding-window variants.
+        and type(single_group_spec) is MLAAttentionSpec
+        # Page accounting: one MLA page per layer, no packed/mixed rows.
+        and worker_kv_bytes_per_block > 0
+        and worker_kv_bytes_per_block
+        == single_group_spec.page_size_bytes
+        * len(kv_cache_config.kv_cache_groups[0].layer_names)
+        # Safe MVP boundary: TP-only, no other parallel axes.
+        and parallel_config.tensor_parallel_size > 1
+        and parallel_config.pipeline_parallel_size == 1
+        and parallel_config.prefill_context_parallel_size == 1
+        and parallel_config.decode_context_parallel_size == 1
+        and parallel_config.world_size == parallel_config.tensor_parallel_size
+        # Shared /dev/shm mmap layout is single-node mp only.
+        and parallel_config.distributed_executor_backend == "mp"
+        and parallel_config.nnodes_within_dp == 1
+    )
+
+    canonical_layout = bool(extra_config.get("canonical_layout", False))
+
+    # Only a single non-MLA full-attention group with genuinely head-sharded
+    # pages is parallelism-invariant: replicated latent or GQA heads,
+    # per-token-head scales, CP token sharding, and the V2 model runner's
+    # layout are all excluded.
+    is_parallelism_agnostic = (
+        not vllm_config.use_v2_model_runner
+        and single_group_spec is not None
+        and isinstance(single_group_spec, FullAttentionSpec)
+        and not isinstance(single_group_spec, MLAAttentionSpec)
+        and single_group_spec.num_kv_heads * parallel_config.tensor_parallel_size
+        == vllm_config.model_config.get_total_num_kv_heads()
+        and not single_group_spec.kv_quant_mode.is_per_token_head
+        and parallel_config.decode_context_parallel_size == 1
+        and parallel_config.prefill_context_parallel_size == 1
+    )
+    # Canonical pages are topology-free by construction, so the canonical
+    # layout widens the gate to every config whose mappings derive portable:
+    # exactly-sharded or replicated GQA heads (writer rotation) and the
+    # TP-replicated MLA latent (one canonical copy for all replicas). The
+    # model-runner version is irrelevant here — certification happens per
+    # layer against live tensor strides at registration, and create_worker
+    # fails closed against this flag if any layer cannot be certified.
+    if canonical_layout and not is_parallelism_agnostic:
+        tp_size = parallel_config.tensor_parallel_size
+        if isinstance(single_group_spec, FullAttentionSpec):
+            if type(single_group_spec) is MLAAttentionSpec:
+                spec_certifiable = (
+                    single_group_spec.compress_ratio == 1
+                    and single_group_spec.real_page_size_bytes
+                    % single_group_spec.block_size
+                    == 0
+                )
+            else:
+                total_kv_heads = vllm_config.model_config.get_total_num_kv_heads()
+                spec_certifiable = (
+                    total_kv_heads % tp_size == 0 or tp_size % total_kv_heads == 0
+                )
+            is_parallelism_agnostic = (
+                spec_certifiable
+                and not single_group_spec.kv_quant_mode.is_per_token_head
+                and parallel_config.decode_context_parallel_size == 1
+                and parallel_config.prefill_context_parallel_size == 1
+                and parallel_config.world_size == tp_size
+            )
+
+    kv_events_config = vllm_config.kv_events_config
+    cache_dtype = (
+        vllm_config.model_config.dtype
+        if vllm_config.cache_config.cache_dtype == "auto"
+        else vllm_config.cache_config.cache_dtype
+    )
+
+    return OffloadingConfig(
+        groups=groups,
+        worker_kv_bytes_per_block=worker_kv_bytes_per_block,
+        enable_kv_cache_events=(
+            kv_events_config is not None and kv_events_config.enable_kv_cache_events
+        ),
+        extra_config=extra_config,
+        engine_id=engine_id,
+        model=OffloadingModelConfig(
+            name=vllm_config.model_config.model,
+            dtype=str(cache_dtype).removeprefix("torch."),
+        ),
+        cache=OffloadingCacheConfig(
+            tokens_per_hash=tokens_per_hash,
+            blocks_per_chunk=blocks_per_chunk,
+        ),
+        parallel=OffloadingParallelConfig(
+            rank=parallel_config.rank,
+            world_size=parallel_config.world_size,
+            tp_size=parallel_config.tensor_parallel_size,
+            pp_size=parallel_config.pipeline_parallel_size,
+            pcp_size=parallel_config.prefill_context_parallel_size,
+            dcp_size=parallel_config.decode_context_parallel_size,
+            data_parallel_index=parallel_config.data_parallel_index,
+            data_parallel_size=parallel_config.data_parallel_size,
+            data_parallel_rank_local=parallel_config.data_parallel_rank_local,
+            is_parallelism_agnostic=is_parallelism_agnostic,
+        ),
+        replicated_layout=replicated_layout,
+        canonical_layout=canonical_layout,
+    )

--- a/tests/fixtures/image_487ecf187_offloading_scheduler.py
+++ b/tests/fixtures/image_487ecf187_offloading_scheduler.py
@@ -1,0 +1,1698 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import time
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from itertools import chain, islice
+from typing import Any, NamedTuple
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_events import KVCacheEvent
+from vllm.distributed.kv_transfer.kv_connector.utils import yield_req_data
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
+    OffloadingConnectorMetadata,
+    OffloadingWorkerMetadata,
+    ReqId,
+    TransferJob,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.events import (
+    OffloadingEventGroupSpec,
+    OffloadingEventsTracker,
+    get_offloading_event_group_spec,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
+    OffloadingConnectorStats,
+    _ConnectorMetricName,
+    _TransferMetricName,
+)
+from vllm.logger import init_logger
+from vllm.utils.math_utils import cdiv, round_down
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheSpec,
+    MambaSpec,
+    SlidingWindowSpec,
+)
+from vllm.v1.kv_offload.base import (
+    GPULoadStoreSpec,
+    Locality,
+    LookupResult,
+    Medium,
+    OffloadingManager,
+    OffloadingSpec,
+    OffloadKey,
+    OffloadPolicy,
+    ReqContext,
+    RequestOffloadingContext,
+    ScheduleEndContext,
+    TierFilter,
+    TierMatcher,
+    make_offload_key,
+)
+from vllm.v1.outputs import KVConnectorOutput
+from vllm.v1.request import Request, RequestStatus
+
+logger = init_logger(__name__)
+
+KV_LOAD_TIERS_KEY = "kv_load_tiers"
+MATCHER_MEDIUM_KEY = "medium"
+MATCHER_LOCALITY_KEY = "locality"
+
+
+@dataclass(slots=True)
+class TransferJobStatus:
+    """Tracks scheduler-side state for a single transfer job."""
+
+    req_id: ReqId
+    # Number of workers still pending. Starts at num_workers,
+    # decremented as each worker reports completion. Job is done at 0.
+    pending_count: int
+    # Offload keys this job covers; passed to manager.complete_*().
+    keys: set[OffloadKey]
+    is_store: bool
+    # Store source blocks fenced after the request finishes.
+    deferred_fence_block_ids: list[int] | None = None
+    # Store source blocks fenced when the transfer is created.
+    fenced_block_ids: list[int] | None = None
+
+
+class GroupOffloadConfig(NamedTuple):
+    group_idx: int
+    tokens_per_block: int
+    tokens_per_chunk: int
+    hashes_per_chunk: int
+    # KV cache spec metadata propagated onto emitted BlockStored events so
+    # KV-aware consumers can classify and filter the group.
+    kv_event_group_spec: OffloadingEventGroupSpec
+    # None below means full attention
+    sliding_window_size_in_chunks: int | None
+    # Partial-tail data for this group comes from the scheduler's CoW hand-off
+    # rather than the request block table.
+    requires_cow_source: bool = False
+    # Number of this group's offloaded chunks per full-attention alignment
+    # segment. Used to skip storing SWA chunks that can never serve a load
+    # hit (e.g. DeepSeek V4 where SWA groups have much smaller block sizes
+    # than the MLA full-attention group).
+    # None for full-attention groups or when the optimization doesn't apply.
+    alignment_chunk_count: int | None = None
+    # True for EAGLE/MTP draft-model attention groups. The trailing chunk
+    # of these groups is volatile and lacks a stable hash, so it must
+    # be excluded from store and load scheduling.
+    is_eagle_group: bool = False
+
+
+def get_sliding_window_size_in_chunks(
+    kv_cache_spec: KVCacheSpec, tokens_per_chunk: int
+) -> int | None:
+    if isinstance(kv_cache_spec, SlidingWindowSpec):
+        assert kv_cache_spec.sliding_window > 0
+        return cdiv(kv_cache_spec.sliding_window, tokens_per_chunk)
+
+    if isinstance(kv_cache_spec, ChunkedLocalAttentionSpec):
+        # Attention never reaches back past one chunk
+        assert kv_cache_spec.attention_chunk_size > 0
+        return cdiv(kv_cache_spec.attention_chunk_size, tokens_per_chunk)
+
+    if isinstance(kv_cache_spec, MambaSpec):
+        # Mamba depends on a single state
+        return 1
+
+    assert isinstance(kv_cache_spec, FullAttentionSpec)
+    return None
+
+
+def is_store_reachable_swa_chunk(
+    absolute_chunk_index: int,
+    storable_chunk_count: int,
+    alignment_chunk_count: int | None,
+    sliding_window_chunks: int | None,
+    is_eagle_group: bool,
+) -> bool:
+    """Return whether an SWA chunk can participate in an external-cache hit."""
+    if alignment_chunk_count is None:
+        return True
+    assert sliding_window_chunks is not None
+    position_in_segment = absolute_chunk_index % alignment_chunk_count
+    segment_start = absolute_chunk_index - position_in_segment
+    actual_segment_length = min(
+        alignment_chunk_count, storable_chunk_count - segment_start
+    )
+    reachable_tail = sliding_window_chunks + int(is_eagle_group)
+    return position_in_segment >= actual_segment_length - reachable_tail
+
+
+def resolve_mamba_align_size(
+    spec: "OffloadingSpec", kv_cache_config: KVCacheConfig
+) -> int | None:
+    """Scan all KV cache groups in *spec* and return the single mamba alignment
+    size, or None if no group requires mamba alignment.
+
+    For MambaSpec groups in "align" or "all" cache mode the hit window must be
+    rounded down to a multiple of the offloaded chunk size. Asserts that all
+    such groups agree on the same value.
+    """
+    mamba_align_size: int | None = None
+    for idx, tokens_per_block in enumerate(spec.tokens_per_block):
+        kv_spec = kv_cache_config.kv_cache_groups[idx].kv_cache_spec
+        if isinstance(kv_spec, MambaSpec) and kv_spec.mamba_cache_mode in (
+            "align",
+            "all",
+        ):
+            tokens_per_chunk = tokens_per_block * spec.blocks_per_chunk
+            assert mamba_align_size is None or mamba_align_size == tokens_per_chunk
+            mamba_align_size = tokens_per_chunk
+    return mamba_align_size
+
+
+class SchedulerOffloadConfig(NamedTuple):
+    kv_group_configs: tuple[GroupOffloadConfig, ...]
+    blocks_per_chunk: int
+    tokens_per_hash: int
+    num_workers: int
+    offload_prompt_only: bool
+    supports_partial_tail: bool
+
+    @classmethod
+    def from_spec(
+        cls,
+        spec: OffloadingSpec,
+        vllm_config: VllmConfig,
+        kv_cache_config: KVCacheConfig,
+    ) -> "SchedulerOffloadConfig":
+        # Determine the alignment token count from the full-attention group(s).
+        # This is the tokens_per_chunk of the full-attention group; load
+        # hits are always aligned to this boundary, so SWA blocks earlier in
+        # each segment can never serve a load hit. Relevant for hybrid
+        # architectures like DeepSeek V4 (MLA + SWA groups).
+        full_attn_tokens_per_chunk: set[int] = set()
+        for idx, tokens_per_block in enumerate(spec.tokens_per_block):
+            kv_spec = kv_cache_config.kv_cache_groups[idx].kv_cache_spec
+            sw = get_sliding_window_size_in_chunks(
+                kv_spec, tokens_per_block * spec.blocks_per_chunk
+            )
+            if sw is None:
+                full_attn_tokens_per_chunk.add(tokens_per_block * spec.blocks_per_chunk)
+
+        # Only apply the optimization if there's a single consistent
+        # full-attention alignment size.
+        alignment_tokens: int | None = None
+        if len(full_attn_tokens_per_chunk) == 1:
+            alignment_tokens = full_attn_tokens_per_chunk.pop()
+
+        def _alignment_chunk_count(
+            tokens_per_chunk: int,
+            sliding_window_size_in_chunks: int | None,
+        ) -> int | None:
+            if alignment_tokens is None or sliding_window_size_in_chunks is None:
+                return None
+            if alignment_tokens <= tokens_per_chunk:
+                return None
+            per_segment = alignment_tokens // tokens_per_chunk
+            if sliding_window_size_in_chunks >= per_segment:
+                return None
+            return per_segment
+
+        eagle_groups = {
+            idx
+            for idx, g in enumerate(kv_cache_config.kv_cache_groups)
+            if g.is_eagle_group
+        }
+
+        use_eagle = (
+            vllm_config.speculative_config is not None
+            and vllm_config.speculative_config.use_eagle()
+        )
+        if use_eagle and not eagle_groups:
+            eagle_groups = set(range(len(kv_cache_config.kv_cache_groups)))
+
+        if eagle_groups:
+            logger.info(
+                "KV offloading: EAGLE/MTP draft attention groups %s "
+                "detected. The trailing chunk of these groups will be "
+                "excluded from offloading due to volatility.",
+                sorted(eagle_groups),
+            )
+
+        kv_group_configs_list: list[GroupOffloadConfig] = []
+        for idx, tokens_per_block in enumerate(spec.tokens_per_block):
+            kv_cache_group = kv_cache_config.kv_cache_groups[idx]
+            kv_spec = kv_cache_group.kv_cache_spec
+            sw = get_sliding_window_size_in_chunks(
+                kv_spec, tokens_per_block * spec.blocks_per_chunk
+            )
+            kv_group_configs_list.append(
+                GroupOffloadConfig(
+                    group_idx=idx,
+                    tokens_per_block=tokens_per_block,
+                    tokens_per_chunk=tokens_per_block * spec.blocks_per_chunk,
+                    hashes_per_chunk=(
+                        (tokens_per_block * spec.blocks_per_chunk)
+                        // spec.tokens_per_hash
+                    ),
+                    sliding_window_size_in_chunks=sw,
+                    alignment_chunk_count=_alignment_chunk_count(
+                        tokens_per_block * spec.blocks_per_chunk, sw
+                    ),
+                    kv_event_group_spec=get_offloading_event_group_spec(kv_cache_group),
+                    is_eagle_group=idx in eagle_groups,
+                    requires_cow_source=(
+                        isinstance(kv_spec, MambaSpec)
+                        and kv_spec.mamba_cache_mode == "align"
+                    ),
+                )
+            )
+        kv_group_configs = tuple(kv_group_configs_list)
+        group_block_sizes = {config.tokens_per_block for config in kv_group_configs}
+        has_partial_recurrent_group = any(
+            config.requires_cow_source
+            and config.tokens_per_block > spec.tokens_per_hash
+            for config in kv_group_configs
+        )
+        # Partial tails currently require one physical block per offload chunk
+        # and uniform, non-windowed groups so one boundary identifies every
+        # group's source. EAGLE and DCP need additional hand-off semantics.
+        supports_partial_tail = (
+            spec.blocks_per_chunk == 1
+            and len(group_block_sizes) == 1
+            and has_partial_recurrent_group
+            and all(
+                config.sliding_window_size_in_chunks is None
+                or config.requires_cow_source
+                for config in kv_group_configs
+            )
+            and not any(config.is_eagle_group for config in kv_group_configs)
+            and vllm_config.parallel_config.decode_context_parallel_size == 1
+        )
+
+        return cls(
+            num_workers=vllm_config.parallel_config.world_size,
+            kv_group_configs=kv_group_configs,
+            blocks_per_chunk=spec.blocks_per_chunk,
+            tokens_per_hash=spec.tokens_per_hash,
+            offload_prompt_only=spec.offload_prompt_only,
+            supports_partial_tail=supports_partial_tail,
+        )
+
+
+@dataclass
+class RequestGroupState:
+    offload_keys: list[OffloadKey] = field(default_factory=list)
+    block_ids: list[int] = field(default_factory=list)
+    # Index of the next chunk to offload.
+    next_stored_chunk_idx: int = 0
+    # Number of offloaded chunks hit (including GPU prefix cache)
+    # when the request first started
+    num_hit_chunks: int = 0
+
+
+@dataclass(slots=True)
+class RequestOffloadState:
+    config: SchedulerOffloadConfig
+    req: Request
+    req_context: ReqContext
+    offloading_context: RequestOffloadingContext
+    group_states: tuple[RequestGroupState, ...] = field(init=False)
+    # upper bound on tokens to offload for this request; None means no cap
+    max_offload_tokens: int | None = None
+    # number of hits in the GPU cache
+    num_locally_computed_tokens: int = 0
+    # In-flight job IDs. Per the connector's invariant, at any given time
+    # this contains either a single load job, or one or more store jobs.
+    transfer_jobs: set[int] = field(default_factory=set)
+    # time.monotonic() of this request's first deferred offload lookup;
+    # None once consumed (observed) or while no lookup is pending.
+    deferred_lookup_start_time: float | None = None
+    # Fine-grained token boundary selected beyond the last complete offload
+    # chunk. It is consumed when the corresponding load is scheduled.
+    partial_tail_boundary: int | None = None
+    # True once on_request_finished has been signaled to the manager.
+    finished_signaled: bool = False
+
+    def __post_init__(self) -> None:
+        self.group_states = tuple(
+            RequestGroupState() for _ in self.config.kv_group_configs
+        )
+        params = self.req.kv_transfer_params
+
+        # NOTE: This field is experimental and subject to change in the future.
+        raw = params.get("max_offload_tokens") if params else None
+        if type(raw) is int and raw >= 0:
+            self.max_offload_tokens = raw
+            logger.debug(
+                "Request %s: max_offload_tokens set to %d",
+                self.req.request_id,
+                raw,
+            )
+        elif raw is not None:
+            logger.warning(
+                "max_offload_tokens must be a non-negative int, got %r; ignoring", raw
+            )
+
+    def update_offload_keys(self) -> None:
+        for group_config, group_state in zip(
+            self.config.kv_group_configs, self.group_states
+        ):
+            for req_block_hash in islice(
+                self.req.block_hashes,
+                group_config.hashes_per_chunk * len(group_state.offload_keys)
+                + group_config.hashes_per_chunk
+                - 1,
+                None,
+                group_config.hashes_per_chunk,
+            ):
+                group_state.offload_keys.append(
+                    make_offload_key(req_block_hash, group_config.group_idx)
+                )
+
+    def update_block_id_groups(
+        self, new_block_id_groups: tuple[list[int], ...] | None
+    ) -> None:
+        if new_block_id_groups is None:
+            return
+
+        assert len(new_block_id_groups) == len(self.group_states)
+        for group_state, new_blocks in zip(self.group_states, new_block_id_groups):
+            group_state.block_ids.extend(new_blocks)
+
+    def storable_chunks(
+        self,
+        group_config: "GroupOffloadConfig",
+        group_state: RequestGroupState,
+        num_offloadable_tokens: int,
+    ) -> int:
+        """Number of allocated leading offloaded chunks eligible for store.
+
+        For eagle/MTP groups the volatile trailing chunk of the offloadable
+        range is excluded while decoding: the draft-layer KV of the last
+        accepted position may be rewritten after spec-token rejection. During
+        prefill the trailing chunk is stable (the draft input for a chunk's
+        last position is the next prompt token), so it is stored immediately.
+        The exclusion must be applied consistently everywhere
+        ``next_stored_chunk_idx`` is derived: otherwise the trailing chunk of
+        each step is skipped on collection but jumped over by
+        ``next_stored_chunk_idx``, so it is never re-considered and a
+        permanent hole breaks prefix-reuse lookup.
+        """
+        num_chunks = num_offloadable_tokens // group_config.tokens_per_chunk
+        is_decoding = num_offloadable_tokens > self.req.num_prompt_tokens
+        if group_config.is_eagle_group and is_decoding:
+            num_chunks = max(0, num_chunks - 1)
+        num_allocated_chunks = (
+            len(group_state.block_ids) // self.config.blocks_per_chunk
+        )
+        return min(num_chunks, num_allocated_chunks)
+
+    def advance_stored_idx(self, num_offloadable_tokens: int) -> None:
+        # max(): at the prefill->decode transition of a chunk-aligned prompt,
+        # storable_chunks drops by one (the eagle exclusion kicks in), and the
+        # index must not move backwards past already-stored chunks.
+        for group_config, group_state in zip(
+            self.config.kv_group_configs, self.group_states
+        ):
+            group_state.next_stored_chunk_idx = max(
+                group_state.next_stored_chunk_idx,
+                self.storable_chunks(group_config, group_state, num_offloadable_tokens),
+            )
+
+    def update_num_hit_chunks(self, num_cached_tokens: int) -> None:
+        for group_config, group_state in zip(
+            self.config.kv_group_configs, self.group_states
+        ):
+            group_state.num_hit_chunks = (
+                num_cached_tokens // group_config.tokens_per_chunk
+            )
+
+
+def _parse_tier_filter(raw: Any) -> TierFilter:
+    """Parse raw kv_transfer_params tier matchers into a TierFilter."""
+    if not isinstance(raw, list):
+        logger.warning(
+            "_parse_tier_filter: expected list, got %s; ignoring",
+            type(raw).__name__,
+        )
+        return TierFilter.ALL
+    matchers: list[TierMatcher] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            logger.warning("_parse_tier_filter: entry is not a dict; skipping")
+            continue
+        medium: Medium | None = None
+        locality: Locality | None = None
+        raw_medium = entry.get(MATCHER_MEDIUM_KEY)
+        if raw_medium is not None:
+            try:
+                medium = Medium(raw_medium.upper())
+            except (ValueError, AttributeError):
+                logger.warning(
+                    "_parse_tier_filter: unknown medium %r; skipping entry",
+                    raw_medium,
+                )
+                continue
+        raw_locality = entry.get(MATCHER_LOCALITY_KEY)
+        if raw_locality is not None:
+            try:
+                locality = Locality(raw_locality.upper())
+            except (ValueError, AttributeError):
+                logger.warning(
+                    "_parse_tier_filter: unknown locality %r; skipping entry",
+                    raw_locality,
+                )
+                continue
+        matchers.append(TierMatcher(medium=medium, locality=locality))
+    if not matchers:
+        if not raw:  # input was [] — user explicitly wants nothing
+            return TierFilter(matchers=())
+        # all entries were invalid — fall back to ALL
+        return TierFilter.ALL
+    return TierFilter(matchers=tuple(matchers))
+
+
+def _create_req_context(req: Request) -> ReqContext:
+    params = req.kv_transfer_params
+    load_filter = TierFilter.ALL
+    if params:
+        raw = params.get(KV_LOAD_TIERS_KEY)
+        if raw is not None:
+            load_filter = _parse_tier_filter(raw)
+    return ReqContext(
+        req_id=req.request_id,
+        kv_transfer_params=params,
+        load_tier_filter=load_filter,
+    )
+
+
+class OffloadingConnectorScheduler:
+    """Implementation of Scheduler side methods"""
+
+    def __init__(
+        self,
+        spec: OffloadingSpec,
+        vllm_config: VllmConfig,
+        kv_cache_config: KVCacheConfig,
+    ):
+        self.config = SchedulerOffloadConfig.from_spec(
+            spec, vllm_config, kv_cache_config
+        )
+        self.manager: OffloadingManager = spec.get_manager()
+        self._connector_stats = OffloadingConnectorStats()
+
+        full_attention_groups: list[int] = []
+        sliding_window_groups: list[int] = []
+        for group_config in self.config.kv_group_configs:
+            if group_config.sliding_window_size_in_chunks is None:
+                full_attention_groups.append(group_config.group_idx)
+            else:
+                sliding_window_groups.append(group_config.group_idx)
+
+        # sort sliding window groups by window size in decreasing order
+        def _sliding_window_sort_key(i: int) -> int:
+            val = self.config.kv_group_configs[i].sliding_window_size_in_chunks
+            assert val is not None
+            return val
+
+        sliding_window_groups.sort(key=_sliding_window_sort_key, reverse=True)
+
+        # used by _lookup
+        self._sliding_window_groups: tuple[int, ...] = tuple(sliding_window_groups)
+        self._lookup_groups = tuple(full_attention_groups) + self._sliding_window_groups
+        self._mamba_align_size: int | None = resolve_mamba_align_size(
+            spec, kv_cache_config
+        )
+        self._partial_tail_block_size = (
+            self.config.kv_group_configs[0].tokens_per_block
+            if self.config.supports_partial_tail
+            else 0
+        )
+        self._cow_source_groups = frozenset(
+            config.group_idx
+            for config in self.config.kv_group_configs
+            if config.requires_cow_source
+        )
+
+        self._req_status: dict[ReqId, RequestOffloadState] = {}
+        self._current_batch_load_jobs: dict[int, TransferJob] = {}
+        self._current_batch_jobs_to_flush: set[int] = set()
+        # GPU block IDs allocated in the current engine step
+        self._current_batch_allocated_block_ids: set[int] = set()
+        # if GPU prefix caching is enabled,
+        # Track loaded chunks to avoid redundant loads.
+        self._chunks_being_loaded: set[OffloadKey] | None = (
+            set() if vllm_config.cache_config.enable_prefix_caching else None
+        )
+
+        # Job ID counter shared by loads and stores.
+        self._job_counter: int = 0
+        # Threshold value for stale jobs. All job ids >= _stale_job_threshold are
+        # active jobs.
+        self._stale_job_threshold: int = 0
+        self._jobs: dict[int, TransferJobStatus] = {}
+
+        # block_id -> pending store job_ids. Used to track jobs that needs
+        # flushing in case a block is re-allocated by the KV cache manager.
+        # Populated only for finished requests (running-request blocks are
+        # protected by their ref_cnt) and for sliding window blocks (which can
+        # be freed before a request finishes).
+        self._block_id_to_pending_jobs: dict[int, set[int]] = {}
+
+        self._events_tracker = OffloadingEventsTracker(spec.kv_events_config)
+
+    def _maybe_observe_lookup_async_delay(
+        self, req_status: RequestOffloadState
+    ) -> None:
+        start_time = req_status.deferred_lookup_start_time
+        if start_time is None:
+            return
+        req_status.deferred_lookup_start_time = None
+        self._connector_stats.observe_histogram(
+            _ConnectorMetricName.LOOKUP_ASYNC_DELAY,
+            time.monotonic() - start_time,
+        )
+
+    def _generate_job_id(self) -> int:
+        job_id = self._job_counter
+        self._job_counter += 1
+        return job_id
+
+    def _remove_pending_job(self, job_id: int, block_ids: list[int] | None) -> None:
+        for bid in block_ids or ():
+            pending = self._block_id_to_pending_jobs[bid]
+            pending.remove(job_id)
+            if not pending:
+                del self._block_id_to_pending_jobs[bid]
+
+    def _calc_num_offloadable_tokens(
+        self, req_status: RequestOffloadState, num_computed_tokens: int
+    ) -> int:
+        num = min(num_computed_tokens, req_status.req.num_tokens)
+        max_offload_tokens = req_status.max_offload_tokens
+        if max_offload_tokens is not None:
+            num = min(num, max_offload_tokens)
+        if self.config.offload_prompt_only:
+            num = min(num, req_status.req.num_prompt_tokens)
+        return num
+
+    def _maximal_prefix_lookup(
+        self,
+        keys: Iterable[OffloadKey],
+        req_context: ReqContext,
+        req: Request,
+        group_config: GroupOffloadConfig,
+        start_chunk_idx: int,
+    ) -> int | None:
+        """Return the number of consecutive offloaded chunks from the start,
+        or None if the backend deferred a lookup."""
+        hit_count = 0
+        defer_lookup = False
+        for local_idx, key in enumerate(keys):
+            result = self.manager.lookup(key, req_context)
+            match result:
+                case LookupResult.HIT:
+                    self._events_tracker.record_lookup(
+                        req,
+                        group_config,
+                        start_chunk_idx + local_idx,
+                        key,
+                    )
+                    hit_count += 1
+                case LookupResult.HIT_PENDING:
+                    defer_lookup = True
+                    hit_count += 1
+                case LookupResult.RETRY:
+                    # Don't break: keep scanning to let manager kick off
+                    # async lookups (until a miss is detected).
+                    defer_lookup = True
+                case LookupResult.MISS:
+                    break
+        return hit_count if not defer_lookup else None
+
+    def _sliding_window_lookup(
+        self,
+        keys: Sequence[OffloadKey],
+        sliding_window_size: int,
+        req_context: ReqContext,
+    ) -> int | None:
+        """Return the end index (in `keys`) of the last run of
+        `sliding_window_size` consecutive hits, scanning from the end.
+        Returns 0 on miss, None if the backend deferred a lookup."""
+        defer_lookup = False
+        consecutive_hits = 0
+        for idx in range(len(keys) - 1, -1, -1):
+            match self.manager.lookup(keys[idx], req_context):
+                case LookupResult.HIT:
+                    consecutive_hits += 1
+                case LookupResult.HIT_PENDING:
+                    # Block is in cache, just not readable yet — counts
+                    # as hit for the consecutive streak. Don't break:
+                    # keep scanning to let manager kick off async lookups.
+                    defer_lookup = True
+                    consecutive_hits += 1
+                case LookupResult.RETRY:
+                    # Block location uncertain — does not count as hit.
+                    # Don't break: keep scanning to let manager kick off
+                    # async lookups.
+                    defer_lookup = True
+                    consecutive_hits = 0
+                case LookupResult.MISS:
+                    consecutive_hits = 0
+            if consecutive_hits == sliding_window_size:
+                return idx + sliding_window_size if not defer_lookup else None
+        return consecutive_hits if not defer_lookup else None
+
+    def _touch(self, req_status: RequestOffloadState):
+        for group_config, group_state in zip(
+            self.config.kv_group_configs, req_status.group_states
+        ):
+            if group_config.sliding_window_size_in_chunks is None:
+                self.manager.touch(group_state.offload_keys, req_status.req_context)
+            else:
+                # Keep only chunks needed to hit the original request, plus
+                # decoded chunks.
+                chunks_to_skip = max(
+                    0,
+                    group_state.num_hit_chunks
+                    - group_config.sliding_window_size_in_chunks,
+                )
+                self.manager.touch(
+                    group_state.offload_keys[chunks_to_skip:],
+                    req_status.req_context,
+                )
+        if req_status.partial_tail_boundary is not None:
+            self.manager.touch(
+                tuple(
+                    self._make_boundary_key(
+                        req_status.req,
+                        group.group_idx,
+                        req_status.partial_tail_boundary,
+                    )
+                    for group in self.config.kv_group_configs
+                ),
+                req_status.req_context,
+            )
+
+    def _lookup_complete_chunks(self, req_status: RequestOffloadState) -> int | None:
+        """
+        Find how many tokens beyond num_locally_computed_tokens can be loaded.
+
+        Iterates full-attention groups first (prefix lookup), then sliding-window
+        groups (suffix lookup). Each group may tighten max_hit_size_tokens, which
+        can invalidate an earlier group's result, so the loop re-runs when that
+        happens until num_hit_tokens converges.
+        """
+        num_computed_tokens = req_status.num_locally_computed_tokens
+        max_hit_size_tokens: int = req_status.req.num_tokens
+        if self._sliding_window_groups:
+            # the last prompt token has to be recomputed to get the logprobs
+            # for sliding window attention, we must reduce by 1 to make sure
+            # we still have a hit after reduction
+            max_hit_size_tokens -= 1
+            if self._mamba_align_size is not None:
+                # Constrain hit-window to the mamba block size.
+                max_hit_size_tokens = round_down(
+                    max_hit_size_tokens, self._mamba_align_size
+                )
+
+        num_hit_tokens: int = 0
+        defer_lookup = False
+        lookup_groups = self._lookup_groups
+
+        # Tracks which eagle groups have already popped their volatile trailing chunk
+        # in the current convergence iteration. Reset when a non-eagle group
+        # tightens the hit boundary, requiring a fresh pop.
+        eagle_verified: set[int] = set()
+        while lookup_groups:
+            looked_up_sliding_window: bool = False
+            groups_iter = iter(lookup_groups)
+            lookup_groups = ()
+            for group_idx in groups_iter:
+                group_config: GroupOffloadConfig = self.config.kv_group_configs[
+                    group_idx
+                ]
+                group_state: RequestGroupState = req_status.group_states[group_idx]
+                tokens_per_chunk = group_config.tokens_per_chunk
+                offload_keys = group_state.offload_keys
+
+                assert (
+                    len(offload_keys) >= req_status.req.num_tokens // tokens_per_chunk
+                )
+
+                is_eagle_unverified = (
+                    group_config.is_eagle_group and group_idx not in eagle_verified
+                )
+
+                # Constrain to a chunk-aligned boundary for this group.
+                max_hit_size_tokens = min(
+                    max_hit_size_tokens, len(offload_keys) * tokens_per_chunk
+                )
+                if max_hit_size_tokens - num_computed_tokens < tokens_per_chunk:
+                    # We can only load less than a chunk, so skip.
+                    return 0
+
+                sliding_window_size_in_chunks = (
+                    group_config.sliding_window_size_in_chunks
+                )
+
+                # For eagle groups, query one extra chunk that will be popped.
+                # We only need to increase the query size for sliding window groups.
+                query_max = max_hit_size_tokens
+                if is_eagle_unverified and sliding_window_size_in_chunks is not None:
+                    query_max = min(
+                        max_hit_size_tokens + tokens_per_chunk,
+                        len(offload_keys) * tokens_per_chunk,
+                    )
+
+                num_chunks = min(cdiv(query_max, tokens_per_chunk), len(offload_keys))
+                start_chunk_idx = num_computed_tokens // tokens_per_chunk
+                offload_keys = offload_keys[start_chunk_idx:num_chunks]
+
+                # end index (in the sliced offload_keys) up to which we
+                # have backend-confirmed hits
+                num_hit_chunks: int | None
+                if sliding_window_size_in_chunks is None:
+                    num_hit_chunks = self._maximal_prefix_lookup(
+                        offload_keys,
+                        req_status.req_context,
+                        req_status.req,
+                        group_config,
+                        start_chunk_idx,
+                    )
+                else:
+                    required_window = sliding_window_size_in_chunks
+                    if is_eagle_unverified:
+                        required_window += 1
+                    num_hit_chunks = self._sliding_window_lookup(
+                        offload_keys,
+                        required_window,
+                        req_status.req_context,
+                    )
+                if num_hit_chunks == 0:
+                    return 0
+
+                if num_hit_chunks is None:
+                    defer_lookup = True
+                else:
+                    if is_eagle_unverified:
+                        num_hit_chunks -= 1
+                        eagle_verified.add(group_idx)
+
+                    max_hit_size_tokens = min(
+                        max_hit_size_tokens,
+                        tokens_per_chunk * (start_chunk_idx + num_hit_chunks),
+                    )
+
+                new_num_hit_tokens = max_hit_size_tokens - num_computed_tokens
+                if new_num_hit_tokens < tokens_per_chunk:
+                    # We can only load less than a chunk, so skip.
+                    return 0
+
+                if new_num_hit_tokens < num_hit_tokens:
+                    if not group_config.is_eagle_group:
+                        eagle_verified.clear()
+                    if defer_lookup:
+                        # make another iteration on all groups to check
+                        # if we still need to defer lookup
+                        defer_lookup = False
+                        lookup_groups = self._lookup_groups
+                    elif looked_up_sliding_window and not lookup_groups:
+                        # we need another iteration to confirm previously looked up
+                        # sliding window works with the new_num_hit_tokens
+                        lookup_groups = self._sliding_window_groups
+
+                looked_up_sliding_window |= sliding_window_size_in_chunks is not None
+                num_hit_tokens = new_num_hit_tokens
+
+        if defer_lookup:
+            logger.debug(
+                "Offloading manager delayed request %s as backend requested",
+                req_status.req.request_id,
+            )
+            return None
+
+        # Possibly delay the request if any hit chunk is already being loaded.
+        if self._chunks_being_loaded:
+            for group_config, group_state in zip(
+                self.config.kv_group_configs, req_status.group_states
+            ):
+                tokens_per_chunk = group_config.tokens_per_chunk
+                sliding_window_size_in_chunks = (
+                    group_config.sliding_window_size_in_chunks
+                )
+                offload_keys = group_state.offload_keys
+                num_chunks = cdiv(
+                    num_computed_tokens + num_hit_tokens, tokens_per_chunk
+                )
+                start_chunk_idx = num_computed_tokens // tokens_per_chunk
+                offload_keys = offload_keys[start_chunk_idx:num_chunks]
+                if sliding_window_size_in_chunks is not None:
+                    offload_keys = offload_keys[-sliding_window_size_in_chunks:]
+                if any(key in self._chunks_being_loaded for key in offload_keys):
+                    # Hit chunks are being loaded, so delay the request.
+                    logger.debug(
+                        "Delaying request %s since some of its"
+                        " chunks are already being loaded",
+                        req_status.req.request_id,
+                    )
+                    return None
+
+        logger.debug(
+            "Request %s hit %s offloaded tokens after %s GPU hit tokens",
+            req_status.req.request_id,
+            num_hit_tokens,
+            num_computed_tokens,
+        )
+
+        return num_hit_tokens
+
+    def _make_boundary_key(
+        self, request: Request, group_idx: int, boundary_tokens: int
+    ) -> OffloadKey:
+        hash_idx = boundary_tokens // self.config.tokens_per_hash - 1
+        return make_offload_key(request.block_hashes[hash_idx], group_idx)
+
+    def _lookup(self, req_status: RequestOffloadState) -> int | None:
+        complete_hit = self._lookup_complete_chunks(req_status)
+        req_status.partial_tail_boundary = None
+        if complete_hit is None or not self.config.supports_partial_tail:
+            return complete_hit
+
+        local_tokens = req_status.num_locally_computed_tokens
+        complete_boundary = local_tokens + complete_hit
+        tokens_per_hash = self.config.tokens_per_hash
+        block_end = complete_boundary + self._partial_tail_block_size
+        max_boundary = round_down(
+            min(req_status.req.num_prompt_tokens - 1, block_end - 1), tokens_per_hash
+        )
+        if max_boundary <= complete_boundary:
+            return complete_hit
+
+        pending = False
+        for boundary in range(max_boundary, complete_boundary, -tokens_per_hash):
+            boundary_pending = False
+            boundary_missed = False
+            boundary_keys = []
+            for group_config in self.config.kv_group_configs:
+                key = self._make_boundary_key(
+                    req_status.req, group_config.group_idx, boundary
+                )
+                boundary_keys.append(key)
+                result = self.manager.lookup(key, req_status.req_context)
+                if result is LookupResult.MISS:
+                    boundary_missed = True
+                    break
+                if result in (LookupResult.HIT_PENDING, LookupResult.RETRY):
+                    boundary_pending = True
+
+            pending |= boundary_pending
+            if not boundary_missed and not boundary_pending:
+                for group_config, key in zip(
+                    self.config.kv_group_configs, boundary_keys
+                ):
+                    self._events_tracker.record_partial_lookup(
+                        req_status.req, group_config, boundary, key
+                    )
+                req_status.partial_tail_boundary = boundary
+                return boundary - local_tokens
+
+        if pending and complete_hit == 0:
+            return None
+        return complete_hit
+
+    def on_new_request(self, request: Request) -> None:
+        """Called when a new request is added to the scheduler."""
+        req_context = _create_req_context(request)
+        offloading_context = self.manager.on_new_request(req_context)
+        req_status = RequestOffloadState(
+            config=self.config,
+            req=request,
+            req_context=req_context,
+            offloading_context=offloading_context,
+        )
+        self._req_status[request.request_id] = req_status
+
+    def get_num_new_matched_tokens(
+        self, request: Request, num_computed_tokens: int
+    ) -> tuple[int | None, bool]:
+        """
+        Get number of new tokens that can be loaded beyond the
+        num_computed_tokens.
+
+        Args:
+            request (Request): the request object.
+            num_computed_tokens (int): the number of locally
+                computed tokens for this request
+
+        Returns:
+            A tuple with the following elements:
+                - The number of tokens that can be loaded beyond what is
+                  already computed.
+                  If None, it means that the connector needs more time to
+                  determine the number of matched tokens, and the scheduler
+                  should query for this request again later.
+                - `True` if tokens will be loaded asynchronously
+                  (between scheduler steps).
+        """
+        req_status = self._req_status[request.request_id]
+        for group_state in req_status.group_states:
+            group_state.block_ids.clear()
+
+        if req_status.transfer_jobs:
+            logger.debug(
+                "Delaying request %s since it still has in-flight transfers",
+                request.request_id,
+            )
+            return None, False
+
+        req_status.update_offload_keys()
+        req_status.num_locally_computed_tokens = num_computed_tokens
+
+        num_hit_tokens: int | None
+        if request.skip_reading_prefix_cache:
+            num_hit_tokens = 0
+        else:
+            lookup_start = time.monotonic()
+            num_hit_tokens = self._lookup(req_status)
+            self._connector_stats.observe_histogram(
+                _ConnectorMetricName.LOOKUP_SYNC_DELAY,
+                time.monotonic() - lookup_start,
+            )
+            if num_hit_tokens is None:
+                if req_status.deferred_lookup_start_time is None:
+                    req_status.deferred_lookup_start_time = lookup_start
+            else:
+                self._maybe_observe_lookup_async_delay(req_status)
+        req_status.update_num_hit_chunks(num_computed_tokens + (num_hit_tokens or 0))
+
+        self._touch(req_status)
+
+        return num_hit_tokens, bool(num_hit_tokens)
+
+    def update_state_after_alloc(
+        self, request: Request, blocks: KVCacheBlocks, num_external_tokens: int
+    ):
+        if num_external_tokens == 0:
+            return
+
+        req_status = self._req_status[request.request_id]
+
+        num_locally_computed_tokens = req_status.num_locally_computed_tokens
+        num_cached_tokens = num_locally_computed_tokens + num_external_tokens
+        partial_tail_boundary = req_status.partial_tail_boundary
+        if partial_tail_boundary is not None:
+            assert partial_tail_boundary == num_cached_tokens
+
+        keys_to_load: list[OffloadKey] = []
+        dst_block_ids: list[int] = []
+        # per group
+        group_sizes: list[int] = []
+        block_indices: list[int] = []
+        for group_config, group_state, group_blocks in zip(
+            self.config.kv_group_configs,
+            req_status.group_states,
+            blocks.blocks,
+        ):
+            self._current_batch_allocated_block_ids.update(
+                block.block_id for block in group_blocks if block.block_id != 0
+            )
+
+            tokens_per_block = group_config.tokens_per_block
+            tokens_per_chunk = group_config.tokens_per_chunk
+            offload_keys = group_state.offload_keys
+            num_gpu_blocks = cdiv(num_cached_tokens, tokens_per_block)
+
+            assert len(group_blocks) >= num_gpu_blocks
+            num_locally_computed_gpu_blocks = num_gpu_blocks
+            # Skip null placeholder blocks (used for sliding window or mamba padding).
+            for i, block in enumerate(group_blocks[:num_gpu_blocks]):
+                if not block.is_null and block.block_hash is None:
+                    num_locally_computed_gpu_blocks = i
+                    break
+
+            assert (
+                num_locally_computed_tokens
+                <= num_locally_computed_gpu_blocks * tokens_per_block
+            )
+            num_pending_gpu_blocks = num_gpu_blocks - num_locally_computed_gpu_blocks
+
+            if group_config.sliding_window_size_in_chunks is not None:
+                assert (
+                    num_pending_gpu_blocks
+                    <= group_config.sliding_window_size_in_chunks
+                    * self.config.blocks_per_chunk
+                    + 1
+                )
+
+            num_chunks = cdiv(num_cached_tokens, tokens_per_chunk)
+            if num_pending_gpu_blocks:
+                start_chunk_idx = (
+                    num_locally_computed_gpu_blocks // self.config.blocks_per_chunk
+                )
+                end_chunk_idx = num_chunks - (partial_tail_boundary is not None)
+                assert len(offload_keys) >= end_chunk_idx
+                keys_to_load.extend(offload_keys[start_chunk_idx:end_chunk_idx])
+                if partial_tail_boundary is not None:
+                    keys_to_load.append(
+                        self._make_boundary_key(
+                            request, group_config.group_idx, partial_tail_boundary
+                        )
+                    )
+
+            dst_block_ids.extend(
+                block.block_id
+                for block in group_blocks[
+                    num_locally_computed_gpu_blocks:num_gpu_blocks
+                ]
+            )
+            group_sizes.append(num_pending_gpu_blocks)
+            block_indices.append(num_locally_computed_gpu_blocks)
+
+            # Skip prefix-hit chunks for block-level policy; for
+            # request-level, next_stored_chunk_idx stays at 0 so all
+            # chunks (including hits) are offloaded.
+            if req_status.offloading_context.policy == OffloadPolicy.BLOCK_LEVEL:
+                group_state.next_stored_chunk_idx = num_chunks
+
+        src_spec = self.manager.prepare_load(keys_to_load, req_status.req_context)
+        dst_spec = GPULoadStoreSpec(
+            dst_block_ids, group_sizes=group_sizes, block_indices=block_indices
+        )
+
+        load_job_id = self._generate_job_id()
+        self._current_batch_load_jobs[load_job_id] = TransferJob(
+            req_id=request.request_id,
+            src_spec=src_spec,
+            dst_spec=dst_spec,
+        )
+        # a load can only be issued when no other jobs are pending.
+        assert not req_status.transfer_jobs
+        req_status.transfer_jobs.add(load_job_id)
+        self._jobs[load_job_id] = TransferJobStatus(
+            req_id=request.request_id,
+            pending_count=self.config.num_workers,
+            keys=set(keys_to_load),
+            is_store=False,
+        )
+
+        if self._chunks_being_loaded is not None:
+            self._chunks_being_loaded.update(keys_to_load)
+        req_status.partial_tail_boundary = None
+
+    def _update_req_states(self, scheduler_output: SchedulerOutput) -> None:
+        """
+        Update request states from the Scheduler's output.
+        """
+
+        # new_block_ids_end[req_id][i] = end of pre-existing block_ids for
+        # the i-th sliding window group (before this step's extend).
+        # Used to detect sliding window blocks that got re-allocated.
+        new_block_ids_end: dict[str, tuple[int, ...]] = {}
+
+        for req_id, new_block_id_groups, preempted in yield_req_data(scheduler_output):
+            req_status = self._req_status[req_id]
+            req_status.update_offload_keys()
+
+            if preempted:
+                for group_state in req_status.group_states:
+                    group_state.block_ids.clear()
+
+            if new_block_id_groups:
+                if self._sliding_window_groups:
+                    new_block_ids_end[req_id] = tuple(
+                        len(req_status.group_states[grp_idx].block_ids)
+                        for grp_idx in self._sliding_window_groups
+                    )
+                req_status.update_block_id_groups(new_block_id_groups)
+                for new_blocks in new_block_id_groups:
+                    for bid in new_blocks:
+                        if bid != 0:
+                            self._current_batch_allocated_block_ids.add(bid)
+
+        # Zero out stale block_ids in sliding window groups' pending-store
+        # positions. Only sliding window groups can have stale entries (blocks
+        # freed by remove_skipped_blocks then reallocated). Only positions in
+        # [next_stored_chunk_idx * bsf, end) need checking where end is the
+        # pre-extend length: earlier positions were already offloaded, later
+        # ones are fresh allocations from this step.
+        if self._sliding_window_groups and self._current_batch_allocated_block_ids:
+            blocks_per_chunk = self.config.blocks_per_chunk
+            for req_id, req_status in self._req_status.items():
+                ends = new_block_ids_end.get(req_id)
+                for i, grp_idx in enumerate(self._sliding_window_groups):
+                    group_state = req_status.group_states[grp_idx]
+                    start = group_state.next_stored_chunk_idx * blocks_per_chunk
+                    end = ends[i] if ends is not None else len(group_state.block_ids)
+                    for j in range(start, end):
+                        if (
+                            group_state.block_ids[j]
+                            in self._current_batch_allocated_block_ids
+                        ):
+                            group_state.block_ids[j] = 0
+
+    def _build_partial_tail_store_jobs(
+        self, scheduler_output: SchedulerOutput
+    ) -> dict[int, TransferJob]:
+        handoffs = scheduler_output.partial_tail_offloads
+        if not self.config.supports_partial_tail or not handoffs:
+            return {}
+
+        store_jobs: dict[int, TransferJob] = {}
+        for req_id, entries in handoffs.items():
+            req_status = self._req_status.get(req_id)
+            assert req_status is not None
+            assert entries
+            boundaries = {boundary for _, _, boundary in entries}
+            assert len(boundaries) == 1
+            boundary = boundaries.pop()
+            req = req_status.req
+            max_boundary = min(
+                req.num_prompt_tokens,
+                req_status.max_offload_tokens or req.num_prompt_tokens,
+            )
+            assert boundary > 0
+            assert boundary % self.config.tokens_per_hash == 0
+            assert boundary <= max_boundary
+
+            cow_blocks = {group_idx: block_id for group_idx, block_id, _ in entries}
+            assert self._cow_source_groups.issubset(cow_blocks)
+
+            assert boundary % self._partial_tail_block_size != 0
+            block_idx = boundary // self._partial_tail_block_size
+            if any(
+                group.group_idx not in self._cow_source_groups
+                and block_idx >= len(req_status.group_states[group.group_idx].block_ids)
+                for group in self.config.kv_group_configs
+            ):
+                continue
+            keys = [
+                self._make_boundary_key(req, group.group_idx, boundary)
+                for group in self.config.kv_group_configs
+            ]
+            block_ids = [
+                cow_blocks[group.group_idx]
+                if group.group_idx in self._cow_source_groups
+                else req_status.group_states[group.group_idx].block_ids[block_idx]
+                for group in self.config.kv_group_configs
+            ]
+            assert all(block_id != 0 for block_id in block_ids)
+
+            store_output = self.manager.prepare_store(keys, req_status.req_context)
+            if store_output is None:
+                self._connector_stats.increase_counter(
+                    _ConnectorMetricName.ALLOCATION_FAILURE
+                )
+                continue
+            if not store_output.keys_to_store:
+                continue
+
+            for group_config, key in zip(self.config.kv_group_configs, keys):
+                if key in store_output.keys_to_store:
+                    self._events_tracker.record_partial_store(
+                        req, group_config, boundary, key
+                    )
+
+            group_by_key = {key: idx for idx, key in enumerate(keys)}
+            accepted_groups = [group_by_key[key] for key in store_output.keys_to_store]
+            group_sizes = [0] * len(self.config.kv_group_configs)
+            block_indices = [0] * len(self.config.kv_group_configs)
+            for group_idx in accepted_groups:
+                group_sizes[group_idx] = 1
+                block_indices[group_idx] = block_idx
+            source_blocks = [block_ids[group_idx] for group_idx in accepted_groups]
+
+            job_id = self._generate_job_id()
+            req_status.transfer_jobs.add(job_id)
+            for block_id in source_blocks:
+                self._block_id_to_pending_jobs.setdefault(block_id, set()).add(job_id)
+            self._jobs[job_id] = TransferJobStatus(
+                req_id=req_id,
+                pending_count=self.config.num_workers,
+                keys=set(store_output.keys_to_store),
+                is_store=True,
+                fenced_block_ids=source_blocks,
+            )
+            store_jobs[job_id] = TransferJob(
+                req_id=req_id,
+                src_spec=GPULoadStoreSpec(
+                    source_blocks,
+                    group_sizes=group_sizes,
+                    block_indices=block_indices,
+                ),
+                dst_spec=store_output.store_spec,
+            )
+
+        return store_jobs
+
+    def _build_store_jobs(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> dict[int, TransferJob]:
+        blocks_per_chunk = self.config.blocks_per_chunk
+        store_jobs: dict[int, TransferJob] = {}
+        for req_id in chain(
+            scheduler_output.num_scheduled_tokens,
+            scheduler_output.finished_req_ids or (),
+        ):
+            req_status = self._req_status.get(req_id)
+            if req_status is None:
+                continue
+            req = req_status.req
+
+            if req.status is RequestStatus.FINISHED_ABORTED:
+                num_tokens_after_batch = req.num_computed_tokens
+            elif req.is_finished():
+                num_tokens_after_batch = req.num_tokens
+            else:
+                num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
+                num_tokens_after_batch = req.num_computed_tokens + num_scheduled_tokens
+
+            num_offloadable_tokens = self._calc_num_offloadable_tokens(
+                req_status, num_tokens_after_batch
+            )
+
+            # Filter out chunks skipped due to sliding window attention / SSM
+            # or unreachable by the load path's alignment constraints.
+            new_offload_keys: list[OffloadKey] = []
+            for group_config, group_state in zip(
+                self.config.kv_group_configs, req_status.group_states
+            ):
+                num_chunks = req_status.storable_chunks(
+                    group_config, group_state, num_offloadable_tokens
+                )
+
+                start_chunk_idx = group_state.next_stored_chunk_idx
+                if num_chunks <= start_chunk_idx:
+                    continue
+                offload_keys = group_state.offload_keys[start_chunk_idx:num_chunks]
+                # For each chunk, take the last corresponding GPU block. For
+                # blocks_per_chunk=3 and GPU block IDs 1 5 6 7 2 4 9 3 8,
+                # this selects GPU blocks 6 4 8.
+                # A block_id of 0 means either a sliding window / SSM skip
+                # or a stale entry that was zeroed out — skip it either way.
+                offload_block_ids = group_state.block_ids[
+                    start_chunk_idx * blocks_per_chunk
+                    + blocks_per_chunk
+                    - 1 : num_chunks * blocks_per_chunk : blocks_per_chunk
+                ]
+                assert len(offload_keys) == len(offload_block_ids)
+
+                for key_idx, (offload_key, block_id) in enumerate(
+                    zip(offload_keys, offload_block_ids)
+                ):
+                    if block_id == 0:
+                        continue
+                    # Skip SWA chunks that can never serve a load hit:
+                    # within each full-attention alignment segment, only the
+                    # trailing chunks queried by _sliding_window_lookup are
+                    # reachable. EAGLE/MTP requires one additional chunk that
+                    # lookup later drops as its volatile draft tail.
+                    abs_chunk_idx = start_chunk_idx + key_idx
+                    if not is_store_reachable_swa_chunk(
+                        abs_chunk_idx,
+                        num_chunks,
+                        group_config.alignment_chunk_count,
+                        group_config.sliding_window_size_in_chunks,
+                        group_config.is_eagle_group,
+                    ):
+                        continue
+                    new_offload_keys.append(offload_key)
+
+            if not new_offload_keys:
+                req_status.advance_stored_idx(num_offloadable_tokens)
+                continue
+
+            store_output = self.manager.prepare_store(
+                new_offload_keys, req_status.req_context
+            )
+            if store_output is None:
+                self._connector_stats.increase_counter(
+                    _ConnectorMetricName.ALLOCATION_FAILURE
+                )
+                logger.warning("Request %s: cannot store chunks", req_id)
+                continue
+
+            if not store_output.keys_to_store:
+                req_status.advance_stored_idx(num_offloadable_tokens)
+                continue
+
+            self._touch(req_status)
+
+            keys_to_store = set(store_output.keys_to_store)
+
+            group_sizes: list[int] = []
+            block_indices: list[int] = []
+            src_block_ids: list[int] = []
+            fenced_block_ids: list[int] = []
+            deferred_fence_block_ids: list[int] = []
+            for group_config, group_state in zip(
+                self.config.kv_group_configs, req_status.group_states
+            ):
+                is_sliding_window = (
+                    group_config.sliding_window_size_in_chunks is not None
+                )
+                num_chunks = req_status.storable_chunks(
+                    group_config, group_state, num_offloadable_tokens
+                )
+                start_chunk_idx = group_state.next_stored_chunk_idx
+                block_ids = group_state.block_ids
+                num_group_blocks = 0
+                start_gpu_block_idx: int | None = None
+                for idx, offload_key in enumerate(
+                    group_state.offload_keys[start_chunk_idx:num_chunks]
+                ):
+                    if offload_key not in keys_to_store:
+                        continue
+
+                    chunk_idx = start_chunk_idx + idx
+
+                    self._events_tracker.record_store(
+                        req, group_config, chunk_idx, offload_key
+                    )
+
+                    gpu_block_idx = chunk_idx * blocks_per_chunk
+                    for i in range(blocks_per_chunk):
+                        block_id = block_ids[gpu_block_idx + i]
+                        if block_id == 0:
+                            continue
+                        if start_gpu_block_idx is None:
+                            start_gpu_block_idx = gpu_block_idx + i
+                        src_block_ids.append(block_id)
+                        num_group_blocks += 1
+                        if is_sliding_window:
+                            fenced_block_ids.append(block_id)
+                        else:
+                            deferred_fence_block_ids.append(block_id)
+
+                group_sizes.append(num_group_blocks)
+                block_indices.append(start_gpu_block_idx or 0)
+                group_state.next_stored_chunk_idx = max(
+                    group_state.next_stored_chunk_idx, num_chunks
+                )
+
+            src_spec = GPULoadStoreSpec(
+                src_block_ids, group_sizes=group_sizes, block_indices=block_indices
+            )
+            dst_spec = store_output.store_spec
+
+            job_id = self._generate_job_id()
+            # a store can only be issued when no load is pending.
+            if req_status.transfer_jobs:
+                any_jid = next(iter(req_status.transfer_jobs))
+                assert self._jobs[any_jid].is_store
+            req_status.transfer_jobs.add(job_id)
+
+            # Watch sliding window blocks as they may get evicted
+            # before the request finishes
+            for bid in fenced_block_ids:
+                self._block_id_to_pending_jobs.setdefault(bid, set()).add(job_id)
+
+            # the non-sliding window blocks will be watched only
+            # when the request finishes
+            self._jobs[job_id] = TransferJobStatus(
+                req_id=req_id,
+                pending_count=self.config.num_workers,
+                keys=set(keys_to_store),
+                is_store=True,
+                deferred_fence_block_ids=deferred_fence_block_ids,
+                fenced_block_ids=fenced_block_ids or None,
+            )
+
+            store_jobs[job_id] = TransferJob(
+                req_id=req_id, src_spec=src_spec, dst_spec=dst_spec
+            )
+
+            logger.debug(
+                "Request %s offloading %s chunks upto %d tokens (job %d)",
+                req_id,
+                len(keys_to_store),
+                num_offloadable_tokens,
+                job_id,
+            )
+
+            if req.is_finished():
+                # Register non-sliding-window blocks for flush detection.
+                for bid in deferred_fence_block_ids:
+                    self._block_id_to_pending_jobs.setdefault(bid, set()).add(job_id)
+                    if bid in self._current_batch_allocated_block_ids:
+                        self._current_batch_jobs_to_flush.add(job_id)
+
+        return store_jobs
+
+    def build_connector_meta(
+        self, scheduler_output: SchedulerOutput
+    ) -> KVConnectorMetadata:
+        self._update_req_states(scheduler_output)
+        schedule_end_context = ScheduleEndContext(
+            new_req_ids=[req.req_id for req in scheduler_output.scheduled_new_reqs],
+            preempted_req_ids=scheduler_output.preempted_req_ids or (),
+        )
+        self.manager.on_schedule_end(schedule_end_context)
+
+        # Flush jobs for preempted requests.
+        for req_id in scheduler_output.preempted_req_ids or ():
+            req_status = self._req_status.get(req_id)
+            if req_status is None or not req_status.transfer_jobs:
+                continue
+            any_jid = next(iter(req_status.transfer_jobs))
+            assert self._jobs[any_jid].is_store
+            self._current_batch_jobs_to_flush.update(req_status.transfer_jobs)
+
+        # Flush jobs that contain re-allocated blocks.
+        if (
+            self._block_id_to_pending_jobs
+            and not self._block_id_to_pending_jobs.keys().isdisjoint(
+                self._current_batch_allocated_block_ids
+            )
+        ):
+            self._current_batch_jobs_to_flush.update(
+                jid
+                for bid in self._current_batch_allocated_block_ids
+                if bid in self._block_id_to_pending_jobs
+                for jid in self._block_id_to_pending_jobs[bid]
+            )
+
+        partial_store_jobs = self._build_partial_tail_store_jobs(scheduler_output)
+        normal_store_jobs = self._build_store_jobs(scheduler_output)
+        meta = OffloadingConnectorMetadata(
+            load_jobs=self._current_batch_load_jobs,
+            store_jobs=partial_store_jobs | normal_store_jobs,
+            jobs_to_flush=self._current_batch_jobs_to_flush,
+        )
+
+        # All prepare_store calls for finished requests have been issued.
+        # Signal on_request_finished and clean up state where possible.
+        for req_id in scheduler_output.finished_req_ids or ():
+            req_status = self._req_status.get(req_id)
+            if req_status is None:
+                continue
+            req_status.finished_signaled = True
+            self.manager.on_request_finished(req_status.req_context)
+            if not req_status.transfer_jobs:
+                del self._req_status[req_id]
+        self._current_batch_load_jobs = {}
+        self._current_batch_jobs_to_flush = set()
+        self._current_batch_allocated_block_ids = set()
+        return meta
+
+    def has_pending_push_work(self) -> bool:
+        """Whether the engine must keep stepping.
+
+        While True, build_connector_meta() and update_connector_output()
+        continue to be called even when no requests are scheduled.
+        """
+        return bool(self._jobs) or self.manager.has_pending_work()
+
+    def update_connector_output(self, connector_output: KVConnectorOutput):
+        """
+        Update KVConnector state from worker-side connectors output.
+
+        Args:
+            connector_output (KVConnectorOutput): the worker-side
+                connectors output.
+        """
+        meta = connector_output.kv_connector_worker_meta
+        if not isinstance(meta, OffloadingWorkerMetadata):
+            assert meta is None
+            meta = OffloadingWorkerMetadata()
+        if not meta.transfer_stats.is_empty():
+            transfer_stats = OffloadingConnectorStats()
+            if not meta.transfer_stats.load.is_empty():
+                transfer_stats.increase_counter(
+                    _TransferMetricName.LOAD_BYTES,
+                    meta.transfer_stats.load.bytes,
+                )
+                transfer_stats.increase_counter(
+                    _TransferMetricName.LOAD_TIME,
+                    meta.transfer_stats.load.time,
+                )
+                for size in meta.transfer_stats.load.sizes:
+                    transfer_stats.observe_histogram(
+                        _TransferMetricName.LOAD_SIZE, size
+                    )
+            if not meta.transfer_stats.store.is_empty():
+                transfer_stats.increase_counter(
+                    _TransferMetricName.STORE_BYTES,
+                    meta.transfer_stats.store.bytes,
+                )
+                transfer_stats.increase_counter(
+                    _TransferMetricName.STORE_TIME,
+                    meta.transfer_stats.store.time,
+                )
+                for size in meta.transfer_stats.store.sizes:
+                    transfer_stats.observe_histogram(
+                        _TransferMetricName.STORE_SIZE, size
+                    )
+            self._connector_stats.aggregate(transfer_stats)
+
+        for job_id, count in meta.completed_jobs.items():
+            assert count > 0
+            if job_id < self._stale_job_threshold:
+                logger.debug(
+                    "Skipping stale completed job %d (pre-reset counter: %d)",
+                    job_id,
+                    self._stale_job_threshold,
+                )
+                continue
+            job_status = self._jobs[job_id]
+            job_status.pending_count -= count
+            if job_status.pending_count > 0:
+                continue
+            assert job_status.pending_count == 0
+
+            req_status = self._req_status[job_status.req_id]
+            if job_status.is_store:
+                self.manager.complete_store(job_status.keys, req_status.req_context)
+            else:
+                self.manager.complete_load(job_status.keys, req_status.req_context)
+                if self._chunks_being_loaded:
+                    self._chunks_being_loaded.difference_update(job_status.keys)
+            if self._block_id_to_pending_jobs:
+                # Sliding window blocks are tracked from store creation
+                # and must be cleaned up unconditionally.
+                self._remove_pending_job(job_id, job_status.fenced_block_ids)
+                # Non-sliding-window blocks are only tracked after
+                # request_finished, so only clean up for finished requests.
+                if req_status.req.is_finished():
+                    self._remove_pending_job(
+                        job_id, job_status.deferred_fence_block_ids
+                    )
+
+            del self._jobs[job_id]
+            req_status.transfer_jobs.remove(job_id)
+            if req_status.finished_signaled and not req_status.transfer_jobs:
+                del self._req_status[job_status.req_id]
+
+    def get_stats(self) -> OffloadingConnectorStats | None:
+        stats: OffloadingConnectorStats | None = None
+        if not self._connector_stats.is_empty():
+            stats = self._connector_stats
+            self._connector_stats = OffloadingConnectorStats()
+
+        manager_stats = self.manager.get_stats()
+        if manager_stats is not None:
+            if stats is None:
+                stats = manager_stats
+            else:
+                stats.aggregate(manager_stats)
+
+        return stats
+
+    def request_finished(
+        self,
+        request: Request,
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """
+        Called when a request has finished, before its blocks are freed.
+
+        Returns:
+            True if the request is being saved/sent asynchronously and blocks
+            should not be freed until the request_id is returned from
+            get_finished().
+            Optional KVTransferParams to be included in the request outputs
+            returned by the engine.
+        """
+        req_status = self._req_status.get(request.request_id)
+
+        if req_status is None:
+            # Untracked request (offloading never started): no in-flight jobs,
+            # nothing was deferred, so finalize immediately.
+            req_context = _create_req_context(request)
+            self.manager.on_new_request(req_context)
+            self.manager.on_request_finished(req_context)
+            return False, None
+
+        self._maybe_observe_lookup_async_delay(req_status)
+
+        # Update offload keys with final block hash so _build_store_jobs can
+        # create store jobs for the last block(s) on the next schedule step.
+        req_status.update_offload_keys()
+
+        # Keep req_status alive: _build_store_jobs will process finished_req_ids
+        # on the next step and handle cleanup after creating store jobs.
+        # Register deferred fences so future block reuse triggers a flush via
+        # _block_id_to_pending_jobs.
+        for job_id in req_status.transfer_jobs:
+            job_status = self._jobs[job_id]
+            for bid in job_status.deferred_fence_block_ids or ():
+                self._block_id_to_pending_jobs.setdefault(bid, set()).add(job_id)
+
+        return False, None
+
+    def take_events(self) -> Iterable[KVCacheEvent]:
+        """Drain pending KV cache events.
+
+        Complete metadata is available only when self-describing KV events
+        are enabled, and only for full-attention groups. Other shapes retain
+        the previous placeholder payload so consumers can ignore them.
+
+        Yields:
+            ``BlockStored`` or ``BlockRemoved`` events corresponding to
+            the underlying :class:`OffloadingEvent` stream.
+        """
+        yield from self._events_tracker.take_events(self.manager.take_events())
+
+    def reset_cache(self) -> None:
+        """Reset the offloading manager cache, evicting all stored chunks."""
+
+        # reset_cache cannot be called in the middle of a schedule step
+        assert not self._current_batch_load_jobs
+        assert not self._current_batch_jobs_to_flush
+        assert not self._current_batch_allocated_block_ids
+
+        # Flush all in-flight jobs
+        self._current_batch_jobs_to_flush.update(self._jobs.keys())
+
+        for req_id, status in list(self._req_status.items()):
+            if status.req.is_finished():
+                if not status.finished_signaled:
+                    self.manager.on_request_finished(status.req_context)
+                del self._req_status[req_id]
+
+        # Reset offloading manager cache
+        self.manager.reset_cache()
+
+        # Reset store progress so active requests re-offload from chunk 0.
+        for status in self._req_status.values():
+            for group_state in status.group_states:
+                group_state.next_stored_chunk_idx = 0
+            status.transfer_jobs.clear()
+            status.partial_tail_boundary = None
+
+        # Discard jobs and save job_counter to be able to discard worker responses
+        self._stale_job_threshold = self._job_counter
+        self._jobs.clear()
+        self._block_id_to_pending_jobs.clear()
+
+        # The manager pool is empty; pending event payloads and announced
+        # reference counts are stale.
+        self._events_tracker.reset()
+
+        # Note: _current_batch_jobs_to_flush is intentionally NOT cleared.
+        # The load flush IDs collected above must be delivered to workers.
+        if self._chunks_being_loaded is not None:
+            self._chunks_being_loaded.clear()
+
+    def shutdown(self) -> None:
+        self.manager.shutdown()

--- a/tests/fixtures/image_487ecf187_offloading_worker.py
+++ b/tests/fixtures/image_487ecf187_offloading_worker.py
@@ -1,0 +1,396 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections import defaultdict
+from dataclasses import replace
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.canonical_mapping import (
+    derive_canonical_mappings,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
+    OffloadingConnectorMetadata,
+    OffloadingWorkerMetadata,
+    ReqId,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.config import (
+    is_kv_cache_tensor_packed,
+)
+from vllm.logger import init_logger
+from vllm.v1.attention.backend import AttentionBackend
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    KVCacheConfig,
+    MambaSpec,
+    UniformTypeKVCacheSpecs,
+)
+from vllm.v1.kv_offload.base import (
+    CanonicalKVCacheRef,
+    CanonicalKVCaches,
+    CanonicalKVCacheTensor,
+    GPULoadStoreSpec,
+    LoadStoreSpec,
+    OffloadingSpec,
+    OffloadingWorker,
+)
+
+logger = init_logger(__name__)
+
+
+class OffloadingConnectorWorker:
+    """Implementation of Worker side methods"""
+
+    def __init__(
+        self,
+        spec: OffloadingSpec,
+        vllm_config: "VllmConfig",
+        kv_cache_config: KVCacheConfig,
+    ):
+        self.spec = spec
+        self.vllm_config = vllm_config
+        self.kv_cache_config = kv_cache_config
+        self.worker: OffloadingWorker | None = None
+        # Non-writers still ack: pending_count waits for world_size per job.
+        self._is_store_writer = (
+            not self.spec.replicated_layout or self.spec.config.parallel.rank == 0
+        )
+
+        # job_id -> req_id for in-flight loads.
+        self._load_jobs: dict[int, ReqId] = {}
+        self._unsubmitted_store_jobs: list[
+            tuple[int, GPULoadStoreSpec, LoadStoreSpec]
+        ] = []
+        self._connector_worker_meta = OffloadingWorkerMetadata()
+
+    def _init_worker(self, kv_caches: CanonicalKVCaches) -> None:
+        self.worker = self.spec.get_worker(kv_caches)
+
+    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
+        kv_cache_config = self.kv_cache_config
+        num_blocks = kv_cache_config.num_blocks
+        mappings = derive_canonical_mappings(
+            self.vllm_config, kv_cache_config, kv_caches
+        )
+
+        # Packed layouts (e.g. DSv4) set block_stride > 0; their tensors use
+        # stride(0) as the manager-block stride (equals total_num_bytes_per_block).
+        # General (non-packed) layouts size the tensor at page_size_bytes per
+        # manager block, so page_size_bytes is the correct offloading stride.
+        layer_is_packed: dict[str, bool] = {
+            ln: is_kv_cache_tensor_packed(kv_tensor)
+            for kv_tensor in kv_cache_config.kv_cache_tensors
+            for ln in kv_tensor.shared_by
+        }
+
+        # layer_name -> (num_blocks, page_size_bytes) tensor
+        tensors_per_block: dict[str, tuple[torch.Tensor, ...]] = {}
+        # layer_name -> size of (un-padded) page in bytes
+        unpadded_page_size_bytes: dict[str, int] = {}
+        # layer_name -> size of page in bytes
+        page_size_bytes: dict[str, int] = {}
+        for kv_cache_group in kv_cache_config.kv_cache_groups:
+            group_layer_names = kv_cache_group.layer_names
+            group_kv_cache_spec = kv_cache_group.kv_cache_spec
+            if isinstance(group_kv_cache_spec, UniformTypeKVCacheSpecs):
+                per_layer_specs = group_kv_cache_spec.kv_cache_specs
+            else:
+                per_layer_specs = {}
+            for layer_name in group_layer_names:
+                layer_kv_cache_spec = per_layer_specs.get(
+                    layer_name, group_kv_cache_spec
+                )
+                if isinstance(layer_kv_cache_spec, AttentionSpec):
+                    layer_kv_cache = kv_caches[layer_name]
+                    assert isinstance(layer_kv_cache, torch.Tensor)
+
+                    page = layer_kv_cache_spec.page_size_bytes
+                    elem_size = layer_kv_cache.element_size()
+                    byte_offset = layer_kv_cache.storage_offset() * elem_size
+                    block_stride_bytes = (
+                        layer_kv_cache.stride(0) * elem_size
+                        if layer_is_packed[layer_name]
+                        else page
+                    )
+                    raw = torch.empty(
+                        0,
+                        dtype=torch.int8,
+                        device=layer_kv_cache.device,
+                    ).set_(layer_kv_cache.untyped_storage())
+                    tensors_per_block[layer_name] = (
+                        torch.as_strided(
+                            raw,
+                            (num_blocks, page),
+                            (block_stride_bytes, 1),
+                            byte_offset,
+                        ),
+                    )
+                    page_size_bytes[layer_name] = layer_kv_cache_spec.page_size_bytes
+                    unpadded_page_size_bytes[layer_name] = (
+                        layer_kv_cache_spec.unpadded_page_size_bytes
+                    )
+
+                elif isinstance(layer_kv_cache_spec, MambaSpec):
+                    layer_kv_cache = kv_caches[layer_name]
+                    assert layer_kv_cache.dtype == torch.int8
+                    tensors_per_block[layer_name] = (
+                        layer_kv_cache.view(
+                            num_blocks, layer_kv_cache_spec.page_size_bytes
+                        ),
+                    )
+
+                    page_size_bytes[layer_name] = layer_kv_cache_spec.page_size_bytes
+                    unpadded_page_size_bytes[layer_name] = replace(
+                        layer_kv_cache_spec, page_size_padded=None
+                    ).page_size_bytes
+
+                else:
+                    raise NotImplementedError
+
+        packed_kv_cache_tensor = next(
+            (
+                t
+                for t in kv_cache_config.kv_cache_tensors
+                if is_kv_cache_tensor_packed(t) and t.shared_by
+            ),
+            None,
+        )
+        if packed_kv_cache_tensor is not None:
+            (tensor,) = tensors_per_block[packed_kv_cache_tensor.shared_by[0]]
+            block_stride = tensor.stride(0)
+            packed_tensor = tensor.as_strided(
+                (num_blocks, block_stride),
+                (block_stride, 1),
+                storage_offset=0,
+            )
+            self._init_worker(
+                CanonicalKVCaches(
+                    [CanonicalKVCacheTensor(packed_tensor, block_stride)],
+                    [
+                        [CanonicalKVCacheRef(0, block_stride)]
+                        for _ in kv_cache_config.kv_cache_groups
+                    ],
+                )
+            )
+            return
+
+        block_tensors: list[CanonicalKVCacheTensor] = []
+        block_data_refs: dict[str, list[CanonicalKVCacheRef]] = defaultdict(list)
+        for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
+            # Filter to layers that were actually processed above.
+            # Packed KV allocation emits KVCacheTensor entries for
+            # every (tuple_idx, page_size) slot; slots where no group has a
+            # layer at that index produce an empty shared_by (reserved memory
+            # with no corresponding model layer).
+            tensor_layer_names = [
+                n for n in kv_cache_tensor.shared_by if n in tensors_per_block
+            ]
+            if not tensor_layer_names:
+                continue
+
+            # verify all layers in the group reference the exact same tensors
+            assert len({len(tensors_per_block[n]) for n in tensor_layer_names}) == 1
+            assert (
+                len({tensors_per_block[n][0].data_ptr() for n in tensor_layer_names})
+                == 1
+            )
+            assert (
+                len({tensors_per_block[n][0].stride() for n in tensor_layer_names}) == 1
+            )
+
+            # pick the first layer to represent the group
+            first_layer_name = tensor_layer_names[0]
+            for tensor in tensors_per_block[first_layer_name]:
+                block_tensors.append(
+                    CanonicalKVCacheTensor(
+                        tensor=tensor,
+                        page_size_bytes=page_size_bytes[first_layer_name],
+                    )
+                )
+
+                curr_tensor_idx = len(block_tensors) - 1
+                for layer_name in tensor_layer_names:
+                    mapping = (
+                        mappings.get(layer_name)
+                        if len(tensors_per_block[first_layer_name]) == 1
+                        else None
+                    )
+                    assert (
+                        mapping is None
+                        or mapping.local_page_size_bytes
+                        == unpadded_page_size_bytes[layer_name]
+                    )
+                    block_data_refs[layer_name].append(
+                        CanonicalKVCacheRef(
+                            tensor_idx=curr_tensor_idx,
+                            page_size_bytes=(unpadded_page_size_bytes[layer_name]),
+                            mapping=mapping,
+                        )
+                    )
+
+        group_data_refs: list[list[CanonicalKVCacheRef]] = []
+        for kv_cache_group in kv_cache_config.kv_cache_groups:
+            group_refs: list[CanonicalKVCacheRef] = []
+            for layer_name in kv_cache_group.layer_names:
+                group_refs += block_data_refs[layer_name]
+            group_data_refs.append(group_refs)
+
+        canonical_kv_caches = CanonicalKVCaches(
+            tensors=block_tensors,
+            group_data_refs=group_data_refs,
+        )
+
+        self._init_worker(canonical_kv_caches)
+
+    def register_cross_layers_kv_cache(
+        self, kv_cache: torch.Tensor, attn_backend: type[AttentionBackend]
+    ):
+        # verify that num_blocks is at physical position 0 in the cross-layers
+        # tensor layout.
+        test_shape = attn_backend.get_kv_cache_shape(
+            num_blocks=1234, block_size=16, num_kv_heads=1, head_size=256
+        )
+        num_blocks_logical_dim = test_shape.index(1234) + 1
+        physical_to_logical = attn_backend.get_kv_cache_stride_order(
+            include_num_layers_dimension=True
+        )
+        num_blocks_physical_dim = physical_to_logical.index(num_blocks_logical_dim)
+        assert num_blocks_physical_dim == 0
+
+        kv_cache_groups = self.kv_cache_config.kv_cache_groups
+        assert len(kv_cache_groups) == 1
+        kv_cache_spec = kv_cache_groups[0].kv_cache_spec
+        num_layers = len(kv_cache_groups[0].layer_names)
+        page_size_bytes = kv_cache_spec.page_size_bytes * num_layers
+
+        assert kv_cache.storage_offset() == 0
+        storage = kv_cache.untyped_storage()
+        assert len(storage) % page_size_bytes == 0
+        num_blocks = len(storage) // page_size_bytes
+        tensor = (
+            torch.tensor(
+                [],
+                dtype=torch.int8,
+                device=kv_cache.device,
+            )
+            .set_(storage)
+            .view(num_blocks, page_size_bytes)
+        )
+        kv_cache_tensor = CanonicalKVCacheTensor(
+            tensor=tensor, page_size_bytes=page_size_bytes
+        )
+        # in cross layers layout, there's currently only a single group
+        kv_cache_data_ref = CanonicalKVCacheRef(
+            tensor_idx=0, page_size_bytes=page_size_bytes
+        )
+        canonical_kv_caches = CanonicalKVCaches(
+            tensors=[kv_cache_tensor], group_data_refs=[[kv_cache_data_ref]]
+        )
+
+        self._init_worker(canonical_kv_caches)
+
+    def handle_preemptions(self, kv_connector_metadata: OffloadingConnectorMetadata):
+        assert self.worker is not None
+
+        # Pop jobs_to_flush from store_jobs into _unsubmitted_store_jobs
+        # so the existing submission loop below submits them before wait().
+        if kv_connector_metadata.jobs_to_flush:
+            for job_id in kv_connector_metadata.jobs_to_flush:
+                entry = kv_connector_metadata.store_jobs.pop(job_id, None)
+                if entry is not None:
+                    if not self._is_store_writer:
+                        self._connector_worker_meta.mark_completed(job_id)
+                        continue
+                    assert isinstance(entry.src_spec, GPULoadStoreSpec)
+                    self._unsubmitted_store_jobs.append(
+                        (job_id, entry.src_spec, entry.dst_spec)
+                    )
+
+        # Submit deferred stores from previous step (and jobs_to_flush above).
+        for job_id, src_spec, dst_spec in self._unsubmitted_store_jobs:
+            assert isinstance(src_spec, GPULoadStoreSpec)
+            success = self.worker.submit_store(job_id, src_spec, dst_spec)
+            assert success
+        self._unsubmitted_store_jobs.clear()
+
+        if kv_connector_metadata.jobs_to_flush:
+            self.worker.wait(kv_connector_metadata.jobs_to_flush)
+
+    def start_kv_transfers(self, metadata: OffloadingConnectorMetadata):
+        assert self.worker is not None
+        for job_id, src_spec, dst_spec in self._unsubmitted_store_jobs:
+            success = self.worker.submit_store(job_id, src_spec, dst_spec)
+            assert success
+        self._unsubmitted_store_jobs.clear()
+
+        for job_id, entry in metadata.load_jobs.items():
+            self._load_jobs[job_id] = entry.req_id
+            assert isinstance(entry.dst_spec, GPULoadStoreSpec)
+            success = self.worker.submit_load(job_id, entry.src_spec, entry.dst_spec)
+            assert success
+
+    def prepare_store_kv(self, metadata: OffloadingConnectorMetadata):
+        for job_id, entry in metadata.store_jobs.items():
+            if not self._is_store_writer:
+                # Gate before queueing: no _unsubmitted_store_jobs entry.
+                self._connector_worker_meta.mark_completed(job_id)
+                continue
+            # NOTE(orozery): defer the store to the beginning of the next
+            # engine step, so that offloading starts AFTER transfers related
+            # to token sampling, thereby avoiding delays to token generation.
+            assert isinstance(entry.src_spec, GPULoadStoreSpec)
+            self._unsubmitted_store_jobs.append(
+                (job_id, entry.src_spec, entry.dst_spec)
+            )
+
+    def get_finished(self, finished_req_ids: set[str]) -> tuple[set[str], set[str]]:
+        """
+        Returns:
+            tuple of (finished_sending, finished_recving). Stores never
+            emit finished_sending — the scheduler tracks store completion
+            via kv_connector_worker_meta.completed_jobs and fences any
+            block reuse via jobs_to_flush. Loads still emit
+            finished_recving so the base scheduler can resume requests
+            blocked on remote KV (and free aborted-during-load reqs).
+        """
+        assert self.worker is not None
+        finished_recving: set[str] = set()
+        for transfer_result in self.worker.get_finished():
+            # we currently do not support job failures
+            job_id = transfer_result.job_id
+            assert transfer_result.success
+            is_load = job_id in self._load_jobs
+            if (
+                transfer_result.transfer_time is not None
+                and transfer_result.transfer_size is not None
+            ):
+                if is_load:
+                    stats = self._connector_worker_meta.transfer_stats.load
+                else:
+                    stats = self._connector_worker_meta.transfer_stats.store
+                stats.record(
+                    transfer_result.transfer_size,
+                    transfer_result.transfer_time,
+                )
+
+            self._connector_worker_meta.mark_completed(job_id)
+            req_id = self._load_jobs.pop(job_id, None)
+            if req_id is not None:
+                finished_recving.add(req_id)
+
+        return set(), finished_recving
+
+    def build_connector_worker_meta(self) -> OffloadingWorkerMetadata | None:
+        """Return completed transfer job IDs since the last call."""
+        if not self._connector_worker_meta.completed_jobs:
+            return None
+        meta = self._connector_worker_meta
+        self._connector_worker_meta = OffloadingWorkerMetadata()
+        return meta
+
+    def shutdown(self) -> None:
+        self._unsubmitted_store_jobs.clear()
+        self._load_jobs.clear()
+        self._connector_worker_meta = OffloadingWorkerMetadata()
+        if self.worker is not None:
+            self.worker.shutdown()

--- a/tests/test_kpool_tail_slotmap.py
+++ b/tests/test_kpool_tail_slotmap.py
@@ -182,7 +182,12 @@ def test_recipe_wiring_if_present() -> None:
     launcher = start.read_text()
     image = dockerfile.read_text()
     assert 'KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-' in launcher
-    assert launcher.count("python3 /opt/glm53/patch_kpool_tail_slotmap.py") == 2
+    # Both ranks apply the one pinned list (GLM53_OVERLAY_ORDER) that
+    # write_inner_scripts emits into the head and worker inner scripts.
+    order = launcher[launcher.index("GLM53_OVERLAY_ORDER=(") : launcher.index(")", launcher.index("GLM53_OVERLAY_ORDER=("))]
+    assert "\n    patch_kpool_tail_slotmap.py\n" in order
+    assert 'emit_overlay_block >> "$HEAD_SCRIPT"' in launcher
+    assert 'emit_overlay_block >> "$WORKER_SCRIPT"' in launcher
     assert (
         "-v '/tmp/patch_kpool_tail_slotmap.py:"
         "/opt/glm53/patch_kpool_tail_slotmap.py:ro'" in launcher

--- a/tests/test_kv_offload_scope.py
+++ b/tests/test_kv_offload_scope.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Regression tests for overlay/patch_kv_offload_scope.py (port of vllm#54743).
+
+A  Patcher mechanics on the PINNED image fixtures (byte-exact captures of the
+   deployed tree, tests/fixtures/README.md): preflight, apply, idempotence,
+   tamper/drift refusal, half-patched refusal, compile of the patched text.
+B  Eligibility predicate (the exec'd shipped helper, not a replica): kpool
+   scratch never eligible; drafter excluded only under EAGLE context and only
+   while GLM53_KV_OFFLOAD_DRAFTER=0; strict 0/1 env parsing.
+C  Patched-runtime drive (Codex OFFLOAD1 finding 6): the PATCHED
+   build_offloading_config / scheduler module executed under a stubbed vllm
+   namespace on the 7-group boot layout — eligible set {0,2,3,4,5}, original
+   indices in keys, full-length group_sizes with zeros for ineligible groups,
+   num_kv_cache_groups=7, mamba alignment 3584, supports_partial_tail False,
+   no-scratch uniform model unchanged (upstream-equivalence guard).
+D  In-image preflight when GLM53_REQUIRE_TARGET=1 (Docker build): the real
+   tree must accept the anchors before the patcher bakes them in.
+
+Run:  python3 tests/test_kv_offload_scope.py   (or pytest)
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str((ROOT / "overlay")))
+# In-image the test rides next to the overlay under /opt/glm53.
+sys.path.insert(0, str(HERE.parent))
+
+import patch_kv_offload_scope as scope  # noqa: E402
+
+FIXTURES = HERE / "fixtures"
+IN_IMAGE = not FIXTURES.is_dir()
+
+FAILURES: list[str] = []
+
+
+def check(cond: bool, label: str) -> None:
+    print(("  ok   " if cond else "  FAIL ") + label)
+    if not cond:
+        FAILURES.append(label)
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURES / name).read_text()
+
+
+# ------------------------------------------------------------------ part A --
+def test_patcher_mechanics() -> None:
+    if IN_IMAGE:
+        print("Part A: skipped (fixtures not shipped in-image; D covers the real tree)")
+        return
+    print("Part A: patcher mechanics on pinned image fixtures")
+    cases = [
+        ("image_487ecf187_kv_offload_config.py", scope.SITES_KVO_CONFIG),
+        ("image_487ecf187_offloading_config.py", scope.SITES_CONN_CONFIG),
+        ("image_487ecf187_offloading_scheduler.py", scope.SITES_SCHED),
+    ]
+    for name, sites in cases:
+        src = _fixture(name)
+        patched, action = scope.prepare(src, sites, name)
+        check(action == "patched" and patched != src, f"A1 {name}: applies")
+        try:
+            compile(patched, name, "exec")
+            check(True, f"A2 {name}: patched text compiles")
+        except SyntaxError as exc:
+            check(False, f"A2 {name}: patched text compiles ({exc})")
+        again, action2 = scope.prepare(patched, sites, name)
+        check(
+            action2 == "already present" and again == patched,
+            f"A3 {name}: idempotent second run",
+        )
+        # Drift: tamper the first anchor (drop its first character — always a
+        # real mutation regardless of the anchor's shape).
+        _n, _m, anchor, _p = sites[0]
+        broken = src.replace(anchor, anchor[1:], 1)
+        assert broken != src
+        try:
+            scope.prepare(broken, sites, name)
+            check(False, f"A4 {name}: tampered anchor refused")
+        except ValueError:
+            check(True, f"A4 {name}: tampered anchor refused")
+        # Half-patched: one mark present, others missing.
+        if len(sites) > 1:
+            half = src
+            n0, m0, a0, p0 = sites[0]
+            half = half.replace(a0, p0, 1)
+            try:
+                scope.prepare(half, sites, name)
+                check(False, f"A5 {name}: half-patched file refused")
+            except ValueError:
+                check(True, f"A5 {name}: half-patched file refused")
+
+
+# ------------------------------------------------------------------ part B --
+def test_eligibility_predicate() -> None:
+    print("Part B: eligibility predicate (exec'd shipped helper)")
+    from _kv_offload_stub_env import boot_layout
+
+    layout = boot_layout().kv_cache_groups
+    layout[6].is_eagle_group = False  # GLM sets no flag; EAGLE context decides
+
+    def eligible(drafter: bool, use_eagle: bool = True) -> list[int]:
+        return [
+            i
+            for i, g in enumerate(layout)
+            if scope.kvo_group_eligible(g, drafter, use_eagle)
+        ]
+
+    check(eligible(False) == [0, 2, 3, 4, 5], "B1 default eligible set {0,2,3,4,5}")
+    check(
+        eligible(True) == [0, 2, 3, 4, 5, 6],
+        "B2 GLM53_KV_OFFLOAD_DRAFTER=1 adds only the drafter group",
+    )
+    check(
+        eligible(False, use_eagle=False) == [0, 2, 3, 4, 5, 6],
+        "B3 without EAGLE context a SlidingWindowSpec group is genuine SWA and stays",
+    )
+    layout[6].is_eagle_group = True
+    check(
+        eligible(False, use_eagle=False) == [0, 2, 3, 4, 5],
+        "B4 is_eagle_group excludes even without speculative context",
+    )
+    layout[6].is_eagle_group = False
+    check(1 not in eligible(True), "B5 kpool scratch is NEVER eligible")
+
+    for raw, expect in ((None, False), ("0", False), ("1", True)):
+        if raw is None:
+            os.environ.pop("GLM53_KV_OFFLOAD_DRAFTER", None)
+        else:
+            os.environ["GLM53_KV_OFFLOAD_DRAFTER"] = raw
+        check(
+            scope.kvo_drafter_included() is expect,
+            f"B6 GLM53_KV_OFFLOAD_DRAFTER={raw!r} -> {expect}",
+        )
+    for junk in ("", "2", "yes", " 1", "01"):
+        os.environ["GLM53_KV_OFFLOAD_DRAFTER"] = junk
+        try:
+            scope.kvo_drafter_included()
+            check(False, f"B7 junk {junk!r} raises")
+        except ValueError:
+            check(True, f"B7 junk {junk!r} raises")
+    os.environ.pop("GLM53_KV_OFFLOAD_DRAFTER", None)
+
+
+# ------------------------------------------------------------------ part C --
+def test_patched_runtime() -> None:
+    if IN_IMAGE:
+        print("Part C: skipped in-image (fixtures not shipped)")
+        return
+    print("Part C: patched-runtime drive (stubbed vllm, PATCHED module text)")
+    os.environ.pop("GLM53_KV_OFFLOAD_DRAFTER", None)
+    os.environ["GLM53_KV_OFFLOAD"] = "0"
+    os.environ["GLM53_KV_OFFLOAD_RESTORE"] = "0"
+    from _kv_offload_stub_env import (
+        FakeRequest,
+        FakeSchedSpec,
+        FakeVllmConfig,
+        FakeKVTransferConfig,
+        boot_layout,
+        build_offloading_config,
+        install_fake_vllm,
+    )
+
+    mods = install_fake_vllm()
+    kv_cache_config = boot_layout()
+    vllm_config = FakeVllmConfig(kv_transfer_config=FakeKVTransferConfig())
+
+    cfg = build_offloading_config(mods, vllm_config, kv_cache_config)
+    check(
+        [g.group_idx for g in cfg.groups] == [0, 2, 3, 4, 5],
+        "C1 build_offloading_config scopes to {0,2,3,4,5} and boots (no g1 assert crash)",
+    )
+    check(
+        all(g.tokens_per_block == 3584 for g in cfg.groups),
+        "C2 every eligible group is on the 3584 grid",
+    )
+    log_lines = "\n".join(mods["logger"].lines)
+    check(
+        "eligible groups" in log_lines and "[0, 2, 3, 4, 5]" in log_lines,
+        "C3 boot log names the eligible set",
+    )
+
+    sched_mod = mods["scheduler"]
+    spec = FakeSchedSpec(mods, cfg)
+    sched_cfg = sched_mod.SchedulerOffloadConfig.from_spec(
+        spec, vllm_config, kv_cache_config
+    )
+    check(sched_cfg.num_kv_cache_groups == 7, "C4 num_kv_cache_groups is the FULL count")
+    check(
+        tuple(g.group_idx for g in sched_cfg.kv_group_configs) == (0, 2, 3, 4, 5),
+        "C5 kv_group_configs keep original indices",
+    )
+    check(
+        sched_mod.resolve_mamba_align_size(spec, kv_cache_config) == 3584,
+        "C6 mamba alignment resolves to 3584 over eligible groups",
+    )
+    check(not sched_cfg.supports_partial_tail, "C7 partial tails off (scratch groups)")
+
+    scheduler = sched_mod.OffloadingConnectorScheduler(
+        spec, vllm_config, kv_cache_config
+    )
+    check(
+        sorted(scheduler._group_config_by_idx) == [0, 2, 3, 4, 5],
+        "C8 _group_config_by_idx keyed by original indices",
+    )
+    check(
+        scheduler._sliding_window_groups == (2, 3, 4, 5)
+        and scheduler._lookup_groups[0] == 0,
+        "C9 mamba groups looked up as window groups after the full-attn group",
+    )
+
+    req = FakeRequest(num_tokens=7 * 3584 + 100)
+    scheduler.on_new_request(req)
+    st = scheduler._req_status[req.request_id]
+    check(len(st.group_states) == 7, "C10 group_states sized by the FULL group count")
+
+    num_hit, is_async = scheduler.get_num_new_matched_tokens(req, 0)
+    check(
+        (num_hit, is_async) == (0, False),
+        "C11 store-only mode: external hits are always (0, False)",
+    )
+    check(
+        spec._manager.lookup_calls == [],
+        "C12 store-only mode: the manager lookup is NEVER consulted",
+    )
+
+    base = mods["base"]
+    gidxs = set()
+    for g_idx, gs in enumerate(st.group_states):
+        for key in gs.offload_keys:
+            gidxs.add(base.get_offload_group_idx(key))
+            check_hash = base.get_offload_block_hash(key)
+            assert check_hash in req.block_hashes
+    check(
+        gidxs == {0, 2, 3, 4, 5},
+        f"C13 offload keys carry ONLY eligible original indices (got {sorted(gidxs)})",
+    )
+    n_expected = (req.num_tokens // 3584)
+    check(
+        all(
+            len(st.group_states[g].offload_keys) == n_expected
+            for g in (0, 2, 3, 4, 5)
+        )
+        and all(len(st.group_states[g].offload_keys) == 0 for g in (1, 6)),
+        "C14 per-group key counts: full chunks for eligible, zero for scratch/drafter",
+    )
+
+    # update_state_after_alloc: full-length layout, zeros at 1 and 6.
+    class FakeBlock:
+        def __init__(self, block_id):
+            self.block_id = block_id
+            self.is_null = False
+            self.block_hash = None
+
+    kvm = mods["kv_cache_manager"]
+    n_cached = 3584
+    per_group_needed = [1, 896, 1, 1, 1, 1, 56]
+    blocks = kvm.KVCacheBlocks(
+        tuple(
+            [FakeBlock(100 * g + j + 1) for j in range(per_group_needed[g])]
+            for g in range(7)
+        )
+    )
+    st.num_locally_computed_tokens = 0
+    scheduler.update_state_after_alloc(req, blocks, n_cached)
+    job = next(iter(scheduler._current_batch_load_jobs.values()))
+    gs = job.dst_spec.group_sizes
+    check(
+        len(gs) == 7 and gs[1] == 0 and gs[6] == 0 and gs[0] == 1,
+        f"C15 load-job group_sizes full-length with zeros at 1/6 (got {gs})",
+    )
+    check(
+        len(job.dst_spec.block_indices) == 7,
+        "C16 block_indices full-length",
+    )
+
+    # Upstream-equivalence guard: a uniform no-scratch model is unchanged.
+    from _kv_offload_stub_env import (
+        FakeKVCacheConfig,
+        FakeKVCacheGroup,
+        MLAAttentionSpec,
+    )
+
+    uniform = FakeKVCacheConfig(
+        [
+            FakeKVCacheGroup(MLAAttentionSpec(64), ("l0", "l1")),
+        ]
+    )
+    vllm_plain = FakeVllmConfig(
+        kv_transfer_config=FakeKVTransferConfig(), speculative_config=None
+    )
+    cfg_u = build_offloading_config(mods, vllm_plain, uniform)
+    check(
+        [g.group_idx for g in cfg_u.groups] == [0],
+        "C17 no-scratch uniform model keeps every group (behaviour unchanged)",
+    )
+
+    # Divisibility regression: a prefix-cacheable misaligned group still asserts.
+    bad = boot_layout()
+    bad.kv_cache_groups[2].kv_cache_spec.block_size = 96  # 96 % 64 != 0
+    try:
+        build_offloading_config(mods, vllm_config, bad)
+        check(False, "C18 misaligned CACHEABLE group still asserts at boot")
+    except AssertionError:
+        check(True, "C18 misaligned CACHEABLE group still asserts at boot")
+    _cleanup_env()
+
+
+# ------------------------------------------------------------------ part D --
+def test_in_image_preflight() -> None:
+    if os.environ.get("GLM53_REQUIRE_TARGET") != "1":
+        print("Part D: skipped (GLM53_REQUIRE_TARGET!=1)")
+        return
+    print("Part D: real-tree preflight (in-image)")
+    rc = 0
+    try:
+        scope.main(["patch_kv_offload_scope.py", "--preflight"])
+    except SystemExit as exc:
+        rc = int(exc.code or 0)
+    check(rc == 0, "D1 patcher preflight accepts the real in-image tree")
+    _cleanup_env()
+
+
+
+
+def _cleanup_env() -> None:
+    """These tests mutate GLM53_KV_OFFLOAD* in os.environ; scrub them so the
+    rest of the suite (and any subprocess-driving test that inherits the
+    process env) sees a clean slate."""
+    for name in ("GLM53_KV_OFFLOAD","GLM53_KV_OFFLOAD_DIR","GLM53_KV_OFFLOAD_CPU_GB","GLM53_KV_OFFLOAD_RESTORE","GLM53_KV_OFFLOAD_DRAFTER","GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"):
+        os.environ.pop(name, None)
+
+
+def main() -> int:
+    test_patcher_mechanics()
+    test_eligibility_predicate()
+    test_patched_runtime()
+    test_in_image_preflight()
+    print(f"\n{len(FAILURES)} failure(s)")
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_kv_offload_store_local.py
+++ b/tests/test_kv_offload_store_local.py
@@ -608,6 +608,32 @@ def test_writer() -> None:
             w7._namespace_hash != w8._namespace_hash,
             "C22 num_speculative_tokens forks the namespace hash",
         )
+        # Policy/diagnostic fields must NOT disable a later boot (fenced-only
+        # comparison): same config, different keep_boundaries reuses the store.
+        os.environ["GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"] = "5"
+        cw7b, _, _ = _mini_env(num_spec=7)
+        w7b = ns["Glm53LocalStoreWriter"](cw7b, logger5)
+        check(
+            w7b._disabled_reason is None
+            and w7b._namespace_hash == w7._namespace_hash,
+            "C22b retention-K change neither forks nor disables the namespace",
+        )
+        os.environ["GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"] = "2"
+        # A corrupted namespace record fails closed.
+        ns_files = [
+            f
+            for f in Path(os.environ["GLM53_KV_OFFLOAD_DIR"]).glob("glm53kv_*.json")
+            if w7._namespace_hash in f.name
+        ]
+        check(len(ns_files) == 1, "C22c one namespace record per namespace")
+        ns_files[0].write_text("{ truncated")
+        cw7c, _, _ = _mini_env(num_spec=7)
+        w7c = ns["Glm53LocalStoreWriter"](cw7c, logger5)
+        check(
+            w7c._disabled_reason is not None
+            and "unreadable" in w7c._disabled_reason,
+            "C22d corrupted namespace record disables the writer (fail closed)",
+        )
 
     # Capture helpers through the connector-worker seam (both call sites).
     logger6 = _TestLogger()
@@ -731,12 +757,18 @@ def test_gc_tool() -> None:
             out == 1,
             "D8 orphan reported with ZERO manifests present (header-based)",
         )
-        # Stale temp: any *.tmp.* is reported and swept.
+        # Stale temps: payload temps under the base AND namespace-record
+        # temps beside it (the store root) are reported and swept.
         t = base / _hash(3)[:3] / f"{_hash(3)[3:5]}_g4" / "x.bin.tmp.r0.1.2"
         t.write_bytes(b"partial")
-        check(gc_tool.main([str(base)]) == 1, "D9 stale temp flagged by dry-run")
+        ns_t = base.parent / "glm53kv_test_model_deadbeef.json.tmp.r0.1"
+        ns_t.write_text("{}")
+        check(gc_tool.main([str(base)]) == 1, "D9 stale temps flagged by dry-run")
         gc_tool.main([str(base), "--sweep"])
-        check(not t.exists(), "D10 --sweep removes stale temps")
+        check(
+            not t.exists() and not ns_t.exists(),
+            "D10 --sweep removes payload AND namespace temps",
+        )
 
     # Forked chains: a shared divergence-point boundary survives while ANY
     # branch still keeps it (writer rule mirrored in the GC tool).

--- a/tests/test_kv_offload_store_local.py
+++ b/tests/test_kv_offload_store_local.py
@@ -1,0 +1,702 @@
+#!/usr/bin/env python3
+"""Regression tests for overlay/patch_kv_offload_store_local.py.
+
+A  Chunk-header codec (format v1): round-trip, truncation at every region,
+   CRC corruption, wrong magic, oversized header — all rejected.
+B  Patched-runtime store-job drive (stubbed vllm, PATCHED modules): a request
+   walking three 3584 boundaries produces store jobs whose GPULoadStoreSpec
+   is full-length with zeros for scratch/drafter groups, whose
+   glm53_store_meta keys align 1:1 with the src/dst block order, whose
+   manifest candidates carry CUMULATIVE chunk-hash chains, and whose
+   TransferJob pickles round-trip. Knob off => meta is None.
+C  Worker-local writer on a miniature 7-group layout: per-(hash,group) files
+   with REAL (unpadded) bytes gathered ref-by-ref from the staging tensors,
+   headers with KDA conv/temporal segment split (shape/dtype/stride),
+   manifest publish ordering (missing any mamba payload or any cumulative
+   full-attn chunk => no manifest), inline K-boundary retention, dedup,
+   failed-key ledger, ENOSPC pause, rank-disagreement disable, delayed-ack
+   drain semantics, namespace forking on num_spec change.
+D  GC tool (overlay/kv_offload_store_gc.py): dry-run reports orphans and
+   corrupt files without deleting; --sweep removes them; --keep-boundaries
+   preserves cumulative full-attn references (plan §4 C1).
+
+Run:  python3 tests/test_kv_offload_store_local.py   (or pytest)
+"""
+from __future__ import annotations
+
+import errno
+import json
+import os
+import pickle
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(ROOT / "overlay"))
+sys.path.insert(0, str(HERE.parent))
+
+import patch_kv_offload_store_local as store  # noqa: E402
+
+FIXTURES = HERE / "fixtures"
+IN_IMAGE = not FIXTURES.is_dir()
+
+FAILURES: list[str] = []
+
+
+def check(cond: bool, label: str) -> None:
+    print(("  ok   " if cond else "  FAIL ") + label)
+    if not cond:
+        FAILURES.append(label)
+
+
+# ------------------------------------------------------------------ part A --
+def test_codec() -> None:
+    print("Part A: chunk-header codec")
+    payload = bytes(range(256)) * 4
+    header = {"namespace_hash": "abc", "group_idx": 2, "hash": "ff" * 16}
+    blob = store.encode_chunk(header, payload)
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "x.bin"
+        p.write_bytes(blob)
+        h = store.read_chunk_header(str(p), verify_payload=True)
+        check(
+            h["group_idx"] == 2 and h["payload_len"] == len(payload),
+            "A1 round-trip keeps fields and payload length",
+        )
+        check(h["crc_algo"] == "crc32-zlib", "A2 header names its CRC algorithm")
+
+        cuts = {
+            "magic": 4,
+            "header-length": 10,
+            "header": 14,
+            "header-crc": len(blob) - len(payload) - 2,
+            "payload": len(blob) - 100,
+        }
+        for label, cut in cuts.items():
+            p.write_bytes(blob[:cut])
+            try:
+                store.read_chunk_header(str(p), verify_payload=True)
+                check(False, f"A3 truncated at {label} rejected")
+            except ValueError:
+                check(True, f"A3 truncated at {label} rejected")
+
+        flipped = bytearray(blob)
+        flipped[-1] ^= 0xFF
+        p.write_bytes(bytes(flipped))
+        try:
+            store.read_chunk_header(str(p), verify_payload=True)
+            check(False, "A4 payload bit-flip rejected (CRC)")
+        except ValueError:
+            check(True, "A4 payload bit-flip rejected (CRC)")
+
+        p.write_bytes(b"NOTMAGIC" + blob[8:])
+        try:
+            store.read_chunk_header(str(p))
+            check(False, "A5 wrong magic rejected")
+        except ValueError:
+            check(True, "A5 wrong magic rejected")
+
+        # Extra trailing bytes (torn rename of a longer file) rejected too.
+        p.write_bytes(blob + b"x")
+        try:
+            store.read_chunk_header(str(p))
+            check(False, "A6 trailing garbage rejected")
+        except ValueError:
+            check(True, "A6 trailing garbage rejected")
+
+
+# ------------------------------------------------------------------ part B --
+def test_store_job_meta() -> None:
+    if IN_IMAGE:
+        print("Part B: skipped in-image (fixtures not shipped)")
+        return
+    print("Part B: patched-runtime store-job drive")
+    os.environ["GLM53_KV_OFFLOAD"] = "1"
+    os.environ["GLM53_KV_OFFLOAD_RESTORE"] = "0"
+    os.environ.pop("GLM53_KV_OFFLOAD_DRAFTER", None)
+    from _kv_offload_stub_env import (
+        FakeRequest,
+        FakeSchedSpec,
+        FakeVllmConfig,
+        FakeKVTransferConfig,
+        boot_layout,
+        build_offloading_config,
+        install_fake_vllm,
+    )
+
+    mods = install_fake_vllm()
+    kv_cache_config = boot_layout()
+    vllm_config = FakeVllmConfig(kv_transfer_config=FakeKVTransferConfig())
+    cfg = build_offloading_config(mods, vllm_config, kv_cache_config)
+    sched_mod = mods["scheduler"]
+    spec = FakeSchedSpec(mods, cfg)
+    scheduler = sched_mod.OffloadingConnectorScheduler(
+        spec, vllm_config, kv_cache_config
+    )
+
+    n_chunks = 3
+    req = FakeRequest(num_tokens=n_chunks * 3584 + 5)
+    scheduler.on_new_request(req)
+    scheduler.get_num_new_matched_tokens(req, 0)
+
+    per_group_blocks = {0: 1, 1: 896, 2: 1, 3: 1, 4: 1, 5: 1, 6: 56}
+    block_id_groups = tuple(
+        [1000 * g + j + 1 for j in range(per_group_blocks[g] * n_chunks)]
+        for g in range(7)
+    )
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={req.request_id: req.num_tokens},
+        finished_req_ids=set(),
+        req_data={req.request_id: (block_id_groups, False)},
+        partial_tail_offloads=None,
+    )
+    scheduler._update_req_states(scheduler_output)
+    store_jobs = scheduler._build_store_jobs(scheduler_output)
+    check(len(store_jobs) == 1, "B1 one store job for the request")
+    job = next(iter(store_jobs.values()))
+    gs = job.src_spec.group_sizes
+    check(
+        len(gs) == 7 and gs[1] == 0 and gs[6] == 0 and gs[0] == n_chunks,
+        f"B2 store group_sizes full-length, zeros at 1/6 (got {gs})",
+    )
+    meta = job.glm53_store_meta
+    check(meta is not None and meta["v"] == 1, "B3 store meta attached, versioned")
+    check(
+        len(meta["keys"]) == len(job.src_spec.block_ids) == 5 * n_chunks,
+        "B4 meta keys align 1:1 with src blocks (5 eligible groups x 3 chunks)",
+    )
+    check(
+        meta["cow_groups"] == [2, 3, 4, 5] and meta["full_groups"] == [0],
+        "B5 cow/full group sets carry original indices",
+    )
+    bounds = {m["boundary_token_index"]: len(m["chunk_hashes"]) for m in meta["manifests"]}
+    check(
+        bounds == {3584: 1, 7168: 2, 10752: 3},
+        f"B6 manifest candidates cumulative per boundary (got {bounds})",
+    )
+    # Pickle round-trip: the stub spec classes are function-local (unpicklable
+    # by construction), so exercise the WIRE payload — the patched TransferJob
+    # dataclass with its meta field — with picklable stand-in specs.
+    wire = mods["common"].TransferJob(
+        req_id=job.req_id, src_spec=None, dst_spec=None, glm53_store_meta=meta
+    )
+    job2 = pickle.loads(pickle.dumps(wire))
+    check(
+        job2.glm53_store_meta == meta,
+        "B7 TransferJob.glm53_store_meta pickles round-trip unchanged",
+    )
+    default_job = mods["common"].TransferJob(req_id="r", src_spec=None, dst_spec=None)
+    check(
+        default_job.glm53_store_meta is None,
+        "B7b meta defaults to None (stock constructors unchanged)",
+    )
+
+    # Knob off => no meta (and a fresh request to avoid job-state carryover).
+    os.environ["GLM53_KV_OFFLOAD"] = "0"
+    req_off = FakeRequest(num_tokens=3584 + 5, req_id="req-off", salt=b"t")
+    scheduler.on_new_request(req_off)
+    scheduler.get_num_new_matched_tokens(req_off, 0)
+    bid_off = tuple(
+        [5000 * (g + 1) + j + 1 for j in range(per_group_blocks[g])] for g in range(7)
+    )
+    so_off = SimpleNamespace(
+        num_scheduled_tokens={req_off.request_id: req_off.num_tokens},
+        finished_req_ids=set(),
+        req_data={req_off.request_id: (bid_off, False)},
+        partial_tail_offloads=None,
+    )
+    scheduler._update_req_states(so_off)
+    jobs_off = scheduler._build_store_jobs(so_off)
+    check(
+        all(j.glm53_store_meta is None for j in jobs_off.values()),
+        "B8 GLM53_KV_OFFLOAD=0: no store meta is attached",
+    )
+    _cleanup_env()
+
+
+# ------------------------------------------------------------------ part C --
+class FakeSlice:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def numpy(self):
+        return self
+
+    def tobytes(self) -> bytes:
+        return self._data
+
+
+class FakeCpuTensor:
+    """(num_rows, page) staging tensor; row content is deterministic."""
+
+    def __init__(self, tensor_idx: int, num_rows: int, page: int):
+        self.page = page
+        self.rows = [
+            bytes(((tensor_idx * 31 + r * 7 + i) % 256) for i in range(page))
+            for r in range(num_rows)
+        ]
+
+    def __getitem__(self, key):
+        row, sl = key
+        return FakeSlice(self.rows[row][sl])
+
+
+@dataclass
+class FakeRef:
+    tensor_idx: int
+    page_size_bytes: int
+
+
+def _mini_env(rank=0, cfg_rank=None, num_spec=7):
+    """Miniature 7-group layout for the writer (tiny pages, real semantics)."""
+    from _kv_offload_stub_env import (
+        FakeKVCacheGroup,
+        FakeParallelConfig,
+        FakeVllmConfig,
+        MLAAttentionSpec,
+        KpoolTailSpec,
+        MambaSpec,
+        SlidingWindowSpec,
+        UniformTypeKVCacheSpecs,
+        FakeSpeculativeConfig,
+    )
+
+    # conv (2,3) bf16 = 12 B + temporal (2,2) f32 = 16 B => real page 28.
+    mamba_spec = lambda: MambaSpec(  # noqa: E731
+        3584, shapes=((2, 3), (2, 2)), dtypes=("torch.bfloat16", "torch.float32")
+    )
+    groups = [
+        FakeKVCacheGroup(
+            UniformTypeKVCacheSpecs(
+                3584,
+                {"mla.0": MLAAttentionSpec(3584), "mla.1": MLAAttentionSpec(3584), "idx.0": MLAAttentionSpec(3584)},
+            ),
+            ("mla.0", "mla.1", "idx.0"),
+        ),
+        FakeKVCacheGroup(KpoolTailSpec(4, prefix_cacheable=False), ("kpool.0",)),
+        FakeKVCacheGroup(UniformTypeKVCacheSpecs(3584, {"kda2.0": mamba_spec(), "kda2.1": mamba_spec()}), ("kda2.0", "kda2.1")),
+        FakeKVCacheGroup(UniformTypeKVCacheSpecs(3584, {"kda3.0": mamba_spec()}), ("kda3.0",)),
+        FakeKVCacheGroup(UniformTypeKVCacheSpecs(3584, {"kda4.0": mamba_spec()}), ("kda4.0",)),
+        FakeKVCacheGroup(UniformTypeKVCacheSpecs(3584, {"kda5.0": mamba_spec()}), ("kda5.0",)),
+        FakeKVCacheGroup(SlidingWindowSpec(64, 2048), ("draft.0",)),
+    ]
+    kv_cache_config = SimpleNamespace(kv_cache_groups=groups)
+
+    # tensors: t0/t1 page 64 (MLA slots, mamba parasitizes), t2 page 8 (idx)
+    tensors = [FakeCpuTensor(0, 64, 64), FakeCpuTensor(1, 64, 64), FakeCpuTensor(2, 64, 8)]
+    refs_per_group = [
+        [FakeRef(0, 64), FakeRef(1, 64), FakeRef(2, 8)],  # g0 (3 layers)
+        [FakeRef(2, 2)],                                   # g1 (never written)
+        [FakeRef(0, 28), FakeRef(1, 28)],                  # g2 (2 KDA layers)
+        [FakeRef(0, 28)],                                  # g3
+        [FakeRef(1, 28)],                                  # g4
+        [FakeRef(0, 28)],                                  # g5
+        [FakeRef(1, 16)],                                  # g6 (never written)
+    ]
+    handler = SimpleNamespace(
+        dst_tensors=tensors,
+        layer_refs_per_group=refs_per_group,
+        _canonical_copy_plans=None,
+    )
+    worker = SimpleNamespace(_store_handler=handler)
+    # Shaped like OffloadingParallelConfig (rank/world_size/tp_size), NOT the
+    # vllm ParallelConfig: that is what the writer reads via spec.config.
+    parallel = SimpleNamespace(
+        rank=cfg_rank if cfg_rank is not None else rank,
+        world_size=2,
+        tp_size=2,
+    )
+    del FakeParallelConfig  # imported for parity; unused on purpose
+    eligible = []
+    for gidx in (0, 2, 3, 4, 5):
+        eligible.append(
+            SimpleNamespace(
+                group_idx=gidx,
+                tokens_per_block=3584,
+                layer_names=groups[gidx].layer_names,
+            )
+        )
+    spec = SimpleNamespace(
+        blocks_per_chunk=1,
+        tokens_per_hash=64,
+        config=SimpleNamespace(
+            parallel=parallel,
+            model=SimpleNamespace(name="test/model", dtype="fp8"),
+            groups=eligible,
+        ),
+    )
+    vllm_config = FakeVllmConfig()
+    vllm_config.speculative_config = FakeSpeculativeConfig(
+        num_speculative_tokens=num_spec
+    )
+    cw = SimpleNamespace(
+        spec=spec,
+        worker=worker,
+        kv_cache_config=kv_cache_config,
+        vllm_config=vllm_config,
+        _glm53_store_writer=None,
+        _glm53_job_meta={},
+        _connector_worker_meta=SimpleNamespace(
+            completed=[], mark_completed=lambda job_id: None
+        ),
+    )
+    cw._connector_worker_meta.mark_completed = cw._connector_worker_meta.completed.append
+    return cw, tensors, refs_per_group
+
+
+class _TestLogger:
+    def __init__(self):
+        self.lines = []
+
+    def _fmt(self, msg, *args):
+        try:
+            self.lines.append(msg % args if args else str(msg))
+        except TypeError:
+            self.lines.append(str(msg))
+
+    info = debug = warning = error = exception = _fmt
+
+
+def _hash(i: int) -> str:
+    import hashlib
+
+    return hashlib.sha256(b"chunk%d" % i).hexdigest()[:64]
+
+
+def _job_meta(n_boundaries: int):
+    """Meta for one job storing all 5 eligible groups at n boundaries."""
+    keys = []
+    for k in range(n_boundaries):
+        for g in (0, 2, 3, 4, 5):
+            keys.append((_hash(k), g, k, 3584))
+    manifests = [
+        {
+            "boundary_token_index": (k + 1) * 3584,
+            "chunk_hashes": [_hash(j) for j in range(k + 1)],
+        }
+        for k in range(n_boundaries)
+    ]
+    return {
+        "v": 1,
+        "keys": keys,
+        "cow_groups": [2, 3, 4, 5],
+        "full_groups": [0],
+        "manifests": manifests,
+    }
+
+
+def test_writer() -> None:
+    print("Part C: worker-local writer")
+    import _kv_offload_stub_env as stub
+
+    if "vllm" not in sys.modules:
+        stub.install_fake_vllm()
+
+    logger = _TestLogger()
+    with tempfile.TemporaryDirectory() as td:
+        os.environ["GLM53_KV_OFFLOAD_DIR"] = td
+        os.environ["GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"] = "0"
+        ns = store.load_writer_helpers(logger)
+        cw, tensors, refs = _mini_env()
+        writer = ns["Glm53LocalStoreWriter"](cw, logger)
+        check(writer._disabled_reason is None, "C1 writer initialises on the layout")
+        check(writer._rank == 0 and writer._base.endswith("_r0"), "C2 per-rank base dir")
+
+        meta = _job_meta(2)
+        rows = list(range(len(meta["keys"])))
+        deferred = writer.submit_job(7, meta, rows)
+        check(deferred, "C3 job ack deferred to the disk writer")
+        writer.shutdown(timeout=20)
+        done = writer.drain_done()
+        check(done == [7], "C4 job completion surfaces via the done queue")
+
+        base = Path(writer._base)
+        g2_path = base / _hash(0)[:3] / f"{_hash(0)[3:5]}_g2" / f"{_hash(0)}.bin"
+        check(g2_path.is_file(), "C5 mamba chunk file lands under its group dir")
+        h = store.read_chunk_header(str(g2_path), verify_payload=True)
+        check(
+            h["payload_len"] == 56 and h["spec_kind"] == "MambaSpec",
+            "C6 mamba payload = REAL bytes (2 layers x 28 B, padding never written)",
+        )
+        segs = h["segment_table"]
+        check(
+            len(segs) == 4
+            and segs[0]["kind"] == "conv_state"
+            and segs[0]["shape"] == [2, 3]
+            and segs[0]["dtype"] == "torch.bfloat16"
+            and segs[0]["stride"] == [3, 1]
+            and segs[1]["kind"] == "temporal_state"
+            and segs[1]["length"] == 16
+            and segs[2]["offset"] == 28,
+            "C7 KDA segment table: conv/temporal split with shape/dtype/stride",
+        )
+        # Payload bytes must equal the staging rows' unpadded prefixes, in
+        # group layer order (row = dst cpu block of that key).
+        g2_row = rows[meta["keys"].index((_hash(0), 2, 0, 3584))]
+        expected = tensors[0].rows[g2_row][:28] + tensors[1].rows[g2_row][:28]
+        blob = g2_path.read_bytes()
+        check(blob.endswith(expected), "C8 payload bytes == staging real bytes per ref")
+
+        g0_path = base / _hash(0)[:3] / f"{_hash(0)[3:5]}_g0" / f"{_hash(0)}.bin"
+        h0 = store.read_chunk_header(str(g0_path))
+        check(h0["payload_len"] == 64 + 64 + 8, "C9 g0 payload spans all 3 layer pages")
+
+        m0 = base / "manifests" / _hash(0)[:3] / f"{_hash(0)}.json"
+        m1 = base / "manifests" / _hash(1)[:3] / f"{_hash(1)}.json"
+        check(m0.is_file() and m1.is_file(), "C10 manifests published for both boundaries")
+        man = json.loads(m1.read_text())
+        check(
+            man["chunk_hashes"] == [_hash(0), _hash(1)]
+            and set(man["cow_groups"]) == {"2", "3", "4", "5"}
+            and man["full_groups"] == {"0": 2},
+            "C11 manifest carries cumulative chunk chain + per-group entries",
+        )
+        n_files = len(list(base.rglob("*.bin")))
+        check(n_files == 10, f"C12 5 groups x 2 boundaries = 10 chunk files (got {n_files})")
+
+        # Incomplete boundary: mamba g3 write missing => no manifest.
+        meta3 = _job_meta(3)
+        del_idx = meta3["keys"].index((_hash(2), 3, 2, 3584))
+        meta3["keys"] = meta3["keys"][:del_idx] + meta3["keys"][del_idx + 1 :]
+        meta3["manifests"] = meta3["manifests"][2:]  # only the new boundary
+        writer.submit_job(8, meta3, list(range(len(meta3["keys"]))))
+        writer.shutdown(timeout=20)
+        m2 = base / "manifests" / _hash(2)[:3] / f"{_hash(2)}.json"
+        check(
+            not m2.is_file(),
+            "C13 a boundary missing one mamba payload publishes NO manifest",
+        )
+
+        # Failed-key ledger: even with the file later present, a key that
+        # failed this boot cannot enter a manifest.
+        writer._failed_keys.add((_hash(2), 3))
+        meta_fk = {
+            "v": 1,
+            "keys": [(_hash(2), 3, 2, 3584)],
+            "cow_groups": [2, 3, 4, 5],
+            "full_groups": [0],
+            "manifests": [
+                {
+                    "boundary_token_index": 3 * 3584,
+                    "chunk_hashes": [_hash(0), _hash(1), _hash(2)],
+                }
+            ],
+        }
+        writer.submit_job(9, meta_fk, [40])
+        writer.shutdown(timeout=20)
+        check(
+            not m2.is_file(),
+            "C14 failed-key ledger blocks the manifest even after a later write",
+        )
+
+    # ENOSPC pause.
+    logger2 = _TestLogger()
+    with tempfile.TemporaryDirectory() as td:
+        os.environ["GLM53_KV_OFFLOAD_DIR"] = td
+        ns = store.load_writer_helpers(logger2)
+        cw, _, _ = _mini_env()
+        writer = ns["Glm53LocalStoreWriter"](cw, logger2)
+        real_open = open
+
+        def enospc_open(path, mode="r", *a, **k):
+            if "b" in mode and "w" in mode:
+                raise OSError(errno.ENOSPC, "No space left on device")
+            return real_open(path, mode, *a, **k)
+
+        ns["open"] = enospc_open
+        writer.submit_job(1, _job_meta(1), list(range(5)))
+        writer.shutdown(timeout=20)
+        check(
+            writer._paused_reason == "ENOSPC" and writer.drain_done() == [1],
+            "C15 ENOSPC pauses the writer; the job still completes (lost store)",
+        )
+        check(
+            not list(Path(writer._base).rglob("*.bin"))
+            and not list(Path(writer._base).rglob("*.tmp.*")),
+            "C16 no partial files or stale temps left behind",
+        )
+        check(
+            not list(Path(writer._base).rglob("manifests/**/*.json")),
+            "C17 paused writer publishes no manifests",
+        )
+
+    # Retention K=1: publishing boundary 2 supersedes boundary 1.
+    logger3 = _TestLogger()
+    with tempfile.TemporaryDirectory() as td:
+        os.environ["GLM53_KV_OFFLOAD_DIR"] = td
+        os.environ["GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"] = "1"
+        ns = store.load_writer_helpers(logger3)
+        cw, _, _ = _mini_env()
+        writer = ns["Glm53LocalStoreWriter"](cw, logger3)
+        writer.submit_job(1, _job_meta(2), list(range(10)))
+        writer.shutdown(timeout=20)
+        base = Path(writer._base)
+        m0 = base / "manifests" / _hash(0)[:3] / f"{_hash(0)}.json"
+        m1 = base / "manifests" / _hash(1)[:3] / f"{_hash(1)}.json"
+        g2_b0 = base / _hash(0)[:3] / f"{_hash(0)[3:5]}_g2" / f"{_hash(0)}.bin"
+        g0_b0 = base / _hash(0)[:3] / f"{_hash(0)[3:5]}_g0" / f"{_hash(0)}.bin"
+        check(
+            m1.is_file() and not m0.is_file(),
+            "C18 keep_boundaries=1: older boundary manifest superseded",
+        )
+        check(
+            not g2_b0.is_file() and g0_b0.is_file(),
+            "C19 superseded boundary: mamba payload unlinked, full-attn chunk kept (C1)",
+        )
+
+    # Rank disagreement: TP rank 0 vs config rank 1 => disabled, no writes.
+    ps = sys.modules["vllm.distributed.parallel_state"]
+
+    old = ps.get_tensor_model_parallel_rank
+    ps.get_tensor_model_parallel_rank = lambda: 0
+    try:
+        logger4 = _TestLogger()
+        with tempfile.TemporaryDirectory() as td:
+            os.environ["GLM53_KV_OFFLOAD_DIR"] = td
+            ns = store.load_writer_helpers(logger4)
+            cw, _, _ = _mini_env(cfg_rank=1)
+            writer = ns["Glm53LocalStoreWriter"](cw, logger4)
+            check(
+                writer._disabled_reason is not None
+                and "disagrees" in writer._disabled_reason,
+                "C20 TP-rank/config-rank disagreement DISABLES the writer",
+            )
+            check(
+                writer.submit_job(1, _job_meta(1), list(range(5))) is False,
+                "C21 disabled writer never defers acks (jobs flow normally)",
+            )
+    finally:
+        ps.get_tensor_model_parallel_rank = old
+
+    # Namespace forks on num_spec (stage-0 A2: num_spec is state-ABI).
+    logger5 = _TestLogger()
+    with tempfile.TemporaryDirectory() as td:
+        os.environ["GLM53_KV_OFFLOAD_DIR"] = td
+        os.environ["GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"] = "2"
+        ns = store.load_writer_helpers(logger5)
+        cw7, _, _ = _mini_env(num_spec=7)
+        cw8, _, _ = _mini_env(num_spec=8)
+        w7 = ns["Glm53LocalStoreWriter"](cw7, logger5)
+        w8 = ns["Glm53LocalStoreWriter"](cw8, logger5)
+        check(
+            w7._namespace_hash != w8._namespace_hash,
+            "C22 num_speculative_tokens forks the namespace hash",
+        )
+
+    # Delayed-ack drain semantics through the connector-worker helpers.
+    logger6 = _TestLogger()
+    with tempfile.TemporaryDirectory() as td:
+        os.environ["GLM53_KV_OFFLOAD_DIR"] = td
+        ns = store.load_writer_helpers(logger6)
+        cw, _, _ = _mini_env()
+        dst = SimpleNamespace(block_ids=list(range(5)))
+        cw._glm53_job_meta[42] = (_job_meta(1), dst)
+        intercepted = ns["_glm53_intercept_store_completion"](cw, 42)
+        check(
+            intercepted and cw._connector_worker_meta.completed == [],
+            "C23 store completion intercepted: no immediate ack",
+        )
+        cw._glm53_store_writer.shutdown(timeout=20)
+        ns["_glm53_drain_finished_disk_writes"](cw)
+        check(
+            cw._connector_worker_meta.completed == [42],
+            "C24 ack lands via drain after the disk write finishes",
+        )
+        check(
+            ns["_glm53_intercept_store_completion"](cw, 43) is False,
+            "C25 jobs without meta (loads) are never intercepted",
+        )
+    _cleanup_env()
+
+
+# ------------------------------------------------------------------ part D --
+def test_gc_tool() -> None:
+    print("Part D: GC/verify tool")
+    import _kv_offload_stub_env as stub
+
+    if "vllm" not in sys.modules:
+        stub.install_fake_vllm()
+    import kv_offload_store_gc as gc_tool
+
+    logger = _TestLogger()
+    with tempfile.TemporaryDirectory() as td:
+        os.environ["GLM53_KV_OFFLOAD_DIR"] = td
+        os.environ["GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"] = "0"
+        ns = store.load_writer_helpers(logger)
+        cw, _, _ = _mini_env()
+        writer = ns["Glm53LocalStoreWriter"](cw, logger)
+        writer.submit_job(1, _job_meta(2), list(range(10)))
+        writer.shutdown(timeout=20)
+        base = Path(writer._base)
+
+        rc = gc_tool.main([str(base)])
+        check(rc == 0, "D1 clean store passes the dry-run")
+
+        # Orphan: a mamba payload whose manifest never published.
+        meta3 = {
+            "v": 1,
+            "keys": [(_hash(9), 2, 9, 3584)],
+            "cow_groups": [2, 3, 4, 5],
+            "full_groups": [0],
+            "manifests": [],
+        }
+        writer2 = ns["Glm53LocalStoreWriter"](cw, logger)
+        writer2.submit_job(2, meta3, [50])
+        writer2.shutdown(timeout=20)
+        orphan = base / _hash(9)[:3] / f"{_hash(9)[3:5]}_g2" / f"{_hash(9)}.bin"
+        check(orphan.is_file(), "D2 orphan payload staged")
+        rc = gc_tool.main([str(base)])
+        check(rc == 1 and orphan.is_file(), "D3 dry-run reports the orphan, deletes nothing")
+
+        # Corrupt file: truncate one chunk.
+        victim = base / _hash(1)[:3] / f"{_hash(1)[3:5]}_g3" / f"{_hash(1)}.bin"
+        victim.write_bytes(victim.read_bytes()[:20])
+        rc = gc_tool.main([str(base)])
+        check(rc == 1, "D4 dry-run flags the truncated chunk")
+
+        rc = gc_tool.main([str(base), "--sweep"])
+        check(
+            not orphan.is_file() and not victim.is_file(),
+            "D5 --sweep removes orphan and corrupt files",
+        )
+
+        # keep-boundaries: keep 1 => boundary-0 manifest superseded, its mamba
+        # chunk swept, but the cumulative g0 chunk of boundary 0 survives (C1).
+        rc = gc_tool.main([str(base), "--sweep", "--keep-boundaries", "1"])
+        m0 = base / "manifests" / _hash(0)[:3] / f"{_hash(0)}.json"
+        g0_b0 = base / _hash(0)[:3] / f"{_hash(0)[3:5]}_g0" / f"{_hash(0)}.bin"
+        g2_b0 = base / _hash(0)[:3] / f"{_hash(0)[3:5]}_g2" / f"{_hash(0)}.bin"
+        check(not m0.is_file(), "D6 --keep-boundaries supersedes the older manifest")
+        check(
+            g0_b0.is_file() and not g2_b0.is_file(),
+            "D7 cumulative full-attn refs protected; superseded mamba swept",
+        )
+    _cleanup_env()
+
+
+
+
+def _cleanup_env() -> None:
+    """These tests mutate GLM53_KV_OFFLOAD* in os.environ; scrub them so the
+    rest of the suite (and any subprocess-driving test that inherits the
+    process env) sees a clean slate."""
+    for name in ("GLM53_KV_OFFLOAD","GLM53_KV_OFFLOAD_DIR","GLM53_KV_OFFLOAD_CPU_GB","GLM53_KV_OFFLOAD_RESTORE","GLM53_KV_OFFLOAD_DRAFTER","GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"):
+        os.environ.pop(name, None)
+
+
+def main() -> int:
+    test_codec()
+    test_store_job_meta()
+    test_writer()
+    test_gc_tool()
+    print(f"\n{len(FAILURES)} failure(s)")
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_kv_offload_store_local.py
+++ b/tests/test_kv_offload_store_local.py
@@ -13,12 +13,17 @@ C  Worker-local writer on a miniature 7-group layout: per-(hash,group) files
    with REAL (unpadded) bytes gathered ref-by-ref from the staging tensors,
    headers with KDA conv/temporal segment split (shape/dtype/stride),
    manifest publish ordering (missing any mamba payload or any cumulative
-   full-attn chunk => no manifest), inline K-boundary retention, dedup,
-   failed-key ledger, ENOSPC pause, rank-disagreement disable, delayed-ack
-   drain semantics, namespace forking on num_spec change.
-D  GC tool (overlay/kv_offload_store_gc.py): dry-run reports orphans and
-   corrupt files without deleting; --sweep removes them; --keep-boundaries
-   preserves cumulative full-attn references (plan §4 C1).
+   full-attn chunk => no manifest), inline K-boundary retention,
+   header-verified dedup, failed-key ledger, ENOSPC pause,
+   rank-disagreement disable, capture-then-write snapshot isolation (the
+   reset_cache()/row-reuse regression: staging mutated after capture must
+   not change disk bytes), flush-path capture, namespace forking on
+   num_spec change.
+D  GC tool (overlay/kv_offload_store_gc.py): dry-run reports orphans (found
+   from headers even with zero manifests), corrupt files and stale temps
+   without deleting; --sweep removes them; --keep-boundaries applies the
+   writer's leaf-walk keep-set (forked chains: shared divergence ancestors
+   survive) and preserves cumulative full-attn references (plan §4 C1).
 
 Run:  python3 tests/test_kv_offload_store_local.py   (or pytest)
 """
@@ -409,11 +414,22 @@ def test_writer() -> None:
 
         meta = _job_meta(2)
         rows = list(range(len(meta["keys"])))
-        deferred = writer.submit_job(7, meta, rows)
-        check(deferred, "C3 job ack deferred to the disk writer")
+        # Capture-then-write (review finding 1): the capture snapshots bytes
+        # synchronously; mutating the staging rows AFTERWARDS must not change
+        # what lands on disk (this is the reset_cache()/row-reuse regression).
+        g2_row = rows[meta["keys"].index((_hash(0), 2, 0, 3584))]
+        pre0 = tensors[0].rows[g2_row][:28]
+        pre1 = tensors[1].rows[g2_row][:28]
+        writer.capture_job(7, meta, rows)
+        for t in tensors:
+            t.rows = [bytes(len(r)) for r in t.rows]  # zero every staging row
         writer.shutdown(timeout=20)
         done = writer.drain_done()
-        check(done == [7], "C4 job completion surfaces via the done queue")
+        check(done == [7], "C3 job completion surfaces via the done queue")
+        check(
+            writer.capture_job(7, meta, rows) is None,
+            "C4 capture is idempotent per job id and never defers acks",
+        )
 
         base = Path(writer._base)
         g2_path = base / _hash(0)[:3] / f"{_hash(0)[3:5]}_g2" / f"{_hash(0)}.bin"
@@ -435,12 +451,14 @@ def test_writer() -> None:
             and segs[2]["offset"] == 28,
             "C7 KDA segment table: conv/temporal split with shape/dtype/stride",
         )
-        # Payload bytes must equal the staging rows' unpadded prefixes, in
-        # group layer order (row = dst cpu block of that key).
-        g2_row = rows[meta["keys"].index((_hash(0), 2, 0, 3584))]
-        expected = tensors[0].rows[g2_row][:28] + tensors[1].rows[g2_row][:28]
+        # Payload bytes must equal the PRE-MUTATION staging snapshot, in
+        # group layer order — proof the writer worked from private buffers.
+        expected = pre0 + pre1
         blob = g2_path.read_bytes()
-        check(blob.endswith(expected), "C8 payload bytes == staging real bytes per ref")
+        check(
+            blob.endswith(expected) and any(expected),
+            "C8 payload == pre-mutation staging snapshot (private buffers)",
+        )
 
         g0_path = base / _hash(0)[:3] / f"{_hash(0)[3:5]}_g0" / f"{_hash(0)}.bin"
         h0 = store.read_chunk_header(str(g0_path))
@@ -450,11 +468,13 @@ def test_writer() -> None:
         m1 = base / "manifests" / _hash(1)[:3] / f"{_hash(1)}.json"
         check(m0.is_file() and m1.is_file(), "C10 manifests published for both boundaries")
         man = json.loads(m1.read_text())
+        g0_chunks = man["full_groups"]["0"]
         check(
             man["chunk_hashes"] == [_hash(0), _hash(1)]
             and set(man["cow_groups"]) == {"2", "3", "4", "5"}
-            and man["full_groups"] == {"0": 2},
-            "C11 manifest carries cumulative chunk chain + per-group entries",
+            and [c[0] for c in g0_chunks] == [_hash(0), _hash(1)]
+            and all(c[1] == 136 and isinstance(c[2], int) for c in g0_chunks),
+            "C11 manifest: cumulative chain + per-chunk [hash, len, crc] per group",
         )
         n_files = len(list(base.rglob("*.bin")))
         check(n_files == 10, f"C12 5 groups x 2 boundaries = 10 chunk files (got {n_files})")
@@ -464,7 +484,7 @@ def test_writer() -> None:
         del_idx = meta3["keys"].index((_hash(2), 3, 2, 3584))
         meta3["keys"] = meta3["keys"][:del_idx] + meta3["keys"][del_idx + 1 :]
         meta3["manifests"] = meta3["manifests"][2:]  # only the new boundary
-        writer.submit_job(8, meta3, list(range(len(meta3["keys"]))))
+        writer.capture_job(8, meta3, list(range(len(meta3["keys"]))))
         writer.shutdown(timeout=20)
         m2 = base / "manifests" / _hash(2)[:3] / f"{_hash(2)}.json"
         check(
@@ -487,7 +507,7 @@ def test_writer() -> None:
                 }
             ],
         }
-        writer.submit_job(9, meta_fk, [40])
+        writer.capture_job(9, meta_fk, [40])
         writer.shutdown(timeout=20)
         check(
             not m2.is_file(),
@@ -509,7 +529,7 @@ def test_writer() -> None:
             return real_open(path, mode, *a, **k)
 
         ns["open"] = enospc_open
-        writer.submit_job(1, _job_meta(1), list(range(5)))
+        writer.capture_job(1, _job_meta(1), list(range(5)))
         writer.shutdown(timeout=20)
         check(
             writer._paused_reason == "ENOSPC" and writer.drain_done() == [1],
@@ -533,7 +553,7 @@ def test_writer() -> None:
         ns = store.load_writer_helpers(logger3)
         cw, _, _ = _mini_env()
         writer = ns["Glm53LocalStoreWriter"](cw, logger3)
-        writer.submit_job(1, _job_meta(2), list(range(10)))
+        writer.capture_job(1, _job_meta(2), list(range(10)))
         writer.shutdown(timeout=20)
         base = Path(writer._base)
         m0 = base / "manifests" / _hash(0)[:3] / f"{_hash(0)}.json"
@@ -566,9 +586,10 @@ def test_writer() -> None:
                 and "disagrees" in writer._disabled_reason,
                 "C20 TP-rank/config-rank disagreement DISABLES the writer",
             )
+            writer.capture_job(1, _job_meta(1), list(range(5)))
             check(
-                writer.submit_job(1, _job_meta(1), list(range(5))) is False,
-                "C21 disabled writer never defers acks (jobs flow normally)",
+                not list(Path(td).rglob("*.bin")),
+                "C21 disabled writer captures nothing (jobs flow normally)",
             )
     finally:
         ps.get_tensor_model_parallel_rank = old
@@ -588,7 +609,7 @@ def test_writer() -> None:
             "C22 num_speculative_tokens forks the namespace hash",
         )
 
-    # Delayed-ack drain semantics through the connector-worker helpers.
+    # Capture helpers through the connector-worker seam (both call sites).
     logger6 = _TestLogger()
     with tempfile.TemporaryDirectory() as td:
         os.environ["GLM53_KV_OFFLOAD_DIR"] = td
@@ -596,20 +617,30 @@ def test_writer() -> None:
         cw, _, _ = _mini_env()
         dst = SimpleNamespace(block_ids=list(range(5)))
         cw._glm53_job_meta[42] = (_job_meta(1), dst)
-        intercepted = ns["_glm53_intercept_store_completion"](cw, 42)
+        ns["_glm53_capture_store_job"](cw, 42)
         check(
-            intercepted and cw._connector_worker_meta.completed == [],
-            "C23 store completion intercepted: no immediate ack",
+            42 not in cw._glm53_job_meta
+            and cw._glm53_store_writer is not None,
+            "C23 get_finished capture consumes the job meta",
         )
         cw._glm53_store_writer.shutdown(timeout=20)
-        ns["_glm53_drain_finished_disk_writes"](cw)
+        base = Path(cw._glm53_store_writer._base)
         check(
-            cw._connector_worker_meta.completed == [42],
-            "C24 ack lands via drain after the disk write finishes",
+            len(list(base.rglob("*.bin"))) == 5,
+            "C24 captured job's files land on disk",
         )
+        ns["_glm53_capture_store_job"](cw, 43)
         check(
-            ns["_glm53_intercept_store_completion"](cw, 43) is False,
-            "C25 jobs without meta (loads) are never intercepted",
+            43 not in cw._glm53_job_meta,
+            "C25 jobs without meta (loads) are a no-op capture",
+        )
+        # Flush/reset path: capture fires for exactly the flushed store jobs.
+        cw._glm53_job_meta[44] = (_job_meta(1), dst)
+        ns["_glm53_capture_flushed_store_jobs"](cw, {44, 45})
+        cw._glm53_store_writer.shutdown(timeout=20)
+        check(
+            44 not in cw._glm53_job_meta,
+            "C26 flush-path capture consumes flushed store jobs (reset-safe)",
         )
     _cleanup_env()
 
@@ -630,7 +661,7 @@ def test_gc_tool() -> None:
         ns = store.load_writer_helpers(logger)
         cw, _, _ = _mini_env()
         writer = ns["Glm53LocalStoreWriter"](cw, logger)
-        writer.submit_job(1, _job_meta(2), list(range(10)))
+        writer.capture_job(1, _job_meta(2), list(range(10)))
         writer.shutdown(timeout=20)
         base = Path(writer._base)
 
@@ -646,7 +677,7 @@ def test_gc_tool() -> None:
             "manifests": [],
         }
         writer2 = ns["Glm53LocalStoreWriter"](cw, logger)
-        writer2.submit_job(2, meta3, [50])
+        writer2.capture_job(2, meta3, [50])
         writer2.shutdown(timeout=20)
         orphan = base / _hash(9)[:3] / f"{_hash(9)[3:5]}_g2" / f"{_hash(9)}.bin"
         check(orphan.is_file(), "D2 orphan payload staged")
@@ -675,6 +706,78 @@ def test_gc_tool() -> None:
         check(
             g0_b0.is_file() and not g2_b0.is_file(),
             "D7 cumulative full-attn refs protected; superseded mamba swept",
+        )
+
+    # Crash-before-first-manifest: orphans must be found from HEADERS alone.
+    logger7 = _TestLogger()
+    with tempfile.TemporaryDirectory() as td:
+        os.environ["GLM53_KV_OFFLOAD_DIR"] = td
+        os.environ["GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"] = "0"
+        ns = store.load_writer_helpers(logger7)
+        cw, _, _ = _mini_env()
+        w = ns["Glm53LocalStoreWriter"](cw, logger7)
+        meta = {
+            "v": 1,
+            "keys": [(_hash(3), 4, 3, 3584)],
+            "cow_groups": [2, 3, 4, 5],
+            "full_groups": [0],
+            "manifests": [],
+        }
+        w.capture_job(1, meta, [7])
+        w.shutdown(timeout=20)
+        base = Path(w._base)
+        out = gc_tool.main([str(base)])
+        check(
+            out == 1,
+            "D8 orphan reported with ZERO manifests present (header-based)",
+        )
+        # Stale temp: any *.tmp.* is reported and swept.
+        t = base / _hash(3)[:3] / f"{_hash(3)[3:5]}_g4" / "x.bin.tmp.r0.1.2"
+        t.write_bytes(b"partial")
+        check(gc_tool.main([str(base)]) == 1, "D9 stale temp flagged by dry-run")
+        gc_tool.main([str(base), "--sweep"])
+        check(not t.exists(), "D10 --sweep removes stale temps")
+
+    # Forked chains: a shared divergence-point boundary survives while ANY
+    # branch still keeps it (writer rule mirrored in the GC tool).
+    logger8 = _TestLogger()
+    with tempfile.TemporaryDirectory() as td:
+        os.environ["GLM53_KV_OFFLOAD_DIR"] = td
+        os.environ["GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"] = "0"
+        ns = store.load_writer_helpers(logger8)
+        cw, _, _ = _mini_env()
+        w = ns["Glm53LocalStoreWriter"](cw, logger8)
+        keys = []
+        for k, h in ((0, _hash(0)), (1, _hash(10)), (1, _hash(11))):
+            for g in (0, 2, 3, 4, 5):
+                keys.append((h, g, k, 3584))
+        meta = {
+            "v": 1,
+            "keys": keys,
+            "cow_groups": [2, 3, 4, 5],
+            "full_groups": [0],
+            "manifests": [
+                {"boundary_token_index": 3584, "chunk_hashes": [_hash(0)]},
+                {"boundary_token_index": 7168, "chunk_hashes": [_hash(0), _hash(10)]},
+                {"boundary_token_index": 7168, "chunk_hashes": [_hash(0), _hash(11)]},
+            ],
+        }
+        w.capture_job(1, meta, list(range(len(keys))))
+        w.shutdown(timeout=20)
+        base = Path(w._base)
+        m_shared = base / "manifests" / _hash(0)[:3] / f"{_hash(0)}.json"
+        check(m_shared.is_file(), "D11 forked store staged (shared ancestor manifested)")
+        gc_tool.main([str(base), "--sweep", "--keep-boundaries", "2"])
+        check(
+            m_shared.is_file(),
+            "D12 K=2: shared divergence-point ancestor kept (both branches need it)",
+        )
+        gc_tool.main([str(base), "--sweep", "--keep-boundaries", "1"])
+        m_a = base / "manifests" / _hash(10)[:3] / f"{_hash(10)}.json"
+        m_b = base / "manifests" / _hash(11)[:3] / f"{_hash(11)}.json"
+        check(
+            m_a.is_file() and m_b.is_file() and not m_shared.is_file(),
+            "D13 K=1: both leaves kept, only the shared ancestor superseded",
         )
     _cleanup_env()
 

--- a/tests/test_launcher_kv_offload.py
+++ b/tests/test_launcher_kv_offload.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Static + dry-run launcher regression for the kv-offload store tier knobs.
+
+A  Knob guard matrix (numeric-config block lifted by its sentinels): the
+   three bool knobs are exactly 0/1; GLM53_KV_OFFLOAD_RESTORE=1 is REFUSED
+   (stage 1 is store-only); CPU_GB is a canonical positive int <= 64; the
+   store dir must be absolute with no quotes/whitespace; KEEP_BOUNDARIES is
+   an integer 0..1024. All validated only when the tier is on, except the
+   bool shape and the restore refusal (always).
+B  Pre-stop gate: `./start.sh restart` with a bad knob, or with the scope or
+   store overlay missing/truncated/mis-pointed, exits 2 with ZERO docker or
+   ssh calls (the healthy pair is never stopped); a valid configuration
+   reaches the stop path.
+C  knob=0 byte-parity: the generated inner scripts gate --kv-transfer-config
+   on the env, both docker runs replay GLM53_KV_OFFLOAD=0, and NO store
+   mount or store mkdir appears anywhere.
+D  knob=1 both-rank parity: every GLM53_KV_OFFLOAD* env is present and
+   identical on both ranks (container dir path, CPU GiB, restore, drafter,
+   keep-boundaries), the store dir is mounted rw on both ranks from the same
+   host path, both overlays ride the scp -> /tmp -> mount chain, and
+   GLM53_OVERLAY_ORDER pins scope BEFORE store_local in BOTH inner scripts.
+   The parity comparator itself is exercised with a synthetic one-rank
+   mismatch. The inner scripts' JSON builder is executed and its shape
+   checked (OffloadingConnector / TieringOffloadingSpec / cpu_bytes /
+   blocks_per_chunk=1 / NO secondary tiers — Codex OFFLOAD1 finding 3).
+
+Everything drives the shipped start.sh under bash from an allow-listed
+environment with docker/ssh/scp/rsync/curl/ip/nvidia-smi stubbed first on
+PATH. Nothing talks to a real host.
+
+Run:  python3 tests/test_launcher_kv_offload.py   (or pytest)
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+START = ROOT / "start.sh"
+
+FAILURES: list[str] = []
+SEP = "\x1f"
+
+KNOBS = (
+    "GLM53_KV_OFFLOAD",
+    "GLM53_KV_OFFLOAD_DIR",
+    "GLM53_KV_OFFLOAD_CPU_GB",
+    "GLM53_KV_OFFLOAD_RESTORE",
+    "GLM53_KV_OFFLOAD_DRAFTER",
+    "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES",
+)
+
+STUB = """#!/usr/bin/env bash
+{ printf '%s\\x1f' "$(basename "$0")" "$@"; printf '\\n'; } >> "$GLM53_STUB_LOG"
+case "$(basename "$0")" in
+    ip) printf 'inet %s/24\\n' "${GLM53_STUB_HEAD_IP:-10.0.0.1}" ;;
+esac
+exit 0
+"""
+
+
+def check(cond: bool, label: str) -> None:
+    print(("  ok   " if cond else "  FAIL ") + label)
+    if not cond:
+        FAILURES.append(label)
+
+
+def source() -> str:
+    return START.read_text()
+
+
+def guard_source() -> str:
+    text = source()
+    begin = text.index("# GLM53 numeric config guard (begin)")
+    end_marker = "# GLM53 numeric config guard (end)"
+    return text[begin : text.index(end_marker, begin) + len(end_marker)]
+
+
+def base_env(**extra: str) -> dict[str, str]:
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", "/"),
+        "USER": "glm53-kvo",
+        "LC_ALL": "C",
+        "TERM": "dumb",
+    }
+    env.update(extra)
+    return env
+
+
+def run_guard(extra_env: dict[str, str]) -> tuple[int, str]:
+    script = (
+        guard_source()
+        + "\nGPU_MEM_UTIL=0.87; MAX_MODEL_LEN=1000000; MAX_NUM_SEQS=4\n"
+        + "MAX_NUM_BATCHED_TOKENS=1024\n"
+        + 'GLM53_KV_OFFLOAD_DIR="${GLM53_KV_OFFLOAD_DIR:-/tmp/kvo}"\n'
+        + 'GLM53_KV_OFFLOAD_CPU_GB="${GLM53_KV_OFFLOAD_CPU_GB:-4}"\n'
+        + 'GLM53_KV_OFFLOAD_KEEP_BOUNDARIES="${GLM53_KV_OFFLOAD_KEEP_BOUNDARIES:-2}"\n'
+        + "validate_numeric_config || exit $?\n"
+        + 'echo OK\n'
+    )
+    r = subprocess.run(
+        ["bash", "-c", script], text=True, capture_output=True, env=base_env(**extra_env)
+    )
+    return r.returncode, (r.stderr or r.stdout).strip()
+
+
+def part_a() -> None:
+    print("Part A: knob guard matrix")
+    ok_cases = [
+        {},
+        {"GLM53_KV_OFFLOAD": "0"},
+        {"GLM53_KV_OFFLOAD": "1"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_CPU_GB": "64"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES": "0"},
+        {"GLM53_KV_OFFLOAD": "0", "GLM53_KV_OFFLOAD_CPU_GB": "junk"},  # gated off
+    ]
+    for env in ok_cases:
+        rc, out = run_guard(env)
+        check(rc == 0, f"A1 accepted: {env} (rc={rc} {out[:60]!r})")
+    bad_cases = [
+        {"GLM53_KV_OFFLOAD": ""},
+        {"GLM53_KV_OFFLOAD": "2"},
+        {"GLM53_KV_OFFLOAD": "yes"},
+        {"GLM53_KV_OFFLOAD_RESTORE": "1"},  # refused even with the tier off
+        {"GLM53_KV_OFFLOAD_RESTORE": "x"},
+        {"GLM53_KV_OFFLOAD_DRAFTER": "01"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_CPU_GB": "0"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_CPU_GB": "65"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_CPU_GB": "4.5"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES": "-1"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES": "1025"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_DIR": "relative/path"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_DIR": "/tmp/has space"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_DIR": "/tmp/it's"},
+    ]
+    for env in bad_cases:
+        rc, out = run_guard(env)
+        named = any(k.split("_")[0] == "GLM53" and k in out for k in env) or "GLM53" in out
+        check(rc == 2 and named, f"A2 rejected rc=2 with named error: {env} (rc={rc} {out[:70]!r})")
+
+
+class Harness:
+    def __init__(self, tmp: Path) -> None:
+        self.tmp = tmp
+        self.repo = tmp / "repo"
+        self.repo.mkdir()
+        shutil.copy2(START, self.repo / "start.sh")
+        shutil.copy2(ROOT / ".env.example", self.repo / ".env.example")
+        (self.repo / ".env").write_text((ROOT / ".env.example").read_text())
+        for sub in ("overlay", "files", "ablit"):
+            if (ROOT / sub).is_dir():
+                shutil.copytree(ROOT / sub, self.repo / sub)
+        self.home = tmp / "home"
+        self.home.mkdir()
+        self.bin = tmp / "bin"
+        self.bin.mkdir()
+        for tool in ("docker", "ssh", "scp", "rsync", "curl", "ip", "nvidia-smi"):
+            p = self.bin / tool
+            p.write_text(STUB)
+            p.chmod(p.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        self.log = tmp / "calls.log"
+        text = (self.repo / "start.sh").read_text()
+        assert text.rstrip().endswith('\nmain "$@"')
+        (self.repo / "start.fn.sh").write_text(
+            text.rstrip()[: -len('main "$@"')] + '"$@"\n'
+        )
+
+    def env(self, **extra: str) -> dict[str, str]:
+        return base_env(
+            PATH=f"{self.bin}{os.pathsep}{os.environ.get('PATH', '/usr/bin:/bin')}",
+            HOME=str(self.home),
+            GLM53_STUB_LOG=str(self.log),
+            **extra,
+        )
+
+    def calls(self) -> list[list[str]]:
+        if not self.log.exists():
+            return []
+        out = []
+        for line in self.log.read_text().splitlines():
+            argv = line.split(SEP)
+            if argv and argv[-1] == "":
+                argv.pop()
+            out.append(argv)
+        return out
+
+    def run(self, args: list[str], entry: str = "start.sh", **extra: str):
+        if self.log.exists():
+            self.log.unlink()
+        return subprocess.run(
+            ["bash", f"./{entry}", *args],
+            cwd=self.repo,
+            text=True,
+            capture_output=True,
+            check=False,
+            env=self.env(**extra),
+        )
+
+    def host_calls(self) -> list[list[str]]:
+        return [c for c in self.calls() if c and c[0] in ("docker", "ssh", "scp", "rsync")]
+
+
+def part_b(h: Harness) -> None:
+    print("Part B: pre-stop gate fails closed")
+    r = h.run(["restart"], GLM53_KV_OFFLOAD="maybe")
+    check(
+        r.returncode == 2 and not h.host_calls(),
+        f"B1 bad knob: rc=2, zero docker/ssh calls (rc={r.returncode}, calls={len(h.host_calls())})",
+    )
+    r = h.run(["restart"], GLM53_KV_OFFLOAD_RESTORE="1")
+    check(
+        r.returncode == 2 and "store-only" in r.stderr and not h.host_calls(),
+        "B2 RESTORE=1 refused pre-stop with the stage-1 reason",
+    )
+    scope = h.repo / "overlay" / "patch_kv_offload_scope.py"
+    backup = scope.read_text()
+    scope.unlink()
+    r = h.run(["restart"])
+    check(
+        r.returncode == 2 and not h.host_calls(),
+        "B3 missing scope overlay: rc=2 before any host call",
+    )
+    scope.write_text(backup[: len(backup) // 2])
+    r = h.run(["restart"])
+    check(
+        r.returncode == 2 and not h.host_calls(),
+        "B4 truncated scope overlay: rc=2 before any host call",
+    )
+    scope.write_text(backup)
+    store_p = h.repo / "overlay" / "patch_kv_offload_store_local.py"
+    store_backup = store_p.read_text()
+    store_p.write_text(backup)  # mis-pointed: scope contents under store name
+    r = h.run(["restart"])
+    check(
+        r.returncode == 2 and not h.host_calls(),
+        "B5 mis-pointed store overlay (identity string): rc=2 pre-stop",
+    )
+    store_p.write_text(store_backup)
+    r = h.run(["restart"])
+    stopped = any(c[:3] == ["docker", "rm", "-f"] or (c[0] == "docker" and "stop" in c) for c in h.host_calls()) or any(
+        c[0] == "ssh" for c in h.host_calls()
+    )
+    check(
+        r.returncode != 2 and stopped,
+        f"B6 valid config passes the gate and reaches the stop path (rc={r.returncode})",
+    )
+
+
+def _inner_scripts(h: Harness, **env: str) -> tuple[str, str]:
+    r = h.run(["eval", "write_inner_scripts"], entry="start.fn.sh", **env)
+    assert r.returncode == 0, r.stderr[-800:]
+    head = (h.repo / ".glm53-exl3-head.inner.sh").read_text()
+    worker = (h.repo / ".glm53-exl3-worker.inner.sh").read_text()
+    return head, worker
+
+
+def _launch(h: Harness, **env: str):
+    r = h.run(
+        ["eval", "MODEL_DIR=/models/glm DFLASH_MODEL_DIR=/models/dflash; write_inner_scripts; launch_cluster"],
+        entry="start.fn.sh",
+        **env,
+    )
+    assert r.returncode == 0, (r.stderr[-1200:], r.stdout[-400:])
+    calls = h.calls()
+    head_run = next(
+        c for c in calls if c[0] == "docker" and c[1] == "run" and "glm53-exl3-head" in c
+    )
+    worker_cmds = [c[-1] for c in calls if c[0] == "ssh" and "docker run" in c[-1]]
+    assert worker_cmds, "no worker docker run captured"
+    return calls, head_run, worker_cmds[0]
+
+
+def _env_of_head(head_run: list[str]) -> dict[str, str]:
+    envs: dict[str, str] = {}
+    for i, tok in enumerate(head_run):
+        if tok == "-e" and i + 1 < len(head_run) and "=" in head_run[i + 1]:
+            k, v = head_run[i + 1].split("=", 1)
+            envs[k] = v
+    return envs
+
+
+def _env_of_worker(worker_cmd: str) -> dict[str, str]:
+    envs: dict[str, str] = {}
+    for tok in shlex.split(worker_cmd):
+        if "=" in tok and tok.split("=", 1)[0].replace("_", "").isalnum():
+            k, v = tok.split("=", 1)
+            if k.isupper():
+                envs[k] = v
+    return envs
+
+
+def part_c(h: Harness) -> None:
+    print("Part C: knob=0 parity (byte-identical serving)")
+    head, worker = _inner_scripts(h)
+    gate = 'if [ "${GLM53_KV_OFFLOAD:-0}" = "1" ]; then'
+    check(
+        gate in head and gate in worker,
+        "C1 both inner scripts gate --kv-transfer-config on the env knob",
+    )
+    calls, head_run, worker_cmd = _launch(h)
+    henv, wenv = _env_of_head(head_run), _env_of_worker(worker_cmd)
+    check(
+        henv.get("GLM53_KV_OFFLOAD") == "0" and wenv.get("GLM53_KV_OFFLOAD") == "0",
+        "C2 knob replayed as 0 to BOTH ranks",
+    )
+    # A mount token is "host:/data/glm53-kv-offload" (no '='); the env replay
+    # token "GLM53_KV_OFFLOAD_DIR=/data/..." must NOT count as a mount.
+    mounts = [
+        t for t in head_run if ":/data/glm53-kv-offload" in t and "=" not in t
+    ]
+    worker_mounts = [
+        t
+        for t in shlex.split(worker_cmd)
+        if ":/data/glm53-kv-offload" in t and "=" not in t
+    ]
+    check(
+        not mounts and not worker_mounts,
+        "C3 knob=0: no store mount on either rank",
+    )
+    mkdirs = [c for c in calls if c[0] == "ssh" and "glm53-kv-offload" in c[-1] and "mkdir" in c[-1]]
+    check(not mkdirs, "C4 knob=0: no store mkdir on the worker")
+
+
+def part_d(h: Harness) -> None:
+    print("Part D: knob=1 both-rank parity")
+    store_dir = str(h.tmp / "kv-store")
+    env = {
+        "GLM53_KV_OFFLOAD": "1",
+        "GLM53_KV_OFFLOAD_DIR": store_dir,
+        "GLM53_KV_OFFLOAD_CPU_GB": "6",
+        "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES": "3",
+    }
+    calls, head_run, worker_cmd = _launch(h, **env)
+    henv, wenv = _env_of_head(head_run), _env_of_worker(worker_cmd)
+    expected = {
+        "GLM53_KV_OFFLOAD": "1",
+        "GLM53_KV_OFFLOAD_DIR": "/data/glm53-kv-offload",
+        "GLM53_KV_OFFLOAD_CPU_GB": "6",
+        "GLM53_KV_OFFLOAD_RESTORE": "0",
+        "GLM53_KV_OFFLOAD_DRAFTER": "0",
+        "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES": "3",
+    }
+    for k, v in expected.items():
+        check(
+            henv.get(k) == v and wenv.get(k) == v,
+            f"D1 {k}={v!r} present and identical on BOTH ranks "
+            f"(head={henv.get(k)!r} worker={wenv.get(k)!r})",
+        )
+    head_mount = f"{store_dir}:/data/glm53-kv-offload"
+    check(
+        any(head_mount == t for t in head_run),
+        "D2 head mounts the store dir rw at the container path",
+    )
+    check(
+        f"-v '{head_mount}'" in worker_cmd,
+        "D3 worker mounts the SAME host dir at the same container path",
+    )
+    mkdirs = [c for c in calls if c[0] == "ssh" and store_dir in c[-1] and "mkdir" in c[-1]]
+    check(bool(mkdirs), "D4 worker store dir mkdir'ed over ssh")
+
+    # scp -> /tmp -> mount chain for both overlays.
+    for name in ("patch_kv_offload_scope.py", "patch_kv_offload_store_local.py"):
+        scps = [
+            c
+            for c in calls
+            if c[0] == "scp" and any(name in a for a in c) and any(f"/tmp/{name}" in a for a in c)
+        ]
+        head_m = any(f"/opt/glm53/{name}:ro" in t for t in head_run)
+        worker_m = f"-v '/tmp/{name}:/opt/glm53/{name}:ro'" in worker_cmd
+        check(
+            bool(scps) and head_m and worker_m,
+            f"D5 {name}: scp chain + both-rank mounts",
+        )
+
+    # Overlay order: scope before store_local, identically in both scripts.
+    head, worker = _inner_scripts(h, **env)
+    m = re.findall(r"python3 /opt/glm53/(patch_[a-z0-9_]+\.py)", head)
+    check(
+        m.index("patch_kv_offload_scope.py") < m.index("patch_kv_offload_store_local.py"),
+        "D6 overlay order pins scope before store_local",
+    )
+    m2 = re.findall(r"python3 /opt/glm53/(patch_[a-z0-9_]+\.py)", worker)
+    check(m == m2, "D7 both ranks apply the identical overlay list")
+
+    # The comparator itself must catch a planted one-rank difference.
+    planted = dict(wenv)
+    planted["GLM53_KV_OFFLOAD_CPU_GB"] = "5"
+    mismatch = [k for k in expected if henv.get(k) != planted.get(k)]
+    check(
+        mismatch == ["GLM53_KV_OFFLOAD_CPU_GB"],
+        "D8 synthetic one-rank mismatch is detected by the parity comparison",
+    )
+
+    # JSON shape: execute the inner script's builder verbatim.
+    snippet = re.search(
+        r"python3 -S -c '([^']*GLM53_KV_OFFLOAD_CPU_GB[^']*)'", head, re.S
+    )
+    check(snippet is not None, "D9 inner script builds the connector JSON via python3")
+    if snippet:
+        out = subprocess.run(
+            [sys.executable, "-S", "-c", snippet.group(1)],
+            text=True,
+            capture_output=True,
+            env={**os.environ, "GLM53_KV_OFFLOAD_CPU_GB": "6"},
+        )
+        cfg = json.loads(out.stdout.strip())
+        extra = cfg["kv_connector_extra_config"]
+        check(
+            cfg["kv_connector"] == "OffloadingConnector"
+            and cfg["kv_role"] == "kv_both"
+            and extra["spec_name"] == "TieringOffloadingSpec"
+            and extra["cpu_bytes_to_use"] == 6 * (1 << 30)
+            and extra["blocks_per_chunk"] == 1
+            and "secondary_tiers" not in extra,
+            f"D10 connector JSON shape (got {cfg})",
+        )
+
+
+def main() -> int:
+    part_a()
+    with tempfile.TemporaryDirectory() as td:
+        h = Harness(Path(td))
+        part_b(h)
+        part_c(h)
+        part_d(h)
+    print(f"\n{len(FAILURES)} failure(s)")
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_launcher_kv_offload.py
+++ b/tests/test_launcher_kv_offload.py
@@ -421,6 +421,7 @@ def part_d(h: Harness) -> None:
             and extra["spec_name"] == "TieringOffloadingSpec"
             and extra["cpu_bytes_to_use"] == 6 * (1 << 30)
             and extra["blocks_per_chunk"] == 1
+            and extra["offload_prompt_only"] is False
             and "secondary_tiers" not in extra,
             f"D10 connector JSON shape (got {cfg})",
         )

--- a/tests/test_launcher_kv_offload.py
+++ b/tests/test_launcher_kv_offload.py
@@ -290,12 +290,17 @@ def _env_of_head(head_run: list[str]) -> dict[str, str]:
 
 
 def _env_of_worker(worker_cmd: str) -> dict[str, str]:
+    # Only count KEY=value tokens that immediately follow a -e flag: a malformed
+    # worker command whose env assignment drifted away from its -e must FAIL the
+    # env checks, not pass on a stray token (Codex 087b5ea review, finding 1).
     envs: dict[str, str] = {}
-    for tok in shlex.split(worker_cmd):
-        if "=" in tok and tok.split("=", 1)[0].replace("_", "").isalnum():
-            k, v = tok.split("=", 1)
-            if k.isupper():
-                envs[k] = v
+    toks = shlex.split(worker_cmd)
+    for i in range(len(toks) - 1):
+        if toks[i] != "-e" or "=" not in toks[i + 1]:
+            continue
+        k, v = toks[i + 1].split("=", 1)
+        if k.replace("_", "").isalnum() and k.isupper():
+            envs[k] = v
     return envs
 
 
@@ -362,7 +367,8 @@ def part_d(h: Harness) -> None:
             f"D1 {k}={v!r} present and identical on BOTH ranks "
             f"(head={henv.get(k)!r} worker={wenv.get(k)!r})",
         )
-    # vLLM refuses OffloadingConnector + expandable_segments:True (VMM remap
+    # vLLM refuses OffloadingConnector + expandable_segments:True unless the
+    # CuMem allocator is enabled — it is not on this deployment (VMM remap
     # under pinned KV memory; live receipt-window finding): knob=1 must DROP
     # the env on both ranks; knob=0 keeps the stock value (see part_c).
     check(

--- a/tests/test_launcher_kv_offload.py
+++ b/tests/test_launcher_kv_offload.py
@@ -327,6 +327,12 @@ def part_c(h: Harness) -> None:
         not mounts and not worker_mounts,
         "C3 knob=0: no store mount on either rank",
     )
+    check(
+        henv.get("PYTORCH_CUDA_ALLOC_CONF") == "expandable_segments:True"
+        and wenv.get("PYTORCH_CUDA_ALLOC_CONF") == "expandable_segments:True",
+        "C3b knob=0 keeps the stock PYTORCH_CUDA_ALLOC_CONF on BOTH ranks "
+        "(byte-identical container env)",
+    )
     mkdirs = [c for c in calls if c[0] == "ssh" and "glm53-kv-offload" in c[-1] and "mkdir" in c[-1]]
     check(not mkdirs, "C4 knob=0: no store mkdir on the worker")
 
@@ -356,6 +362,16 @@ def part_d(h: Harness) -> None:
             f"D1 {k}={v!r} present and identical on BOTH ranks "
             f"(head={henv.get(k)!r} worker={wenv.get(k)!r})",
         )
+    # vLLM refuses OffloadingConnector + expandable_segments:True (VMM remap
+    # under pinned KV memory; live receipt-window finding): knob=1 must DROP
+    # the env on both ranks; knob=0 keeps the stock value (see part_c).
+    check(
+        "PYTORCH_CUDA_ALLOC_CONF" not in henv
+        and "PYTORCH_CUDA_ALLOC_CONF" not in wenv,
+        f"D1b knob=1 drops PYTORCH_CUDA_ALLOC_CONF on BOTH ranks "
+        f"(head={henv.get('PYTORCH_CUDA_ALLOC_CONF')!r} "
+        f"worker={wenv.get('PYTORCH_CUDA_ALLOC_CONF')!r})",
+    )
     head_mount = f"{store_dir}:/data/glm53-kv-offload"
     check(
         any(head_mount == t for t in head_run),

--- a/tests/test_warm_restart_stdout.py
+++ b/tests/test_warm_restart_stdout.py
@@ -13,7 +13,9 @@ ROOT = Path(__file__).resolve().parents[1]
 def test_json_command_substitutions_skip_sitecustomize() -> None:
     source = (ROOT / "start.sh").read_text()
     marker = '$(python3 -S -c \'import json,os'
-    assert source.count(marker) == 2
+    # 2 speculative-config builders + 2 kv-offload connector-JSON builders
+    # (one per rank inner script each).
+    assert source.count(marker) == 4
 
 
 def test_import_time_overlay_never_writes_stdout() -> None:

--- a/tests/test_xgrammar_termination.py
+++ b/tests/test_xgrammar_termination.py
@@ -385,7 +385,12 @@ def test_recipe_wiring_if_present() -> None:
     launcher = start.read_text()
     image = dockerfile.read_text()
     assert 'XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-' in launcher
-    assert launcher.count("python3 /opt/glm53/patch_xgrammar_termination.py") == 2
+    # Both ranks apply the one pinned list (GLM53_OVERLAY_ORDER) that
+    # write_inner_scripts emits into the head and worker inner scripts.
+    order = launcher[launcher.index("GLM53_OVERLAY_ORDER=(") : launcher.index(")", launcher.index("GLM53_OVERLAY_ORDER=("))]
+    assert "\n    patch_xgrammar_termination.py\n" in order
+    assert 'emit_overlay_block >> "$HEAD_SCRIPT"' in launcher
+    assert 'emit_overlay_block >> "$WORKER_SCRIPT"' in launcher
     assert (
         "-v '/tmp/patch_xgrammar_termination.py:"
         "/opt/glm53/patch_xgrammar_termination.py:ro'" in launcher


### PR DESCRIPTION
# Stage-1 store-only disk KV tier: eligible-group scoping + worker-local store with chunk headers (`GLM53_KV_OFFLOAD`)

**Status:** knobs default OFF (control boot byte-identical). Host-side evidence below is complete; the live boot receipts (section ‘Receipts’) will be posted in this thread at the next server window — a measurement run currently owns the pair.
window after the #77 measurement pass. Codex gates: advisory
CODEX-OFFLOAD1-PLAN.md (DO-NOT-PROCEED v1 → all findings adopted/rebutted in
writing before build), adversarial diff review CODEX-OFFLOAD1-REVIEW.md
(DO-NOT-SHIP → all findings adopted/rebutted, fixes in 32f993e, confirm pass
appended there).**

## Problem

A session whose KV has left the ~455K-token resident GPU envelope reprefills from
zero (174 s measured at 120K; 15–25 min estimated at 450K). The research plan
(PLAN-KV-OFFLOAD.md v2.1 + stage-0 receipts) designs a disk tier: park-to-disk on
store-cascade, restore on next touch. This PR is **stage 1 only: store-only,
restore disabled by flag (the launcher refuses `GLM53_KV_OFFLOAD_RESTORE=1`),
no restore/read path** — the tier writes; nothing reads it back yet. knob=0 is
byte-identical serving; knob=1 carries one process-wide side effect (the
allocator change described in the Launcher section below).

Three things stand between the image's shipped `kv_offload` stack (present —
stage-0 receipt O4/R14) and a safe store on this deployment:

1. **The connector cannot boot on the hybrid layout.** `build_offloading_config`
   asserts `tokens_per_block % tokens_per_hash == 0` for every KV-cache group;
   the KpoolTailSpec scratch group (block 4, `prefix_cacheable=False`) fails
   (4 % 64). Upstream PR vllm-project/vllm#54743 (ours) scopes the group configs
   to prefix-cacheable groups; this overlay ports that scoping onto the image's
   older tree.
2. **The image wraps group specs.** The connector receives
   `UniformTypeKVCacheSpecs` wrappers (subclass of `KVCacheSpec` only): the
   scheduler's isinstance dispatch would crash on group 0's full-attention
   assert and silently strip the mamba groups' alignment/CoW semantics. The
   port adds a fail-closed single-type unwrap and reads cacheability through
   the image's `participates_in_prefix_caching` name.
3. **The stock fs tier is silently wrong on a 2-node TP pair (plan risk R0).**
   `TieringOffloadingSpec.get_manager()` constructs every secondary tier
   scheduler-side against the scheduler node's staging memoryview; on
   `--nnodes 2` rank 1's staging mmap lives on the other Spark, so the fs tier
   would persist rank-0 bytes plus never-written garbage as the rank-1 half of
   every file — corruption that only surfaces at restore time. The store path
   must be **worker-local**: each rank writes its own bytes from its own
   staging mmap to its own NVMe.

## What this ships

### `overlay/patch_kv_offload_scope.py` — eligible-group scoping (port of vllm#54743)

- `OffloadingGroupConfig` gains `group_idx` (original boot index, required);
  `build_offloading_config` filters to prefix-cacheable groups minus the fork
  policy exclusion of draft-model attention groups (`is_eagle_group`, or exact
  `SlidingWindowSpec` under an EAGLE speculative config) unless
  `GLM53_KV_OFFLOAD_DRAFTER=1`; the divisibility assert still guards eligible
  groups.
- Scheduler port: `group_states` sized by the full group count; every pairing
  through `group_idx`; `GPULoadStoreSpec.group_sizes`/`block_indices` stay
  full-length with zeros for ineligible groups (worker layout unchanged);
  `supports_partial_tail` conservatively requires every group eligible.
- Final eligible set on this deployment: **{0, 2, 3, 4, 5}** — g1 out by the
  upstream predicate, g6 out by fork policy (min-exempt drafter; #83
  retention-0). Logged at boot.

### `overlay/patch_kv_offload_store_local.py` — worker-local store + §4 chunk headers

- Store jobs carry a versioned metadata side-channel (`TransferJob.glm53_store_meta`):
  ordered keys aligned 1:1 with the job's block order, plus boundary-manifest
  candidates (cumulative chunk-hash chains).
- Each worker SNAPSHOTS the job's bytes out of its own staging mmap
  synchronously at DMA completion (capture-then-write — `reset_cache()`
  frees staging rows regardless of pending disk work, so async mmap reads
  could tear; captured at `get_finished` before this rank's ack, or right
  after `worker.wait()` on the flush/reset path), then writes the private
  buffers (512 MB budget) to
  `GLM53_KV_OFFLOAD_DIR/glm53kv_<model>_<ns>_r<rank>/<hhh>/<hh>_g<g>/<hash>.bin`
  on its local NVMe — **real (unpadded) bytes only** (the slot-share padding
  never hits disk), fsync + tmp-rename + dir-fsync; acks are never deferred.
  Rank = the initialized TP rank cross-checked against the connector config;
  any disagreement disables the writer (never cross-rank mixing).
- **Every chunk gets a real header** (format v1): magic, namespace hash
  (fences model/vllm/build/TP/KV-dtype/hash-algo/`num_speculative_tokens`/
  per-group real page sizes/KDA state-ABI/format version), original group
  index, per-layer segment table (conv/temporal split with shape+dtype+stride
  for KDA layers), boundary token index, payload CRC, header CRC. Any mismatch
  at read ⇒ reject.
- **Boundary manifests** publish per-rank only after all four mamba payloads +
  every cumulative full-attention chunk are durable AND header-verified
  (namespace+hash+group identity; per-chunk `[hash, len, crc]` recorded for
  full groups too); a key that failed to write this boot can never be
  manifested (failed-key ledger). Dedup likewise requires a verifying
  header, else the file is rewritten.
- **Inline keep-K retention** (`GLM53_KV_OFFLOAD_KEEP_BOUNDARIES`, default 2):
  a manifest is superseded once beyond the K most recent boundaries of EVERY
  chain containing it (mamba payloads unlinked; full-attention chunks stay
  dense — cumulative references keep shallower boundaries restorable).
- Failure semantics (plan §8): failed write ⇒ unlink + log (lost store = future
  reprefill; nothing can serve wrong bytes); ENOSPC ⇒ writer pauses; crash
  between group writes ⇒ orphans, no live manifest; `overlay/kv_offload_store_gc.py`
  (dry-run default) verifies headers, reports orphans, sweeps on request.
- Restore stays cold: `get_num_new_matched_tokens` short-circuits to 0 external
  hits under `GLM53_KV_OFFLOAD_RESTORE=0` — no loads, no promotions, no
  WAITING_FOR_REMOTE_KVS.

### Launcher (`start.sh`)

Knobs validated fail-closed inside the pre-stop gate (bad knob or broken overlay
artifact exits 2 before `restart` stops anything); knob=0 adds **no** serve
argv, no mounts, no store dir — byte-identical serving. Knob=1 appends identical
`--kv-transfer-config` JSON to both ranks (`TieringOffloadingSpec`,
`cpu_bytes_to_use`, `blocks_per_chunk=1`, `offload_prompt_only=false` so
decoded tokens store too, **no secondary tiers** — see deviations), mounts
the store dir rw on both nodes, ships both overlays to both ranks, pins
their order (scope → store_local) in `GLM53_OVERLAY_ORDER`, and self-checks
both patchers' injected sources (`--check-injected`) inside the pre-stop
gate. The store namespace is fenced by the recipe checkout SHA
(`GLM53_KV_OFFLOAD_BUILD_ID`).

When `GLM53_KV_OFFLOAD=1`, the launcher also omits
`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` from both containers
(`087b5ea`, found live in the receipt window): vLLM rejects OffloadingConnector
under expandable segments unless the CuMem allocator is enabled, which this
deployment does not use. knob=1 therefore runs **both processes on PyTorch's
default native caching allocator — a process-wide change, not scoped to the
store writer**. Expandable segments exists to reduce fragmentation OOM under
changing allocation sizes, so long-context workloads on knob=1 can in principle
OOM despite apparent free capacity where knob=0 would not (`GPU_MEM_UTIL`
headroom is not a fragmentation guarantee). The knob=0 path keeps the stock
entry and remains byte-identical. The +8.3% cold-prefill overhead in the
receipts thread is entangled with this allocator change; an isolation
experiment (allocator-only vs store+allocator arms) is protocolized for the
next server window.

## Deviations (recorded, with reasons)

- **No fs secondary tier in the connector JSON** (Codex advisory finding 3/Q1,
  adopted): the scheduler-side `FileSystemTierManager` byte path is exactly the
  R0 hazard; configuring-then-neutering it adds fake cascade bookkeeping and a
  stock-namespace config.json for no benefit. The worker-local writer IS the
  disk tier; the in-image fs tier remains available untouched for stage-2 read
  work.
- `blocks_per_chunk=1` uniformly (plan §4 wanted 16 for MLA): the image has one
  global chunk size; all eligible groups share block 3584. g0 chunk files carry
  27,163,136 B payloads (11 MLA + 11 indexer pages — the stage-0 correction
  pricing the indexer KV rides in automatically).
- CRC is zlib crc32, not crc32c (stdlib; the header names its algorithm).
- The worker→scheduler ack protocol has no per-job failure bit in stage 1
  (Codex finding 2, partially rebutted): a failed key is un-retried this boot
  but can never be manifested; the failure bit lands with stage 2's T4 work,
  where it becomes load-bearing.

## Tests (host-side, all green; suite 33 passed)

| file | covers |
|---|---|
| `tests/test_kv_offload_scope.py` | patcher preflight/idempotence/tamper/half-patch on pinned image fixtures (sha256-recorded byte-exact captures); eligibility predicate matrix; patched-runtime drive under a stubbed vllm: eligible {0,2,3,4,5}, original-index keys, full-length zero group_sizes, mamba alignment 3584, store-only lookup short-circuit, no-scratch-model equivalence, divisibility regression |
| `tests/test_kv_offload_store_local.py` | header codec round-trip + truncation at every region + CRC flips; store-job meta 1:1 alignment + cumulative manifests + TransferJob pickle; writer: capture-then-write snapshot isolation (staging mutated after capture ⇒ disk bytes unchanged), flush-path capture, real-bytes payloads, KDA segment split, header-verified dedup + manifest ordering, failed-key ledger, keep-K retention, ENOSPC pause (no partials/temps left), TP-rank disagreement disable; GC dry-run/sweep/keep-K incl. zero-manifest orphans, stale temps, forked-chain shared-ancestor protection |
| `tests/test_launcher_kv_offload.py` | knob guard matrix incl. the RESTORE=1 refusal; pre-stop gate with zero docker/ssh calls; knob=0 no-mount parity; knob=1 both-rank env/mount/scp/JSON-shape parity + synthetic one-rank mismatch; overlay order pin |

## Receipts (pending: server window)

To be captured in the post-#77 window; the PR stays unopened until every line
has a receipt — and thereafter until the maintainer-response hold lifts:

1. **knob=0 byte-identical behaviour**: boot with `GLM53_KV_OFFLOAD=0`; the
   `vllm serve` argv is byte-identical to the previous boot (no
   `--kv-transfer-config`), no connector init in the log, no store mounts;
   serving probes green.
2. **knob=1 boot receipts**: `[glm53-kv-offload-scope] eligible groups:
   [0, 2, 3, 4, 5] of 7` on both ranks; TieringOffloadingManager created with
   0 secondary tiers; `[glm53-kv-offload-store] writer up: rank 0/2 …` on deb8
   and `rank 1/2` on d9d5 with per-rank base dirs; namespace JSON on both
   Sparks' local NVMe; driver version pinned in the capture.
3. **Store-cascade evidence**: during a normal session, headered files appear
   under `…_r0/**_g{0,2,3,4,5}/` on deb8 AND `…_r1/**` on d9d5 with payload
   sizes 27,163,136 (g0) / 21,086,208 (g2,g3) / 18,743,296 (g4,g5); boundary
   manifests for every complete 3584 boundary within keep-K; per-rank byte
   totals within ±10% of the stage-0 §C model; **R0 rank-routing receipt**: GC
   verifier reopen + checksum pass on BOTH ranks' stores across a container
   restart (verifier-level, not a GPU restore — stage 1 has no restore).
4. **Store overhead on prefill within noise**: prefill/decode rates knob=1 vs
   knob=0 on the standard probe within the kit's measured noise band.
5. **Fail-closed negatives**: bad knob values + `GLM53_KV_OFFLOAD_RESTORE=1`
   refused pre-stop with zero docker/ssh calls (live run); GC dry-run flags a
   deliberately truncated chunk and a manifest-less orphan; ENOSPC simulation
   (small loopback fs) pauses the writer with serving unaffected.

Submitted by nood-co1 on behalf of Blockbrain Labs (https://x.com/blockbrain_labs, GitHub org blockbrain-ai). Measured on our 2× NVIDIA DGX Spark deployment.

