### PR TITLE
Stage-2 g0 (MLA + indexer) disk restore at 3584 boundaries (GLM53_KV_OFFLOAD_RESTORE, default off) + stage-3 mamba differential harness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,6 +140,17 @@ GLM53_SUPPRESS_STOPS_IN_REASONING=1
 # When a decode seq is running, do not mix a peer prefill into that step
 # (issue #6). skip = decode-only steps; N>0 = cap mixed prefill tokens; 0 = off.
 GLM53_MIXED_PREFILL_CHUNK=skip
+# Disk KV-offload store tier, stage 1 (store-only; overlays
+# patch_kv_offload_scope.py + patch_kv_offload_store_local.py). 1 = enable the
+# OffloadingConnector: CPU staging bounce + worker-local per-rank headered
+# chunk files on each Spark's NVMe. 0 (default) = OFF, byte-identical serving.
+# Restore stays 0 in stage 1 (the launcher refuses 1). Exactly 0 or 1 each.
+GLM53_KV_OFFLOAD=0
+# GLM53_KV_OFFLOAD_DIR=$HOME/glm53-kv-offload
+# GLM53_KV_OFFLOAD_CPU_GB=4
+# GLM53_KV_OFFLOAD_RESTORE=0
+# GLM53_KV_OFFLOAD_DRAFTER=0
+# GLM53_KV_OFFLOAD_KEEP_BOUNDARIES=2
 # EngineCore execute timeout (seconds). Stock 300 is short for a cold JIT.
 # VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -446,6 +446,11 @@ COPY overlay/patch_scheduler_decode_floor.py /opt/glm53/patch_scheduler_decode_f
 COPY tests/test_scheduler_decode_floor.py /opt/glm53/test_scheduler_decode_floor.py
 COPY overlay/patch_hybrid_prefix_hit.py /opt/glm53/patch_hybrid_prefix_hit.py
 COPY tests/test_hybrid_prefix_hit.py /opt/glm53/test_hybrid_prefix_hit.py
+COPY overlay/patch_kv_offload_scope.py /opt/glm53/patch_kv_offload_scope.py
+COPY overlay/patch_kv_offload_store_local.py /opt/glm53/patch_kv_offload_store_local.py
+COPY overlay/kv_offload_store_gc.py /opt/glm53/kv_offload_store_gc.py
+COPY tests/test_kv_offload_scope.py /opt/glm53/test_kv_offload_scope.py
+COPY tests/test_kv_offload_store_local.py /opt/glm53/test_kv_offload_store_local.py
 COPY overlay/patch_xgrammar_termination.py /opt/glm53/patch_xgrammar_termination.py
 COPY tests/test_xgrammar_termination.py /opt/glm53/test_xgrammar_termination.py
 COPY overlay/patch_kpool_tail_slotmap.py /opt/glm53/patch_kpool_tail_slotmap.py
@@ -461,6 +466,14 @@ RUN python3 /opt/glm53/patch_glm5_drafter_group.py
 RUN python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
 RUN python3 /opt/glm53/patch_scheduler_decode_floor.py
 RUN python3 /opt/glm53/patch_hybrid_prefix_hit.py
+# Order-dependent pair: scope rewrites the offloading connector group
+# pairing; store_local anchors on scope's scheduler output. Host tests run
+# against the REAL in-image tree first (preflight + patched-runtime drive),
+# then the patchers bake the overlays in.
+RUN GLM53_REQUIRE_TARGET=1 python3 /opt/glm53/test_kv_offload_scope.py
+RUN python3 /opt/glm53/patch_kv_offload_scope.py
+RUN python3 /opt/glm53/patch_kv_offload_store_local.py
+RUN python3 /opt/glm53/test_kv_offload_store_local.py
 RUN python3 /opt/glm53/patch_xgrammar_termination.py
 RUN python3 /opt/glm53/patch_kpool_tail_slotmap.py
 RUN python3 /opt/glm53/patch_ablit.py

--- a/README.md
+++ b/README.md
@@ -533,6 +533,12 @@ this Dockerfile instead. After CUDA compile, Python overlay edits
 | `tests/test_xgrammar_termination.py` | exact two-file patch, idempotence, cross-file fail-closed drift, termination/rollback/reset and post-reasoning draft behavior, launcher wiring |
 | `overlay/patch_kpool_tail_slotmap.py` | clamp KpoolTail one-block circular slot mapping; identity for other KV groups |
 | `tests/test_kpool_tail_slotmap.py` | circular addressing math, exact kernel patch, idempotence, fail-closed drift, launcher wiring |
+| `overlay/patch_kv_offload_scope.py` | offloading-connector eligible-group scoping (port of vllm#54743 onto this image): prefix-cacheable groups minus the drafter policy exclusion, original indices preserved, full-length worker layout; unblocks the connector on the hybrid layout (KpoolTail scratch crashed it at boot) |
+| `overlay/patch_kv_offload_store_local.py` | stage-1 store-only disk KV tier (`GLM53_KV_OFFLOAD=1`): worker-local per-rank chunk files with versioned headers + segment tables, boundary manifests, inline keep-K retention; restore hard-off (`GLM53_KV_OFFLOAD_RESTORE` refused at 1); see `docs/DESIGN-kv-offload-store-only.md` |
+| `overlay/kv_offload_store_gc.py` | store verifier/GC: header+CRC checks, orphan/corrupt reporting (dry-run default), manifest-mediated keep-K sweep |
+| `tests/test_kv_offload_scope.py` | patcher preflight/idempotence/drift on pinned image fixtures; eligibility predicate; patched-runtime drive under a stubbed vllm (eligible {0,2,3,4,5}, original-index keys, full-length group_sizes, store-only lookup short-circuit) |
+| `tests/test_kv_offload_store_local.py` | header codec + torn-file rejection, store-job meta alignment + pickle, writer real-bytes/segment-table/manifest-ordering/retention/ENOSPC/rank-guard/delayed-ack, GC tool |
+| `tests/test_launcher_kv_offload.py` | knob guard matrix, fail-closed pre-stop gate, knob=0 no-mount parity, knob=1 both-rank env/mount/scp/JSON parity, overlay order pin |
 | `overlay/ablit_runtime.py` | load-time o_proj transplant / projection (`ABLIT=1`); no-op when off |
 | `overlay/patch_ablit.py` | install the load_weights hook; bind-mounted and run on both ranks |
 | `ablit/` | direction vectors + `LAYER_MAP.json` from drowzeys' published recipe; `fetch_transplant.py` + `transplant/` for the donor o_proj byte-copy |

--- a/docs/DESIGN-kv-offload-mla-restore.md
+++ b/docs/DESIGN-kv-offload-mla-restore.md
@@ -1,0 +1,194 @@
+# Stage-2 g0 (MLA + indexer) disk restore (`GLM53_KV_OFFLOAD_RESTORE`)
+
+Design record for `overlay/patch_kv_offload_restore_g0.py` + the `start.sh`
+wiring + the stage-3 mamba differential harness under `tests/`. Stage 2 of
+the disk KV-offload research plan (PLAN-KV-OFFLOAD.md §11), stacked on the
+stage-1 store-only tier (`docs/DESIGN-kv-offload-store-only.md`).
+
+## The honest headline
+
+**A group-0-only restore yields ZERO hit uplift on GLM-5.3-Flash itself, by
+design.** Two independent facts force this:
+
+1. **The hybrid min.** The connector's reconciled external hit is the min
+   across all KV-cache groups. The four mamba (KDA) groups have no restore
+   source in this stage; reporting external tokens their recurrent state
+   cannot back would serve garbage as a hit.
+2. **The core invalid-block path is single-group.** Pinned receipt
+   `tests/fixtures/image_487ecf187_core_sched_scheduler.py:2954-2955`:
+   `(req_block_ids,) = self.kv_cache_manager.get_block_ids(req_id)` under
+   `TODO (davidb): add support for hybrid memory allocator` — a load-failure
+   report on the 7-group live layout would crash the scheduler core.
+
+The eligibility predicate therefore requires **exactly one TOTAL KV-cache
+group** (not one *eligible* group — an excluded scratch/drafter group is
+still a core group the restored tokens cannot back; Codex OFFLOAD2
+finding 2), full attention, `blocks_per_chunk=1`, prefix caching on, both
+knobs on. On the live hybrid the restore machinery is **INERT with one boot
+log line naming the reason** and serving is byte-identical to stage 1.
+
+**What stage-2 receipts CAN prove** (on a probe that isolates g0 — a
+single-full-attention-group deployment, exactly the shape of g0's mixed
+MLA+indexer group):
+- wire-correct restore of g0 bytes through the plan-§5 chain: on-disk
+  manifests answer the lookup → `allocate_slots(delay_cache_blocks=True)` →
+  `WAITING_FOR_REMOTE_KVS` → worker pread with header/CRC/segment-table
+  verification → DMA into the allocated blocks → `cache_blocks` re-entry →
+  the restored prefix serves as an ordinary GPU prefix hit (the fork-trace
+  receipt);
+- correct failure degradation (the stage-2 T4 contract): per-(chunk, rank)
+  failure → zero-fill + `invalid_block_ids` → core truncation at the failed
+  chunk → recompute; fresh-session control green.
+
+**What they CANNOT prove**: any TTFT uplift on this model (needs stage-3
+mamba restore); mamba state semantic correctness across boots (the
+differential harness built here is the stage-3 instrument for exactly that —
+and it is a fixture comparator, not evidence; see below).
+
+## How the restore path works
+
+### Lookup: on-disk manifests, keys/hashes only (plan §4 C2)
+
+The scheduler NEVER touches the filesystem (plan R0: "the scheduler handles
+only keys/hashes, never paths"). Each rank's store writer emits **manifest
+availability events** over the existing worker→scheduler metadata channel:
+
+    ("+" | "-" | "F", rank, namespace_hash, key, aux, writer_boot_id)
+
+- `+` on a validated manifest publication (including the pre-existing-file
+  dedup path, which now VALIDATES the manifest and every referenced chunk
+  header before registering or announcing — Codex OFFLOAD2 finding 9);
+- `-` on a keep-K retention supersession;
+- `F` on a chunk write failure — **the per-job store failure bit is on the
+  wire and load-bearing**: the lookup denies any boundary whose g0 key
+  failed on any rank this boot (this closes the recorded stage-1 limit).
+
+The scheduler ANDs `+` events across ranks (`min across ranks`, plan §4 C2):
+a boundary is offer-able IFF every rank reported it under the pinned
+namespace and none retracted it. Contiguity needs no chain walk: prefix-cache
+block hashes are prefix-CHAINED (sha256, receipt R15), so boundary-hash
+equality implies an identical cumulative chunk chain. Each WORKER re-validates
+its own on-disk manifest (namespace, boundary, chain tail) before its preads;
+a manifest missing at load time (retention race, crash) degrades to
+recompute, never to a guess.
+
+v1 restores at 3584 boundaries only (plan F6): a fine-grained local hit tail
+is never extended from disk (non-chunk-aligned local hit ⇒ miss).
+
+Restore concurrency = 1: while a disk load job is in flight the lookup
+returns None (the stock deferred-lookup machinery re-queries). The gate
+stores the job id and **self-heals** if the job vanished (reset), clears on
+all-rank completion and on `reset_cache` (Codex OFFLOAD2 finding 11).
+
+### Load job: a versioned plain dict, worker-local paths
+
+`update_state_after_alloc` skips `manager.prepare_load` entirely for disk
+hits (the CPU staging tier is a bounce buffer, never a restore source) and
+ships `{"glm53_disk_load": 1, "v": 1, namespace, boundary_token_index,
+entries}` with entries aligned 1:1 with the dst block order. A scheduler-side
+shape mismatch ships an empty-entry spec, which the worker turns into an
+all-chunks-failed job (T4 degradation).
+
+The worker's `Glm53DiskLoader` runs SYNCHRONOUSLY inside
+`start_kv_transfers` — one chunk at a time, pread → verify → scatter into the
+GPU canonical tensors. Verification per chunk (Codex OFFLOAD2 finding 13):
+full-payload CRC, header identity (namespace, hash, group, spec kind, block
+size, token count, `tp_rank == this rank`, `tp_world`), and **exact
+segment-table equality** against the expectation derived from this rank's own
+specs (the writer's `_layer_segments` derivation) — a byte-count match alone
+cannot detect swapped layers. Preconditions fail closed (writer disabled,
+unknown spec version, GPU/staging ref layout mismatch, canonical-mapped
+layout, missing GPU caches ⇒ every chunk failed, never a guess).
+
+### T4: failure → zero-fill → invalid ids → recompute
+
+ANY failure stops the read loop, zero-fills the failed chunk **and every
+later chunk's** dst blocks (their contents are unwritten or garbage; DS4F
+over-report pattern), records their physical block ids (never null block 0)
+and STILL completes the job — every terminal path acks. The facade override
+`get_block_ids_with_load_errors` drains the ids; the model-runner mixin reads
+them immediately after `get_finished`
+(`kv_connector_model_runner_mixin.py:105`, captured receipt), so failures
+ride the same step's `KVConnectorOutput.invalid_block_ids`; the executor
+unions across ranks; the core (`recompute_kv_load_failures=True` default,
+core fixture :241) truncates `num_computed_tokens` at the first invalid block
+and recomputes. Core truncation and core zeroing (`needs_kv_cache_zeroing`)
+are separate, conditional mechanisms — which is why the loader zero-fills
+itself and never relies on them.
+
+**Why no cross-step fencing machinery** (Codex OFFLOAD2 finding 4,
+dispositioned): the loader is synchronous within the engine step — there is
+no cross-step disk DMA to fence; restore concurrency is 1; and a late ack
+after `reset_cache` is discarded by the scheduler's existing
+`_stale_job_threshold`. Preemption of a request holding the disk load job no
+longer trips the stock `assert is_store` (the flush loop skips load jobs and
+clears the gate — finding 3); a store job for the same request cannot race
+the load job because both ranks ack in the same step the job started, and the
+scheduler processes those acks before the request can be scheduled again.
+
+### T2: restored boundaries stay reachable
+
+`update_state_after_alloc` sets `request.glm53_restored_boundary` — the
+**end-exclusive** restored token count (a multiple of the chunk size; 7168
+keeps the mamba state block ending at token 7168 via the fixture's
+`aligned // block_size - 1` arithmetic). The single_type manager's
+`cache_blocks` appends it to `reachable_boundaries`, so sparse retention
+masks (SWA/Mamba subclasses) can never silently drop a restored boundary's
+re-entry; dense (full-attention) masks return None and are unaffected.
+Lifecycle: set at allocation, persists for the request's lifetime
+(deliberately not cleared — the restored anchor must stay reachable in every
+later `cache_blocks` of this request), overwritten by a later re-restore,
+dies with the Request. The anchor also applies verbatim to the upstream tree
+(core scalar retention exists at [U]) — verified by
+`tests/test_kv_offload_restore_venv.py`.
+
+### S1: manifests on zero-cow layouts
+
+Stage-1's manifest-candidate builder required recurrent (cow) groups, so a
+pure full-attention layout — the g0 probe — would never publish a manifest
+and the lookup would answer from nothing. The restore overlay extends the
+rule: candidates = mamba chunk idxs when cow groups exist (live hybrid:
+byte-identical to stage 1), else the job's full-group chunk idxs.
+
+## Stage-3 mamba differential harness (designed here, NOT evidence)
+
+`tests/_mamba_differential.py` + `tests/test_mamba_differential_harness.py`
+build park-at-boundary fixtures with STUBBED KDA state tensors at the
+receipted ABI (conv (10, 12288) bf16 245,760 B + temporal (32, 128, 128)
+fp32 2,097,152 B per layer; real page 2,342,912 B; 9/9/8/8 layers; num_spec 7
+in every header; the +8,192 B/layer slot-share padding never on disk) and the
+exact bit-comparator (`compare_state_bits`) stage 3 will run against real
+captures — a single flipped bit is localized to its (group, layer, tensor).
+`tests/stage3_mamba_differential_protocol.sh` pins the live protocol
+(step 0 = receipt the still-open mamba state-index convention, then boot-A
+park → restart → boot-B restore → bit differential → logprob equivalence →
+needle → fresh-session control → the full T4 fault matrix) and refuses to run
+in this branch. None of this proves cross-boot mamba restore correctness —
+that is precisely what stage 3 must measure (Codex OFFLOAD2 finding 14).
+
+## Knobs
+
+| knob | default | meaning |
+|---|---|---|
+| `GLM53_KV_OFFLOAD_RESTORE` | 0 | 1 = enable the g0 disk-restore lookup/load path. Refused by the launcher unless `GLM53_KV_OFFLOAD=1`. 0 = stage-1 behavior (store-only short-circuit) |
+
+All stage-1 knobs unchanged; the launcher ships the restore overlay to both
+ranks, pins the order scope → store_local → restore_g0, self-checks its
+injected sources pre-stop, and keeps `offload_prompt_only: false` untouched.
+
+## Codex gates (stage 2)
+
+Advisory on the build plan BEFORE coding: CODEX-OFFLOAD2-PLAN.md
+(gpt-5.6-luna, DO-NOT-PROCEED, 5 BLOCKER + 10 MAJOR → every finding adopted
+or rebutted in writing; the build implements the revised design). Adversarial
+review of the final diff: CODEX-OFFLOAD2-REVIEW.md (in
+cache-scheduling-2026-08-31/).
+
+## Receipts
+
+Host-side coverage: `tests/test_kv_offload_restore_g0.py` (patcher hygiene,
+patched-runtime scheduler/loader/event-channel/T2 drives),
+`tests/test_mamba_differential_harness.py`, `tests/test_kv_offload_restore_venv.py`,
+extensions to `tests/test_launcher_kv_offload.py`. Live receipts (probe
+window) are enumerated in the PR body and pending: inert-on-hybrid boot line,
+probe fork-trace, fault-matrix cells, fresh-session control.

--- a/docs/DESIGN-kv-offload-mla-restore.md
+++ b/docs/DESIGN-kv-offload-mla-restore.md
@@ -181,8 +181,10 @@ injected sources pre-stop, and keeps `offload_prompt_only: false` untouched.
 Advisory on the build plan BEFORE coding: CODEX-OFFLOAD2-PLAN.md
 (gpt-5.6-luna, DO-NOT-PROCEED, 5 BLOCKER + 10 MAJOR → every finding adopted
 or rebutted in writing; the build implements the revised design). Adversarial
-review of the final diff: CODEX-OFFLOAD2-REVIEW.md (in
-cache-scheduling-2026-08-31/).
+review of the final diff: CODEX-OFFLOAD2-REVIEW.md (DO-NOT-SHIP, 1 BLOCKER +
+8 MAJOR + 2 MINOR → all adopted or rebutted; fixes in the review-fixes
+commit; confirm pass appended there). Both docs live in
+cache-scheduling-2026-08-31/.
 
 ## Receipts
 

--- a/docs/DESIGN-kv-offload-store-only.md
+++ b/docs/DESIGN-kv-offload-store-only.md
@@ -1,0 +1,135 @@
+# Stage-1 store-only disk KV tier (`GLM53_KV_OFFLOAD`)
+
+Design record for `overlay/patch_kv_offload_scope.py` +
+`overlay/patch_kv_offload_store_local.py` + the `start.sh` wiring. Stage 1 of
+the disk KV-offload research plan: the tier **writes**; nothing reads it back
+(`GLM53_KV_OFFLOAD_RESTORE` is refused at 1 by the launcher). Restore plumbing
+is stage 2.
+
+## Why
+
+A session whose KV has left the ~455K-token resident GPU envelope reprefills
+from zero (174 s measured at 120K). The plan's endgame is
+park-to-disk/restore-on-touch; stage 1 lands the write side with zero blast
+radius: knob off ⇒ no connector, byte-identical serving.
+
+## The two boot blockers this image has
+
+1. **Scratch-group divisibility crash.** `build_offloading_config` builds an
+   offload group config for every KV-cache group and asserts
+   `tokens_per_block % tokens_per_hash == 0` — the KpoolTailSpec scratch group
+   (block 4, hash grid 64) crashes the connector at boot. Our upstream PR
+   vllm-project/vllm#54743 scopes the group list to prefix-cacheable groups;
+   the scope overlay ports that onto this image's older tree.
+2. **Wrapped group specs.** This image hands the connector
+   `UniformTypeKVCacheSpecs` wrappers (subclass of `KVCacheSpec` only), which
+   the connector's isinstance dispatch cannot classify: the full-attention
+   assert would crash on group 0, and mamba groups would silently lose their
+   alignment/CoW semantics. The scope overlay adds a fail-closed single-type
+   unwrap (`_glm53_kvo_inner_spec`), and reads cacheability through the
+   image's `participates_in_prefix_caching` name.
+
+Eligible set on this deployment: **{0, 2, 3, 4, 5}** — g1 (kpool scratch) out
+by the upstream predicate, g6 (DFlash2 drafter) out by fork policy
+(min-exempt, retention 0: its window is rebuilt by the remainder's prefill;
+`GLM53_KV_OFFLOAD_DRAFTER=1` re-includes it for experiments). All eligible
+groups sit on the 3584 grid, so `blocks_per_chunk=1` gives one 3584-token
+chunk per group per boundary.
+
+## Why the store is worker-local (risk R0)
+
+`TieringOffloadingSpec.get_manager()` constructs the CPU primary tier AND all
+secondary tiers on the scheduler and hands the fs tier the *scheduler node's*
+staging memoryview. On this 2-node TP=2 kit, rank 1's staging mmap lives on
+the other Spark: the scheduler-side view's rank-1 slots are never written,
+and the stock fs tier would persist rank-0 bytes + uninitialised garbage as
+rank-1 halves — corruption that only surfaces at restore. So:
+
+- the connector JSON configures **CPU staging only** (no `secondary_tiers`);
+- store jobs carry a metadata side-channel (`TransferJob.glm53_store_meta`):
+  ordered `(hash, group_idx, chunk_idx)` aligned with the job's block order,
+  plus boundary-manifest candidates (cumulative chunk-hash chains);
+- each worker, after its GPU→CPU DMA completes, writes **its own bytes** from
+  **its own mmap** to **its own NVMe** under
+  `GLM53_KV_OFFLOAD_DIR/glm53kv_<model>_<ns>_r<rank>/…`, and only then acks
+  the store job (staging stays pinned until every worker acks, so bytes
+  cannot be evicted under the writer);
+- rank is the initialized TP rank cross-checked against the connector
+  config's rank — disagreement disables the writer rather than risking
+  cross-rank mixing.
+
+## On-disk format (v1)
+
+`GLM53KV1` magic | u32 header_len | canonical-JSON header | u32 header-crc32
+| payload. Header: format_version, namespace_hash, ORIGINAL group_idx,
+spec_kind, layers, block_size_tokens, n_tokens_valid, boundary_token_index,
+tp_rank/tp_world, per-layer segment table (KDA layers: conv/temporal split
+with shape/dtype/derived-contiguous stride), state-ABI tag +
+num_speculative_tokens for mamba groups, payload_len, payload_crc32
+(zlib crc32; the header names the algorithm). Payload = **real (unpadded)
+bytes only** — the CanonicalKVCacheRef layout the DMA uses already carries
+unpadded page sizes, so the mamba slot-share padding never reaches disk.
+
+Namespace hash: sha256[:12] over model, vllm version, build id, TP/world, KV
+dtype, prefix-cache hash algo, tokens_per_hash, blocks_per_chunk,
+num_speculative_tokens (baked into the KDA conv width), per-eligible-group
+(original idx, block size, layers, real page sizes), the KDA state-ABI
+descriptor, format_version. Any change forks the directory. Retention K is
+recorded in the namespace file but does NOT fence the hash.
+
+**Boundary manifests**: per (chain, boundary), keyed by the boundary hash,
+published only after all four mamba payloads AND the cumulative full-attn
+chunks are durable on that rank (fsync file+dir, tmp+rename). No manifest ⇒
+the boundary does not exist for stage-2 lookup. Cross-rank rule (stage 2): a
+boundary is restore-eligible iff BOTH ranks hold a valid manifest.
+
+**Retention** (`GLM53_KV_OFFLOAD_KEEP_BOUNDARIES`, default 2): inline, per
+publish — a manifest is superseded (manifest deleted, its mamba payloads
+unlinked) once it is beyond the K most recent boundaries of every chain
+containing it; full-attention chunks stay dense (cheap, and cumulative
+references from any live manifest keep shallower boundaries restorable).
+Cross-boot leftovers: `overlay/kv_offload_store_gc.py` (dry-run default).
+
+## Failure semantics (everything degrades to reprefill)
+
+| failure | behaviour |
+|---|---|
+| write fails | tmp unlinked, one log line, key enters the failed ledger (never manifested this boot), job acked — lost store only |
+| ENOSPC | writer pauses (all further writes dropped, one log); serving unaffected |
+| crash between group writes | orphan payloads, no live manifest; GC reports/sweeps |
+| torn/truncated file | header+CRC verification rejects at read (stage 2 / GC) |
+| rank mismatch, wrong layout, blocks_per_chunk≠1 | writer disabled at init with a named reason; jobs flow normally |
+
+Known stage-1 limit (recorded): the worker→scheduler ack protocol has no
+per-job failure bit, so the CPU tier believes a failed key stored and will
+not retry it this boot. Safe while restore is off (an incomplete boundary is
+simply invisible); the failure bit lands with stage 2's T4 invalidation work.
+
+## Knobs
+
+| knob | default | meaning |
+|---|---|---|
+| `GLM53_KV_OFFLOAD` | 0 | 1 = enable the connector + store tier. 0 = byte-identical serving (no argv, no mounts) |
+| `GLM53_KV_OFFLOAD_DIR` | `~/glm53-kv-offload` | host dir on EACH Spark's local NVMe; mounted rw at `/data/glm53-kv-offload` on both ranks |
+| `GLM53_KV_OFFLOAD_CPU_GB` | 4 | CPU staging bounce (`cpu_bytes_to_use`); never a capacity tier |
+| `GLM53_KV_OFFLOAD_RESTORE` | 0 | stage-1 hard rule: 1 is refused by the launcher |
+| `GLM53_KV_OFFLOAD_DRAFTER` | 0 | 1 = include the drafter group (stage-4 experiment) |
+| `GLM53_KV_OFFLOAD_KEEP_BOUNDARIES` | 2 | inline manifest retention (0 = dense) |
+
+## Deviations from the research plan (recorded)
+
+- `blocks_per_chunk=1` uniformly (plan wanted 16 for MLA): the image has one
+  global chunk size and all eligible groups share block 3584.
+- CRC is zlib crc32, not crc32c (stdlib; algorithm named in the header).
+- The stock fs secondary tier is not configured (Codex advisory finding 3 /
+  Q1): scheduler-side byte I/O is exactly the R0 hazard; the worker-local
+  writer is the disk tier.
+
+## Receipts
+
+Live receipts (knob=0 byte-parity, knob=1 boot + store-cascade evidence on
+both Sparks, store overhead within noise, fail-closed negatives) are captured
+in the PR body before the PR opens; host-side coverage is
+`tests/test_kv_offload_scope.py`, `tests/test_kv_offload_store_local.py`,
+`tests/test_launcher_kv_offload.py` against the pinned image fixtures
+(`tests/fixtures/`, sha256s in its README).

--- a/docs/DESIGN-kv-offload-store-only.md
+++ b/docs/DESIGN-kv-offload-store-only.md
@@ -45,15 +45,22 @@ the other Spark: the scheduler-side view's rank-1 slots are never written,
 and the stock fs tier would persist rank-0 bytes + uninitialised garbage as
 rank-1 halves — corruption that only surfaces at restore. So:
 
-- the connector JSON configures **CPU staging only** (no `secondary_tiers`);
+- the connector JSON configures **CPU staging only** (no `secondary_tiers`)
+  and sets `offload_prompt_only: false` — the upstream default (true) would
+  silently skip decoded tokens, and a parked session must cover its
+  responses too;
 - store jobs carry a metadata side-channel (`TransferJob.glm53_store_meta`):
   ordered `(hash, group_idx, chunk_idx)` aligned with the job's block order,
   plus boundary-manifest candidates (cumulative chunk-hash chains);
-- each worker, after its GPU→CPU DMA completes, writes **its own bytes** from
-  **its own mmap** to **its own NVMe** under
-  `GLM53_KV_OFFLOAD_DIR/glm53kv_<model>_<ns>_r<rank>/…`, and only then acks
-  the store job (staging stays pinned until every worker acks, so bytes
-  cannot be evicted under the writer);
+- each worker SNAPSHOTS the job's bytes out of its own staging mmap
+  synchronously at DMA completion (capture-then-write; adversarial-review
+  finding 1: `reset_cache()` frees staging rows regardless of pending disk
+  work, so async reads from the mmap could tear) — at `get_finished` before
+  its ack, or right after `worker.wait()` on the flush/reset path — then a
+  2-thread pool writes the private buffers (512 MB budget, over-budget
+  captures dropped as lost stores) to **its own NVMe** under
+  `GLM53_KV_OFFLOAD_DIR/glm53kv_<model>_<ns>_r<rank>/…`; acks are never
+  deferred;
 - rank is the initialized TP rank cross-checked against the connector
   config's rank — disagreement disables the writer rather than risking
   cross-rank mixing.
@@ -78,8 +85,11 @@ descriptor, format_version. Any change forks the directory. Retention K is
 recorded in the namespace file but does NOT fence the hash.
 
 **Boundary manifests**: per (chain, boundary), keyed by the boundary hash,
-published only after all four mamba payloads AND the cumulative full-attn
-chunks are durable on that rank (fsync file+dir, tmp+rename). No manifest ⇒
+published only after all four mamba payloads AND every cumulative full-attn
+chunk are durable AND header-verified on that rank (namespace + hash + group
+identity; per-chunk `[hash, len, crc]` recorded for full groups too; dedup of
+an existing file likewise requires a verifying header, else it is rewritten).
+fsync file+dir, tmp+rename. No manifest ⇒
 the boundary does not exist for stage-2 lookup. Cross-rank rule (stage 2): a
 boundary is restore-eligible iff BOTH ranks hold a valid manifest.
 
@@ -94,7 +104,8 @@ Cross-boot leftovers: `overlay/kv_offload_store_gc.py` (dry-run default).
 
 | failure | behaviour |
 |---|---|
-| write fails | tmp unlinked, one log line, key enters the failed ledger (never manifested this boot), job acked — lost store only |
+| write fails | tmp unlinked, one log line, key enters the failed ledger (never manifested this boot) — lost store only |
+| capture over budget | write dropped (lost store), key stays manifest-eligible for a later re-store |
 | ENOSPC | writer pauses (all further writes dropped, one log); serving unaffected |
 | crash between group writes | orphan payloads, no live manifest; GC reports/sweeps |
 | torn/truncated file | header+CRC verification rejects at read (stage 2 / GC) |

--- a/overlay/kv_offload_store_gc.py
+++ b/overlay/kv_offload_store_gc.py
@@ -44,10 +44,16 @@ from patch_kv_offload_store_local import read_chunk_header  # noqa: E402
 
 
 def find_stale_temps(base: Path):
-    """Yield every leftover ``*.tmp.*`` under the base (payloads, manifests,
-    namespace records). Any temp is stale by definition: publication is
-    tmp+rename, so a temp only survives a crash mid-write."""
+    """Yield every leftover ``*.tmp.*`` under the base (payloads, manifests)
+    plus namespace-record temps, which live BESIDE the per-rank base in the
+    store root (non-recursive). Any temp is stale by definition: publication
+    is tmp+rename, so a temp only survives a crash mid-write."""
     yield from base.rglob("*.tmp.*")
+    root = base.parent
+    if root.is_dir():
+        for p in root.glob("glm53kv_*.json.tmp.*"):
+            if p.is_file():
+                yield p
 
 
 def find_chunk_files(base: Path):

--- a/overlay/kv_offload_store_gc.py
+++ b/overlay/kv_offload_store_gc.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Verify / garbage-collect a GLM53 KV-offload store (stage-1 companion tool).
+
+Walks one per-rank store base directory (``glm53kv_<model>_<ns>_r<rank>``, as
+written by ``patch_kv_offload_store_local.py``), header-verifies every chunk
+file, cross-references boundary manifests, and reports:
+
+- corrupt/torn files (bad magic, truncated header/payload, CRC mismatch);
+- orphan payloads: mamba-group chunks referenced by NO live manifest (a crash
+  between group writes and manifest publish leaves exactly these);
+- manifest health: per manifest, whether every referenced payload (the four
+  mamba chunks at the boundary and the CUMULATIVE g0 chunk chain — plan §4
+  C1) exists and matches its recorded size/CRC.
+
+DRY-RUN by default: nothing is deleted or modified unless flags say so.
+
+- ``--sweep``          delete corrupt files and orphan mamba payloads
+- ``--keep-boundaries K``  manifest-mediated retention (plan §7): per chain,
+                       keep the K most recent boundary manifests (by
+                       boundary_token_index), mark the rest superseded
+                       (delete the manifest file), then sweep payloads no
+                       live manifest references. Full-attention chunks are
+                       liveness-protected by ANY live manifest of any chain
+                       (cumulative references), so superseding a boundary
+                       never strands a shallower restorable boundary.
+- ``--verify-crc``     full payload CRC verification (reads every byte)
+
+Chains are identified by their deepest manifest's chunk-hash chain: manifest
+A belongs to chain C when A's chunk_hashes is a prefix of C's. Runs on the
+host against the mounted store dir or inside the container; stdlib only.
+
+Exit code: 0 clean, 1 findings (corrupt/orphans), 2 usage/IO error.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# The header codec lives in the store overlay (single implementation).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from patch_kv_offload_store_local import read_chunk_header  # noqa: E402
+
+
+def find_chunk_files(base: Path):
+    """Yield (path, hash_hex, group_idx) for every .bin under the base."""
+    for sub1 in sorted(base.iterdir()):
+        if not sub1.is_dir() or sub1.name == "manifests":
+            continue
+        for sub2 in sorted(sub1.iterdir()):
+            if not sub2.is_dir() or "_g" not in sub2.name:
+                continue
+            try:
+                group_idx = int(sub2.name.rsplit("_g", 1)[1])
+            except ValueError:
+                continue
+            for f in sorted(sub2.glob("*.bin")):
+                yield f, f.stem, group_idx
+
+
+def load_manifests(base: Path):
+    import json
+
+    manifests = []
+    mdir = base / "manifests"
+    if not mdir.is_dir():
+        return manifests
+    for sub in sorted(mdir.iterdir()):
+        if not sub.is_dir():
+            continue
+        for f in sorted(sub.glob("*.json")):
+            try:
+                with open(f, encoding="utf-8") as fh:
+                    m = json.load(fh)
+            except (OSError, ValueError) as exc:
+                manifests.append({"_path": f, "_error": str(exc)})
+                continue
+            m["_path"] = f
+            manifests.append(m)
+    return manifests
+
+
+def assign_chains(manifests):
+    """Group manifests into chains: A joins C's chain when A.chunk_hashes is a
+    prefix of C.chunk_hashes (C the deepest)."""
+    valid = [m for m in manifests if "_error" not in m and m.get("chunk_hashes")]
+    valid.sort(key=lambda m: len(m["chunk_hashes"]), reverse=True)
+    chains: list[list[dict]] = []
+    for m in valid:
+        placed = False
+        for chain in chains:
+            deepest = chain[0]["chunk_hashes"]
+            mine = m["chunk_hashes"]
+            if deepest[: len(mine)] == mine:
+                chain.append(m)
+                placed = True
+                break
+        if not placed:
+            chains.append([m])
+    return chains
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("base", help="per-rank store base dir (…_r<rank>)")
+    ap.add_argument("--sweep", action="store_true", help="delete corrupt files and orphan mamba payloads")
+    ap.add_argument("--keep-boundaries", type=int, default=0, metavar="K", help="keep only the K most recent boundary manifests per chain (0 = keep all)")
+    ap.add_argument("--verify-crc", action="store_true", help="full payload CRC verification")
+    args = ap.parse_args(argv)
+
+    base = Path(args.base)
+    if not base.is_dir():
+        print(f"ERROR: not a directory: {base}", file=sys.stderr)
+        return 2
+    dry = not args.sweep
+
+    corrupt: list[Path] = []
+    headers: dict[tuple[str, int], dict] = {}
+    total_bytes = 0
+    n_files = 0
+    for path, hash_hex, group_idx in find_chunk_files(base):
+        n_files += 1
+        total_bytes += path.stat().st_size
+        try:
+            h = read_chunk_header(str(path), verify_payload=args.verify_crc)
+        except (OSError, ValueError) as exc:
+            corrupt.append(path)
+            print(f"CORRUPT {path}: {exc}")
+            continue
+        if h.get("hash") != hash_hex or h.get("group_idx") != group_idx:
+            corrupt.append(path)
+            print(f"CORRUPT {path}: header identity mismatch (hash/group)")
+            continue
+        headers[(hash_hex, group_idx)] = h
+
+    manifests = load_manifests(base)
+    broken_manifests = [m for m in manifests if "_error" in m]
+    for m in broken_manifests:
+        print(f"BAD-MANIFEST {m['_path']}: {m['_error']}")
+
+    # Retention: keep K most recent per chain (by boundary_token_index).
+    superseded: list[dict] = []
+    chains = assign_chains(manifests)
+    if args.keep_boundaries > 0:
+        for chain in chains:
+            chain.sort(key=lambda m: m.get("boundary_token_index", 0), reverse=True)
+            for m in chain[args.keep_boundaries :]:
+                superseded.append(m)
+        for m in superseded:
+            print(f"SUPERSEDE {m['_path']} (boundary {m.get('boundary_token_index')})")
+            if not dry:
+                m["_path"].unlink(missing_ok=True)
+        live = [
+            m
+            for m in manifests
+            if "_error" not in m and m not in superseded
+        ]
+    else:
+        live = [m for m in manifests if "_error" not in m]
+
+    # Liveness: any chunk referenced by any live manifest.
+    live_keys: set[tuple[str, int]] = set()
+    incomplete_manifests = 0
+    for m in live:
+        ok = True
+        chunk_hashes = m.get("chunk_hashes") or []
+        for gidx_s, entry in (m.get("cow_groups") or {}).items():
+            key = (entry.get("hash"), int(gidx_s))
+            live_keys.add(key)
+            h = headers.get(key)
+            if h is None:
+                print(f"MANIFEST-MISSING-PAYLOAD {m['_path']}: g{gidx_s} {entry.get('hash', '?')[:12]}")
+                ok = False
+            elif (
+                h.get("payload_len") != entry.get("payload_len")
+                or h.get("payload_crc32") != entry.get("payload_crc32")
+            ):
+                print(f"MANIFEST-PAYLOAD-MISMATCH {m['_path']}: g{gidx_s}")
+                ok = False
+        for gidx_s in (m.get("full_groups") or {}):
+            for hh in chunk_hashes:
+                key = (hh, int(gidx_s))
+                live_keys.add(key)
+                if key not in headers:
+                    print(f"MANIFEST-MISSING-PAYLOAD {m['_path']}: g{gidx_s} {hh[:12]}")
+                    ok = False
+        if not ok:
+            incomplete_manifests += 1
+
+    # Orphans: mamba-group payloads no live manifest references. Full-attn
+    # chunks without a manifest are NOT orphans by default (a boundary may
+    # legitimately be mid-store); report them only under retention mode.
+    mamba_groups = {
+        int(g) for m in live for g in (m.get("cow_groups") or {})
+    }
+    orphans = [
+        (key, h)
+        for key, h in headers.items()
+        if key not in live_keys
+        and (key[1] in mamba_groups or (args.keep_boundaries > 0))
+    ]
+    for (hash_hex, gidx), _h in orphans:
+        print(f"ORPHAN {hash_hex} g{gidx}")
+
+    if not dry:
+        for path in corrupt:
+            path.unlink(missing_ok=True)
+            print(f"DELETED {path}")
+        for (hash_hex, gidx), _h in orphans:
+            p = base / hash_hex[:3] / f"{hash_hex[3:5]}_g{gidx}" / f"{hash_hex}.bin"
+            p.unlink(missing_ok=True)
+            print(f"DELETED {p}")
+
+    print(
+        f"SUMMARY files={n_files} bytes={total_bytes} manifests={len(manifests)} "
+        f"chains={len(chains)} corrupt={len(corrupt)} orphans={len(orphans)} "
+        f"superseded={len(superseded)} incomplete_manifests={incomplete_manifests} "
+        f"broken_manifests={len(broken_manifests)} mode={'DRY-RUN' if dry else 'SWEEP'}"
+    )
+    return 1 if (corrupt or orphans or broken_manifests or incomplete_manifests) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/overlay/kv_offload_store_gc.py
+++ b/overlay/kv_offload_store_gc.py
@@ -43,6 +43,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from patch_kv_offload_store_local import read_chunk_header  # noqa: E402
 
 
+def find_stale_temps(base: Path):
+    """Yield every leftover ``*.tmp.*`` under the base (payloads, manifests,
+    namespace records). Any temp is stale by definition: publication is
+    tmp+rename, so a temp only survives a crash mid-write."""
+    yield from base.rglob("*.tmp.*")
+
+
 def find_chunk_files(base: Path):
     """Yield (path, hash_hex, group_idx) for every .bin under the base."""
     for sub1 in sorted(base.iterdir()):
@@ -134,28 +141,51 @@ def main(argv=None) -> int:
             continue
         headers[(hash_hex, group_idx)] = h
 
+    stale_temps = list(find_stale_temps(base))
+    for t in stale_temps:
+        print(f"STALE-TEMP {t}")
+    if not dry:
+        for t in stale_temps:
+            t.unlink(missing_ok=True)
+            print(f"DELETED {t}")
+
     manifests = load_manifests(base)
     broken_manifests = [m for m in manifests if "_error" in m]
     for m in broken_manifests:
         print(f"BAD-MANIFEST {m['_path']}: {m['_error']}")
 
-    # Retention: keep K most recent per chain (by boundary_token_index).
+    # Retention: the same keep-set rule as the writer's inline retention — a
+    # manifest survives while it is within the K most recent boundaries of
+    # ANY chain containing it. Chains are parent-linked via chunk_hashes
+    # (parent = chunk_hashes[-2]); walking up from every leaf keeps shared
+    # divergence-point ancestors alive as long as any branch needs them.
     superseded: list[dict] = []
-    chains = assign_chains(manifests)
-    if args.keep_boundaries > 0:
-        for chain in chains:
-            chain.sort(key=lambda m: m.get("boundary_token_index", 0), reverse=True)
-            for m in chain[args.keep_boundaries :]:
-                superseded.append(m)
+    chains = assign_chains(manifests)  # reporting only
+    valid = [m for m in manifests if "_error" not in m and m.get("chunk_hashes")]
+    if args.keep_boundaries > 0 and valid:
+        by_hash = {m["chunk_hashes"][-1]: m for m in valid}
+        parents = {
+            h: (m["chunk_hashes"][-2] if len(m["chunk_hashes"]) > 1 else None)
+            for h, m in by_hash.items()
+        }
+        child_count = {h: 0 for h in by_hash}
+        for h, parent in parents.items():
+            if parent in child_count:
+                child_count[parent] += 1
+        keep: set[str] = set()
+        for leaf in [h for h, c in child_count.items() if c == 0]:
+            node, kept = leaf, 0
+            while node is not None and kept < args.keep_boundaries:
+                if node in by_hash:
+                    keep.add(node)
+                    kept += 1
+                node = parents.get(node)
+        superseded = [m for h, m in by_hash.items() if h not in keep]
         for m in superseded:
             print(f"SUPERSEDE {m['_path']} (boundary {m.get('boundary_token_index')})")
             if not dry:
                 m["_path"].unlink(missing_ok=True)
-        live = [
-            m
-            for m in manifests
-            if "_error" not in m and m not in superseded
-        ]
+        live = [m for m in valid if m not in superseded]
     else:
         live = [m for m in manifests if "_error" not in m]
 
@@ -178,22 +208,37 @@ def main(argv=None) -> int:
             ):
                 print(f"MANIFEST-PAYLOAD-MISMATCH {m['_path']}: g{gidx_s}")
                 ok = False
-        for gidx_s in (m.get("full_groups") or {}):
+        for gidx_s, entry in (m.get("full_groups") or {}).items():
+            # entry: [[hash, payload_len, payload_crc32], ...] (current) or a
+            # bare chunk count (early format) — hashes come from chunk_hashes.
+            expected = {
+                e[0]: (e[1], e[2]) for e in entry
+            } if isinstance(entry, list) else {}
             for hh in chunk_hashes:
                 key = (hh, int(gidx_s))
                 live_keys.add(key)
-                if key not in headers:
+                h = headers.get(key)
+                if h is None:
                     print(f"MANIFEST-MISSING-PAYLOAD {m['_path']}: g{gidx_s} {hh[:12]}")
+                    ok = False
+                elif hh in expected and (
+                    h.get("payload_len"), h.get("payload_crc32")
+                ) != expected[hh]:
+                    print(f"MANIFEST-PAYLOAD-MISMATCH {m['_path']}: g{gidx_s} {hh[:12]}")
                     ok = False
         if not ok:
             incomplete_manifests += 1
 
-    # Orphans: mamba-group payloads no live manifest references. Full-attn
+    # Orphans: mamba-group payloads no live manifest references. Mamba-ness
+    # comes from the chunk HEADERS (spec_kind == MambaSpec), so a store whose
+    # crash predates its first manifest still reports its orphans. Full-attn
     # chunks without a manifest are NOT orphans by default (a boundary may
-    # legitimately be mid-store); report them only under retention mode.
+    # legitimately be mid-store); they count only under retention mode.
     mamba_groups = {
-        int(g) for m in live for g in (m.get("cow_groups") or {})
+        gidx for (_h, gidx), hdr in headers.items()
+        if hdr.get("spec_kind") == "MambaSpec"
     }
+    mamba_groups |= {int(g) for m in live for g in (m.get("cow_groups") or {})}
     orphans = [
         (key, h)
         for key, h in headers.items()
@@ -216,9 +261,20 @@ def main(argv=None) -> int:
         f"SUMMARY files={n_files} bytes={total_bytes} manifests={len(manifests)} "
         f"chains={len(chains)} corrupt={len(corrupt)} orphans={len(orphans)} "
         f"superseded={len(superseded)} incomplete_manifests={incomplete_manifests} "
+        f"stale_temps={len(stale_temps)} "
         f"broken_manifests={len(broken_manifests)} mode={'DRY-RUN' if dry else 'SWEEP'}"
     )
-    return 1 if (corrupt or orphans or broken_manifests or incomplete_manifests) else 0
+    return (
+        1
+        if (
+            corrupt
+            or orphans
+            or broken_manifests
+            or incomplete_manifests
+            or stale_temps
+        )
+        else 0
+    )
 
 
 if __name__ == "__main__":

--- a/overlay/patch_kv_offload_restore_g0.py
+++ b/overlay/patch_kv_offload_restore_g0.py
@@ -429,7 +429,10 @@ class Glm53RestoreState:
                 # Restore concurrency = 1: defer; the stock deferred-lookup
                 # machinery re-queries this request later.
                 return None
-            # The job vanished (reset/terminal path missed): self-heal.
+            # The job vanished (reset/terminal path missed): self-heal --
+            # and drop its id from the disk-job set so stale ids never
+            # accumulate (final-confirm minor).
+            self._disk_jobs.discard(self._inflight_job)
             self._inflight_job = None
         max_chunk = min(req.num_tokens // tpc, len(req.block_hashes) // hpc)
         for k in range(max_chunk - 1, local // tpc - 1, -1):
@@ -1479,19 +1482,26 @@ ANCHOR_W13 = """            try:
                 h = glm53_read_chunk_header(path)
                 if (
                     h.get("namespace_hash") == self._namespace_hash
+                    and h.get("hash") == hash_hex
+                    and h.get("group_idx") == group_idx
+                ):
 """
 
 PATCHED_W13 = """            try:
                 # [glm53-kv-offload-restore] dedup: bounded payload verification
-                # (review f4 + confirm N3): identity and length equality
-                # FIRST -- length equality with THIS job's payload caps the
-                # verifying read -- then a full CRC pass; a stale file with a
-                # valid header but torn payload is rewritten, never deduped.
+                # (review f4 + confirm N3, ordering per the final confirm):
+                # identity and length equality FIRST -- length equality with
+                # THIS job's payload caps the verifying read -- then a full
+                # CRC pass; a stale file with a valid header but torn payload
+                # is rewritten, never deduped.
                 h = glm53_read_chunk_header(path)
                 if (
                     h.get("payload_len") == len(payload)
-                    and glm53_read_chunk_header(path, verify_payload=True)
                     and h.get("namespace_hash") == self._namespace_hash
+                    and h.get("hash") == hash_hex
+                    and h.get("group_idx") == group_idx
+                    and glm53_read_chunk_header(path, verify_payload=True)
+                ):
 """
 
 SITES_WORKER = (

--- a/overlay/patch_kv_offload_restore_g0.py
+++ b/overlay/patch_kv_offload_restore_g0.py
@@ -181,15 +181,19 @@ class Glm53RestoreState:
         self._log = log
         self._config = config
         self._inflight_job = None
+        self._disk_jobs = set()
         self._namespace = None
         # boundary_hash -> {"ranks": set[int], "tokens": int}
         self._boundaries = {}
-        # (hash_hex, group_idx) whose store WRITE failed on any rank this
-        # boot -- the per-job store failure bit, on the wire and load-bearing
-        # at lookup (stage-1 known limit closed per the task contract).
-        # Sticky by design: it mirrors the stage-1 writer's failed-key
-        # ledger, which never un-fails a key within a boot.
-        self._failed_keys = set()
+        # rank -> set[(hash_hex, group_idx)] whose store WRITE failed on
+        # that rank under its CURRENT writer generation -- the per-job store
+        # failure bit, on the wire and load-bearing at lookup (stage-1 known
+        # limit closed per the task contract). Sticky WITHIN a generation
+        # (mirrors the stage-1 writer's failed-key ledger); a writer restart
+        # (boot-id change) retracts that rank's failures along with its
+        # availability, so a recovered writer is not permanently suppressed
+        # (Codex confirm pass, finding 9).
+        self._failed_by_rank = {}
         # rank -> writer boot id: a changed boot id means that rank's writer
         # restarted; its previous availability is void (finding 8 fencing).
         self._rank_boot = {}
@@ -217,6 +221,10 @@ class Glm53RestoreState:
             not config.kv_group_configs
             or config.kv_group_configs[0].tokens_per_chunk <= 0
             or config.kv_group_configs[0].hashes_per_chunk <= 0
+            or config.tokens_per_hash <= 0
+            or config.kv_group_configs[0].tokens_per_chunk
+            != config.kv_group_configs[0].hashes_per_chunk
+            * config.tokens_per_hash
         ):
             reason = "degenerate chunk/hash geometry"
         elif reason is None and (
@@ -270,6 +278,9 @@ class Glm53RestoreState:
             entry["ranks"].discard(rank)
             if not entry["ranks"]:
                 self._boundaries.pop(key, None)
+        # Failures are generation-scoped too: a restarted writer starts a
+        # fresh ledger, so its old failures must not suppress it forever.
+        self._failed_by_rank.pop(rank, None)
 
     def consume_events(self, events) -> None:
         for ev in events:
@@ -346,8 +357,21 @@ class Glm53RestoreState:
                     if not entry["ranks"]:
                         self._boundaries.pop(key, None)
             elif code == "F":
-                if len(self._failed_keys) < self._MAX_FAILED_KEYS:
-                    self._failed_keys.add((key, aux))
+                failed = self._failed_by_rank.setdefault(rank, set())
+                if len(failed) < self._MAX_FAILED_KEYS:
+                    failed.add((key, aux))
+                elif not self._failed_overflow:
+                    # Losing failure knowledge would be fail-OPEN; poison the
+                    # lookup instead (restore off for the rest of the boot).
+                    self._failed_overflow = True
+                    self._log.error(
+                        "%s failed-key ledger full (%d) for rank %d: disk "
+                        "lookup DISABLED for the rest of this boot "
+                        "(fail closed)",
+                        _GLM53_KVR_TAG,
+                        self._MAX_FAILED_KEYS,
+                        rank,
+                    )
                 elif not self._failed_overflow:
                     # Losing failure knowledge would be fail-OPEN; poison the
                     # lookup instead (restore off for the rest of the boot).
@@ -362,13 +386,22 @@ class Glm53RestoreState:
     # ---- single-flight gate (finding 11: self-healing invariant) --------
     def job_started(self, job_id: int) -> None:
         self._inflight_job = job_id
+        # DISK job ids, so the preemption/store-jobs guards act only on OUR
+        # loads and preserve stock semantics (the assert) for any other
+        # load-job kind (Codex confirm pass, new finding 1).
+        self._disk_jobs.add(job_id)
+
+    def is_disk_job(self, job_id: int) -> bool:
+        return job_id in self._disk_jobs
 
     def job_done(self, job_id: int) -> None:
         if self._inflight_job == job_id:
             self._inflight_job = None
+        self._disk_jobs.discard(job_id)
 
     def reset(self) -> None:
         self._inflight_job = None
+        self._disk_jobs.clear()
         self._pending_hits.clear()
 
     # ---- the lookup -----------------------------------------------------
@@ -409,7 +442,10 @@ class Glm53RestoreState:
             # Exact rank-set equality (finding 7): every worker, no strays.
             if entry["ranks"] != set(range(self._config.num_workers)):
                 continue
-            if (bhash, cfg.group_idx) in self._failed_keys:
+            if any(
+                (bhash, cfg.group_idx) in failed
+                for failed in self._failed_by_rank.values()
+            ):
                 continue
             hit = (k + 1) * tpc - local
             if hit <= 0:
@@ -995,14 +1031,20 @@ ANCHOR_R9 = """            any_jid = next(iter(req_status.transfer_jobs))
 
 PATCHED_R9 = """            any_jid = next(iter(req_status.transfer_jobs))
             if not self._jobs[any_jid].is_store:  # [glm53-kv-offload-restore]
-                # A disk-restore load job (per the connector invariant, the
-                # ONLY job then): not flushable through the store path. The
-                # synchronous loader already ran (or acks next step) and a
-                # late ack after reset is fenced by _stale_job_threshold;
-                # clear the single-flight gate so the re-admitted request
-                # re-runs the manifest lookup (T5).
-                self._glm53_restore.job_done(any_jid)
-                continue
+                if self._glm53_restore.is_disk_job(any_jid):
+                    # OUR disk-restore load job: not flushable through the
+                    # store path. The synchronous loader already ran (or
+                    # acks next step) and a late ack after reset is fenced
+                    # by _stale_job_threshold; clear the single-flight gate
+                    # so the re-admitted request re-runs the lookup (T5).
+                    self._glm53_restore.job_done(any_jid)
+                    continue
+                # Any OTHER load-job kind keeps the stock invariant crash
+                # semantics (Codex confirm pass, new finding 1: never
+                # misclassify a CPU-tier load as ours).
+                raise AssertionError(
+                    f"non-store, non-disk job {any_jid} on a preempted request"
+                )
             self._current_batch_jobs_to_flush.update(req_status.transfer_jobs)
 """
 
@@ -1067,14 +1109,17 @@ PATCHED_R11 = """            req_status = self._req_status.get(req_id)
                 continue
             if req_status.transfer_jobs and not self._jobs[  # [glm53-kv-offload-restore] R11
                 next(iter(req_status.transfer_jobs))
-            ].is_store:
-                # A disk-restore LOAD job is still registered for this
+            ].is_store and self._glm53_restore.is_disk_job(
+                next(iter(req_status.transfer_jobs))
+            ):
+                # OUR disk-restore LOAD job is still registered for this
                 # request (per the connector invariant, the only job then):
                 # defer store-job creation to a later step -- reaching the
                 # is_store assert below would crash the scheduler, and the
                 # stock invariant is exactly "stores only when no load is
                 # pending". next_stored_chunk_idx is untouched: nothing is
-                # lost.
+                # lost. Any OTHER load-job kind falls through to the stock
+                # assert (confirm pass, new finding 1).
                 continue
             req = req_status.req
 
@@ -1225,7 +1270,10 @@ PATCHED_W8 = """        with self._lock:
                 "boundary": cand["boundary_token_index"],
                 "mamba_keys": [(boundary_hash, g) for g in cow_groups],
             }
-            if len(self._glm53_manifest_events) < 100000:  # bounded, fail closed
+            # Cap applies to "+" ONLY: a dropped "+" is a missed hit
+            # (fail closed); dropping "-"/"F" would be fail-OPEN (stale
+            # availability / lost failure knowledge), so those always ride.
+            if len(self._glm53_manifest_events) < 100000:  # "+" cap
                 self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] publish
                     (
                         "+",
@@ -1246,7 +1294,7 @@ ANCHOR_W9 = """            with self._lock:
 
 PATCHED_W9 = """            with self._lock:
                 self._manifest_index.pop(boundary_hash, None)
-                if len(self._glm53_manifest_events) < 100000:  # bounded
+                if True:  # "-" always rides (fail-closed direction)
                     self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] supersede
                         (
                             "-",
@@ -1271,7 +1319,7 @@ PATCHED_W10 = """        self._files_dropped += 1
             self._failed_keys.add((hash_hex, group_idx))
             # The per-job store failure bit, on the wire: the scheduler's
             # disk lookup denies boundaries whose keys failed on ANY rank.
-            if len(self._glm53_manifest_events) < 100000:  # bounded
+            if True:  # "F" always rides (fail-closed direction)
                 self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] write failure
                     (
                         "F",
@@ -1325,12 +1373,65 @@ PATCHED_W12 = """    # [glm53-kv-offload-restore] manifest validation + event dr
             self._glm53_manifest_events = []
         return events
 
+    def _glm53_expected_chunk_shape(self, gidx):
+        \"\"\"(spec_kind, block_size, segment_table, payload_len) this rank
+        expects for one chunk of group ``gidx`` -- the writer's own gather
+        derivation, JSON-normalized for header comparison.\"\"\"
+        refs = self._refs_per_group[gidx]
+        group = self._kv_groups[gidx]
+        names = list(group.layer_names)
+        segs = []
+        off = 0
+        for i, ref in enumerate(refs):
+            layer = names[i] if i < len(names) else f"ref{i}"
+            segs.extend(
+                self._layer_segments(group, layer, off, ref.page_size_bytes)
+            )
+            off += ref.page_size_bytes
+        inner = _glm53_unwrap_kv_spec(group.kv_cache_spec)
+        return (
+            type(inner).__name__,
+            getattr(inner, "block_size", None),
+            _glm53_json.loads(_glm53_json.dumps(segs)),
+            off,
+        )
+
+    def _glm53_chunk_verifies(self, hash_hex, gidx, expected) -> bool:
+        \"\"\"Full chunk verification: identity + spec/rank/world + segment
+        table + payload length (checked BEFORE the payload read, which
+        bounds it) + full payload CRC.\"\"\"
+        kind, bs, segs, plen = expected
+        fp = self._file_path(hash_hex, gidx)
+        try:
+            fh = glm53_read_chunk_header(fp)
+        except (OSError, ValueError):
+            return False
+        if (
+            fh.get("namespace_hash") != self._namespace_hash
+            or fh.get("hash") != hash_hex
+            or fh.get("group_idx") != gidx
+            or fh.get("spec_kind") != kind
+            or fh.get("block_size_tokens") != bs
+            or fh.get("tp_rank") != self._rank
+            or fh.get("tp_world") != self._world
+            or fh.get("payload_len") != plen
+            or fh.get("segment_table") != segs
+        ):
+            return False
+        try:
+            glm53_read_chunk_header(fp, verify_payload=True)
+        except (OSError, ValueError):
+            return False
+        return True
+
     def _glm53_validate_manifest_file(
         self, mpath, boundary_hash, cand, cow_groups, full_groups
     ) -> bool:
         \"\"\"Full validation of a pre-existing manifest before it is
-        registered/announced: parse, identity, chain equality, and a
-        verifying header for EVERY referenced chunk on this rank.\"\"\"
+        registered/announced (Codex OFFLOAD2-REVIEW f4 + confirm pass):
+        parse, identity, chain equality, and full chunk verification
+        (identity + spec/rank/world + segment table + bounded payload CRC)
+        for EVERY referenced chunk on this rank.\"\"\"
         try:
             with open(mpath, encoding="utf-8") as f:
                 man = _glm53_json.load(f)
@@ -1345,36 +1446,23 @@ PATCHED_W12 = """    # [glm53-kv-offload-restore] manifest validation + event dr
             return False
         with self._lock:
             failed = set(self._failed_keys)
+        shapes = {}
         for gidx in cow_groups:
             if (boundary_hash, gidx) in failed:
                 return False
-            try:
-                fh = glm53_read_chunk_header(
-                    self._file_path(boundary_hash, gidx), verify_payload=True
-                )
-            except (OSError, ValueError):
-                return False
-            if (
-                fh.get("namespace_hash") != self._namespace_hash
-                or fh.get("hash") != boundary_hash
-                or fh.get("group_idx") != gidx
+            if gidx not in shapes:
+                shapes[gidx] = self._glm53_expected_chunk_shape(gidx)
+            if not self._glm53_chunk_verifies(
+                boundary_hash, gidx, shapes[gidx]
             ):
                 return False
         for gidx in full_groups:
+            if gidx not in shapes:
+                shapes[gidx] = self._glm53_expected_chunk_shape(gidx)
             for h in cand["chunk_hashes"]:
                 if (h, gidx) in failed:
                     return False
-                try:
-                    fh = glm53_read_chunk_header(
-                        self._file_path(h, gidx), verify_payload=True
-                    )
-                except (OSError, ValueError):
-                    return False
-                if (
-                    fh.get("namespace_hash") != self._namespace_hash
-                    or fh.get("hash") != h
-                    or fh.get("group_idx") != gidx
-                ):
+                if not self._glm53_chunk_verifies(h, gidx, shapes[gidx]):
                     return False
         return True
 
@@ -1385,7 +1473,7 @@ PATCHED_W12 = """    # [glm53-kv-offload-restore] manifest validation + event dr
 # W13: the store writer's existing-chunk dedup must verify the PAYLOAD, not
 # only the header (Codex OFFLOAD2-REVIEW finding 4: a stale file with a valid
 # unchanged header but torn payload must be rewritten, not deduped).
-MARK_W13 = "                h = glm53_read_chunk_header(path, verify_payload=True)  # [glm53-kv-offload-restore] dedup\n"
+MARK_W13 = "                # [glm53-kv-offload-restore] dedup: bounded payload verification\n"
 
 ANCHOR_W13 = """            try:
                 h = glm53_read_chunk_header(path)
@@ -1394,9 +1482,16 @@ ANCHOR_W13 = """            try:
 """
 
 PATCHED_W13 = """            try:
-                h = glm53_read_chunk_header(path, verify_payload=True)  # [glm53-kv-offload-restore] dedup
+                # [glm53-kv-offload-restore] dedup: bounded payload verification
+                # (review f4 + confirm N3): identity and length equality
+                # FIRST -- length equality with THIS job's payload caps the
+                # verifying read -- then a full CRC pass; a stale file with a
+                # valid header but torn payload is rewritten, never deduped.
+                h = glm53_read_chunk_header(path)
                 if (
-                    h.get("namespace_hash") == self._namespace_hash
+                    h.get("payload_len") == len(payload)
+                    and glm53_read_chunk_header(path, verify_payload=True)
+                    and h.get("namespace_hash") == self._namespace_hash
 """
 
 SITES_WORKER = (

--- a/overlay/patch_kv_offload_restore_g0.py
+++ b/overlay/patch_kv_offload_restore_g0.py
@@ -171,6 +171,12 @@ class Glm53RestoreState:
     lookup. Keys/hashes only -- the scheduler NEVER touches the filesystem
     (plan R0; Codex OFFLOAD2 finding 8)."""
 
+    # Registry bounds (Codex OFFLOAD2-REVIEW finding 8): fail CLOSED on
+    # overflow -- new boundaries are dropped (missed hits only), never wrong
+    # hits; one log line when first hit.
+    _MAX_BOUNDARIES = 1 << 16
+    _MAX_FAILED_KEYS = 1 << 16
+
     def __init__(self, config, vllm_config, log):
         self._log = log
         self._config = config
@@ -181,11 +187,18 @@ class Glm53RestoreState:
         # (hash_hex, group_idx) whose store WRITE failed on any rank this
         # boot -- the per-job store failure bit, on the wire and load-bearing
         # at lookup (stage-1 known limit closed per the task contract).
+        # Sticky by design: it mirrors the stage-1 writer's failed-key
+        # ledger, which never un-fails a key within a boot.
         self._failed_keys = set()
+        # rank -> writer boot id: a changed boot id means that rank's writer
+        # restarted; its previous availability is void (finding 8 fencing).
+        self._rank_boot = {}
         # req_id -> pending disk-hit boundary (end-exclusive tokens), set by
         # lookup, consumed by update_state_after_alloc, dropped on miss/reset.
         self._pending_hits = {}
         self._ns_mismatch_logged = False
+        self._overflow_logged = False
+        self._failed_overflow = False
 
         reason = None
         try:
@@ -200,6 +213,12 @@ class Glm53RestoreState:
             reason = "GLM53_KV_OFFLOAD=0 (restore reads the store tier)"
         elif reason is None and config.blocks_per_chunk != 1:
             reason = f"blocks_per_chunk={config.blocks_per_chunk} (need 1)"
+        elif reason is None and (
+            not config.kv_group_configs
+            or config.kv_group_configs[0].tokens_per_chunk <= 0
+            or config.kv_group_configs[0].hashes_per_chunk <= 0
+        ):
+            reason = "degenerate chunk/hash geometry"
         elif reason is None and (
             config.num_kv_cache_groups != 1 or len(config.kv_group_configs) != 1
         ):
@@ -245,6 +264,13 @@ class Glm53RestoreState:
             )
 
     # ---- worker event registry (plan C2: min across ranks) --------------
+    def _retract_rank(self, rank: int) -> None:
+        for key in list(self._boundaries):
+            entry = self._boundaries[key]
+            entry["ranks"].discard(rank)
+            if not entry["ranks"]:
+                self._boundaries.pop(key, None)
+
     def consume_events(self, events) -> None:
         for ev in events:
             try:
@@ -253,7 +279,12 @@ class Glm53RestoreState:
                 ns = str(ev[2])
                 key = str(ev[3])
                 aux = int(ev[4])
+                boot = str(ev[5]) if len(ev) > 5 else ""
             except (TypeError, ValueError, IndexError):
+                continue
+            # Rank must name a real worker (Codex OFFLOAD2-REVIEW finding 7):
+            # garbage ranks must never help satisfy the quorum.
+            if not 0 <= rank < self._config.num_workers:
                 continue
             if self._namespace is None:
                 self._namespace = ns
@@ -268,7 +299,37 @@ class Glm53RestoreState:
                         self._namespace[:12],
                     )
                 continue
+            # Writer-generation fencing (finding 8): a changed boot id means
+            # that rank's writer restarted -- everything it previously
+            # announced is void.
+            pinned_boot = self._rank_boot.get(rank)
+            if pinned_boot is None:
+                self._rank_boot[rank] = boot
+            elif pinned_boot != boot:
+                self._log.warning(
+                    "%s rank %d writer generation changed (%s -> %s): "
+                    "retracting its availability",
+                    _GLM53_KVR_TAG,
+                    rank,
+                    pinned_boot[:16],
+                    boot[:16],
+                )
+                self._retract_rank(rank)
+                self._rank_boot[rank] = boot
             if code == "+":
+                if (
+                    key not in self._boundaries
+                    and len(self._boundaries) >= self._MAX_BOUNDARIES
+                ):
+                    if not self._overflow_logged:
+                        self._overflow_logged = True
+                        self._log.warning(
+                            "%s boundary registry full (%d): new boundaries "
+                            "are dropped (missed hits only, fail closed)",
+                            _GLM53_KVR_TAG,
+                            self._MAX_BOUNDARIES,
+                        )
+                    continue
                 entry = self._boundaries.setdefault(
                     key, {"ranks": set(), "tokens": aux}
                 )
@@ -285,7 +346,18 @@ class Glm53RestoreState:
                     if not entry["ranks"]:
                         self._boundaries.pop(key, None)
             elif code == "F":
-                self._failed_keys.add((key, aux))
+                if len(self._failed_keys) < self._MAX_FAILED_KEYS:
+                    self._failed_keys.add((key, aux))
+                elif not self._failed_overflow:
+                    # Losing failure knowledge would be fail-OPEN; poison the
+                    # lookup instead (restore off for the rest of the boot).
+                    self._failed_overflow = True
+                    self._log.error(
+                        "%s failed-key ledger full (%d): disk lookup "
+                        "DISABLED for the rest of this boot (fail closed)",
+                        _GLM53_KVR_TAG,
+                        self._MAX_FAILED_KEYS,
+                    )
 
     # ---- single-flight gate (finding 11: self-healing invariant) --------
     def job_started(self, job_id: int) -> None:
@@ -308,7 +380,7 @@ class Glm53RestoreState:
         None = defer while another restore is in flight)."""
         req_id = req_status.req.request_id
         self._pending_hits.pop(req_id, None)
-        if self.disabled_reason is not None:
+        if self.disabled_reason is not None or self._failed_overflow:
             return 0
         cfg = self._config.kv_group_configs[0]
         tpc = cfg.tokens_per_chunk
@@ -334,7 +406,8 @@ class Glm53RestoreState:
                 continue
             if entry["tokens"] != (k + 1) * tpc:
                 continue
-            if len(entry["ranks"]) < self._config.num_workers:
+            # Exact rank-set equality (finding 7): every worker, no strays.
+            if entry["ranks"] != set(range(self._config.num_workers)):
                 continue
             if (bhash, cfg.group_idx) in self._failed_keys:
                 continue
@@ -357,9 +430,13 @@ class Glm53RestoreState:
         entries = []
         if (
             boundary_tokens == num_cached
+            and tpc > 0
+            and hpc > 0
             and local % tpc == 0
             and boundary_tokens % tpc == 0
-            and boundary_tokens // hpc // (tpc // hpc) <= len(request.block_hashes)
+            # Enough HASHES for every entry (Codex OFFLOAD2-REVIEW finding 2:
+            # the draft compared the CHUNK count against the hash list).
+            and (boundary_tokens // tpc) * hpc <= len(request.block_hashes)
         ):
             for j in range(local // tpc, boundary_tokens // tpc):
                 entries.append(
@@ -448,37 +525,71 @@ def _glm53_expected_segments(writer, gidx, gpu_refs):
     return segments, offset
 
 
+def _glm53_hex64(value) -> bool:
+    """Exact 64-char lowercase hex -- required before ANY path construction
+    from wire/manifest data (Codex OFFLOAD2-REVIEW finding 5: a corrupt hash
+    must never contribute separators or traversal components)."""
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(c in "0123456789abcdef" for c in value)
+    )
+
+
+# Hard per-chunk payload cap (finding 6): the live g0 chunk is 27,163,136 B;
+# anything past 256 MiB is garbage regardless of layout.
+_GLM53_KVR_MAX_PAYLOAD = 256 * 1024 * 1024
+
+
 def _glm53_read_chunk_payload(path, header):
-    """Read one chunk's payload bytes (the codec's header reader validates
-    structure/length; this re-reads the payload and CRC-checks it)."""
+    """Bounded read of one chunk's payload (the codec's header reader already
+    validated envelope structure and total file length; this seeks past the
+    envelope, reads exactly the expected bytes, and CRC-checks them)."""
     import zlib as _zlib
 
+    expected = header["payload_len"]
     with open(path, "rb") as f:
-        blob = f.read()
-    hlen = int.from_bytes(blob[8:12], "little")
-    payload = blob[16 + hlen :]
-    if len(payload) != header["payload_len"]:
+        head = f.read(12)
+        if len(head) != 12:
+            raise ValueError(f"truncated envelope in {path!r}")
+        hlen = int.from_bytes(head[8:12], "little")
+        f.seek(12 + hlen + 4)
+        payload = f.read(expected + 1)
+    if len(payload) != expected:
         raise ValueError(f"payload length changed under us in {path!r}")
-    if (_zlib.crc32(payload) & 0xFFFFFFFF) != header["payload_crc32"]:
+    if (_glm53_zlib_crc32(payload)) != header["payload_crc32"]:
         raise ValueError(f"payload crc mismatch in {path!r}")
     return payload
+
+
+def _glm53_zlib_crc32(data) -> int:
+    import zlib as _zlib
+
+    return _zlib.crc32(data) & 0xFFFFFFFF
 
 
 def _glm53_run_disk_load(cw, job_id, src_spec, dst_spec) -> None:
     """Synchronous disk restore of one load job (restore concurrency = 1).
 
-    Terminal-result contract (Codex OFFLOAD2 finding 5): EVERY exit -- happy
-    path, precondition failure, manifest failure, per-chunk pread/header/
-    CRC/segment/scatter failure -- marks the job done (drained by
-    get_finished, which acks + reports finished_recving) and, for failures,
-    zero-fills the failed chunk and every later chunk's dst blocks and
-    records their physical ids for get_block_ids_with_load_errors. The copy
-    runs entirely inside this engine step: there is no cross-step disk DMA
-    to fence (the preemption/reset fence of finding 4), and a late ack after
-    reset_cache is discarded by the scheduler's _stale_job_threshold."""
+    Terminal-result contract (Codex OFFLOAD2 findings 5 + REVIEW finding 3):
+    the done-list append lives in a ``finally`` -- EVERY exit (happy path,
+    precondition failure, manifest failure, per-chunk pread/header/CRC/
+    segment/scatter failure, even an exception inside the failure
+    bookkeeping) marks the job done (drained by get_finished, which acks +
+    reports finished_recving) and, for failures, records the failed suffix's
+    physical ids for get_block_ids_with_load_errors BEFORE zero-filling
+    best-effort. The ONE deliberate exception: an unparseable dst_spec
+    (destinations not identifiable) PROPAGATES -- acking without being able
+    to report or zero the destinations could serve stale pool bytes as a
+    hit, and fail-stop is the stage-1-adopted rule for exactly that class.
+    The copy runs entirely inside this engine step: no cross-step disk DMA
+    exists (the preemption/reset fence), and a late ack after reset_cache is
+    discarded by the scheduler's _stale_job_threshold."""
     import time as _time
 
+    # Destinations must be identifiable BEFORE the catch-all: see docstring.
     dst_ids = [int(b) for b in dst_spec.block_ids]
+
     failed_from = None
     reason = None
     tensors = None
@@ -487,146 +598,205 @@ def _glm53_run_disk_load(cw, job_id, src_spec, dst_spec) -> None:
     t0 = _time.monotonic()
     entries = []
     try:
-        writer = _glm53_get_store_writer(cw)
-        if writer._disabled_reason is not None:
-            raise ValueError(f"store writer disabled: {writer._disabled_reason}")
-        if not isinstance(src_spec, dict) or src_spec.get("v") != _GLM53_KVR_SPEC_V:
-            raise ValueError(
-                f"unknown disk-load spec version {src_spec.get('v')!r}"
+        try:
+            writer = _glm53_get_store_writer(cw)
+            if writer._disabled_reason is not None:
+                raise ValueError(
+                    f"store writer disabled: {writer._disabled_reason}"
+                )
+            if (
+                not isinstance(src_spec, dict)
+                or src_spec.get("v") != _GLM53_KVR_SPEC_V
+            ):
+                raise ValueError(
+                    f"unknown disk-load spec version {src_spec.get('v')!r}"
+                )
+            if src_spec.get("namespace_hash") != writer._namespace_hash:
+                raise ValueError("disk-load namespace mismatch")
+            entries = list(src_spec.get("entries") or [])
+            if not entries or len(entries) != len(dst_ids):
+                raise ValueError(
+                    f"{len(entries)} entries vs {len(dst_ids)} dst blocks"
+                )
+            gidx = int(entries[0][1])
+            if gidx not in writer._eligible_groups:
+                raise ValueError(f"group {gidx} not eligible on this rank")
+            caches = cw._glm53_gpu_caches
+            if caches is None:
+                raise ValueError("GPU canonical caches not registered")
+            tensors = caches.tensors
+            gpu_refs = list(caches.group_data_refs[gidx])
+            staging_refs = writer._refs_per_group[gidx]
+            if [r.page_size_bytes for r in gpu_refs] != [
+                r.page_size_bytes for r in staging_refs
+            ]:
+                raise ValueError("GPU vs staging ref layout mismatch")
+            for ref in gpu_refs:
+                if getattr(ref, "mapping", None) is not None:
+                    # A canonical mapping means a raw row copy is NOT the
+                    # inverse of the store-side gather: fail closed.
+                    raise ValueError(
+                        "canonical-mapped layout not restorable (v1)"
+                    )
+            expected_segments, expected_len = _glm53_expected_segments(
+                writer, gidx, gpu_refs
             )
-        if src_spec.get("namespace_hash") != writer._namespace_hash:
-            raise ValueError("disk-load namespace mismatch")
-        entries = list(src_spec.get("entries") or [])
-        if not entries or len(entries) != len(dst_ids):
-            raise ValueError(
-                f"{len(entries)} entries vs {len(dst_ids)} dst blocks"
-            )
-        gidx = int(entries[0][1])
-        if gidx not in writer._eligible_groups:
-            raise ValueError(f"group {gidx} not eligible on this rank")
-        caches = cw._glm53_gpu_caches
-        if caches is None:
-            raise ValueError("GPU canonical caches not registered")
-        tensors = caches.tensors
-        gpu_refs = list(caches.group_data_refs[gidx])
-        staging_refs = writer._refs_per_group[gidx]
-        if [r.page_size_bytes for r in gpu_refs] != [
-            r.page_size_bytes for r in staging_refs
-        ]:
-            raise ValueError("GPU vs staging ref layout mismatch")
-        for ref in gpu_refs:
-            if getattr(ref, "mapping", None) is not None:
-                # A canonical mapping means a raw row copy is NOT the
-                # inverse of the store-side gather: fail closed.
-                raise ValueError("canonical-mapped layout not restorable (v1)")
-        expected_segments, expected_len = _glm53_expected_segments(
-            writer, gidx, gpu_refs
-        )
+            expected_segments = _glm53_json_norm(expected_segments)
+            if not 0 < expected_len <= _GLM53_KVR_MAX_PAYLOAD:
+                raise ValueError(f"implausible payload size {expected_len}")
+            group = writer._kv_groups[gidx]
+            inner = _glm53_unwrap_kv_spec(group.kv_cache_spec)
+            expected_spec_kind = type(inner).__name__
+            expected_block_size = getattr(inner, "block_size", None)
 
-        # Manifest re-validation on THIS rank before any pread (finding 8:
-        # each worker validates its own store; a retention race or missing
-        # manifest degrades to recompute, never to a guess).
-        boundary_hash = str(entries[-1][0])
-        mpath = writer._manifest_path(boundary_hash)
-        with open(mpath, encoding="utf-8") as f:
-            man = _glm53_json.load(f)
-        if (
-            man.get("namespace_hash") != writer._namespace_hash
-            or man.get("boundary_token_index")
-            != src_spec.get("boundary_token_index")
-            or (man.get("chunk_hashes") or [])[-1:] != [boundary_hash]
-        ):
-            raise ValueError("manifest identity mismatch at load time")
+            # Manifest re-validation on THIS rank before any pread
+            # (finding 8 of the advisory + REVIEW finding 4): identity,
+            # FULL cumulative chain arithmetic, hex-validated hashes, and
+            # the per-chunk [len, crc] ledger used against every header.
+            boundary_tokens = src_spec.get("boundary_token_index")
+            boundary_hash = str(entries[-1][0])
+            if not _glm53_hex64(boundary_hash):
+                raise ValueError("boundary hash is not 64-char lowercase hex")
+            mpath = writer._manifest_path(boundary_hash)
+            with open(mpath, encoding="utf-8") as f:
+                man = _glm53_json.load(f)
+            chain = man.get("chunk_hashes") or []
+            tpc = int(entries[0][3])
+            if (
+                man.get("namespace_hash") != writer._namespace_hash
+                or man.get("boundary_token_index") != boundary_tokens
+                or not isinstance(boundary_tokens, int)
+                or tpc <= 0
+                or boundary_tokens != len(chain) * tpc
+                or chain[-1:] != [boundary_hash]
+                or not all(_glm53_hex64(h) for h in chain)
+            ):
+                raise ValueError("manifest identity mismatch at load time")
+            # The job's entries must BE the chain's tail (content addressing
+            # makes deeper equality redundant, but the manifest is the
+            # commit record -- trust nothing shallower).
+            tail = chain[len(chain) - len(entries):]
+            if [str(e[0]) for e in entries] != tail:
+                raise ValueError("job entries diverge from the manifest chain")
+            ledger = (man.get("full_groups") or {}).get(str(gidx))
+            if (
+                not isinstance(ledger, list)
+                or len(ledger) != len(chain)
+                or any(
+                    not (isinstance(entry_l, list) and len(entry_l) == 3)
+                    for entry_l in ledger
+                )
+            ):
+                raise ValueError("manifest chunk ledger missing/malformed")
+            ledger_by_hash = {row[0]: (row[1], row[2]) for row in ledger}
 
-        import torch as _torch
+            import torch as _torch
 
-        for i, ent in enumerate(entries):
-            try:
-                hash_hex = str(ent[0])
-                egidx = int(ent[1])
-                n_tokens = int(ent[3])
-                if egidx != gidx:
-                    raise ValueError("mixed groups in one disk load job")
-                row = dst_ids[i]
-                if row == 0:
-                    raise ValueError("null dst block in a disk load job")
-                path = writer._file_path(hash_hex, gidx)
-                header = glm53_read_chunk_header(path)
-                if (
-                    header.get("namespace_hash") != writer._namespace_hash
-                    or header.get("hash") != hash_hex
-                    or header.get("group_idx") != gidx
-                    or header.get("tp_rank") != writer._rank
-                    or header.get("tp_world") != writer._world
-                    or header.get("n_tokens_valid") != n_tokens
-                    or header.get("payload_len") != expected_len
-                ):
-                    raise ValueError(f"chunk header identity mismatch: {path}")
-                if header.get("segment_table") != expected_segments_at(
-                    expected_segments
-                ):
-                    raise ValueError(f"segment table mismatch: {path}")
-                payload = _glm53_read_chunk_payload(path, header)
-                offset = 0
-                for ref in gpu_refs:
-                    seg = payload[offset : offset + ref.page_size_bytes]
-                    buf = _torch.frombuffer(bytearray(seg), dtype=_torch.int8)
-                    tensors[ref.tensor_idx].tensor[
-                        row, : ref.page_size_bytes
-                    ].copy_(buf)
-                    offset += ref.page_size_bytes
-                n_bytes += len(payload)
-            except Exception as exc:  # noqa: BLE001 - per-chunk T4 cell
-                failed_from = i
-                reason = f"{type(exc).__name__}: {exc}"
-                break
-    except Exception as exc:  # noqa: BLE001 - whole-job T4 cell
-        failed_from = 0
-        reason = f"{type(exc).__name__}: {exc}"
-
-    if failed_from is not None:
-        logger.warning(
-            "%s disk load job %d FAILED at chunk %d/%d (%s): zero-filling "
-            "the suffix and reporting invalid blocks (recompute)",
-            _GLM53_KVR_TAG,
-            job_id,
-            failed_from,
-            len(entries) or len(dst_ids),
-            reason,
-        )
-        for row in dst_ids[failed_from:]:
-            if row == 0:
-                continue
-            if tensors is not None and gpu_refs is not None:
+            for i, ent in enumerate(entries):
                 try:
+                    hash_hex = str(ent[0])
+                    egidx = int(ent[1])
+                    n_tokens = int(ent[3])
+                    if not _glm53_hex64(hash_hex):
+                        raise ValueError("entry hash is not 64-char hex")
+                    if egidx != gidx:
+                        raise ValueError("mixed groups in one disk load job")
+                    row = dst_ids[i]
+                    if row == 0:
+                        raise ValueError("null dst block in a disk load job")
+                    path = writer._file_path(hash_hex, gidx)
+                    header = glm53_read_chunk_header(path)
+                    led = ledger_by_hash.get(hash_hex)
+                    if (
+                        header.get("namespace_hash") != writer._namespace_hash
+                        or header.get("hash") != hash_hex
+                        or header.get("group_idx") != gidx
+                        or header.get("spec_kind") != expected_spec_kind
+                        or header.get("block_size_tokens")
+                        != expected_block_size
+                        or header.get("tp_rank") != writer._rank
+                        or header.get("tp_world") != writer._world
+                        or header.get("n_tokens_valid") != n_tokens
+                        or header.get("payload_len") != expected_len
+                        or led is None
+                        or (header["payload_len"], header["payload_crc32"])
+                        != (led[0], led[1])
+                    ):
+                        raise ValueError(
+                            f"chunk header/ledger identity mismatch: {path}"
+                        )
+                    if header.get("segment_table") != expected_segments:
+                        raise ValueError(f"segment table mismatch: {path}")
+                    payload = _glm53_read_chunk_payload(path, header)
+                    offset = 0
                     for ref in gpu_refs:
+                        seg = payload[offset : offset + ref.page_size_bytes]
+                        buf = _torch.frombuffer(
+                            bytearray(seg), dtype=_torch.int8
+                        )
                         tensors[ref.tensor_idx].tensor[
                             row, : ref.page_size_bytes
-                        ].zero_()
-                except Exception:  # noqa: BLE001 - reporting still fences
+                        ].copy_(buf)
+                        offset += ref.page_size_bytes
+                    n_bytes += len(payload)
+                except Exception as exc:  # noqa: BLE001 - per-chunk T4 cell
+                    failed_from = i
+                    reason = f"{type(exc).__name__}: {exc}"
+                    break
+        except Exception as exc:  # noqa: BLE001 - whole-job T4 cell
+            failed_from = 0
+            reason = f"{type(exc).__name__}: {exc}"
+
+        if failed_from is not None:
+            # Report FIRST (one atomic update; the ids are the T4 fence),
+            # then zero-fill best-effort.
+            cw._glm53_load_error_ids.update(
+                int(r) for r in dst_ids[failed_from:] if r != 0
+            )
+            logger.warning(
+                "%s disk load job %d FAILED at chunk %d/%d (%s): reported "
+                "%d invalid block(s), zero-filling the suffix (recompute)",
+                _GLM53_KVR_TAG,
+                job_id,
+                failed_from,
+                len(entries) or len(dst_ids),
+                reason,
+                len(dst_ids[failed_from:]),
+            )
+            if tensors is not None and gpu_refs is not None:
+                for row in dst_ids[failed_from:]:
+                    if row == 0:
+                        continue
+                    try:
+                        for ref in gpu_refs:
+                            tensors[ref.tensor_idx].tensor[
+                                row, : ref.page_size_bytes
+                            ].zero_()
+                    except Exception:  # noqa: BLE001 - ids already reported
+                        pass
+        else:
+            stats = getattr(cw._connector_worker_meta, "transfer_stats", None)
+            if stats is not None:
+                try:
+                    stats.load.record(n_bytes, _time.monotonic() - t0)
+                except Exception:  # noqa: BLE001 - stats are best-effort
                     pass
-            cw._glm53_load_error_ids.add(int(row))
-    else:
-        stats = getattr(cw._connector_worker_meta, "transfer_stats", None)
-        if stats is not None:
-            try:
-                stats.load.record(n_bytes, _time.monotonic() - t0)
-            except Exception:  # noqa: BLE001 - stats are best-effort
-                pass
-        logger.info(
-            "%s disk load job %d restored %d chunk(s), %d bytes, %.3f s",
-            _GLM53_KVR_TAG,
-            job_id,
-            len(entries),
-            n_bytes,
-            _time.monotonic() - t0,
-        )
-    cw._glm53_disk_done.append(job_id)
+            logger.info(
+                "%s disk load job %d restored %d chunk(s), %d bytes, %.3f s",
+                _GLM53_KVR_TAG,
+                job_id,
+                len(entries),
+                n_bytes,
+                _time.monotonic() - t0,
+            )
+    finally:
+        if job_id not in cw._glm53_disk_done:
+            cw._glm53_disk_done.append(job_id)
 
 
-def expected_segments_at(expected_segments):
+def _glm53_json_norm(segments):
     """JSON round-trip normalization for the header comparison."""
-    return _glm53_json.loads(_glm53_json.dumps(expected_segments))
+    return _glm53_json.loads(_glm53_json.dumps(segments))
 
 
 '''
@@ -874,7 +1044,45 @@ PATCHED_R10 = """    manifests = []
         for k in _glm53_cand_idxs:
 """
 
+# R11: _build_store_jobs asserts every in-flight job of a request is a store
+# (fixture scheduler :1401-1403). A request whose disk LOAD job is still
+# registered (aborted mid-load, or worker output delayed a step under async
+# scheduling) can reach store-job construction and trip the assert (Codex
+# OFFLOAD2-REVIEW finding 1, BLOCKER). Defer store creation for that request
+# instead: the stock invariant IS "stores only when no load is pending", and
+# next_stored_chunk_idx is untouched so nothing is lost -- the next step
+# reconsiders after the load completes.
+MARK_R11 = "            if req_status.transfer_jobs and not self._jobs[  # [glm53-kv-offload-restore] R11\n"
+
+ANCHOR_R11 = """            req_status = self._req_status.get(req_id)
+            if req_status is None:
+                continue
+            req = req_status.req
+
+            if req.status is RequestStatus.FINISHED_ABORTED:
+"""
+
+PATCHED_R11 = """            req_status = self._req_status.get(req_id)
+            if req_status is None:
+                continue
+            if req_status.transfer_jobs and not self._jobs[  # [glm53-kv-offload-restore] R11
+                next(iter(req_status.transfer_jobs))
+            ].is_store:
+                # A disk-restore LOAD job is still registered for this
+                # request (per the connector invariant, the only job then):
+                # defer store-job creation to a later step -- reaching the
+                # is_store assert below would crash the scheduler, and the
+                # stock invariant is exactly "stores only when no load is
+                # pending". next_stored_chunk_idx is untouched: nothing is
+                # lost.
+                continue
+            req = req_status.req
+
+            if req.status is RequestStatus.FINISHED_ABORTED:
+"""
+
 SITES_SCHED = (
+    ("R11 store-jobs load-defer guard", MARK_R11, ANCHOR_R11, PATCHED_R11),
     ("R1 restore state class", MARK_R1, ANCHOR_R1, PATCHED_R1),
     ("R2 disk lookup route", MARK_R2, ANCHOR_R2, PATCHED_R2),
     ("R3 restore state init", MARK_R3, ANCHOR_R3, PATCHED_R3),
@@ -1001,7 +1209,7 @@ PATCHED_W7 = """        # In-memory manifest index for inline K-boundary retenti
         self._glm53_boot_id = f"{_glm53_time.time():.0f}-{id(self):x}"
 """
 
-MARK_W8 = "            self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] publish\n"
+MARK_W8 = "                self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] publish\n"
 
 ANCHOR_W8 = """        with self._lock:
             self._manifest_index[boundary_hash] = {
@@ -1017,19 +1225,20 @@ PATCHED_W8 = """        with self._lock:
                 "boundary": cand["boundary_token_index"],
                 "mamba_keys": [(boundary_hash, g) for g in cow_groups],
             }
-            self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] publish
-                (
-                    "+",
-                    self._rank,
-                    self._namespace_hash,
-                    boundary_hash,
-                    cand["boundary_token_index"],
-                    self._glm53_boot_id,
+            if len(self._glm53_manifest_events) < 100000:  # bounded, fail closed
+                self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] publish
+                    (
+                        "+",
+                        self._rank,
+                        self._namespace_hash,
+                        boundary_hash,
+                        cand["boundary_token_index"],
+                        self._glm53_boot_id,
+                    )
                 )
-            )
 """
 
-MARK_W9 = "                self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] supersede\n"
+MARK_W9 = "                    self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] supersede\n"
 
 ANCHOR_W9 = """            with self._lock:
                 self._manifest_index.pop(boundary_hash, None)
@@ -1037,19 +1246,20 @@ ANCHOR_W9 = """            with self._lock:
 
 PATCHED_W9 = """            with self._lock:
                 self._manifest_index.pop(boundary_hash, None)
-                self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] supersede
-                    (
-                        "-",
-                        self._rank,
-                        self._namespace_hash,
-                        boundary_hash,
-                        entry["boundary"],
-                        self._glm53_boot_id,
+                if len(self._glm53_manifest_events) < 100000:  # bounded
+                    self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] supersede
+                        (
+                            "-",
+                            self._rank,
+                            self._namespace_hash,
+                            boundary_hash,
+                            entry["boundary"],
+                            self._glm53_boot_id,
+                        )
                     )
-                )
 """
 
-MARK_W10 = "            self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] write failure\n"
+MARK_W10 = "                self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] write failure\n"
 
 ANCHOR_W10 = """        self._files_dropped += 1
         with self._lock:
@@ -1061,16 +1271,17 @@ PATCHED_W10 = """        self._files_dropped += 1
             self._failed_keys.add((hash_hex, group_idx))
             # The per-job store failure bit, on the wire: the scheduler's
             # disk lookup denies boundaries whose keys failed on ANY rank.
-            self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] write failure
-                (
-                    "F",
-                    getattr(self, "_rank", -1),
-                    getattr(self, "_namespace_hash", ""),
-                    hash_hex,
-                    group_idx,
-                    self._glm53_boot_id,
+            if len(self._glm53_manifest_events) < 100000:  # bounded
+                self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] write failure
+                    (
+                        "F",
+                        getattr(self, "_rank", -1),
+                        getattr(self, "_namespace_hash", ""),
+                        hash_hex,
+                        group_idx,
+                        self._glm53_boot_id,
+                    )
                 )
-            )
 """
 
 # W11: validated dedup branch + the validator/drain methods (finding 9).
@@ -1138,7 +1349,9 @@ PATCHED_W12 = """    # [glm53-kv-offload-restore] manifest validation + event dr
             if (boundary_hash, gidx) in failed:
                 return False
             try:
-                fh = glm53_read_chunk_header(self._file_path(boundary_hash, gidx))
+                fh = glm53_read_chunk_header(
+                    self._file_path(boundary_hash, gidx), verify_payload=True
+                )
             except (OSError, ValueError):
                 return False
             if (
@@ -1152,7 +1365,9 @@ PATCHED_W12 = """    # [glm53-kv-offload-restore] manifest validation + event dr
                 if (h, gidx) in failed:
                     return False
                 try:
-                    fh = glm53_read_chunk_header(self._file_path(h, gidx))
+                    fh = glm53_read_chunk_header(
+                        self._file_path(h, gidx), verify_payload=True
+                    )
                 except (OSError, ValueError):
                     return False
                 if (
@@ -1165,6 +1380,23 @@ PATCHED_W12 = """    # [glm53-kv-offload-restore] manifest validation + event dr
 
     # ---- manifests ------------------------------------------------------
     def _finish_job(self, job) -> None:
+"""
+
+# W13: the store writer's existing-chunk dedup must verify the PAYLOAD, not
+# only the header (Codex OFFLOAD2-REVIEW finding 4: a stale file with a valid
+# unchanged header but torn payload must be rewritten, not deduped).
+MARK_W13 = "                h = glm53_read_chunk_header(path, verify_payload=True)  # [glm53-kv-offload-restore] dedup\n"
+
+ANCHOR_W13 = """            try:
+                h = glm53_read_chunk_header(path)
+                if (
+                    h.get("namespace_hash") == self._namespace_hash
+"""
+
+PATCHED_W13 = """            try:
+                h = glm53_read_chunk_header(path, verify_payload=True)  # [glm53-kv-offload-restore] dedup
+                if (
+                    h.get("namespace_hash") == self._namespace_hash
 """
 
 SITES_WORKER = (
@@ -1180,6 +1412,7 @@ SITES_WORKER = (
     ("W10 write-failure event", MARK_W10, ANCHOR_W10, PATCHED_W10),
     ("W11 validated dedup", MARK_W11, ANCHOR_W11, PATCHED_W11),
     ("W12 validator + drain methods", MARK_W12, ANCHOR_W12, PATCHED_W12),
+    ("W13 payload-verifying chunk dedup", MARK_W13, ANCHOR_W13, PATCHED_W13),
 )
 
 
@@ -1271,13 +1504,18 @@ def verified_state(text: str, sites) -> bool:
 def prepare(source: str, sites, label: str) -> tuple[str, str]:
     marks = sum(source.count(mark) for _n, mark, _a, _p in sites)
     if marks:
+        # This overlay is the LAST of the kv-offload trio -- nothing edits
+        # inside its patched regions afterwards, so the already-present path
+        # can and MUST verify the full patched blocks, not just the marks
+        # (Codex OFFLOAD2-REVIEW finding 10: a tampered file that kept its
+        # marker lines would otherwise pass silently).
         if marks != len(sites) or any(
             source.count(mark) != 1 for _n, mark, _a, _p in sites
-        ):
+        ) or not verified_state(source, sites):
             raise ValueError(
-                f"partial/inconsistent kv-offload-restore patch in {label} "
-                f"(marks={marks}, expected {len(sites)}) -- refusing to touch "
-                "a half-patched file"
+                f"partial/inconsistent/tampered kv-offload-restore patch in "
+                f"{label} (marks={marks}, expected {len(sites)}) -- refusing "
+                "to touch the file"
             )
         return source, "already present"
     for name, _mark, anchor, _patched in sites:

--- a/overlay/patch_kv_offload_restore_g0.py
+++ b/overlay/patch_kv_offload_restore_g0.py
@@ -1,0 +1,1378 @@
+#!/usr/bin/env python3
+"""Group-0 (full-attention) disk restore for the kv-offload tier
+(GLM53_KV_OFFLOAD_RESTORE).
+
+Stage 2 of the disk KV-offload plan (PLAN-KV-OFFLOAD.md §11): the tier can now
+READ BACK group-0 payloads (MLA + indexer KV) at 3584-token boundaries — on
+layouts where that is provably safe. Mamba (g2-5) and drafter (g6) groups are
+explicitly NOT restored in this stage.
+
+The honest headline (design doc + PR body carry it verbatim)
+------------------------------------------------------------
+**A group-0-only restore yields ZERO hit uplift on GLM-5.3-Flash itself, by
+design.** The connector's reconciled external hit is the min across all
+groups; the four mamba groups have no restore source in this stage, and
+reporting external tokens the mamba state cannot back would be served garbage.
+Additionally the core scheduler's invalid-block path is single-group
+(pinned fixture image_487ecf187_core_sched_scheduler.py:2954-2955:
+``(req_block_ids,) = self.kv_cache_manager.get_block_ids(req_id)`` under a
+``TODO (davidb): add support for hybrid memory allocator``) — a load-failure
+report on a multi-group layout would crash the core. The eligibility
+predicate therefore requires EXACTLY ONE TOTAL KV-cache group (Codex OFFLOAD2
+findings 1/2/6): on the live 7-group hybrid the restore machinery is INERT
+with one boot log line naming the reason, and serving is unchanged. What
+stage 2 proves, on a single-full-attention-group probe (exactly the shape of
+g0): wire-correct restore of g0 bytes through the §5 chain, and correct
+failure degradation (T4). What it cannot prove: any TTFT uplift on this
+model, or mamba state semantics (stage 3; harness under tests/).
+
+What this overlay does (five files; runs AFTER patch_kv_offload_scope.py AND
+patch_kv_offload_store_local.py — several anchors pin their patched output)
+---------------------------------------------------------------------------
+1. ``offloading/common.py`` — ``OffloadingWorkerMetadata`` gains
+   ``glm53_manifest_events`` (worker→scheduler manifest availability channel,
+   plan §4 C2: "workers report it; the scheduler takes the min across
+   ranks"); ``aggregate()`` concatenates it via ``getattr`` (legacy-meta
+   tolerant; Codex OFFLOAD2 finding 7).
+2. ``offloading/scheduler.py`` —
+   - ``Glm53RestoreState``: the eligibility predicate (one TOTAL group,
+     full-attention, blocks_per_chunk=1, prefix caching on, both knobs on),
+     the AND-across-ranks boundary registry fed by worker events ("+"
+     publish / "-" retention supersede / "F" store-write failure — the
+     per-job store-failure bit is ON THE WIRE and load-bearing at lookup:
+     a boundary whose g0 key failed on any rank is never offered), the
+     single-flight restore gate (concurrency=1; the gate stores the job id
+     and SELF-HEALS if the job vanished — finding 11), and the disk lookup
+     (keys/hashes only, NO filesystem access on the scheduler — finding 8;
+     contiguity needs no chain walk because prefix-cache block hashes are
+     prefix-CHAINED: boundary-hash equality implies an identical cumulative
+     chain).
+   - the stage-1 restore-off short-circuit now routes to the disk lookup
+     when GLM53_KV_OFFLOAD_RESTORE=1 (exactly one line replaced — every
+     piece of stage-1 bookkeeping around it is preserved; finding 12).
+   - ``update_state_after_alloc``: a disk hit skips ``manager.prepare_load``
+     entirely; the load job's ``src_spec`` is a versioned plain dict
+     (``{"glm53_disk_load": 1, "v": 1, namespace, boundary, entries}``,
+     entries aligned 1:1 with the dst blocks); the request gains
+     ``glm53_restored_boundary`` (END-EXCLUSIVE restored token count,
+     multiple of the chunk size; consumed by the T2 patch below; persists
+     for the request's lifetime so the restored anchor stays reachable in
+     every later cache_blocks — finding 10).
+   - preemption flush: the stock path asserts every in-flight job of a
+     preempted request is a store; a disk LOAD job is now skipped with the
+     gate cleared instead of asserting (finding 3).
+   - store-meta builder: boundary-manifest candidates now also exist on
+     layouts with NO recurrent groups (candidates = the job's full-group
+     chunk idxs); hybrid layouts are byte-identical to stage 1
+     (disposition S1 — without this a pure full-attention layout would
+     never publish a manifest and the lookup would answer from nothing).
+3. ``offloading/worker.py`` —
+   - ``_init_worker`` stashes the GPU-side CanonicalKVCaches;
+   - disk load jobs NEVER enter ``worker.submit_load``/``get_finished``'s
+     success asserts: ``_glm53_run_disk_load`` is a SYNCHRONOUS
+     pread → verify → scatter loop (one chunk at a time; restore
+     concurrency 1; no cross-step disk DMA exists, which IS the
+     preemption/reset fence — finding 4 disposition; stale completions are
+     discarded by the scheduler's ``_stale_job_threshold``);
+   - verification per chunk (finding 13): full-payload CRC, header identity
+     (namespace/hash/group/spec/block-size/tokens/rank/world/format), and
+     EXACT segment-table equality against the expectation derived from this
+     rank's own specs (the writer's ``_layer_segments`` derivation);
+     manifest re-validation on THIS rank before any pread;
+   - T4 (stage-2 contract): ANY failure zero-fills the failed chunk and
+     every later chunk's dst blocks, records their physical ids (never null
+     block 0) for ``get_block_ids_with_load_errors``, and the job STILL
+     completes — every terminal path acks + reports before the model
+     runner builds its output (finding 5; the mixin drains load errors
+     immediately after ``get_finished`` — receipt in the design doc);
+   - the stage-1 writer (store overlay's injected class) gains manifest
+     EVENTS: "+" on validated publish, "-" on retention supersede, "F" on a
+     write failure; the pre-existing-manifest dedup branch now VALIDATES
+     the manifest and every referenced chunk header before registering or
+     announcing it, and applies retention (finding 9);
+   - ``build_connector_worker_meta`` returns a meta when events are pending
+     even with zero completed jobs (finding 7).
+4. ``offloading_connector.py`` (facade) — ``get_block_ids_with_load_errors``
+   override draining the worker-side error set (the base default returns
+   empty; the model-runner mixin consumes it into
+   ``KVConnectorOutput.invalid_block_ids``).
+5. ``v1/core/single_type_kv_cache_manager.py`` — T2: ``cache_blocks`` appends
+   ``request.glm53_restored_boundary`` (when set) to ``reachable_boundaries``
+   so sparse retention masks (SWA/Mamba subclasses) can never silently drop
+   a restored boundary's re-entry; dense (full-attention) masks are
+   unaffected (mask None). Live-relevant from stage 3; host-tested now.
+
+Kill switch: GLM53_KV_OFFLOAD_RESTORE=0 (default) keeps stage-1 behavior —
+the lookup short-circuit still returns 0 external hits, no load jobs, no
+WAITING_FOR_REMOTE_KVS. The launcher refuses RESTORE=1 unless
+GLM53_KV_OFFLOAD=1.
+
+Conventions follow the stage-1 patchers: pinned ANCHORs, MARK sentinels,
+``verified_state``, ``prepare``, idempotent, atomic replace, pyc clear,
+drift => nonzero. ALL anchors in ALL five files preflight before ANY write.
+MUST run AFTER patch_kv_offload_scope.py + patch_kv_offload_store_local.py.
+
+Usage::
+
+    python3 patch_kv_offload_restore_g0.py              # apply
+    python3 patch_kv_offload_restore_g0.py --preflight  # validate anchors only
+"""
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+VLLM_ROOT = os.environ.get(
+    "GLM53_VLLM_ROOT", "/usr/local/lib/python3.12/dist-packages/vllm"
+)
+_CONN = "distributed/kv_transfer/kv_connector/v1/offloading"
+
+TARGET_COMMON = Path(
+    os.environ.get("GLM53_KVO_COMMON_PY", f"{VLLM_ROOT}/{_CONN}/common.py")
+)
+TARGET_SCHED = Path(
+    os.environ.get("GLM53_KVO_SCHED_PY", f"{VLLM_ROOT}/{_CONN}/scheduler.py")
+)
+TARGET_WORKER = Path(
+    os.environ.get("GLM53_KVO_WORKER_PY", f"{VLLM_ROOT}/{_CONN}/worker.py")
+)
+TARGET_FACADE = Path(
+    os.environ.get(
+        "GLM53_KVO_FACADE_PY",
+        f"{VLLM_ROOT}/distributed/kv_transfer/kv_connector/v1/offloading_connector.py",
+    )
+)
+TARGET_SINGLE_TYPE = Path(
+    os.environ.get(
+        "GLM53_SINGLE_TYPE_PY",
+        f"{VLLM_ROOT}/v1/core/single_type_kv_cache_manager.py",
+    )
+)
+
+TAG = "[glm53-kv-offload-restore]"
+ENV_RESTORE = "GLM53_KV_OFFLOAD_RESTORE"
+
+
+# ---------------------------------------------------------------------------
+# Scheduler-side injected source: Glm53RestoreState.
+# Uses _glm53_kvo_restore_enabled/_glm53_kvo_store_local_enabled from the
+# store overlay's mode helpers (injected earlier in scheduler.py).
+# ---------------------------------------------------------------------------
+RESTORE_SCHED_SRC = '''# [glm53-kv-offload-restore] scheduler-side disk-restore state
+_GLM53_KVR_TAG = "[glm53-kv-offload-restore]"
+_GLM53_KVR_SPEC_V = 1
+
+
+class Glm53RestoreState:
+    """Disk-restore lookup state: eligibility, the AND-across-ranks manifest
+    registry (worker events), the single-flight gate, and the boundary
+    lookup. Keys/hashes only -- the scheduler NEVER touches the filesystem
+    (plan R0; Codex OFFLOAD2 finding 8)."""
+
+    def __init__(self, config, vllm_config, log):
+        self._log = log
+        self._config = config
+        self._inflight_job = None
+        self._namespace = None
+        # boundary_hash -> {"ranks": set[int], "tokens": int}
+        self._boundaries = {}
+        # (hash_hex, group_idx) whose store WRITE failed on any rank this
+        # boot -- the per-job store failure bit, on the wire and load-bearing
+        # at lookup (stage-1 known limit closed per the task contract).
+        self._failed_keys = set()
+        # req_id -> pending disk-hit boundary (end-exclusive tokens), set by
+        # lookup, consumed by update_state_after_alloc, dropped on miss/reset.
+        self._pending_hits = {}
+        self._ns_mismatch_logged = False
+
+        reason = None
+        try:
+            restore_on = _glm53_kvo_restore_enabled()
+            store_on = _glm53_kvo_store_local_enabled()
+        except ValueError as exc:
+            restore_on = store_on = False
+            reason = str(exc)
+        if reason is None and not restore_on:
+            reason = "GLM53_KV_OFFLOAD_RESTORE=0"
+        elif reason is None and not store_on:
+            reason = "GLM53_KV_OFFLOAD=0 (restore reads the store tier)"
+        elif reason is None and config.blocks_per_chunk != 1:
+            reason = f"blocks_per_chunk={config.blocks_per_chunk} (need 1)"
+        elif reason is None and (
+            config.num_kv_cache_groups != 1 or len(config.kv_group_configs) != 1
+        ):
+            # ONE TOTAL group required, not one eligible group (Codex
+            # OFFLOAD2 finding 2): an excluded scratch/drafter group would
+            # still be a core KV-cache group the restored tokens cannot
+            # back; and the core invalid-block path is single-group (pinned
+            # fixture image_487ecf187_core_sched_scheduler.py:2954-2955).
+            reason = (
+                f"layout has {config.num_kv_cache_groups} KV-cache groups "
+                f"({len(config.kv_group_configs)} eligible): g0-only restore "
+                "yields no external hits on a hybrid layout by design"
+            )
+        elif reason is None:
+            g = config.kv_group_configs[0]
+            if g.sliding_window_size_in_chunks is not None:
+                reason = f"group {g.group_idx} is not full-attention"
+            elif g.requires_cow_source:
+                reason = f"group {g.group_idx} has recurrent (mamba) semantics"
+            elif g.is_eagle_group:
+                reason = f"group {g.group_idx} is a draft-model group"
+            elif not bool(
+                getattr(
+                    getattr(vllm_config, "cache_config", None),
+                    "enable_prefix_caching",
+                    False,
+                )
+            ):
+                reason = "prefix caching disabled"
+        self.disabled_reason = reason
+        if reason is not None and restore_on:
+            self._log.info(
+                "%s restore INERT on this layout: %s", _GLM53_KVR_TAG, reason
+            )
+        elif reason is None:
+            self._log.info(
+                "%s g0 disk restore ACTIVE (single full-attention group %d, "
+                "chunk %d tokens, %d workers)",
+                _GLM53_KVR_TAG,
+                config.kv_group_configs[0].group_idx,
+                config.kv_group_configs[0].tokens_per_chunk,
+                config.num_workers,
+            )
+
+    # ---- worker event registry (plan C2: min across ranks) --------------
+    def consume_events(self, events) -> None:
+        for ev in events:
+            try:
+                code = ev[0]
+                rank = int(ev[1])
+                ns = str(ev[2])
+                key = str(ev[3])
+                aux = int(ev[4])
+            except (TypeError, ValueError, IndexError):
+                continue
+            if self._namespace is None:
+                self._namespace = ns
+            if ns != self._namespace:
+                if not self._ns_mismatch_logged:
+                    self._ns_mismatch_logged = True
+                    self._log.warning(
+                        "%s dropping events from foreign namespace %s "
+                        "(registry pinned to %s)",
+                        _GLM53_KVR_TAG,
+                        ns[:12],
+                        self._namespace[:12],
+                    )
+                continue
+            if code == "+":
+                entry = self._boundaries.setdefault(
+                    key, {"ranks": set(), "tokens": aux}
+                )
+                if entry["tokens"] != aux:
+                    # Same hash, different boundary tokens: corrupt or a
+                    # collision -- drop the boundary entirely, fail closed.
+                    self._boundaries.pop(key, None)
+                    continue
+                entry["ranks"].add(rank)
+            elif code == "-":
+                entry = self._boundaries.get(key)
+                if entry is not None:
+                    entry["ranks"].discard(rank)
+                    if not entry["ranks"]:
+                        self._boundaries.pop(key, None)
+            elif code == "F":
+                self._failed_keys.add((key, aux))
+
+    # ---- single-flight gate (finding 11: self-healing invariant) --------
+    def job_started(self, job_id: int) -> None:
+        self._inflight_job = job_id
+
+    def job_done(self, job_id: int) -> None:
+        if self._inflight_job == job_id:
+            self._inflight_job = None
+
+    def reset(self) -> None:
+        self._inflight_job = None
+        self._pending_hits.clear()
+
+    # ---- the lookup -----------------------------------------------------
+    def take_pending_hit(self, req_id):
+        return self._pending_hits.pop(req_id, None)
+
+    def lookup(self, sched, req_status):
+        """Disk-manifest boundary lookup. Returns hit tokens (0 = miss,
+        None = defer while another restore is in flight)."""
+        req_id = req_status.req.request_id
+        self._pending_hits.pop(req_id, None)
+        if self.disabled_reason is not None:
+            return 0
+        cfg = self._config.kv_group_configs[0]
+        tpc = cfg.tokens_per_chunk
+        hpc = cfg.hashes_per_chunk
+        req = req_status.req
+        local = req_status.num_locally_computed_tokens
+        if local % tpc != 0:
+            # v1 restores at chunk boundaries only (plan F6): a fine-grained
+            # local hit tail is not extended from disk.
+            return 0
+        if self._inflight_job is not None:
+            if self._inflight_job in sched._jobs:
+                # Restore concurrency = 1: defer; the stock deferred-lookup
+                # machinery re-queries this request later.
+                return None
+            # The job vanished (reset/terminal path missed): self-heal.
+            self._inflight_job = None
+        max_chunk = min(req.num_tokens // tpc, len(req.block_hashes) // hpc)
+        for k in range(max_chunk - 1, local // tpc - 1, -1):
+            bhash = bytes(req.block_hashes[(k + 1) * hpc - 1]).hex()
+            entry = self._boundaries.get(bhash)
+            if entry is None:
+                continue
+            if entry["tokens"] != (k + 1) * tpc:
+                continue
+            if len(entry["ranks"]) < self._config.num_workers:
+                continue
+            if (bhash, cfg.group_idx) in self._failed_keys:
+                continue
+            hit = (k + 1) * tpc - local
+            if hit <= 0:
+                return 0
+            self._pending_hits[req_id] = (k + 1) * tpc
+            return hit
+        return 0
+
+    def build_load_spec(self, request, req_status, boundary_tokens, num_cached):
+        """The versioned plain-dict src_spec for a disk load job. Entries are
+        aligned 1:1 with the job's dst block order; a scheduler-side
+        inconsistency ships an empty-entry spec, which the worker turns into
+        an all-chunks-failed job (T4 degradation, never a guess)."""
+        cfg = self._config.kv_group_configs[0]
+        tpc = cfg.tokens_per_chunk
+        hpc = cfg.hashes_per_chunk
+        local = req_status.num_locally_computed_tokens
+        entries = []
+        if (
+            boundary_tokens == num_cached
+            and local % tpc == 0
+            and boundary_tokens % tpc == 0
+            and boundary_tokens // hpc // (tpc // hpc) <= len(request.block_hashes)
+        ):
+            for j in range(local // tpc, boundary_tokens // tpc):
+                entries.append(
+                    (
+                        bytes(request.block_hashes[(j + 1) * hpc - 1]).hex(),
+                        cfg.group_idx,
+                        j,
+                        tpc,
+                    )
+                )
+        else:
+            self._log.error(
+                "%s disk-hit shape mismatch for %s (boundary %d, cached %d): "
+                "shipping an all-fail load spec (recompute)",
+                _GLM53_KVR_TAG,
+                request.request_id,
+                boundary_tokens,
+                num_cached,
+            )
+        return {
+            "glm53_disk_load": 1,
+            "v": _GLM53_KVR_SPEC_V,
+            "namespace_hash": self._namespace,
+            "boundary_token_index": boundary_tokens,
+            "entries": entries,
+        }
+
+
+'''
+
+# ---------------------------------------------------------------------------
+# Worker-side injected source: the synchronous disk loader.
+# Uses the store overlay's codec + writer accessors (injected earlier).
+# ---------------------------------------------------------------------------
+RESTORE_WORKER_SRC = '''# [glm53-kv-offload-restore] worker-side synchronous disk loader
+_GLM53_KVR_TAG = "[glm53-kv-offload-restore]"
+_GLM53_KVR_SPEC_V = 1
+
+
+def _glm53_attach_manifest_events(cw) -> None:
+    """Drain the store writer's manifest events into the worker meta."""
+    writer = cw._glm53_store_writer
+    if writer is None:
+        return
+    drain = getattr(writer, "drain_manifest_events", None)
+    if drain is None:
+        return
+    events = drain()
+    if not events:
+        return
+    meta_events = getattr(
+        cw._connector_worker_meta, "glm53_manifest_events", None
+    )
+    if meta_events is None:
+        logger.warning(
+            "%s worker meta lacks glm53_manifest_events (common.py not "
+            "patched?) -- dropping %d events",
+            _GLM53_KVR_TAG,
+            len(events),
+        )
+        return
+    meta_events.extend(events)
+
+
+def _glm53_drain_disk_loads(cw):
+    done = cw._glm53_disk_done
+    cw._glm53_disk_done = []
+    return done
+
+
+def _glm53_expected_segments(writer, gidx, gpu_refs):
+    """The exact segment table this rank expects for one chunk of group
+    ``gidx`` -- derived from the same spec walk the writer's gather uses, so
+    header equality proves layer identity/shape/dtype/offset/length, not
+    just a total byte count (Codex OFFLOAD2 finding 13)."""
+    group = writer._kv_groups[gidx]
+    layer_names = list(group.layer_names)
+    segments = []
+    offset = 0
+    for i, ref in enumerate(gpu_refs):
+        layer = layer_names[i] if i < len(layer_names) else f"ref{i}"
+        segments.extend(
+            writer._layer_segments(group, layer, offset, ref.page_size_bytes)
+        )
+        offset += ref.page_size_bytes
+    return segments, offset
+
+
+def _glm53_read_chunk_payload(path, header):
+    """Read one chunk's payload bytes (the codec's header reader validates
+    structure/length; this re-reads the payload and CRC-checks it)."""
+    import zlib as _zlib
+
+    with open(path, "rb") as f:
+        blob = f.read()
+    hlen = int.from_bytes(blob[8:12], "little")
+    payload = blob[16 + hlen :]
+    if len(payload) != header["payload_len"]:
+        raise ValueError(f"payload length changed under us in {path!r}")
+    if (_zlib.crc32(payload) & 0xFFFFFFFF) != header["payload_crc32"]:
+        raise ValueError(f"payload crc mismatch in {path!r}")
+    return payload
+
+
+def _glm53_run_disk_load(cw, job_id, src_spec, dst_spec) -> None:
+    """Synchronous disk restore of one load job (restore concurrency = 1).
+
+    Terminal-result contract (Codex OFFLOAD2 finding 5): EVERY exit -- happy
+    path, precondition failure, manifest failure, per-chunk pread/header/
+    CRC/segment/scatter failure -- marks the job done (drained by
+    get_finished, which acks + reports finished_recving) and, for failures,
+    zero-fills the failed chunk and every later chunk's dst blocks and
+    records their physical ids for get_block_ids_with_load_errors. The copy
+    runs entirely inside this engine step: there is no cross-step disk DMA
+    to fence (the preemption/reset fence of finding 4), and a late ack after
+    reset_cache is discarded by the scheduler's _stale_job_threshold."""
+    import time as _time
+
+    dst_ids = [int(b) for b in dst_spec.block_ids]
+    failed_from = None
+    reason = None
+    tensors = None
+    gpu_refs = None
+    n_bytes = 0
+    t0 = _time.monotonic()
+    entries = []
+    try:
+        writer = _glm53_get_store_writer(cw)
+        if writer._disabled_reason is not None:
+            raise ValueError(f"store writer disabled: {writer._disabled_reason}")
+        if not isinstance(src_spec, dict) or src_spec.get("v") != _GLM53_KVR_SPEC_V:
+            raise ValueError(
+                f"unknown disk-load spec version {src_spec.get('v')!r}"
+            )
+        if src_spec.get("namespace_hash") != writer._namespace_hash:
+            raise ValueError("disk-load namespace mismatch")
+        entries = list(src_spec.get("entries") or [])
+        if not entries or len(entries) != len(dst_ids):
+            raise ValueError(
+                f"{len(entries)} entries vs {len(dst_ids)} dst blocks"
+            )
+        gidx = int(entries[0][1])
+        if gidx not in writer._eligible_groups:
+            raise ValueError(f"group {gidx} not eligible on this rank")
+        caches = cw._glm53_gpu_caches
+        if caches is None:
+            raise ValueError("GPU canonical caches not registered")
+        tensors = caches.tensors
+        gpu_refs = list(caches.group_data_refs[gidx])
+        staging_refs = writer._refs_per_group[gidx]
+        if [r.page_size_bytes for r in gpu_refs] != [
+            r.page_size_bytes for r in staging_refs
+        ]:
+            raise ValueError("GPU vs staging ref layout mismatch")
+        for ref in gpu_refs:
+            if getattr(ref, "mapping", None) is not None:
+                # A canonical mapping means a raw row copy is NOT the
+                # inverse of the store-side gather: fail closed.
+                raise ValueError("canonical-mapped layout not restorable (v1)")
+        expected_segments, expected_len = _glm53_expected_segments(
+            writer, gidx, gpu_refs
+        )
+
+        # Manifest re-validation on THIS rank before any pread (finding 8:
+        # each worker validates its own store; a retention race or missing
+        # manifest degrades to recompute, never to a guess).
+        boundary_hash = str(entries[-1][0])
+        mpath = writer._manifest_path(boundary_hash)
+        with open(mpath, encoding="utf-8") as f:
+            man = _glm53_json.load(f)
+        if (
+            man.get("namespace_hash") != writer._namespace_hash
+            or man.get("boundary_token_index")
+            != src_spec.get("boundary_token_index")
+            or (man.get("chunk_hashes") or [])[-1:] != [boundary_hash]
+        ):
+            raise ValueError("manifest identity mismatch at load time")
+
+        import torch as _torch
+
+        for i, ent in enumerate(entries):
+            try:
+                hash_hex = str(ent[0])
+                egidx = int(ent[1])
+                n_tokens = int(ent[3])
+                if egidx != gidx:
+                    raise ValueError("mixed groups in one disk load job")
+                row = dst_ids[i]
+                if row == 0:
+                    raise ValueError("null dst block in a disk load job")
+                path = writer._file_path(hash_hex, gidx)
+                header = glm53_read_chunk_header(path)
+                if (
+                    header.get("namespace_hash") != writer._namespace_hash
+                    or header.get("hash") != hash_hex
+                    or header.get("group_idx") != gidx
+                    or header.get("tp_rank") != writer._rank
+                    or header.get("tp_world") != writer._world
+                    or header.get("n_tokens_valid") != n_tokens
+                    or header.get("payload_len") != expected_len
+                ):
+                    raise ValueError(f"chunk header identity mismatch: {path}")
+                if header.get("segment_table") != expected_segments_at(
+                    expected_segments
+                ):
+                    raise ValueError(f"segment table mismatch: {path}")
+                payload = _glm53_read_chunk_payload(path, header)
+                offset = 0
+                for ref in gpu_refs:
+                    seg = payload[offset : offset + ref.page_size_bytes]
+                    buf = _torch.frombuffer(bytearray(seg), dtype=_torch.int8)
+                    tensors[ref.tensor_idx].tensor[
+                        row, : ref.page_size_bytes
+                    ].copy_(buf)
+                    offset += ref.page_size_bytes
+                n_bytes += len(payload)
+            except Exception as exc:  # noqa: BLE001 - per-chunk T4 cell
+                failed_from = i
+                reason = f"{type(exc).__name__}: {exc}"
+                break
+    except Exception as exc:  # noqa: BLE001 - whole-job T4 cell
+        failed_from = 0
+        reason = f"{type(exc).__name__}: {exc}"
+
+    if failed_from is not None:
+        logger.warning(
+            "%s disk load job %d FAILED at chunk %d/%d (%s): zero-filling "
+            "the suffix and reporting invalid blocks (recompute)",
+            _GLM53_KVR_TAG,
+            job_id,
+            failed_from,
+            len(entries) or len(dst_ids),
+            reason,
+        )
+        for row in dst_ids[failed_from:]:
+            if row == 0:
+                continue
+            if tensors is not None and gpu_refs is not None:
+                try:
+                    for ref in gpu_refs:
+                        tensors[ref.tensor_idx].tensor[
+                            row, : ref.page_size_bytes
+                        ].zero_()
+                except Exception:  # noqa: BLE001 - reporting still fences
+                    pass
+            cw._glm53_load_error_ids.add(int(row))
+    else:
+        stats = getattr(cw._connector_worker_meta, "transfer_stats", None)
+        if stats is not None:
+            try:
+                stats.load.record(n_bytes, _time.monotonic() - t0)
+            except Exception:  # noqa: BLE001 - stats are best-effort
+                pass
+        logger.info(
+            "%s disk load job %d restored %d chunk(s), %d bytes, %.3f s",
+            _GLM53_KVR_TAG,
+            job_id,
+            len(entries),
+            n_bytes,
+            _time.monotonic() - t0,
+        )
+    cw._glm53_disk_done.append(job_id)
+
+
+def expected_segments_at(expected_segments):
+    """JSON round-trip normalization for the header comparison."""
+    return _glm53_json.loads(_glm53_json.dumps(expected_segments))
+
+
+'''
+
+
+# ===========================================================================
+# File 1: offloading/common.py — worker-meta manifest-event channel
+# ===========================================================================
+MARK_M1 = "    glm53_manifest_events: list = field(default_factory=list)  # [glm53-kv-offload-restore]\n"
+
+ANCHOR_M1 = """    completed_jobs: dict[int, int] = field(default_factory=dict)
+    transfer_stats: TransferStats = field(default_factory=TransferStats)
+
+    def mark_completed(self, job_id: int) -> None:
+"""
+
+PATCHED_M1 = """    completed_jobs: dict[int, int] = field(default_factory=dict)
+    transfer_stats: TransferStats = field(default_factory=TransferStats)
+    # Manifest availability events from this rank's store writer:
+    # ("+"|"-"|"F", rank, namespace_hash, key, aux, writer_boot_id) where
+    # key/aux = (boundary_hash, boundary_token_index) for +/- and
+    # (chunk_hash, group_idx) for F. Plain tuples: picklable on the wire.
+    glm53_manifest_events: list = field(default_factory=list)  # [glm53-kv-offload-restore]
+
+    def mark_completed(self, job_id: int) -> None:
+"""
+
+MARK_M2 = "            glm53_manifest_events=(  # [glm53-kv-offload-restore]\n"
+
+ANCHOR_M2 = """        return OffloadingWorkerMetadata(
+            completed_jobs=merged,
+            transfer_stats=self.transfer_stats.aggregate(other.transfer_stats),
+        )
+"""
+
+PATCHED_M2 = """        return OffloadingWorkerMetadata(
+            completed_jobs=merged,
+            transfer_stats=self.transfer_stats.aggregate(other.transfer_stats),
+            glm53_manifest_events=(  # [glm53-kv-offload-restore]
+                # getattr: tolerate a legacy meta without the field (Codex
+                # OFFLOAD2 finding 7).
+                list(getattr(self, "glm53_manifest_events", ()))
+                + list(getattr(other, "glm53_manifest_events", ()))
+            ),
+        )
+"""
+
+SITES_COMMON = (
+    ("M1 worker-meta event field", MARK_M1, ANCHOR_M1, PATCHED_M1),
+    ("M2 aggregate concatenates events", MARK_M2, ANCHOR_M2, PATCHED_M2),
+)
+
+
+# ===========================================================================
+# File 2: offloading/scheduler.py
+# ===========================================================================
+MARK_R1 = "# [glm53-kv-offload-restore] scheduler-side disk-restore state\n"
+
+ANCHOR_R1 = """class OffloadingConnectorScheduler:
+"""
+
+PATCHED_R1 = RESTORE_SCHED_SRC + ANCHOR_R1
+
+# R2: route the enabled-restore lookup to the disk lookup (one line; every
+# piece of stage-1 bookkeeping around it is preserved -- finding 12).
+MARK_R2 = "            num_hit_tokens = self._glm53_restore.lookup(self, req_status)  # [glm53-kv-offload-restore]\n"
+
+ANCHOR_R2 = """            num_hit_tokens = self._lookup(req_status)
+"""
+
+PATCHED_R2 = """            # Restore reads the DISK tier only: the CPU staging tier is a
+            # bounce buffer, never a restore source; self._lookup (the
+            # manager lookup) stays unused under this fork.
+            num_hit_tokens = self._glm53_restore.lookup(self, req_status)  # [glm53-kv-offload-restore]
+"""
+
+MARK_R3 = "        self._glm53_restore = Glm53RestoreState(  # [glm53-kv-offload-restore]\n"
+
+ANCHOR_R3 = """        self._events_tracker = OffloadingEventsTracker(spec.kv_events_config)
+"""
+
+PATCHED_R3 = """        self._events_tracker = OffloadingEventsTracker(spec.kv_events_config)
+        self._glm53_restore = Glm53RestoreState(  # [glm53-kv-offload-restore]
+            self.config, vllm_config, logger
+        )
+"""
+
+# R4: update_state_after_alloc -- disk hits skip the manager entirely.
+MARK_R4 = "        _glm53_boundary = self._glm53_restore.take_pending_hit(  # [glm53-kv-offload-restore]\n"
+
+ANCHOR_R4 = """        src_spec = self.manager.prepare_load(keys_to_load, req_status.req_context)
+        dst_spec = GPULoadStoreSpec(
+            dst_block_ids, group_sizes=group_sizes, block_indices=block_indices
+        )
+"""
+
+PATCHED_R4 = """        _glm53_boundary = self._glm53_restore.take_pending_hit(  # [glm53-kv-offload-restore]
+            request.request_id
+        )
+        if _glm53_boundary is not None:
+            # Disk-restore load job: keys/hashes only (the worker derives
+            # its own paths); no manager staging involvement, so
+            # keys_to_load empties -- TransferJobStatus.keys becomes empty
+            # and complete_load(set()) is a no-op by construction.
+            keys_to_load = []
+            src_spec = self._glm53_restore.build_load_spec(
+                request, req_status, _glm53_boundary, num_cached_tokens
+            )
+            # T2 (finding 10): END-EXCLUSIVE restored token count; persists
+            # for the request's lifetime so the restored boundary stays
+            # reachable in every later cache_blocks of this request.
+            request.glm53_restored_boundary = _glm53_boundary
+        else:
+            src_spec = self.manager.prepare_load(keys_to_load, req_status.req_context)
+        dst_spec = GPULoadStoreSpec(
+            dst_block_ids, group_sizes=group_sizes, block_indices=block_indices
+        )
+"""
+
+# R5: register the single-flight gate on the created load job.
+MARK_R5 = "        if _glm53_boundary is not None:  # [glm53-kv-offload-restore] gate\n"
+
+ANCHOR_R5 = """        self._jobs[load_job_id] = TransferJobStatus(
+            req_id=request.request_id,
+            pending_count=self.config.num_workers,
+            keys=set(keys_to_load),
+            is_store=False,
+        )
+"""
+
+PATCHED_R5 = """        self._jobs[load_job_id] = TransferJobStatus(
+            req_id=request.request_id,
+            pending_count=self.config.num_workers,
+            keys=set(keys_to_load),
+            is_store=False,
+        )
+        if _glm53_boundary is not None:  # [glm53-kv-offload-restore] gate
+            self._glm53_restore.job_started(load_job_id)
+"""
+
+# R6: consume worker manifest events.
+MARK_R6 = "        self._glm53_restore.consume_events(  # [glm53-kv-offload-restore]\n"
+
+ANCHOR_R6 = """        meta = connector_output.kv_connector_worker_meta
+        if not isinstance(meta, OffloadingWorkerMetadata):
+            assert meta is None
+            meta = OffloadingWorkerMetadata()
+"""
+
+PATCHED_R6 = """        meta = connector_output.kv_connector_worker_meta
+        if not isinstance(meta, OffloadingWorkerMetadata):
+            assert meta is None
+            meta = OffloadingWorkerMetadata()
+        self._glm53_restore.consume_events(  # [glm53-kv-offload-restore]
+            getattr(meta, "glm53_manifest_events", None) or ()
+        )
+"""
+
+# R7: completion clears the gate.
+MARK_R7 = "                self._glm53_restore.job_done(job_id)  # [glm53-kv-offload-restore]\n"
+
+ANCHOR_R7 = """            else:
+                self.manager.complete_load(job_status.keys, req_status.req_context)
+                if self._chunks_being_loaded:
+                    self._chunks_being_loaded.difference_update(job_status.keys)
+"""
+
+PATCHED_R7 = """            else:
+                self.manager.complete_load(job_status.keys, req_status.req_context)
+                if self._chunks_being_loaded:
+                    self._chunks_being_loaded.difference_update(job_status.keys)
+                self._glm53_restore.job_done(job_id)  # [glm53-kv-offload-restore]
+"""
+
+# R8: reset clears the gate + pending hits.
+MARK_R8 = "        self._glm53_restore.reset()  # [glm53-kv-offload-restore]\n"
+
+ANCHOR_R8 = """        # Discard jobs and save job_counter to be able to discard worker responses
+        self._stale_job_threshold = self._job_counter
+        self._jobs.clear()
+"""
+
+PATCHED_R8 = """        # Discard jobs and save job_counter to be able to discard worker responses
+        self._stale_job_threshold = self._job_counter
+        self._jobs.clear()
+        self._glm53_restore.reset()  # [glm53-kv-offload-restore]
+"""
+
+# R9: preemption flush must not assert on a disk LOAD job (finding 3).
+MARK_R9 = "            if not self._jobs[any_jid].is_store:  # [glm53-kv-offload-restore]\n"
+
+ANCHOR_R9 = """            any_jid = next(iter(req_status.transfer_jobs))
+            assert self._jobs[any_jid].is_store
+            self._current_batch_jobs_to_flush.update(req_status.transfer_jobs)
+"""
+
+PATCHED_R9 = """            any_jid = next(iter(req_status.transfer_jobs))
+            if not self._jobs[any_jid].is_store:  # [glm53-kv-offload-restore]
+                # A disk-restore load job (per the connector invariant, the
+                # ONLY job then): not flushable through the store path. The
+                # synchronous loader already ran (or acks next step) and a
+                # late ack after reset is fenced by _stale_job_threshold;
+                # clear the single-flight gate so the re-admitted request
+                # re-runs the manifest lookup (T5).
+                self._glm53_restore.job_done(any_jid)
+                continue
+            self._current_batch_jobs_to_flush.update(req_status.transfer_jobs)
+"""
+
+# R10: manifest candidates on zero-cow layouts (disposition S1). Anchors the
+# store overlay's injected meta-builder text.
+MARK_R10 = "        if cow_groups:  # [glm53-kv-offload-restore] S1\n"
+
+ANCHOR_R10 = """    manifests = []
+    if (
+        cow_groups
+        and full_groups
+        and len(set(tokens_per_chunk.values())) == 1
+        and len(set(hashes_per_chunk.values())) == 1
+    ):
+        stride = next(iter(hashes_per_chunk.values()))
+        tokens = next(iter(tokens_per_chunk.values()))
+        for k in sorted(mamba_chunk_idxs):
+"""
+
+PATCHED_R10 = """    manifests = []
+    if (
+        full_groups
+        and len(set(tokens_per_chunk.values())) == 1
+        and len(set(hashes_per_chunk.values())) == 1
+    ):
+        stride = next(iter(hashes_per_chunk.values()))
+        tokens = next(iter(tokens_per_chunk.values()))
+        # Boundary candidates: mamba chunk idxs on hybrid layouts (byte-
+        # identical to stage 1); on layouts with NO recurrent groups (the
+        # g0-isolating probe) every full-group chunk in this job is a
+        # candidate -- without this a pure full-attention layout would never
+        # publish a manifest and the disk lookup would answer from nothing.
+        if cow_groups:  # [glm53-kv-offload-restore] S1
+            _glm53_cand_idxs = sorted(mamba_chunk_idxs)
+        else:
+            _glm53_cand_idxs = sorted(
+                {c for _h, g, c, _t in keys if g in full_groups}
+            )
+        for k in _glm53_cand_idxs:
+"""
+
+SITES_SCHED = (
+    ("R1 restore state class", MARK_R1, ANCHOR_R1, PATCHED_R1),
+    ("R2 disk lookup route", MARK_R2, ANCHOR_R2, PATCHED_R2),
+    ("R3 restore state init", MARK_R3, ANCHOR_R3, PATCHED_R3),
+    ("R4 disk load spec", MARK_R4, ANCHOR_R4, PATCHED_R4),
+    ("R5 single-flight gate", MARK_R5, ANCHOR_R5, PATCHED_R5),
+    ("R6 consume events", MARK_R6, ANCHOR_R6, PATCHED_R6),
+    ("R7 completion clears gate", MARK_R7, ANCHOR_R7, PATCHED_R7),
+    ("R8 reset clears gate", MARK_R8, ANCHOR_R8, PATCHED_R8),
+    ("R9 preemption load-job guard", MARK_R9, ANCHOR_R9, PATCHED_R9),
+    ("R10 zero-cow manifest candidates", MARK_R10, ANCHOR_R10, PATCHED_R10),
+)
+
+
+# ===========================================================================
+# File 3: offloading/worker.py
+# ===========================================================================
+MARK_W1 = "# [glm53-kv-offload-restore] worker-side synchronous disk loader\n"
+
+ANCHOR_W1 = """class OffloadingConnectorWorker:
+"""
+
+PATCHED_W1 = RESTORE_WORKER_SRC + ANCHOR_W1
+
+# W2: per-worker restore state (anchors the store overlay's patched text).
+MARK_W2 = "        self._glm53_gpu_caches = None  # [glm53-kv-offload-restore]\n"
+
+ANCHOR_W2 = """        self._glm53_store_writer = None  # [glm53-kv-offload-store] lazy
+        self._glm53_job_meta: dict[int, tuple] = {}
+"""
+
+PATCHED_W2 = """        self._glm53_store_writer = None  # [glm53-kv-offload-store] lazy
+        self._glm53_job_meta: dict[int, tuple] = {}
+        self._glm53_gpu_caches = None  # [glm53-kv-offload-restore]
+        self._glm53_disk_done: list[int] = []
+        self._glm53_load_error_ids: set[int] = set()
+"""
+
+# W3: stash the GPU-side canonical caches (single chokepoint).
+MARK_W3 = "        self._glm53_gpu_caches = kv_caches  # [glm53-kv-offload-restore]\n"
+
+ANCHOR_W3 = """    def _init_worker(self, kv_caches: CanonicalKVCaches) -> None:
+        self.worker = self.spec.get_worker(kv_caches)
+"""
+
+PATCHED_W3 = """    def _init_worker(self, kv_caches: CanonicalKVCaches) -> None:
+        self._glm53_gpu_caches = kv_caches  # [glm53-kv-offload-restore]
+        self.worker = self.spec.get_worker(kv_caches)
+"""
+
+# W4: disk load jobs bypass worker.submit_load.
+MARK_W4 = "            if (  # [glm53-kv-offload-restore] disk jobs bypass submit_load\n"
+
+ANCHOR_W4 = """        for job_id, entry in metadata.load_jobs.items():
+            self._load_jobs[job_id] = entry.req_id
+            assert isinstance(entry.dst_spec, GPULoadStoreSpec)
+            success = self.worker.submit_load(job_id, entry.src_spec, entry.dst_spec)
+            assert success
+"""
+
+PATCHED_W4 = """        for job_id, entry in metadata.load_jobs.items():
+            self._load_jobs[job_id] = entry.req_id
+            assert isinstance(entry.dst_spec, GPULoadStoreSpec)
+            if (  # [glm53-kv-offload-restore] disk jobs bypass submit_load
+                # and its success asserts: synchronous pread+verify+scatter
+                # with an explicit terminal result either way (T4).
+                isinstance(entry.src_spec, dict)
+                and entry.src_spec.get("glm53_disk_load")
+            ):
+                _glm53_run_disk_load(self, job_id, entry.src_spec, entry.dst_spec)
+                continue
+            success = self.worker.submit_load(job_id, entry.src_spec, entry.dst_spec)
+            assert success
+"""
+
+# W5: drain finished disk loads in get_finished.
+MARK_W5 = "        for job_id in _glm53_drain_disk_loads(self):  # [glm53-kv-offload-restore]\n"
+
+ANCHOR_W5 = """        return set(), finished_recving
+"""
+
+PATCHED_W5 = """        for job_id in _glm53_drain_disk_loads(self):  # [glm53-kv-offload-restore]
+            self._connector_worker_meta.mark_completed(job_id)
+            _glm53_req_id = self._load_jobs.pop(job_id, None)
+            if _glm53_req_id is not None:
+                finished_recving.add(_glm53_req_id)
+        return set(), finished_recving
+"""
+
+# W6: worker meta flows when events are pending, completions or not.
+MARK_W6 = "        _glm53_attach_manifest_events(self)  # [glm53-kv-offload-restore]\n"
+
+ANCHOR_W6 = """    def build_connector_worker_meta(self) -> OffloadingWorkerMetadata | None:
+        \"\"\"Return completed transfer job IDs since the last call.\"\"\"
+        if not self._connector_worker_meta.completed_jobs:
+            return None
+"""
+
+PATCHED_W6 = """    def build_connector_worker_meta(self) -> OffloadingWorkerMetadata | None:
+        \"\"\"Return completed transfer job IDs since the last call.\"\"\"
+        _glm53_attach_manifest_events(self)  # [glm53-kv-offload-restore]
+        if not self._connector_worker_meta.completed_jobs and not getattr(
+            self._connector_worker_meta, "glm53_manifest_events", None
+        ):
+            return None
+"""
+
+# W7-W11: store-writer event emission + validated dedup (anchors the store
+# overlay's injected writer text).
+MARK_W7 = "        self._glm53_manifest_events: list = []  # [glm53-kv-offload-restore]\n"
+
+ANCHOR_W7 = """        # In-memory manifest index for inline K-boundary retention:
+        # boundary_hash -> {"parent": hash|None, "boundary": int,
+        #                   "mamba_keys": [(hash, gidx)...]}
+        self._manifest_index: dict = {}
+"""
+
+PATCHED_W7 = """        # In-memory manifest index for inline K-boundary retention:
+        # boundary_hash -> {"parent": hash|None, "boundary": int,
+        #                   "mamba_keys": [(hash, gidx)...]}
+        self._manifest_index: dict = {}
+        # Manifest availability events for the worker->scheduler channel
+        # (drained by _glm53_attach_manifest_events under the lock).
+        self._glm53_manifest_events: list = []  # [glm53-kv-offload-restore]
+        self._glm53_boot_id = f"{_glm53_time.time():.0f}-{id(self):x}"
+"""
+
+MARK_W8 = "            self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] publish\n"
+
+ANCHOR_W8 = """        with self._lock:
+            self._manifest_index[boundary_hash] = {
+                "parent": chunk_hashes[-2] if len(chunk_hashes) > 1 else None,
+                "boundary": cand["boundary_token_index"],
+                "mamba_keys": [(boundary_hash, g) for g in cow_groups],
+            }
+"""
+
+PATCHED_W8 = """        with self._lock:
+            self._manifest_index[boundary_hash] = {
+                "parent": chunk_hashes[-2] if len(chunk_hashes) > 1 else None,
+                "boundary": cand["boundary_token_index"],
+                "mamba_keys": [(boundary_hash, g) for g in cow_groups],
+            }
+            self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] publish
+                (
+                    "+",
+                    self._rank,
+                    self._namespace_hash,
+                    boundary_hash,
+                    cand["boundary_token_index"],
+                    self._glm53_boot_id,
+                )
+            )
+"""
+
+MARK_W9 = "                self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] supersede\n"
+
+ANCHOR_W9 = """            with self._lock:
+                self._manifest_index.pop(boundary_hash, None)
+"""
+
+PATCHED_W9 = """            with self._lock:
+                self._manifest_index.pop(boundary_hash, None)
+                self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] supersede
+                    (
+                        "-",
+                        self._rank,
+                        self._namespace_hash,
+                        boundary_hash,
+                        entry["boundary"],
+                        self._glm53_boot_id,
+                    )
+                )
+"""
+
+MARK_W10 = "            self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] write failure\n"
+
+ANCHOR_W10 = """        self._files_dropped += 1
+        with self._lock:
+            self._failed_keys.add((hash_hex, group_idx))
+"""
+
+PATCHED_W10 = """        self._files_dropped += 1
+        with self._lock:
+            self._failed_keys.add((hash_hex, group_idx))
+            # The per-job store failure bit, on the wire: the scheduler's
+            # disk lookup denies boundaries whose keys failed on ANY rank.
+            self._glm53_manifest_events.append(  # [glm53-kv-offload-restore] write failure
+                (
+                    "F",
+                    getattr(self, "_rank", -1),
+                    getattr(self, "_namespace_hash", ""),
+                    hash_hex,
+                    group_idx,
+                    self._glm53_boot_id,
+                )
+            )
+"""
+
+# W11: validated dedup branch + the validator/drain methods (finding 9).
+MARK_W11 = "                if self._glm53_validate_manifest_file(  # [glm53-kv-offload-restore]\n"
+
+ANCHOR_W11 = """            mpath = self._manifest_path(boundary_hash)
+            if _os.path.exists(mpath):
+                self._register_manifest(cand, cow_groups)
+                continue
+"""
+
+PATCHED_W11 = """            mpath = self._manifest_path(boundary_hash)
+            if _os.path.exists(mpath):
+                # Validate before registering or ANNOUNCING (Codex OFFLOAD2
+                # finding 9): a pre-existing manifest must parse, match
+                # namespace + boundary + chain, and every referenced chunk
+                # header must verify; retention applies on this branch too.
+                # Invalid => unlink and fall through to a fresh publish.
+                if self._glm53_validate_manifest_file(  # [glm53-kv-offload-restore]
+                    mpath, boundary_hash, cand, cow_groups, full_groups
+                ):
+                    self._register_manifest(cand, cow_groups)
+                    self._apply_retention()
+                    continue
+                try:
+                    _os.unlink(mpath)
+                except OSError:
+                    pass
+"""
+
+MARK_W12 = "    # [glm53-kv-offload-restore] manifest validation + event drain\n"
+
+ANCHOR_W12 = """    # ---- manifests ------------------------------------------------------
+    def _finish_job(self, job) -> None:
+"""
+
+PATCHED_W12 = """    # [glm53-kv-offload-restore] manifest validation + event drain
+    def drain_manifest_events(self):
+        with self._lock:
+            events = self._glm53_manifest_events
+            self._glm53_manifest_events = []
+        return events
+
+    def _glm53_validate_manifest_file(
+        self, mpath, boundary_hash, cand, cow_groups, full_groups
+    ) -> bool:
+        \"\"\"Full validation of a pre-existing manifest before it is
+        registered/announced: parse, identity, chain equality, and a
+        verifying header for EVERY referenced chunk on this rank.\"\"\"
+        try:
+            with open(mpath, encoding="utf-8") as f:
+                man = _glm53_json.load(f)
+        except (OSError, ValueError):
+            return False
+        if (
+            man.get("format_version") != _GLM53_KVO_FORMAT_VERSION
+            or man.get("namespace_hash") != self._namespace_hash
+            or man.get("boundary_token_index") != cand["boundary_token_index"]
+            or man.get("chunk_hashes") != cand["chunk_hashes"]
+        ):
+            return False
+        with self._lock:
+            failed = set(self._failed_keys)
+        for gidx in cow_groups:
+            if (boundary_hash, gidx) in failed:
+                return False
+            try:
+                fh = glm53_read_chunk_header(self._file_path(boundary_hash, gidx))
+            except (OSError, ValueError):
+                return False
+            if (
+                fh.get("namespace_hash") != self._namespace_hash
+                or fh.get("hash") != boundary_hash
+                or fh.get("group_idx") != gidx
+            ):
+                return False
+        for gidx in full_groups:
+            for h in cand["chunk_hashes"]:
+                if (h, gidx) in failed:
+                    return False
+                try:
+                    fh = glm53_read_chunk_header(self._file_path(h, gidx))
+                except (OSError, ValueError):
+                    return False
+                if (
+                    fh.get("namespace_hash") != self._namespace_hash
+                    or fh.get("hash") != h
+                    or fh.get("group_idx") != gidx
+                ):
+                    return False
+        return True
+
+    # ---- manifests ------------------------------------------------------
+    def _finish_job(self, job) -> None:
+"""
+
+SITES_WORKER = (
+    ("W1 disk loader", MARK_W1, ANCHOR_W1, PATCHED_W1),
+    ("W2 worker restore state", MARK_W2, ANCHOR_W2, PATCHED_W2),
+    ("W3 GPU cache stash", MARK_W3, ANCHOR_W3, PATCHED_W3),
+    ("W4 disk load dispatch", MARK_W4, ANCHOR_W4, PATCHED_W4),
+    ("W5 disk load drain", MARK_W5, ANCHOR_W5, PATCHED_W5),
+    ("W6 event-only meta", MARK_W6, ANCHOR_W6, PATCHED_W6),
+    ("W7 writer event state", MARK_W7, ANCHOR_W7, PATCHED_W7),
+    ("W8 publish event", MARK_W8, ANCHOR_W8, PATCHED_W8),
+    ("W9 supersede event", MARK_W9, ANCHOR_W9, PATCHED_W9),
+    ("W10 write-failure event", MARK_W10, ANCHOR_W10, PATCHED_W10),
+    ("W11 validated dedup", MARK_W11, ANCHOR_W11, PATCHED_W11),
+    ("W12 validator + drain methods", MARK_W12, ANCHOR_W12, PATCHED_W12),
+)
+
+
+# ===========================================================================
+# File 4: offloading_connector.py (facade)
+# ===========================================================================
+MARK_F1 = "    def get_block_ids_with_load_errors(self) -> set[int]:  # [glm53-kv-offload-restore]\n"
+
+ANCHOR_F1 = """    def build_connector_worker_meta(self) -> OffloadingWorkerMetadata | None:
+        if self.connector_worker is not None:
+            return self.connector_worker.build_connector_worker_meta()
+        return None
+"""
+
+PATCHED_F1 = """    def get_block_ids_with_load_errors(self) -> set[int]:  # [glm53-kv-offload-restore]
+        # Drained per step by the model-runner mixin right after
+        # get_finished(); the executor unions across ranks into
+        # KVConnectorOutput.invalid_block_ids (T4). Empty without a worker
+        # or without any disk-restore failure.
+        worker = self.connector_worker
+        if worker is None:
+            return set()
+        errors = getattr(worker, "_glm53_load_error_ids", None)
+        if not errors:
+            return set()
+        drained = set(errors)
+        errors.clear()
+        return drained
+
+    def build_connector_worker_meta(self) -> OffloadingWorkerMetadata | None:
+        if self.connector_worker is not None:
+            return self.connector_worker.build_connector_worker_meta()
+        return None
+"""
+
+SITES_FACADE = (("F1 load-error drain", MARK_F1, ANCHOR_F1, PATCHED_F1),)
+
+
+# ===========================================================================
+# File 5: v1/core/single_type_kv_cache_manager.py (T2)
+# ===========================================================================
+MARK_T1 = "        _glm53_rb = getattr(request, \"glm53_restored_boundary\", 0)  # [glm53-kv-offload-restore]\n"
+
+ANCHOR_T1 = """        reachable_boundaries = [request.num_prompt_tokens - 1]
+        if request.shared_prefix_boundary:
+            reachable_boundaries.append(request.shared_prefix_boundary)
+"""
+
+PATCHED_T1 = """        reachable_boundaries = [request.num_prompt_tokens - 1]
+        if request.shared_prefix_boundary:
+            reachable_boundaries.append(request.shared_prefix_boundary)
+        # T2 (kv-offload restore): a disk-restored boundary must stay
+        # reachable in every later cache_blocks of this request, or a sparse
+        # retention mask could silently drop its re-entry. The value is the
+        # END-EXCLUSIVE restored token count (a multiple of the restore
+        # chunk size, e.g. 7168 keeps the mamba state block ending at token
+        # 7168). Dense (full-attention) masks return None and ignore it.
+        _glm53_rb = getattr(request, "glm53_restored_boundary", 0)  # [glm53-kv-offload-restore]
+        if _glm53_rb:
+            reachable_boundaries.append(_glm53_rb)
+"""
+
+SITES_SINGLE_TYPE = (("T1 restored reachable boundary", MARK_T1, ANCHOR_T1, PATCHED_T1),)
+
+
+TARGETS = (
+    ("offloading/common.py", TARGET_COMMON, SITES_COMMON),
+    ("offloading/scheduler.py", TARGET_SCHED, SITES_SCHED),
+    ("offloading/worker.py", TARGET_WORKER, SITES_WORKER),
+    ("offloading_connector.py", TARGET_FACADE, SITES_FACADE),
+    ("single_type_kv_cache_manager.py", TARGET_SINGLE_TYPE, SITES_SINGLE_TYPE),
+)
+
+# The scheduler/worker anchors pin the scope + store overlays' output; refuse
+# to run against an unpatched tree with a clear message instead of drift.
+SCOPE_MARK = "[glm53-kv-offload-scope]"
+STORE_MARK = "[glm53-kv-offload-store]"
+
+
+def verified_state(text: str, sites) -> bool:
+    return all(
+        text.count(mark) == 1
+        and text.count(patched) == 1
+        and text.count(anchor) == patched.count(anchor)
+        for _name, mark, anchor, patched in sites
+    )
+
+
+def prepare(source: str, sites, label: str) -> tuple[str, str]:
+    marks = sum(source.count(mark) for _n, mark, _a, _p in sites)
+    if marks:
+        if marks != len(sites) or any(
+            source.count(mark) != 1 for _n, mark, _a, _p in sites
+        ):
+            raise ValueError(
+                f"partial/inconsistent kv-offload-restore patch in {label} "
+                f"(marks={marks}, expected {len(sites)}) -- refusing to touch "
+                "a half-patched file"
+            )
+        return source, "already present"
+    for name, _mark, anchor, _patched in sites:
+        n = source.count(anchor)
+        if n != 1:
+            raise ValueError(
+                f"pinned kv-offload-restore anchor '{name}' drifted in {label} "
+                f"(found {n}, expected 1)"
+            )
+    out = source
+    for _name, _mark, anchor, patched in sites:
+        out = out.replace(anchor, patched, 1)
+    if not verified_state(out, sites):
+        raise ValueError(
+            f"kv-offload-restore post-patch verification failed in {label}"
+        )
+    return out, "patched"
+
+
+def replace_file(target: Path, source: str) -> None:
+    tmp = target.with_name(f".{target.name}.glm53-kv-offload-restore.tmp")
+    try:
+        tmp.write_text(source)
+        os.chmod(tmp, stat.S_IMODE(target.stat().st_mode))
+        os.replace(tmp, target)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def clear_pyc(target: Path) -> None:
+    cache = target.parent / "__pycache__"
+    if not cache.is_dir():
+        return
+    for pyc in cache.glob(f"{target.stem}*.pyc"):
+        pyc.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv if argv is None else argv
+    preflight_only = "--preflight" in argv[1:]
+
+    if "--check-injected" in argv[1:]:
+        # Host-side gate mode: compile every injected source standalone (no
+        # target access) so a truncated/corrupted string literal inside this
+        # file fails BEFORE the launcher stops a healthy pair.
+        for name, src in (
+            ("scheduler restore state", RESTORE_SCHED_SRC),
+            ("worker disk loader", RESTORE_WORKER_SRC),
+        ):
+            compile(src, f"<glm53-kv-offload-restore {name}>", "exec")
+        print("patch_kv_offload_restore_g0.py: injected sources compile OK")
+        return 0
+
+    sched_source = TARGET_SCHED.read_text() if TARGET_SCHED.is_file() else ""
+    for required_mark, producer in (
+        (SCOPE_MARK, "patch_kv_offload_scope.py"),
+        (STORE_MARK, "patch_kv_offload_store_local.py"),
+    ):
+        if required_mark not in sched_source:
+            raise SystemExit(
+                f"kv-offload-restore preflight failed: scheduler.py is not "
+                f"{required_mark}-patched -- run {producer} first "
+                "(GLM53_OVERLAY_ORDER pins this)"
+            )
+
+    prepared: list[tuple[Path, str, str, str]] = []
+    for label, target, sites in TARGETS:
+        if not target.is_file():
+            raise SystemExit(f"missing {target}")
+        source = target.read_text()
+        try:
+            patched, action = prepare(source, sites, label)
+        except ValueError as exc:
+            raise SystemExit(
+                f"kv-offload-restore preflight failed: {exc}"
+            ) from exc
+        compile(patched, str(target), "exec")
+        prepared.append((target, source, patched, action))
+        if preflight_only:
+            print(f"{target.name}: kv-offload-restore preflight OK ({action})")
+
+    if preflight_only:
+        return 0
+
+    for target, source, patched, action in prepared:
+        if patched != source:
+            replace_file(target, patched)
+            clear_pyc(target)
+    print(
+        f"kv-offload-restore {prepared[0][3]} "
+        f"({ENV_RESTORE}={os.environ.get(ENV_RESTORE, '0 (unset)')!r})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/overlay/patch_kv_offload_scope.py
+++ b/overlay/patch_kv_offload_scope.py
@@ -924,6 +924,16 @@ def main(argv: list[str] | None = None) -> int:
     argv = sys.argv if argv is None else argv
     preflight_only = "--preflight" in argv[1:]
 
+    if "--check-injected" in argv[1:]:
+        # Host-side gate mode: compile the injected helper source standalone
+        # (no target access needed) so a truncated/corrupted string literal
+        # inside this file fails BEFORE the launcher stops a healthy pair.
+        compile(HELPERS_SRC, "<glm53-kv-offload-scope helpers>", "exec")
+        compile(S0_HELPER, "<glm53-kv-offload-scope unwrap>", "exec")
+        load_helpers()
+        print("patch_kv_offload_scope.py: injected sources compile OK")
+        return 0
+
     # Preflight EVERY target before writing ANY (fail-closed: a drifted
     # scheduler must not leave a patched config.py behind).
     prepared: list[tuple[Path, str, str, str]] = []

--- a/overlay/patch_kv_offload_scope.py
+++ b/overlay/patch_kv_offload_scope.py
@@ -1,0 +1,955 @@
+#!/usr/bin/env python3
+"""Eligible-group scoping for the KV-offloading connector (port of vllm#54743).
+
+The problem
+-----------
+``build_offloading_config`` (``vllm/distributed/kv_transfer/kv_connector/v1/
+offloading/config.py``) builds an ``OffloadingGroupConfig`` for EVERY KV-cache
+group and asserts ``tokens_per_block % tokens_per_hash == 0`` across all of
+them, while ``resolve_kv_cache_block_sizes`` derives ``tokens_per_hash`` from
+prefix-cacheable groups only. On this deployment the KpoolTailSpec scratch
+group (group 1: block_size 4, ``prefix_cacheable=False``) fails the assert
+(4 % 64) the moment the OffloadingConnector is enabled — the connector cannot
+even boot on the hybrid layout.
+
+Our upstream PR vllm-project/vllm#54743 (branch
+fix/offloading-config-scope-prefix-cacheable, commit 899699c) fixes this at
+HEAD by scoping the offload group list to prefix-cacheable groups while
+preserving ORIGINAL group indices. This overlay ports that scoping onto the
+image's older tree (vllm 0.1.dev20051+g487ecf187), which sits between the PR's
+base and HEAD: the scheduler-side ``GroupOffloadConfig`` already carries
+``group_idx``, but the config boundary does not, and every scheduler pairing
+still assumes ``index == group_idx`` identity.
+
+What this overlay does (three files)
+------------------------------------
+1. ``vllm/v1/kv_offload/config.py`` — ``OffloadingGroupConfig`` gains
+   ``group_idx`` (original index into ``KVCacheConfig.kv_cache_groups``;
+   trailing default ``-1`` keeps existing constructors valid, and the
+   connector path always sets it).
+2. ``.../offloading/config.py`` — the groups tuple is scoped to the eligible
+   set: prefix-cacheable groups (upstream predicate) MINUS the fork policy
+   exclusion (exact-``SlidingWindowSpec`` drafter groups, unless
+   ``GLM53_KV_OFFLOAD_DRAFTER=1`` — plan §3.2/§11-C5: the DFlash2 drafter is
+   min-exempt with retention 0, so restoring it is pointless and storing it is
+   pure waste). Original indices ride in ``group_idx``; the divisibility
+   assert still guards every eligible group; one boot log line names the
+   eligible set. Final eligible set on this deployment: {0, 2, 3, 4, 5}.
+3. ``.../offloading/scheduler.py`` — the group_idx pairing port, [I]-adapted
+   from 899699c:
+   - ``resolve_mamba_align_size`` / the full-attn alignment scan / the
+     kv_group_configs build loop iterate ``spec.config.groups`` (group_idx +
+     tokens_per_block from the entry) instead of ``enumerate(
+     spec.tokens_per_block)``;
+   - ``SchedulerOffloadConfig`` gains ``num_kv_cache_groups`` (the FULL group
+     count) and ``from_spec`` fills it;
+   - ``RequestOffloadState.group_states`` is sized by the full group count —
+     block-id bookkeeping spans all groups (``update_block_id_groups`` asserts
+     one entry per KV-cache group), while offload keys are only generated for
+     eligible groups;
+   - every ``zip(kv_group_configs, group_states)`` pairing indexes
+     ``group_states[group_config.group_idx]`` instead;
+   - the two ``kv_group_configs[group_idx]`` subscripts go through a new
+     ``_group_config_by_idx`` dict;
+   - ``update_state_after_alloc`` builds FULL-LENGTH ``group_sizes`` /
+     ``block_indices`` (zeros for ineligible groups) and reads
+     ``blocks.blocks[group_config.group_idx]`` — the worker's
+     ``GPULoadStoreSpec`` layout is built from ALL kv-cache groups
+     (``register_kv_caches`` iterates ``kv_cache_config.kv_cache_groups``), so
+     ineligible groups keep zero-size entries and the worker layout is
+     unchanged;
+   - ``_build_store_jobs`` and ``_build_partial_tail_store_jobs`` write their
+     group_sizes/block_indices at ``group_idx`` into full-length lists;
+   - ``supports_partial_tail`` additionally requires every KV-cache group to
+     be eligible (conservative opt-out, exactly HEAD's rule; on this layout it
+     is already False via the EAGLE drafter).
+
+Behaviour for models without scratch/policy-excluded groups is unchanged: the
+eligible set is then every group and all the new indexing degenerates to the
+old identity pairing.
+
+Adaptation notes vs 899699c (per-anchor honesty)
+------------------------------------------------
+- [I] already has ``group_idx``/``is_eagle_group``/``requires_cow_source`` in
+  the scheduler NamedTuple; only the PAIRING is ported, not the fields.
+- HEAD's ``kv_connector_extra_config['block_size']`` assert-message reword is
+  NOT ported: the branch is unused by this deployment and the semantics are
+  already rescoped by the filtered ``groups`` tuple it reads.
+- HEAD hoists the ``_current_batch_allocated_block_ids`` sweep over all
+  groups in ``update_state_after_alloc``; [I]'s loop is shaped differently but
+  the port keeps HEAD's semantics (sweep ALL groups' allocated ids, then walk
+  only eligible groups).
+- The fork policy exclusion (drafter) is fork-only and NOT part of #54743;
+  upstream's predicate alone yields {0,2,3,4,5,6} here.
+
+Conventions follow ``overlay/patch_kv_capacity_log.py``: pinned ANCHORs, MARK
+sentinels, ``verified_state``, ``prepare``, idempotent, atomic replace, pyc
+clear, drift => nonzero exit. ALL anchors in ALL three files are preflighted
+before ANY file is written. Must run BEFORE ``patch_kv_offload_store_local.py``
+(that overlay anchors on this one's output in scheduler.py). No anchors are
+shared with any other overlay (none touch the kv_offload/connector tree).
+
+Usage::
+
+    python3 patch_kv_offload_scope.py              # apply
+    python3 patch_kv_offload_scope.py --preflight  # validate anchors only
+"""
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+VLLM_ROOT = os.environ.get(
+    "GLM53_VLLM_ROOT", "/usr/local/lib/python3.12/dist-packages/vllm"
+)
+
+TARGET_KVO_CONFIG = Path(
+    os.environ.get("GLM53_KVO_CONFIG_PY", f"{VLLM_ROOT}/v1/kv_offload/config.py")
+)
+TARGET_CONN_CONFIG = Path(
+    os.environ.get(
+        "GLM53_KVO_CONN_CONFIG_PY",
+        f"{VLLM_ROOT}/distributed/kv_transfer/kv_connector/v1/offloading/config.py",
+    )
+)
+TARGET_SCHED = Path(
+    os.environ.get(
+        "GLM53_KVO_SCHED_PY",
+        f"{VLLM_ROOT}/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py",
+    )
+)
+
+TAG = "[glm53-kv-offload-scope]"
+ENV_DRAFTER = "GLM53_KV_OFFLOAD_DRAFTER"
+
+
+# ---------------------------------------------------------------------------
+# Shared helper source: the eligibility predicate.
+#
+# Injected into offloading/config.py AND exec'd below so host tests drive the
+# exact shipped predicate (one implementation, no drifting replica).
+# ---------------------------------------------------------------------------
+HELPERS_SRC = '''# [glm53-kv-offload-scope] helpers -- see overlay/patch_kv_offload_scope.py
+_GLM53_KVO_SCOPE_TAG = "[glm53-kv-offload-scope]"
+_GLM53_KVO_DRAFTER_ENV = "GLM53_KV_OFFLOAD_DRAFTER"
+
+
+def _glm53_kvo_drafter_included() -> bool:
+    """Exactly "0" or "1"; unset means "0" (exclude the drafter group).
+
+    Same contract as the launcher's ``_glm53_validate_bool_flag``: "" is a
+    value, not an absence; a typo'd knob raises rather than silently choosing
+    which groups hit the disk tier.
+    """
+    import os as _os
+
+    raw = _os.environ.get(_GLM53_KVO_DRAFTER_ENV)
+    if raw is None or raw == "0":
+        return False
+    if raw == "1":
+        return True
+    raise ValueError(
+        f"{_GLM53_KVO_DRAFTER_ENV} must be exactly 0 or 1 (got: {raw!r})"
+    )
+
+
+def _glm53_kvo_unwrap_spec(spec):
+    """Unwrap a UniformTypeKVCacheSpecs so the group's real spec class is named."""
+    specs = getattr(spec, "kv_cache_specs", None)
+    if isinstance(specs, dict) and specs:
+        return next(iter(specs.values()))
+    return spec
+
+
+def _glm53_kvo_group_eligible(
+    kv_cache_group, drafter_included: bool, use_eagle: bool
+) -> bool:
+    """Upstream predicate (prefix_cacheable) minus the fork policy exclusion.
+
+    - Non-prefix-cacheable groups (KpoolTailSpec scratch) are never offloaded:
+      block hashes only cover prefix-cacheable groups, so a scratch group has
+      no valid hash granularity (vllm#54743's predicate).
+    - Fork policy: DRAFT-model attention groups are excluded unless
+      GLM53_KV_OFFLOAD_DRAFTER=1 — the drafter is min-exempt with retention 0
+      (#83), so its window is rebuilt by the remainder's prefill and storing
+      it is waste (plan §3.2). A group is a drafter group when it carries
+      ``is_eagle_group`` OR — only under an EAGLE-like speculative config
+      (``use_eagle``) — when its unwrapped spec is EXACTLY SlidingWindowSpec
+      (the same exact-class rule as patch_hybrid_prefix_hit's
+      ``_glm53_is_draft_swa_spec``; without EAGLE context a SlidingWindowSpec
+      group is genuine model SWA and stays eligible).
+    """
+    spec = kv_cache_group.kv_cache_spec
+    # [I] names the flag participates_in_prefix_caching (a property, and on
+    # UniformTypeKVCacheSpecs an all-members aggregate); newer trees say
+    # prefix_cacheable. Check both, fork name first (same dual-name rule as
+    # patch_kv_capacity_log). A spec with neither name caches (legacy).
+    for name in ("participates_in_prefix_caching", "prefix_cacheable"):
+        value = getattr(spec, name, None)
+        if callable(value):
+            value = value()
+        if isinstance(value, bool):
+            if not value:
+                return False
+            break
+    if not drafter_included:
+        if bool(getattr(kv_cache_group, "is_eagle_group", False)):
+            return False
+        if use_eagle:
+            inner = _glm53_kvo_unwrap_spec(spec)
+            if type(inner).__name__ == "SlidingWindowSpec":
+                return False
+    return True
+
+
+def _glm53_kvo_use_eagle(vllm_config) -> bool:
+    spec_cfg = getattr(vllm_config, "speculative_config", None)
+    if spec_cfg is None:
+        return False
+    use_eagle = getattr(spec_cfg, "use_eagle", None)
+    if callable(use_eagle):
+        return bool(use_eagle())
+    return bool(use_eagle)
+
+
+'''
+
+
+def load_helpers() -> dict:
+    """Exec HELPERS_SRC into a fresh namespace (what the host tests drive)."""
+    ns: dict = {}
+    exec(compile(HELPERS_SRC, "<glm53-kv-offload-scope helpers>", "exec"), ns)
+    return ns
+
+
+_HELPERS = load_helpers()
+kvo_drafter_included = _HELPERS["_glm53_kvo_drafter_included"]
+kvo_unwrap_spec = _HELPERS["_glm53_kvo_unwrap_spec"]
+kvo_group_eligible = _HELPERS["_glm53_kvo_group_eligible"]
+
+
+# ===========================================================================
+# File 1: vllm/v1/kv_offload/config.py — OffloadingGroupConfig.group_idx
+# ===========================================================================
+MARK_GROUPCFG = "    # [glm53-kv-offload-scope] original index into KVCacheConfig.kv_cache_groups\n"
+
+ANCHOR_GROUPCFG = """@dataclass(frozen=True)
+class OffloadingGroupConfig:
+    # Total token span covered by one block across all workers
+    # (accounts for context parallelism).
+    tokens_per_block: int
+    # Layer names belonging to this group.
+    layer_names: tuple[str, ...]
+"""
+
+PATCHED_GROUPCFG = """@dataclass(frozen=True)
+class OffloadingGroupConfig:
+    # Total token span covered by one block across all workers
+    # (accounts for context parallelism).
+    tokens_per_block: int
+    # Layer names belonging to this group.
+    layer_names: tuple[str, ...]
+    # [glm53-kv-offload-scope] original index into KVCacheConfig.kv_cache_groups
+    # (offload groups are scoped to eligible groups; keys/layouts keep original
+    # indices). Required, matching upstream 899699c: the only constructor is
+    # build_offloading_config, which always sets it.
+    group_idx: int
+"""
+
+SITES_KVO_CONFIG = (
+    ("OffloadingGroupConfig.group_idx", MARK_GROUPCFG, ANCHOR_GROUPCFG, PATCHED_GROUPCFG),
+)
+
+
+# ===========================================================================
+# File 2: offloading/config.py — eligible-group scoping at the boundary
+# ===========================================================================
+MARK_CONN_HELPERS = "# [glm53-kv-offload-scope] helpers -- see overlay/patch_kv_offload_scope.py\n"
+
+ANCHOR_CONN_HELPERS = """def is_kv_cache_tensor_packed(kv_cache_tensor: "KVCacheTensor") -> bool:
+"""
+
+PATCHED_CONN_HELPERS = HELPERS_SRC + ANCHOR_CONN_HELPERS
+
+MARK_CONN_GROUPS = "    # [glm53-kv-offload-scope] scope to eligible groups, keep original indices\n"
+
+ANCHOR_CONN_GROUPS = """    parallel_config = vllm_config.parallel_config
+    groups = tuple(
+        OffloadingGroupConfig(
+            tokens_per_block=(
+                group.kv_cache_spec.block_size
+                * (
+                    parallel_config.decode_context_parallel_size
+                    if isinstance(group.kv_cache_spec, AttentionSpec)
+                    else 1
+                )
+            ),
+            layer_names=tuple(group.layer_names),
+        )
+        for group in kv_cache_config.kv_cache_groups
+    )
+"""
+
+PATCHED_CONN_GROUPS = """    parallel_config = vllm_config.parallel_config
+    # [glm53-kv-offload-scope] scope to eligible groups, keep original indices
+    # (port of vllm#54743): only prefix-cacheable groups can serve offload
+    # hits -- block hashes are computed over prefix-cacheable groups only
+    # (resolve_kv_cache_block_sizes), so scratch groups (KpoolTailSpec) have
+    # no valid hash granularity and must not be offloaded. The fork policy
+    # additionally excludes the exact-SlidingWindowSpec drafter group unless
+    # GLM53_KV_OFFLOAD_DRAFTER=1. Original group indices ride in group_idx.
+    _glm53_drafter_included = _glm53_kvo_drafter_included()
+    _glm53_use_eagle = _glm53_kvo_use_eagle(vllm_config)
+    _glm53_eligible = [
+        group_idx
+        for group_idx, group in enumerate(kv_cache_config.kv_cache_groups)
+        if _glm53_kvo_group_eligible(
+            group, _glm53_drafter_included, _glm53_use_eagle
+        )
+    ]
+    from vllm.logger import init_logger as _glm53_init_logger
+
+    _glm53_init_logger(__name__).info(
+        "%s eligible groups: %s of %d (drafter_included=%s)",
+        _GLM53_KVO_SCOPE_TAG,
+        _glm53_eligible,
+        len(kv_cache_config.kv_cache_groups),
+        _glm53_drafter_included,
+    )
+    groups = tuple(
+        OffloadingGroupConfig(
+            tokens_per_block=(
+                group.kv_cache_spec.block_size
+                * (
+                    parallel_config.decode_context_parallel_size
+                    # Unwrap: [I] wraps per-layer specs in
+                    # UniformTypeKVCacheSpecs (KVCacheSpec subclass only), so
+                    # the stock isinstance would miss attention groups.
+                    if isinstance(
+                        _glm53_kvo_unwrap_spec(group.kv_cache_spec), AttentionSpec
+                    )
+                    else 1
+                )
+            ),
+            layer_names=tuple(group.layer_names),
+            group_idx=group_idx,
+        )
+        for group_idx, group in enumerate(kv_cache_config.kv_cache_groups)
+        if group_idx in _glm53_eligible
+    )
+"""
+
+SITES_CONN_CONFIG = (
+    ("connector config helpers", MARK_CONN_HELPERS, ANCHOR_CONN_HELPERS, PATCHED_CONN_HELPERS),
+    ("eligible-group scoping", MARK_CONN_GROUPS, ANCHOR_CONN_GROUPS, PATCHED_CONN_GROUPS),
+)
+
+
+# ===========================================================================
+# File 3: offloading/scheduler.py — group_idx pairing port
+# ===========================================================================
+
+# --- site S0: spec-unwrap helper (an [I]-specific adaptation) ---------------
+# [I]'s kv-cache groups wrap per-layer specs in UniformTypeKVCacheSpecs
+# (subclass of KVCacheSpec only): the module's isinstance dispatch
+# (get_sliding_window_size_in_chunks' FullAttentionSpec assert, the MambaSpec
+# checks) would crash or silently misclassify every wrapped group. Not part
+# of upstream 899699c (HEAD's group specs reach the connector unwrapped).
+MARK_S0 = "# [glm53-kv-offload-scope] spec unwrap helper\n"
+
+ANCHOR_S0 = """def get_sliding_window_size_in_chunks(
+"""
+
+S0_HELPER = '''# [glm53-kv-offload-scope] spec unwrap helper
+def _glm53_kvo_inner_spec(spec):
+    """Return the single-type member spec of a UniformTypeKVCacheSpecs.
+
+    [I]'s kv-cache groups wrap their per-layer specs (mixed page sizes) in
+    UniformTypeKVCacheSpecs, which subclasses only KVCacheSpec -- the stock
+    isinstance() dispatch in this module would assert on it. Unwrap to the
+    first member when every member is the same class; otherwise return the
+    wrapper unchanged, so the caller's FullAttentionSpec assert fails LOUDLY
+    at boot instead of misclassifying a mixed group.
+    """
+    specs = getattr(spec, "kv_cache_specs", None)
+    if isinstance(specs, dict) and specs:
+        members = list(specs.values())
+        first_cls = type(members[0])
+        if all(type(m) is first_cls for m in members):
+            return members[0]
+    return spec
+
+
+'''
+
+PATCHED_S0 = S0_HELPER + ANCHOR_S0
+
+# --- site S1: resolve_mamba_align_size iterates config.groups ---------------
+MARK_S1 = "    # [glm53-kv-offload-scope] iterate eligible groups (original indices)\n"
+
+ANCHOR_S1 = """    mamba_align_size: int | None = None
+    for idx, tokens_per_block in enumerate(spec.tokens_per_block):
+        kv_spec = kv_cache_config.kv_cache_groups[idx].kv_cache_spec
+        if isinstance(kv_spec, MambaSpec) and kv_spec.mamba_cache_mode in (
+            "align",
+            "all",
+        ):
+            tokens_per_chunk = tokens_per_block * spec.blocks_per_chunk
+            assert mamba_align_size is None or mamba_align_size == tokens_per_chunk
+            mamba_align_size = tokens_per_chunk
+    return mamba_align_size
+"""
+
+PATCHED_S1 = """    mamba_align_size: int | None = None
+    # [glm53-kv-offload-scope] iterate eligible groups (original indices)
+    for group in spec.config.groups:
+        kv_spec = _glm53_kvo_inner_spec(
+            kv_cache_config.kv_cache_groups[group.group_idx].kv_cache_spec
+        )
+        if isinstance(kv_spec, MambaSpec) and kv_spec.mamba_cache_mode in (
+            "align",
+            "all",
+        ):
+            tokens_per_chunk = group.tokens_per_block * spec.blocks_per_chunk
+            assert mamba_align_size is None or mamba_align_size == tokens_per_chunk
+            mamba_align_size = tokens_per_chunk
+    return mamba_align_size
+"""
+
+# --- site S2: SchedulerOffloadConfig fields --------------------------------
+MARK_S2 = "    # [glm53-kv-offload-scope] total number of KV cache groups\n"
+
+ANCHOR_S2 = """class SchedulerOffloadConfig(NamedTuple):
+    kv_group_configs: tuple[GroupOffloadConfig, ...]
+    blocks_per_chunk: int
+"""
+
+PATCHED_S2 = """class SchedulerOffloadConfig(NamedTuple):
+    # One entry per ELIGIBLE KV cache group; group_idx keeps the original
+    # index into KVCacheConfig.kv_cache_groups. Ineligible groups (scratch,
+    # policy-excluded drafter) are never offloaded and get no entry here.
+    kv_group_configs: tuple[GroupOffloadConfig, ...]
+    # [glm53-kv-offload-scope] total number of KV cache groups
+    # (including ineligible ones); sizes per-group structures shared with the
+    # scheduler core and the worker.
+    num_kv_cache_groups: int
+    blocks_per_chunk: int
+"""
+
+# --- site S3: from_spec full-attn alignment scan ---------------------------
+MARK_S3 = "        # [glm53-kv-offload-scope] alignment scan over eligible groups\n"
+
+ANCHOR_S3 = """        full_attn_tokens_per_chunk: set[int] = set()
+        for idx, tokens_per_block in enumerate(spec.tokens_per_block):
+            kv_spec = kv_cache_config.kv_cache_groups[idx].kv_cache_spec
+            sw = get_sliding_window_size_in_chunks(
+                kv_spec, tokens_per_block * spec.blocks_per_chunk
+            )
+            if sw is None:
+                full_attn_tokens_per_chunk.add(tokens_per_block * spec.blocks_per_chunk)
+"""
+
+PATCHED_S3 = """        full_attn_tokens_per_chunk: set[int] = set()
+        # [glm53-kv-offload-scope] alignment scan over eligible groups
+        for group in spec.config.groups:
+            kv_spec = _glm53_kvo_inner_spec(
+                kv_cache_config.kv_cache_groups[group.group_idx].kv_cache_spec
+            )
+            sw = get_sliding_window_size_in_chunks(
+                kv_spec, group.tokens_per_block * spec.blocks_per_chunk
+            )
+            if sw is None:
+                full_attn_tokens_per_chunk.add(
+                    group.tokens_per_block * spec.blocks_per_chunk
+                )
+"""
+
+# --- site S4: from_spec kv_group_configs build loop ------------------------
+MARK_S4 = "        # [glm53-kv-offload-scope] build configs for eligible groups only\n"
+
+ANCHOR_S4 = """        kv_group_configs_list: list[GroupOffloadConfig] = []
+        for idx, tokens_per_block in enumerate(spec.tokens_per_block):
+            kv_cache_group = kv_cache_config.kv_cache_groups[idx]
+            kv_spec = kv_cache_group.kv_cache_spec
+"""
+
+PATCHED_S4 = """        kv_group_configs_list: list[GroupOffloadConfig] = []
+        # [glm53-kv-offload-scope] build configs for eligible groups only
+        for group in spec.config.groups:
+            idx = group.group_idx
+            tokens_per_block = group.tokens_per_block
+            kv_cache_group = kv_cache_config.kv_cache_groups[idx]
+            kv_spec = _glm53_kvo_inner_spec(kv_cache_group.kv_cache_spec)
+"""
+
+# --- site S5: supports_partial_tail + num_kv_cache_groups ------------------
+MARK_S5 = "        # [glm53-kv-offload-scope] partial tails need every group eligible\n"
+
+ANCHOR_S5 = """        kv_group_configs = tuple(kv_group_configs_list)
+        group_block_sizes = {config.tokens_per_block for config in kv_group_configs}
+"""
+
+PATCHED_S5 = """        kv_group_configs = tuple(kv_group_configs_list)
+        # [glm53-kv-offload-scope] partial tails need every group eligible
+        num_kv_cache_groups = len(kv_cache_config.kv_cache_groups)
+        group_block_sizes = {config.tokens_per_block for config in kv_group_configs}
+"""
+
+MARK_S5B = "            and len(kv_group_configs) == num_kv_cache_groups  # [glm53-kv-offload-scope]\n"
+
+ANCHOR_S5B = """        supports_partial_tail = (
+            spec.blocks_per_chunk == 1
+            and len(group_block_sizes) == 1
+            and has_partial_recurrent_group
+"""
+
+PATCHED_S5B = """        supports_partial_tail = (
+            spec.blocks_per_chunk == 1
+            and len(group_block_sizes) == 1
+            and len(kv_group_configs) == num_kv_cache_groups  # [glm53-kv-offload-scope]
+            and has_partial_recurrent_group
+"""
+
+MARK_S5C = "            num_kv_cache_groups=num_kv_cache_groups,  # [glm53-kv-offload-scope]\n"
+
+ANCHOR_S5C = """        return cls(
+            num_workers=vllm_config.parallel_config.world_size,
+            kv_group_configs=kv_group_configs,
+            blocks_per_chunk=spec.blocks_per_chunk,
+"""
+
+PATCHED_S5C = """        return cls(
+            num_workers=vllm_config.parallel_config.world_size,
+            kv_group_configs=kv_group_configs,
+            num_kv_cache_groups=num_kv_cache_groups,  # [glm53-kv-offload-scope]
+            blocks_per_chunk=spec.blocks_per_chunk,
+"""
+
+# --- site S6: RequestOffloadState.group_states full-length -----------------
+MARK_S6 = "        # [glm53-kv-offload-scope] one state per KV cache group (original index)\n"
+
+ANCHOR_S6 = """    def __post_init__(self) -> None:
+        self.group_states = tuple(
+            RequestGroupState() for _ in self.config.kv_group_configs
+        )
+"""
+
+PATCHED_S6 = """    def __post_init__(self) -> None:
+        # [glm53-kv-offload-scope] one state per KV cache group (original index)
+        # -- block-id bookkeeping spans ALL groups (update_block_id_groups gets
+        # one entry per KV cache group from the core), while offload keys are
+        # only ever generated for the eligible kv_group_configs.
+        self.group_states = tuple(
+            RequestGroupState() for _ in range(self.config.num_kv_cache_groups)
+        )
+"""
+
+# --- site S7: update_offload_keys pairing ----------------------------------
+MARK_S7 = "        for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S7\n"
+
+ANCHOR_S7 = """    def update_offload_keys(self) -> None:
+        for group_config, group_state in zip(
+            self.config.kv_group_configs, self.group_states
+        ):
+"""
+
+PATCHED_S7 = """    def update_offload_keys(self) -> None:
+        for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S7
+            group_state = self.group_states[group_config.group_idx]
+"""
+
+# --- site S8: advance_stored_idx pairing -----------------------------------
+MARK_S8 = "        for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S8\n"
+
+ANCHOR_S8 = """        for group_config, group_state in zip(
+            self.config.kv_group_configs, self.group_states
+        ):
+            group_state.next_stored_chunk_idx = max(
+"""
+
+PATCHED_S8 = """        for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S8
+            group_state = self.group_states[group_config.group_idx]
+            group_state.next_stored_chunk_idx = max(
+"""
+
+# --- site S9: update_num_hit_chunks pairing --------------------------------
+MARK_S9 = "        for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S9\n"
+
+ANCHOR_S9 = """        for group_config, group_state in zip(
+            self.config.kv_group_configs, self.group_states
+        ):
+            group_state.num_hit_chunks = (
+"""
+
+PATCHED_S9 = """        for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S9
+            group_state = self.group_states[group_config.group_idx]
+            group_state.num_hit_chunks = (
+"""
+
+# --- site S10: scheduler __init__ dict + sort key --------------------------
+MARK_S10 = "        # [glm53-kv-offload-scope] original group index -> eligible group config\n"
+
+ANCHOR_S10 = """        full_attention_groups: list[int] = []
+        sliding_window_groups: list[int] = []
+        for group_config in self.config.kv_group_configs:
+            if group_config.sliding_window_size_in_chunks is None:
+                full_attention_groups.append(group_config.group_idx)
+            else:
+                sliding_window_groups.append(group_config.group_idx)
+
+        # sort sliding window groups by window size in decreasing order
+        def _sliding_window_sort_key(i: int) -> int:
+            val = self.config.kv_group_configs[i].sliding_window_size_in_chunks
+            assert val is not None
+            return val
+"""
+
+PATCHED_S10 = """        # [glm53-kv-offload-scope] original group index -> eligible group config
+        self._group_config_by_idx: dict[int, GroupOffloadConfig] = {
+            group_config.group_idx: group_config
+            for group_config in self.config.kv_group_configs
+        }
+
+        full_attention_groups: list[int] = []
+        sliding_window_groups: list[int] = []
+        for group_config in self.config.kv_group_configs:
+            if group_config.sliding_window_size_in_chunks is None:
+                full_attention_groups.append(group_config.group_idx)
+            else:
+                sliding_window_groups.append(group_config.group_idx)
+
+        # sort sliding window groups by window size in decreasing order
+        def _sliding_window_sort_key(i: int) -> int:
+            val = self._group_config_by_idx[i].sliding_window_size_in_chunks
+            assert val is not None
+            return val
+"""
+
+# --- site S11: _touch pairing ----------------------------------------------
+MARK_S11 = "        for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S11\n"
+
+ANCHOR_S11 = """    def _touch(self, req_status: RequestOffloadState):
+        for group_config, group_state in zip(
+            self.config.kv_group_configs, req_status.group_states
+        ):
+"""
+
+PATCHED_S11 = """    def _touch(self, req_status: RequestOffloadState):
+        for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S11
+            group_state = req_status.group_states[group_config.group_idx]
+"""
+
+# --- site S12: _lookup_complete_chunks subscript ---------------------------
+MARK_S12 = "                group_config: GroupOffloadConfig = self._group_config_by_idx[  # [glm53-kv-offload-scope]\n"
+
+ANCHOR_S12 = """            for group_idx in groups_iter:
+                group_config: GroupOffloadConfig = self.config.kv_group_configs[
+                    group_idx
+                ]
+"""
+
+PATCHED_S12 = """            for group_idx in groups_iter:
+                group_config: GroupOffloadConfig = self._group_config_by_idx[  # [glm53-kv-offload-scope]
+                    group_idx
+                ]
+"""
+
+# --- site S13: _chunks_being_loaded pairing --------------------------------
+MARK_S13 = "            for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S13\n"
+
+ANCHOR_S13 = """        if self._chunks_being_loaded:
+            for group_config, group_state in zip(
+                self.config.kv_group_configs, req_status.group_states
+            ):
+"""
+
+PATCHED_S13 = """        if self._chunks_being_loaded:
+            for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S13
+                group_state = req_status.group_states[group_config.group_idx]
+"""
+
+# --- site S14: update_state_after_alloc ------------------------------------
+MARK_S14 = "        # [glm53-kv-offload-scope] full-length per-group layout, eligible walk\n"
+
+ANCHOR_S14 = """        keys_to_load: list[OffloadKey] = []
+        dst_block_ids: list[int] = []
+        # per group
+        group_sizes: list[int] = []
+        block_indices: list[int] = []
+        for group_config, group_state, group_blocks in zip(
+            self.config.kv_group_configs,
+            req_status.group_states,
+            blocks.blocks,
+        ):
+            self._current_batch_allocated_block_ids.update(
+                block.block_id for block in group_blocks if block.block_id != 0
+            )
+
+            tokens_per_block = group_config.tokens_per_block
+"""
+
+PATCHED_S14 = """        # [glm53-kv-offload-scope] full-length per-group layout, eligible walk
+        # (GPULoadStoreSpec group_sizes/block_indices are indexed by ORIGINAL
+        # group index; ineligible groups never load, so their entries stay 0).
+        for group_blocks in blocks.blocks:
+            self._current_batch_allocated_block_ids.update(
+                block.block_id for block in group_blocks if block.block_id != 0
+            )
+
+        keys_to_load: list[OffloadKey] = []
+        dst_block_ids: list[int] = []
+        # per group (indexed by original group index)
+        group_sizes: list[int] = [0] * self.config.num_kv_cache_groups
+        block_indices: list[int] = [0] * self.config.num_kv_cache_groups
+        for group_config in self.config.kv_group_configs:
+            group_state = req_status.group_states[group_config.group_idx]
+            group_blocks = blocks.blocks[group_config.group_idx]
+
+            tokens_per_block = group_config.tokens_per_block
+"""
+
+MARK_S14B = "            group_sizes[group_config.group_idx] = num_pending_gpu_blocks  # [glm53-kv-offload-scope]\n"
+
+ANCHOR_S14B = """            group_sizes.append(num_pending_gpu_blocks)
+            block_indices.append(num_locally_computed_gpu_blocks)
+"""
+
+PATCHED_S14B = """            group_sizes[group_config.group_idx] = num_pending_gpu_blocks  # [glm53-kv-offload-scope]
+            block_indices[group_config.group_idx] = num_locally_computed_gpu_blocks
+"""
+
+# --- site S15: _build_partial_tail_store_jobs ------------------------------
+MARK_S15 = "            group_by_key = {  # [glm53-kv-offload-scope] original-index keyed\n"
+
+ANCHOR_S15 = """            group_by_key = {key: idx for idx, key in enumerate(keys)}
+            accepted_groups = [group_by_key[key] for key in store_output.keys_to_store]
+            group_sizes = [0] * len(self.config.kv_group_configs)
+            block_indices = [0] * len(self.config.kv_group_configs)
+"""
+
+PATCHED_S15 = """            group_by_key = {  # [glm53-kv-offload-scope] original-index keyed
+                key: group.group_idx
+                for group, key in zip(self.config.kv_group_configs, keys)
+            }
+            # GPULoadStoreSpec expects blocks ordered by group index.
+            accepted_groups = sorted(
+                group_by_key[key] for key in store_output.keys_to_store
+            )
+            group_sizes = [0] * self.config.num_kv_cache_groups
+            block_indices = [0] * self.config.num_kv_cache_groups
+"""
+
+MARK_S15B = "            source_blocks = [  # [glm53-kv-offload-scope] via block_id_by_group\n"
+
+ANCHOR_S15B = """            source_blocks = [block_ids[group_idx] for group_idx in accepted_groups]
+"""
+
+PATCHED_S15B = """            source_blocks = [  # [glm53-kv-offload-scope] via block_id_by_group
+                _glm53_block_id_by_group[group_idx] for group_idx in accepted_groups
+            ]
+"""
+
+MARK_S15C = "            _glm53_block_id_by_group = {  # [glm53-kv-offload-scope]\n"
+
+ANCHOR_S15C = """            block_ids = [
+                cow_blocks[group.group_idx]
+                if group.group_idx in self._cow_source_groups
+                else req_status.group_states[group.group_idx].block_ids[block_idx]
+                for group in self.config.kv_group_configs
+            ]
+            assert all(block_id != 0 for block_id in block_ids)
+"""
+
+PATCHED_S15C = """            _glm53_block_id_by_group = {  # [glm53-kv-offload-scope]
+                group.group_idx: (
+                    cow_blocks[group.group_idx]
+                    if group.group_idx in self._cow_source_groups
+                    else req_status.group_states[group.group_idx].block_ids[block_idx]
+                )
+                for group in self.config.kv_group_configs
+            }
+            assert all(
+                block_id != 0 for block_id in _glm53_block_id_by_group.values()
+            )
+"""
+
+# --- site S16: _build_store_jobs first pairing (key filter loop) -----------
+MARK_S16 = "            for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S16\n"
+
+ANCHOR_S16 = """            new_offload_keys: list[OffloadKey] = []
+            for group_config, group_state in zip(
+                self.config.kv_group_configs, req_status.group_states
+            ):
+"""
+
+PATCHED_S16 = """            new_offload_keys: list[OffloadKey] = []
+            for group_config in self.config.kv_group_configs:  # [glm53-kv-offload-scope] S16
+                group_state = req_status.group_states[group_config.group_idx]
+"""
+
+# --- site S17: _build_store_jobs source-block walk -------------------------
+MARK_S17 = "            group_sizes = [0] * self.config.num_kv_cache_groups  # [glm53-kv-offload-scope]\n"
+
+ANCHOR_S17 = """            group_sizes: list[int] = []
+            block_indices: list[int] = []
+            src_block_ids: list[int] = []
+            fenced_block_ids: list[int] = []
+            deferred_fence_block_ids: list[int] = []
+            for group_config, group_state in zip(
+                self.config.kv_group_configs, req_status.group_states
+            ):
+"""
+
+PATCHED_S17 = """            group_sizes = [0] * self.config.num_kv_cache_groups  # [glm53-kv-offload-scope]
+            block_indices = [0] * self.config.num_kv_cache_groups
+            src_block_ids: list[int] = []
+            fenced_block_ids: list[int] = []
+            deferred_fence_block_ids: list[int] = []
+            for group_config in self.config.kv_group_configs:
+                group_state = req_status.group_states[group_config.group_idx]
+"""
+
+MARK_S17B = "                group_sizes[group_config.group_idx] = num_group_blocks  # [glm53-kv-offload-scope]\n"
+
+ANCHOR_S17B = """                group_sizes.append(num_group_blocks)
+                block_indices.append(start_gpu_block_idx or 0)
+"""
+
+PATCHED_S17B = """                group_sizes[group_config.group_idx] = num_group_blocks  # [glm53-kv-offload-scope]
+                block_indices[group_config.group_idx] = start_gpu_block_idx or 0
+"""
+
+SITES_SCHED = (
+    ("S0 spec unwrap helper", MARK_S0, ANCHOR_S0, PATCHED_S0),
+    ("S1 resolve_mamba_align_size", MARK_S1, ANCHOR_S1, PATCHED_S1),
+    ("S2 SchedulerOffloadConfig fields", MARK_S2, ANCHOR_S2, PATCHED_S2),
+    ("S3 full-attn alignment scan", MARK_S3, ANCHOR_S3, PATCHED_S3),
+    ("S4 kv_group_configs build loop", MARK_S4, ANCHOR_S4, PATCHED_S4),
+    ("S5 num_kv_cache_groups", MARK_S5, ANCHOR_S5, PATCHED_S5),
+    ("S5B supports_partial_tail", MARK_S5B, ANCHOR_S5B, PATCHED_S5B),
+    ("S5C from_spec return", MARK_S5C, ANCHOR_S5C, PATCHED_S5C),
+    ("S6 group_states sizing", MARK_S6, ANCHOR_S6, PATCHED_S6),
+    ("S7 update_offload_keys", MARK_S7, ANCHOR_S7, PATCHED_S7),
+    ("S8 advance_stored_idx", MARK_S8, ANCHOR_S8, PATCHED_S8),
+    ("S9 update_num_hit_chunks", MARK_S9, ANCHOR_S9, PATCHED_S9),
+    ("S10 scheduler init dict", MARK_S10, ANCHOR_S10, PATCHED_S10),
+    ("S11 _touch", MARK_S11, ANCHOR_S11, PATCHED_S11),
+    ("S12 lookup subscript", MARK_S12, ANCHOR_S12, PATCHED_S12),
+    ("S13 chunks_being_loaded", MARK_S13, ANCHOR_S13, PATCHED_S13),
+    ("S14 update_state_after_alloc", MARK_S14, ANCHOR_S14, PATCHED_S14),
+    ("S14B alloc group sizes", MARK_S14B, ANCHOR_S14B, PATCHED_S14B),
+    ("S15C partial-tail block ids", MARK_S15C, ANCHOR_S15C, PATCHED_S15C),
+    ("S15 partial-tail group_by_key", MARK_S15, ANCHOR_S15, PATCHED_S15),
+    ("S15B partial-tail source blocks", MARK_S15B, ANCHOR_S15B, PATCHED_S15B),
+    ("S16 store-jobs key filter", MARK_S16, ANCHOR_S16, PATCHED_S16),
+    ("S17 store-jobs block walk", MARK_S17, ANCHOR_S17, PATCHED_S17),
+    ("S17B store-jobs group sizes", MARK_S17B, ANCHOR_S17B, PATCHED_S17B),
+)
+
+
+TARGETS = (
+    ("kv_offload/config.py", TARGET_KVO_CONFIG, SITES_KVO_CONFIG),
+    ("offloading/config.py", TARGET_CONN_CONFIG, SITES_CONN_CONFIG),
+    ("offloading/scheduler.py", TARGET_SCHED, SITES_SCHED),
+)
+
+
+def verified_state(text: str, sites) -> bool:
+    """Exact post-state: one mark per site, one patched block per site, and
+    anchors survive only where the replacement itself contains them."""
+    return all(
+        text.count(mark) == 1
+        and text.count(patched) == 1
+        and text.count(anchor) == patched.count(anchor)
+        for _name, mark, anchor, patched in sites
+    )
+
+
+def prepare(source: str, sites, label: str) -> tuple[str, str]:
+    """Idempotent, fail-closed. Returns (text, action). Nothing written here.
+
+    The already-present check counts MARK sentinels only (each exactly once):
+    patch_kv_offload_store_local.py legitimately edits inside this overlay's
+    patched scheduler regions afterwards, so full patched-block equality only
+    holds between the two applications (and is still enforced post-patch)."""
+    marks = sum(source.count(mark) for _n, mark, _a, _p in sites)
+    if marks:
+        if marks != len(sites) or any(
+            source.count(mark) != 1 for _n, mark, _a, _p in sites
+        ):
+            raise ValueError(
+                f"partial/inconsistent kv-offload-scope patch in {label} "
+                f"(marks={marks}, expected {len(sites)}) -- refusing to touch "
+                "a half-patched file"
+            )
+        return source, "already present"
+
+    for name, _mark, anchor, _patched in sites:
+        n = source.count(anchor)
+        if n != 1:
+            raise ValueError(
+                f"pinned kv-offload-scope anchor '{name}' drifted in {label} "
+                f"(found {n}, expected 1)"
+            )
+    out = source
+    for _name, _mark, anchor, patched in sites:
+        out = out.replace(anchor, patched, 1)
+    if not verified_state(out, sites):
+        raise ValueError(f"kv-offload-scope post-patch verification failed in {label}")
+    return out, "patched"
+
+
+def replace_file(target: Path, source: str) -> None:
+    tmp = target.with_name(f".{target.name}.glm53-kv-offload-scope.tmp")
+    try:
+        tmp.write_text(source)
+        os.chmod(tmp, stat.S_IMODE(target.stat().st_mode))
+        os.replace(tmp, target)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def clear_pyc(target: Path) -> None:
+    cache = target.parent / "__pycache__"
+    if not cache.is_dir():
+        return
+    for pyc in cache.glob(f"{target.stem}*.pyc"):
+        pyc.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv if argv is None else argv
+    preflight_only = "--preflight" in argv[1:]
+
+    # Preflight EVERY target before writing ANY (fail-closed: a drifted
+    # scheduler must not leave a patched config.py behind).
+    prepared: list[tuple[Path, str, str, str]] = []
+    for label, target, sites in TARGETS:
+        if not target.is_file():
+            raise SystemExit(f"missing {target}")
+        source = target.read_text()
+        try:
+            patched, action = prepare(source, sites, label)
+        except ValueError as exc:
+            raise SystemExit(f"kv-offload-scope preflight failed: {exc}") from exc
+        compile(patched, str(target), "exec")
+        prepared.append((target, source, patched, action))
+        if preflight_only:
+            print(f"{target.name}: kv-offload-scope preflight OK ({action})")
+
+    if preflight_only:
+        return 0
+
+    for target, source, patched, action in prepared:
+        if patched != source:
+            replace_file(target, patched)
+            clear_pyc(target)
+        print(f"{target.name}: kv-offload-scope {action}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/overlay/patch_kv_offload_store_local.py
+++ b/overlay/patch_kv_offload_store_local.py
@@ -1,0 +1,1364 @@
+#!/usr/bin/env python3
+"""Store-only worker-local disk KV tier with chunk headers (GLM53_KV_OFFLOAD).
+
+Stage 1 of the disk KV-offload plan (PLAN-KV-OFFLOAD.md §11): the tier WRITES;
+nothing reads it back (restore stays off behind GLM53_KV_OFFLOAD_RESTORE=0).
+
+Why worker-local (plan risk R0)
+-------------------------------
+``TieringOffloadingSpec.get_manager()`` builds the CPU primary tier AND every
+secondary tier on the SCHEDULER side and hands ``FileSystemTierManager`` the
+scheduler node's staging memoryview. On this 2-node TP=2 deployment
+(``--nnodes 2``) rank 1's staging mmap lives on the other Spark: the
+scheduler-side view's rank-1 page slots are never written, so the stock fs
+tier would persist rank-0 bytes plus uninitialised garbage as the rank-1 half
+of every file — corruption that only surfaces at restore time. The CPU
+primary tier itself is multi-node-correct (GPU<->CPU DMA is worker-local
+against each node's own mmap), so this overlay keeps the CPU staging path
+stock and moves the DISK write to the workers: each rank writes its own bytes
+from its own staging mmap to its own local NVMe under a per-rank root.
+
+What this overlay does (three files)
+------------------------------------
+The stock fs secondary tier is NOT configured at all (Codex advisory
+CODEX-OFFLOAD1-PLAN.md, finding 3 / Q1): the launcher's connector JSON is
+``TieringOffloadingSpec`` with CPU staging only, and THIS overlay's
+worker-local writer is the disk tier. The in-image
+``FileSystemTierManager`` stays untouched and unused; stage 2's per-rank
+manifest-aggregating lookup replaces it on the read side.
+
+1. ``offloading/common.py`` — ``TransferJob`` gains an optional
+   ``glm53_store_meta`` field (versioned picklable dict; rides the existing
+   scheduler->worker metadata channel; a plain dict is deliberate — pickled
+   custom classes would couple scheduler/worker code versions on the wire).
+2. ``offloading/scheduler.py`` (AFTER patch_kv_offload_scope.py — two of the
+   anchors below pin that overlay's output) —
+   - store jobs collect an ordered (key, group_idx, chunk_idx) list aligned
+     with the job's src/dst block order and attach it, plus boundary-manifest
+     candidates (chunk-hash chains from ``req.block_hashes``), as
+     ``glm53_store_meta``;
+   - under ``GLM53_KV_OFFLOAD_RESTORE=0`` (default) the external lookup in
+     ``get_num_new_matched_tokens`` is short-circuited to 0 hits: no loads,
+     no promotions, no WAITING_FOR_REMOTE_KVS — store-only, zero restore
+     machinery active.
+3. ``offloading/worker.py`` — the worker-local writer:
+   - store-job metadata is captured per job (both the ``prepare_store_kv``
+     and the ``handle_preemptions`` flush path);
+   - when a store job's GPU->CPU DMA completes, the job is NOT acked to the
+     scheduler yet; a small writer pool (2 threads) writes one file per
+     (block-hash, group): real (unpadded) bytes only, gathered from the
+     worker's own CPU staging tensors via the same CanonicalKVCacheRef layout
+     the DMA used, with a §4 chunk header (format v1: magic, versioned JSON
+     header with namespace hash, ORIGINAL group index, per-layer segment
+     table incl. the KDA conv/temporal split, payload CRC, header CRC);
+   - the job is acked only after its writes finish — staging blocks stay
+     pinned by the store protocol until every worker acks, so the bytes
+     cannot be evicted or rewritten under the disk writer;
+   - after a job's payloads are durable (write+fsync+rename+parent-dir
+     fsync, unique pid-suffixed temp names), boundary manifests are
+     published (existence-verified cumulative references, tmp+rename with
+     file+dir fsync) — a crash between group writes leaves orphan payloads,
+     never a live half-boundary; a key whose write failed this boot can
+     never enter a manifest (failed-key ledger + on-disk header check);
+   - K-boundary retention INLINE (plan §7, ``GLM53_KV_OFFLOAD_KEEP_BOUNDARIES``,
+     default 2): after each publish, a manifest is superseded (deleted, its
+     mamba payloads unlinked) once it is beyond the K most recent boundaries
+     of EVERY chain containing it — chains are prefix-related manifest
+     chains, so a shared divergence-point boundary survives as long as any
+     chain still keeps it; full-attention chunks stay dense (cheap; plan §7).
+     Cross-boot leftovers are the GC tool's job (kv_offload_store_gc.py);
+   - failure semantics (plan §8): a failed write unlinks its tmp and logs
+     (lost store = future reprefill; restore is off, nothing can serve wrong
+     bytes); ENOSPC pauses the writer (all further writes dropped, one log);
+     the job is acked either way so serving is never blocked on the tier.
+     KNOWN stage-1 limit (Codex finding 2, partially rebutted): the ack
+     protocol has no per-job failure bit, so the CPU tier will believe a
+     failed key stored and not retry it this boot — safe while restore is
+     off (a boundary with a missing payload simply never gets a manifest and
+     stays invisible); the protocol failure bit lands with stage 2's T4
+     invalidation work, where it is load-bearing.
+
+File format v1 (see also overlay/kv_offload_store_gc.py, which reads it)
+------------------------------------------------------------------------
+``GLM53KV1`` magic (8 B) | u32 header_len | canonical-JSON header |
+u32 crc32(header) | payload. The header carries format_version,
+namespace_hash, group_idx, spec_kind, layers, block_size_tokens,
+n_tokens_valid, tp_rank/tp_world, an explicit per-layer segment table
+(``(layer, kind, offset, length)``; two segments (conv/temporal, with shapes
+and dtypes) per KDA layer when the spec exposes them), the state-ABI tag +
+``num_speculative_tokens`` for mamba groups, boundary_token_index,
+payload_len and payload_crc32 (zlib crc32 — stdlib has no crc32c; the header
+names its algorithm so a crc32c bump is a format-version change, not silent
+corruption). Any field mismatch at read => reject.
+
+The namespace hash (§6) covers model path, vllm version, TP/world, KV dtype,
+tokens_per_hash, blocks_per_chunk, per-eligible-group (group_idx, block size,
+layer count, real per-layer page sizes), the KDA state-ABI descriptor and
+``num_speculative_tokens`` (stage-0 receipt A2: num_spec is baked into the
+conv width), and format_version. Any change forks the directory.
+
+Preconditions enforced by the writer (fail-closed: refuse to write, never
+write garbage; serving unaffected): ``blocks_per_chunk == 1``, a sane
+``parallel.rank``, and the direct (non-canonical) staging layout.
+
+Conventions follow ``overlay/patch_kv_capacity_log.py``: pinned ANCHORs, MARK
+sentinels, ``verified_state``, ``prepare``, idempotent, atomic replace, pyc
+clear, drift => nonzero. ALL anchors in ALL three files preflight before ANY
+write. MUST run AFTER ``patch_kv_offload_scope.py``.
+
+Usage::
+
+    python3 patch_kv_offload_store_local.py              # apply
+    python3 patch_kv_offload_store_local.py --preflight  # validate anchors only
+"""
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+VLLM_ROOT = os.environ.get(
+    "GLM53_VLLM_ROOT", "/usr/local/lib/python3.12/dist-packages/vllm"
+)
+_CONN = "distributed/kv_transfer/kv_connector/v1/offloading"
+
+TARGET_COMMON = Path(
+    os.environ.get("GLM53_KVO_COMMON_PY", f"{VLLM_ROOT}/{_CONN}/common.py")
+)
+TARGET_SCHED = Path(
+    os.environ.get("GLM53_KVO_SCHED_PY", f"{VLLM_ROOT}/{_CONN}/scheduler.py")
+)
+TARGET_WORKER = Path(
+    os.environ.get("GLM53_KVO_WORKER_PY", f"{VLLM_ROOT}/{_CONN}/worker.py")
+)
+
+TAG = "[glm53-kv-offload-store]"
+ENV_ENABLE = "GLM53_KV_OFFLOAD"
+ENV_RESTORE = "GLM53_KV_OFFLOAD_RESTORE"
+ENV_DIR = "GLM53_KV_OFFLOAD_DIR"
+
+MAGIC = b"GLM53KV1"
+FORMAT_VERSION = 1
+STATE_ABI_VERSION = "v0-kda-r13"
+
+
+# ---------------------------------------------------------------------------
+# Shared mode helpers (exec'd for host tests AND injected into three files).
+# ---------------------------------------------------------------------------
+MODE_HELPERS_SRC = '''# [glm53-kv-offload-store] mode helpers -- see overlay/patch_kv_offload_store_local.py
+_GLM53_KVO_STORE_TAG = "[glm53-kv-offload-store]"
+
+
+def _glm53_kvo_bool_env(name: str, default: str) -> bool:
+    """Exactly "0" or "1"; unset means the given default. "" is a value and
+    an error: a typo'd knob must not silently pick a storage mode."""
+    import os as _os
+
+    raw = _os.environ.get(name)
+    if raw is None:
+        raw = default
+    if raw == "0":
+        return False
+    if raw == "1":
+        return True
+    raise ValueError(f"{name} must be exactly 0 or 1 (got: {raw!r})")
+
+
+def _glm53_kvo_store_local_enabled() -> bool:
+    return _glm53_kvo_bool_env("GLM53_KV_OFFLOAD", "0")
+
+
+def _glm53_kvo_restore_enabled() -> bool:
+    return _glm53_kvo_bool_env("GLM53_KV_OFFLOAD_RESTORE", "0")
+
+
+'''
+
+# ---------------------------------------------------------------------------
+# Chunk-header codec + store-meta builder + worker-local writer.
+#
+# One source string, exec'd below into module scope (tests + the GC tool
+# import the codec from THIS overlay module) and injected verbatim into
+# offloading/worker.py; the meta-builder part is also injected into
+# scheduler.py. Stdlib-only imports: the payload gathering uses only tensor
+# methods (`.numpy().tobytes()`), so no torch/numpy import is needed.
+# ---------------------------------------------------------------------------
+CODEC_SRC = '''# [glm53-kv-offload-store] chunk-header codec (format v1)
+import json as _glm53_json
+import struct as _glm53_struct
+import zlib as _glm53_zlib
+
+_GLM53_KVO_MAGIC = b"GLM53KV1"
+_GLM53_KVO_FORMAT_VERSION = 1
+_GLM53_KVO_STATE_ABI = "v0-kda-r13"
+_GLM53_KVO_MAX_HEADER = 1 << 20
+
+
+def glm53_encode_chunk(header: dict, payload: bytes) -> bytes:
+    """Serialize header+payload into the v1 on-disk chunk format."""
+    h = dict(header)
+    h["format_version"] = _GLM53_KVO_FORMAT_VERSION
+    h["crc_algo"] = "crc32-zlib"
+    h["payload_len"] = len(payload)
+    h["payload_crc32"] = _glm53_zlib.crc32(payload) & 0xFFFFFFFF
+    hjson = _glm53_json.dumps(h, sort_keys=True, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    if len(hjson) > _GLM53_KVO_MAX_HEADER:
+        raise ValueError("chunk header too large")
+    hcrc = _glm53_zlib.crc32(hjson) & 0xFFFFFFFF
+    return (
+        _GLM53_KVO_MAGIC
+        + _glm53_struct.pack("<I", len(hjson))
+        + hjson
+        + _glm53_struct.pack("<I", hcrc)
+        + payload
+    )
+
+
+def glm53_read_chunk_header(path: str, verify_payload: bool = False) -> dict:
+    """Read+validate a v1 chunk header; raises ValueError on ANY mismatch.
+
+    With verify_payload=True the payload is read fully and CRC-checked.
+    """
+    with open(path, "rb") as f:
+        magic = f.read(8)
+        if magic != _GLM53_KVO_MAGIC:
+            raise ValueError(f"bad magic in {path!r}")
+        raw_len = f.read(4)
+        if len(raw_len) != 4:
+            raise ValueError(f"truncated header length in {path!r}")
+        (hlen,) = _glm53_struct.unpack("<I", raw_len)
+        if not 0 < hlen <= _GLM53_KVO_MAX_HEADER:
+            raise ValueError(f"implausible header length {hlen} in {path!r}")
+        hjson = f.read(hlen)
+        if len(hjson) != hlen:
+            raise ValueError(f"truncated header in {path!r}")
+        raw_crc = f.read(4)
+        if len(raw_crc) != 4:
+            raise ValueError(f"truncated header crc in {path!r}")
+        (hcrc,) = _glm53_struct.unpack("<I", raw_crc)
+        if (_glm53_zlib.crc32(hjson) & 0xFFFFFFFF) != hcrc:
+            raise ValueError(f"header crc mismatch in {path!r}")
+        try:
+            header = _glm53_json.loads(hjson.decode("utf-8"))
+        except Exception as exc:
+            raise ValueError(f"header not JSON in {path!r}: {exc}") from exc
+        if header.get("format_version") != _GLM53_KVO_FORMAT_VERSION:
+            raise ValueError(
+                f"format_version {header.get('format_version')!r} in {path!r}"
+            )
+        expected = header.get("payload_len")
+        if not isinstance(expected, int) or expected < 0:
+            raise ValueError(f"bad payload_len in {path!r}")
+        if verify_payload:
+            payload = f.read(expected + 1)
+            if len(payload) != expected:
+                raise ValueError(
+                    f"payload length {len(payload)} != {expected} in {path!r}"
+                )
+            if (_glm53_zlib.crc32(payload) & 0xFFFFFFFF) != header.get(
+                "payload_crc32"
+            ):
+                raise ValueError(f"payload crc mismatch in {path!r}")
+        else:
+            import os as _os
+
+            actual = _os.fstat(f.fileno()).st_size - 8 - 4 - hlen - 4
+            if actual != expected:
+                raise ValueError(
+                    f"payload length {actual} != {expected} in {path!r}"
+                )
+    return header
+
+
+'''
+
+META_BUILDER_SRC = '''# [glm53-kv-offload-store] store-meta builder (scheduler side)
+def _glm53_build_store_meta(config, req, entries):
+    """Build the picklable per-job store metadata.
+
+    ``entries`` is the ordered list of (offload_key, group_idx, chunk_idx)
+    aligned 1:1 with the job's src GPU / dst CPU block order. Returns None
+    when store-local mode is off or the job carries nothing.
+    """
+    if not entries or not _glm53_kvo_store_local_enabled():
+        return None
+    from vllm.v1.kv_offload.base import get_offload_block_hash
+
+    cow_groups = [
+        g.group_idx for g in config.kv_group_configs if g.requires_cow_source
+    ]
+    full_groups = [
+        g.group_idx
+        for g in config.kv_group_configs
+        if g.sliding_window_size_in_chunks is None and not g.requires_cow_source
+    ]
+    tokens_per_chunk = {
+        g.group_idx: g.tokens_per_chunk for g in config.kv_group_configs
+    }
+    hashes_per_chunk = {
+        g.group_idx: g.hashes_per_chunk for g in config.kv_group_configs
+    }
+
+    keys = []
+    mamba_chunk_idxs = set()
+    for key, group_idx, chunk_idx in entries:
+        keys.append(
+            (
+                bytes(get_offload_block_hash(key)).hex(),
+                group_idx,
+                chunk_idx,
+                tokens_per_chunk[group_idx],
+            )
+        )
+        if group_idx in cow_groups:
+            mamba_chunk_idxs.add(chunk_idx)
+
+    # Boundary-manifest candidates need one uniform chunk grid across the
+    # eligible groups (true here: every eligible group is block 3584 with
+    # blocks_per_chunk 1). On a non-uniform layout payloads still land;
+    # manifests are skipped (stage-2 lookup then sees no boundaries).
+    manifests = []
+    if (
+        cow_groups
+        and full_groups
+        and len(set(tokens_per_chunk.values())) == 1
+        and len(set(hashes_per_chunk.values())) == 1
+    ):
+        stride = next(iter(hashes_per_chunk.values()))
+        tokens = next(iter(tokens_per_chunk.values()))
+        for k in sorted(mamba_chunk_idxs):
+            if (k + 1) * stride > len(req.block_hashes):
+                continue
+            chunk_hashes = [
+                bytes(req.block_hashes[(j + 1) * stride - 1]).hex()
+                for j in range(k + 1)
+            ]
+            manifests.append(
+                {
+                    "boundary_token_index": (k + 1) * tokens,
+                    "chunk_hashes": chunk_hashes,
+                }
+            )
+    return {
+        "v": 1,
+        "keys": keys,
+        "cow_groups": cow_groups,
+        "full_groups": full_groups,
+        "manifests": manifests,
+    }
+
+
+'''
+
+WRITER_SRC = '''# [glm53-kv-offload-store] worker-local store writer
+import hashlib as _glm53_hashlib
+import queue as _glm53_queue
+import threading as _glm53_threading
+import time as _glm53_time
+
+
+def _glm53_unwrap_kv_spec(spec):
+    specs = getattr(spec, "kv_cache_specs", None)
+    if isinstance(specs, dict) and specs:
+        return next(iter(specs.values()))
+    return spec
+
+
+def _glm53_dtype_itemsize(dtype) -> int | None:
+    itemsize = getattr(dtype, "itemsize", None)
+    if isinstance(itemsize, int):
+        return itemsize
+    name = str(dtype)
+    sizes = {
+        "torch.float32": 4, "torch.float": 4, "torch.bfloat16": 2,
+        "torch.float16": 2, "torch.half": 2, "torch.uint8": 1,
+        "torch.int8": 1, "torch.float8_e4m3fn": 1,
+    }
+    return sizes.get(name)
+
+
+class Glm53LocalStoreWriter:
+    """Per-worker disk writer: real bytes from the local staging mmap to the
+    local NVMe, one headered file per (block hash, group), plus boundary
+    manifests. Fail-closed: any precondition violation disables the writer
+    (jobs still ack; nothing is ever written half-right)."""
+
+    def __init__(self, connector_worker, logger):
+        self._log = logger
+        self._paused_reason = None
+        self._disabled_reason = None
+        self._pending_jobs = {}
+        self._done_queue = _glm53_queue.Queue()
+        self._task_queue = _glm53_queue.Queue()
+        self._threads = []
+        self._lock = _glm53_threading.Lock()
+        self._files_written = 0
+        self._files_dropped = 0
+        # Keys whose write failed THIS boot: a manifest must never reference
+        # them even if a stale file appears on disk later (plan §8).
+        self._failed_keys: set = set()
+        # In-memory manifest index for inline K-boundary retention:
+        # boundary_hash -> {"parent": hash|None, "boundary": int,
+        #                   "mamba_keys": [(hash, gidx)...]}
+        self._manifest_index: dict = {}
+        try:
+            self._init_layout(connector_worker)
+        except Exception as exc:  # noqa: BLE001 - fail closed, keep serving
+            self._disabled_reason = f"{type(exc).__name__}: {exc}"
+            self._log.error(
+                "%s writer DISABLED (store tier inactive, serving unaffected): %s",
+                _GLM53_KVO_STORE_TAG,
+                self._disabled_reason,
+            )
+
+    # ---- layout / namespace -------------------------------------------
+    def _init_layout(self, cw) -> None:
+        import os as _os
+
+        spec = cw.spec
+        worker = cw.worker
+        assert worker is not None, "writer initialised before register_kv_caches"
+        if spec.blocks_per_chunk != 1:
+            raise ValueError(
+                f"store-local requires blocks_per_chunk == 1 "
+                f"(got {spec.blocks_per_chunk})"
+            )
+        handler = worker._store_handler
+        if getattr(handler, "_canonical_copy_plans", None) is not None:
+            raise ValueError("store-local requires the direct staging layout")
+        parallel = spec.config.parallel
+        world = parallel.world_size
+        # Rank routing (plan R0; Codex OFFLOAD1 finding 1): the initialized
+        # TP rank of THIS worker process is authoritative -- NEVER a local
+        # device index (both one-GPU nodes report device 0). The connector
+        # config's parallel.rank must agree; disagreement disables the
+        # writer rather than risking cross-rank mixing.
+        rank = None
+        try:
+            from vllm.distributed.parallel_state import (
+                get_tensor_model_parallel_rank as _glm53_tp_rank,
+            )
+
+            rank = int(_glm53_tp_rank())
+        except Exception:  # noqa: BLE001 - group not initialized: fall back
+            rank = None
+        cfg_rank = parallel.rank
+        if rank is None:
+            rank = cfg_rank
+        elif isinstance(cfg_rank, int) and cfg_rank != rank:
+            raise ValueError(
+                f"TP rank {rank} disagrees with OffloadingParallelConfig.rank "
+                f"{cfg_rank} -- refusing to pick a per-rank directory"
+            )
+        if not (isinstance(rank, int) and 0 <= rank < world):
+            raise ValueError(f"implausible parallel rank {rank!r} of {world!r}")
+        root = _os.environ.get("GLM53_KV_OFFLOAD_DIR")
+        if not root:
+            raise ValueError("GLM53_KV_OFFLOAD_DIR is not set")
+        keep_raw = _os.environ.get("GLM53_KV_OFFLOAD_KEEP_BOUNDARIES", "2")
+        if not keep_raw.isdigit():
+            raise ValueError(
+                "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES must be a non-negative "
+                f"base-10 integer (got: {keep_raw!r})"
+            )
+        self._keep_boundaries = int(keep_raw)
+
+        self._rank = rank
+        self._world = world
+        self._cpu_tensors = handler.dst_tensors
+        self._refs_per_group = handler.layer_refs_per_group
+        kv_groups = cw.kv_cache_config.kv_cache_groups
+        if len(self._refs_per_group) != len(kv_groups):
+            raise ValueError(
+                f"group refs ({len(self._refs_per_group)}) != kv cache groups "
+                f"({len(kv_groups)})"
+            )
+        self._kv_groups = kv_groups
+        vllm_config = cw.vllm_config
+        spec_cfg = getattr(vllm_config, "speculative_config", None)
+        self._num_spec = int(
+            getattr(spec_cfg, "num_speculative_tokens", 0) or 0
+        )
+        import vllm as _vllm
+
+        eligible = []
+        for g in spec.config.groups:
+            refs = self._refs_per_group[g.group_idx]
+            eligible.append(
+                {
+                    "group_idx": g.group_idx,
+                    "tokens_per_block": g.tokens_per_block,
+                    "layers": len(g.layer_names),
+                    "real_page_sizes": [r.page_size_bytes for r in refs],
+                }
+            )
+        self._eligible_groups = {e["group_idx"] for e in eligible}
+        cache_cfg = getattr(vllm_config, "cache_config", None)
+        namespace_fields = {
+            "format_version": _GLM53_KVO_FORMAT_VERSION,
+            "state_abi_version": _GLM53_KVO_STATE_ABI,
+            "model": spec.config.model.name,
+            "kv_dtype": spec.config.model.dtype,
+            "vllm_version": getattr(_vllm, "__version__", "unknown"),
+            # Fork/overlay build identity (operator-pinned; empty = unpinned).
+            "build_id": _os.environ.get("GLM53_KV_OFFLOAD_BUILD_ID", ""),
+            # Prefix-cache hash algo + seed policy fence (plan §6): sha256 is
+            # content-stable; anything else (process-seeded builtin) must fork
+            # the namespace so cross-boot keys can never collide.
+            "prefix_caching_hash_algo": str(
+                getattr(cache_cfg, "prefix_caching_hash_algo", "unknown")
+            ),
+            "tp_size": parallel.tp_size,
+            "world_size": world,
+            "tokens_per_hash": spec.tokens_per_hash,
+            "blocks_per_chunk": spec.blocks_per_chunk,
+            "num_speculative_tokens": self._num_spec,
+            "groups": eligible,
+            "state_abi": self._state_abi_descriptor(),
+        }
+        canonical = _glm53_json.dumps(
+            namespace_fields, sort_keys=True, separators=(",", ":")
+        )
+        self._namespace_hash = _glm53_hashlib.sha256(
+            canonical.encode("utf-8")
+        ).hexdigest()[:12]
+        # keep_boundaries is retention POLICY, not byte semantics: it rides
+        # the on-disk namespace record for operators but must NOT fence the
+        # namespace hash (changing K must not orphan the whole store).
+        namespace_fields["keep_boundaries"] = self._keep_boundaries
+        canonical = _glm53_json.dumps(
+            namespace_fields, sort_keys=True, separators=(",", ":")
+        )
+        safe_model = spec.config.model.name.replace("/", "_")
+        self._base = (
+            f"{root}/glm53kv_{safe_model}_{self._namespace_hash}_r{rank}"
+        )
+        _os.makedirs(self._base, exist_ok=True)
+        ns_path = f"{root}/glm53kv_{safe_model}_{self._namespace_hash}.json"
+        if not _os.path.exists(ns_path):
+            tmp = ns_path + f".tmp.r{rank}.{_os.getpid()}"
+            with open(tmp, "w", encoding="utf-8") as f:
+                f.write(canonical)
+            _os.replace(tmp, ns_path)
+        for _ in range(2):
+            t = _glm53_threading.Thread(
+                target=self._writer_loop,
+                name="glm53-kv-offload-store",
+                daemon=True,
+            )
+            t.start()
+            self._threads.append(t)
+        self._log.info(
+            "%s writer up: rank %d/%d base=%s eligible=%s",
+            _GLM53_KVO_STORE_TAG,
+            rank,
+            world,
+            self._base,
+            sorted(self._eligible_groups),
+        )
+
+    def _state_abi_descriptor(self):
+        abi = {}
+        for gidx, group in enumerate(self._kv_groups):
+            inner = _glm53_unwrap_kv_spec(group.kv_cache_spec)
+            if type(inner).__name__ != "MambaSpec":
+                continue
+            shapes = getattr(inner, "shapes", None)
+            dtypes = getattr(inner, "dtypes", None)
+            abi[str(gidx)] = {
+                "shapes": [list(s) for s in shapes] if shapes else None,
+                "dtypes": [str(d) for d in dtypes] if dtypes else None,
+                "num_spec": self._num_spec,
+            }
+        return abi
+
+    # ---- job intake ----------------------------------------------------
+    def submit_job(self, job_id: int, meta: dict, dst_block_ids) -> bool:
+        """Queue a completed-DMA store job for disk writing. Returns True when
+        the ack must be deferred until the writes finish."""
+        if self._disabled_reason is not None:
+            return False
+        keys = meta.get("keys") or []
+        rows = [int(b) for b in dst_block_ids]
+        if len(keys) != len(rows):
+            self._log.error(
+                "%s job %d: %d keys vs %d dst blocks -- dropping write "
+                "(lost store only)",
+                _GLM53_KVO_STORE_TAG,
+                job_id,
+                len(keys),
+                len(rows),
+            )
+            return False
+        job = {
+            "job_id": job_id,
+            "meta": meta,
+            "remaining": len(keys),
+            "written": [],
+        }
+        with self._lock:
+            self._pending_jobs[job_id] = job
+        for (hash_hex, group_idx, chunk_idx, n_tokens), row in zip(keys, rows):
+            self._task_queue.put(
+                (job, hash_hex, int(group_idx), int(chunk_idx), int(n_tokens), row)
+            )
+        if not keys:
+            self._finish_job(job)
+        return True
+
+    def drain_done(self):
+        done = []
+        while True:
+            try:
+                done.append(self._done_queue.get_nowait())
+            except _glm53_queue.Empty:
+                return done
+
+    def shutdown(self, timeout: float = 30.0) -> None:
+        deadline = _glm53_time.monotonic() + timeout
+        while _glm53_time.monotonic() < deadline:
+            with self._lock:
+                if not self._pending_jobs:
+                    return
+            _glm53_time.sleep(0.05)
+
+    # ---- write path ----------------------------------------------------
+    def _file_path(self, hash_hex: str, group_idx: int) -> str:
+        return (
+            f"{self._base}/{hash_hex[:3]}/{hash_hex[3:5]}_g{group_idx}"
+            f"/{hash_hex}.bin"
+        )
+
+    def _manifest_path(self, boundary_hash: str) -> str:
+        return f"{self._base}/manifests/{boundary_hash[:3]}/{boundary_hash}.json"
+
+    def _writer_loop(self) -> None:
+        while True:
+            job, hash_hex, group_idx, chunk_idx, n_tokens, row = (
+                self._task_queue.get()
+            )
+            try:
+                self._write_one(job, hash_hex, group_idx, chunk_idx, n_tokens, row)
+            except Exception as exc:  # noqa: BLE001 - lost store only
+                self._on_write_error(hash_hex, group_idx, exc)
+            finally:
+                with self._lock:
+                    job["remaining"] -= 1
+                    finished = job["remaining"] <= 0
+                if finished:
+                    self._finish_job(job)
+
+    def _on_write_error(self, hash_hex, group_idx, exc) -> None:
+        import errno as _errno
+
+        self._files_dropped += 1
+        with self._lock:
+            self._failed_keys.add((hash_hex, group_idx))
+        if isinstance(exc, OSError) and exc.errno == _errno.ENOSPC:
+            if self._paused_reason is None:
+                self._paused_reason = "ENOSPC"
+                self._log.error(
+                    "%s store tier PAUSED (ENOSPC): all further writes are "
+                    "dropped; serving unaffected",
+                    _GLM53_KVO_STORE_TAG,
+                )
+            return
+        self._log.warning(
+            "%s write failed for %s g%d (lost store only): %s: %s",
+            _GLM53_KVO_STORE_TAG,
+            hash_hex[:12],
+            group_idx,
+            type(exc).__name__,
+            exc,
+        )
+
+    def _write_one(self, job, hash_hex, group_idx, chunk_idx, n_tokens, row):
+        import os as _os
+
+        if self._paused_reason is not None or self._disabled_reason is not None:
+            self._files_dropped += 1
+            return
+        if group_idx not in self._eligible_groups:
+            raise ValueError(f"ineligible group {group_idx} reached the writer")
+        path = self._file_path(hash_hex, group_idx)
+        if _os.path.exists(path):
+            _os.utime(path)  # dedup refresh, mtime stays meaningful
+            with self._lock:
+                job["written"].append((hash_hex, group_idx))
+            return
+
+        refs = self._refs_per_group[group_idx]
+        group = self._kv_groups[group_idx]
+        layer_names = list(group.layer_names)
+        segments = []
+        parts = []
+        offset = 0
+        for i, ref in enumerate(refs):
+            tensor = self._cpu_tensors[ref.tensor_idx]
+            chunk = tensor[row, : ref.page_size_bytes]
+            parts.append(chunk.numpy().tobytes())
+            layer = layer_names[i] if i < len(layer_names) else f"ref{i}"
+            segments.extend(
+                self._layer_segments(group, layer, offset, ref.page_size_bytes)
+            )
+            offset += ref.page_size_bytes
+        payload = b"".join(parts)
+
+        inner = _glm53_unwrap_kv_spec(group.kv_cache_spec)
+        header = {
+            "namespace_hash": self._namespace_hash,
+            "group_idx": group_idx,
+            "spec_kind": type(inner).__name__,
+            "layers": len(refs),
+            "block_size_tokens": getattr(inner, "block_size", None),
+            "n_tokens_valid": n_tokens,
+            "boundary_token_index": (chunk_idx + 1) * n_tokens,
+            "tp_rank": self._rank,
+            "tp_world": self._world,
+            "segment_table": segments,
+            "hash": hash_hex,
+        }
+        if type(inner).__name__ == "MambaSpec":
+            header["state_abi_version"] = _GLM53_KVO_STATE_ABI
+            header["num_speculative_tokens"] = self._num_spec
+        blob = glm53_encode_chunk(header, payload)
+
+        _os.makedirs(_os.path.dirname(path), exist_ok=True)
+        tmp = f"{path}.tmp.r{self._rank}.{_os.getpid()}"
+        try:
+            with open(tmp, "wb") as f:
+                f.write(blob)
+                f.flush()
+                _os.fsync(f.fileno())
+            _os.replace(tmp, path)
+            dfd = _os.open(_os.path.dirname(path), _os.O_RDONLY)
+            try:
+                _os.fsync(dfd)
+            finally:
+                _os.close(dfd)
+        except BaseException:
+            try:
+                _os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+        self._files_written += 1
+        with self._lock:
+            job["written"].append((hash_hex, group_idx))
+
+    def _layer_segments(self, group, layer, offset, length):
+        inner = _glm53_unwrap_kv_spec(group.kv_cache_spec)
+        if type(inner).__name__ == "MambaSpec":
+            shapes = getattr(inner, "shapes", None)
+            dtypes = getattr(inner, "dtypes", None)
+            if shapes and dtypes and len(shapes) == len(dtypes):
+                sizes = []
+                for shape, dtype in zip(shapes, dtypes):
+                    n = 1
+                    for d in shape:
+                        n *= int(d)
+                    itemsize = _glm53_dtype_itemsize(dtype)
+                    if itemsize is None:
+                        sizes = None
+                        break
+                    sizes.append((list(shape), str(dtype), n * itemsize))
+                if sizes is not None and sum(s[2] for s in sizes) == length:
+                    segs = []
+                    kinds = ("conv_state", "temporal_state")
+                    run = offset
+                    for i, (shape, dtype, size) in enumerate(sizes):
+                        # Row-major contiguous element strides, DERIVED (not
+                        # observed live -- stage-0 receipt R13 caveat rides
+                        # in "stride_provenance" so a reader cannot mistake
+                        # them for a measured layout).
+                        strides = []
+                        acc = 1
+                        for d in reversed(shape):
+                            strides.append(acc)
+                            acc *= int(d)
+                        strides.reverse()
+                        segs.append(
+                            {
+                                "layer": layer,
+                                "kind": kinds[i] if i < 2 else f"state{i}",
+                                "shape": shape,
+                                "dtype": dtype,
+                                "stride": strides,
+                                "stride_provenance": "derived-contiguous",
+                                "offset": run,
+                                "length": size,
+                            }
+                        )
+                        run += size
+                    return segs
+        return [
+            {
+                "layer": layer,
+                "kind": "raw",
+                "shape": [length],
+                "dtype": "uint8",
+                "stride": [1],
+                "stride_provenance": "derived-contiguous",
+                "offset": offset,
+                "length": length,
+            }
+        ]
+
+    # ---- manifests ------------------------------------------------------
+    def _finish_job(self, job) -> None:
+        try:
+            if self._paused_reason is None and self._disabled_reason is None:
+                self._publish_manifests(job["meta"])
+        except Exception as exc:  # noqa: BLE001 - manifests are best-effort
+            self._log.warning(
+                "%s manifest publish failed (boundary stays invisible): %s: %s",
+                _GLM53_KVO_STORE_TAG,
+                type(exc).__name__,
+                exc,
+            )
+        finally:
+            with self._lock:
+                self._pending_jobs.pop(job["job_id"], None)
+            self._done_queue.put(job["job_id"])
+
+    def _publish_manifests(self, meta) -> None:
+        import os as _os
+
+        cow_groups = meta.get("cow_groups") or []
+        full_groups = meta.get("full_groups") or []
+        for cand in meta.get("manifests") or []:
+            chunk_hashes = cand["chunk_hashes"]
+            boundary_hash = chunk_hashes[-1]
+            mpath = self._manifest_path(boundary_hash)
+            if _os.path.exists(mpath):
+                self._register_manifest(cand, cow_groups)
+                continue
+            # A key that failed to write THIS boot must never be referenced,
+            # even if a stale on-disk file would pass the header check.
+            with self._lock:
+                failed = set(self._failed_keys)
+            groups_entry = {}
+            complete = True
+            for gidx in cow_groups:
+                if (boundary_hash, gidx) in failed:
+                    complete = False
+                    break
+                fpath = self._file_path(boundary_hash, gidx)
+                try:
+                    fheader = glm53_read_chunk_header(fpath)
+                except (OSError, ValueError):
+                    complete = False
+                    break
+                groups_entry[str(gidx)] = {
+                    "hash": boundary_hash,
+                    "payload_len": fheader["payload_len"],
+                    "payload_crc32": fheader["payload_crc32"],
+                }
+            if not complete:
+                continue
+            for gidx in full_groups:
+                for h in chunk_hashes:
+                    if (h, gidx) in failed or not _os.path.exists(
+                        self._file_path(h, gidx)
+                    ):
+                        complete = False
+                        break
+                if not complete:
+                    break
+            if not complete:
+                continue
+            manifest = {
+                "format_version": _GLM53_KVO_FORMAT_VERSION,
+                "namespace_hash": self._namespace_hash,
+                "boundary_token_index": cand["boundary_token_index"],
+                "chunk_hashes": chunk_hashes,
+                "cow_groups": groups_entry,
+                "full_groups": {str(g): len(chunk_hashes) for g in full_groups},
+                "rank": self._rank,
+                "created_at": _glm53_time.time(),
+            }
+            _os.makedirs(_os.path.dirname(mpath), exist_ok=True)
+            tmp = f"{mpath}.tmp.r{self._rank}.{_os.getpid()}"
+            try:
+                with open(tmp, "w", encoding="utf-8") as f:
+                    _glm53_json.dump(manifest, f, sort_keys=True)
+                    f.flush()
+                    _os.fsync(f.fileno())
+                _os.replace(tmp, mpath)
+                dfd = _os.open(_os.path.dirname(mpath), _os.O_RDONLY)
+                try:
+                    _os.fsync(dfd)
+                finally:
+                    _os.close(dfd)
+            except BaseException:
+                try:
+                    _os.unlink(tmp)
+                except OSError:
+                    pass
+                raise
+            self._register_manifest(cand, cow_groups)
+            self._apply_retention()
+
+    # ---- inline K-boundary retention (plan §7; Codex OFFLOAD1 finding 4) --
+    def _register_manifest(self, cand, cow_groups) -> None:
+        chunk_hashes = cand["chunk_hashes"]
+        boundary_hash = chunk_hashes[-1]
+        with self._lock:
+            self._manifest_index[boundary_hash] = {
+                "parent": chunk_hashes[-2] if len(chunk_hashes) > 1 else None,
+                "boundary": cand["boundary_token_index"],
+                "mamba_keys": [(boundary_hash, g) for g in cow_groups],
+            }
+
+    def _apply_retention(self) -> None:
+        """Supersede manifests beyond the K most recent boundaries of EVERY
+        chain containing them (chains = parent-linked manifest chains; a
+        shared divergence-point boundary survives while any chain keeps it).
+        Only manifests published/observed this boot are considered; cross-boot
+        leftovers belong to the GC tool. Mamba payloads of a superseded
+        boundary are unlinked; full-attention chunks stay dense (plan §7)."""
+        import os as _os
+
+        if self._keep_boundaries <= 0:
+            return
+        with self._lock:
+            index = {k: dict(v) for k, v in self._manifest_index.items()}
+        if not index:
+            return
+        parents = {h: v["parent"] for h, v in index.items()}
+        child_count = {h: 0 for h in index}
+        for h, p in parents.items():
+            if p in child_count:
+                child_count[p] += 1
+        leaves = [h for h, c in child_count.items() if c == 0]
+        keep: set = set()
+        for leaf in leaves:
+            node, kept = leaf, 0
+            while node is not None and kept < self._keep_boundaries:
+                if node in index:
+                    keep.add(node)
+                    kept += 1
+                node = parents.get(node)
+        drop = [h for h in index if h not in keep]
+        for boundary_hash in drop:
+            entry = index[boundary_hash]
+            mpath = self._manifest_path(boundary_hash)
+            try:
+                _os.unlink(mpath)
+            except OSError:
+                pass
+            for hash_hex, gidx in entry["mamba_keys"]:
+                try:
+                    _os.unlink(self._file_path(hash_hex, gidx))
+                except OSError:
+                    pass
+            with self._lock:
+                self._manifest_index.pop(boundary_hash, None)
+            self._log.info(
+                "%s superseded boundary %d (%s) under keep_boundaries=%d",
+                _GLM53_KVO_STORE_TAG,
+                entry["boundary"],
+                boundary_hash[:12],
+                self._keep_boundaries,
+            )
+
+
+def _glm53_get_store_writer(connector_worker):
+    writer = connector_worker._glm53_store_writer
+    if writer is None:
+        writer = Glm53LocalStoreWriter(connector_worker, logger)
+        connector_worker._glm53_store_writer = writer
+    return writer
+
+
+def _glm53_drain_finished_disk_writes(connector_worker) -> None:
+    writer = connector_worker._glm53_store_writer
+    if writer is None:
+        return
+    for job_id in writer.drain_done():
+        connector_worker._connector_worker_meta.mark_completed(job_id)
+
+
+def _glm53_intercept_store_completion(connector_worker, job_id: int) -> bool:
+    """Route a DMA-complete store job into the local disk writer. Returns True
+    when the ack is deferred until the disk write finishes."""
+    captured = connector_worker._glm53_job_meta.pop(job_id, None)
+    if captured is None:
+        return False
+    meta, dst_spec = captured
+    try:
+        writer = _glm53_get_store_writer(connector_worker)
+        return writer.submit_job(job_id, meta, dst_spec.block_ids)
+    except Exception as exc:  # noqa: BLE001 - never block serving on the tier
+        logger.error(
+            "%s store interception failed (job acked, store lost): %s: %s",
+            _GLM53_KVO_STORE_TAG,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+
+'''
+
+
+def load_helpers() -> dict:
+    """Exec the shared sources into a namespace (host tests + GC tool)."""
+    ns: dict = {}
+    src = MODE_HELPERS_SRC + CODEC_SRC + META_BUILDER_SRC
+    exec(compile(src, "<glm53-kv-offload-store helpers>", "exec"), ns)
+    return ns
+
+
+_HELPERS = load_helpers()
+kvo_store_local_enabled = _HELPERS["_glm53_kvo_store_local_enabled"]
+kvo_restore_enabled = _HELPERS["_glm53_kvo_restore_enabled"]
+encode_chunk = _HELPERS["glm53_encode_chunk"]
+read_chunk_header = _HELPERS["glm53_read_chunk_header"]
+build_store_meta = _HELPERS["_glm53_build_store_meta"]
+
+
+def load_writer_helpers(logger) -> dict:
+    """Exec the FULL injected worker source with a host-supplied logger."""
+    ns: dict = {"logger": logger}
+    src = MODE_HELPERS_SRC + CODEC_SRC + WRITER_SRC
+    exec(compile(src, "<glm53-kv-offload-store writer>", "exec"), ns)
+    return ns
+
+
+# ===========================================================================
+# File 1: offloading/common.py — TransferJob.glm53_store_meta
+# ===========================================================================
+MARK_C1 = "    # [glm53-kv-offload-store] optional store-side metadata\n"
+
+ANCHOR_C1 = """    req_id: ReqId
+    src_spec: LoadStoreSpec
+    dst_spec: LoadStoreSpec
+"""
+
+PATCHED_C1 = """    req_id: ReqId
+    src_spec: LoadStoreSpec
+    dst_spec: LoadStoreSpec
+    # [glm53-kv-offload-store] optional store-side metadata
+    # (keys/manifests for the worker-local disk writer; None for loads and
+    # when GLM53_KV_OFFLOAD store-local mode is off). Plain dict: picklable
+    # across the scheduler->worker metadata channel.
+    glm53_store_meta: object | None = None
+"""
+
+SITES_COMMON = (("TransferJob.glm53_store_meta", MARK_C1, ANCHOR_C1, PATCHED_C1),)
+
+
+# ===========================================================================
+# File 2: offloading/scheduler.py (anchored on the SCOPE-patched text)
+# ===========================================================================
+MARK_L1 = "# [glm53-kv-offload-store] mode helpers -- see overlay/patch_kv_offload_store_local.py\n"
+
+ANCHOR_L1 = """def get_sliding_window_size_in_chunks(
+"""
+
+PATCHED_L1 = MODE_HELPERS_SRC + META_BUILDER_SRC + ANCHOR_L1
+
+MARK_L2 = "        if request.skip_reading_prefix_cache or not _glm53_kvo_restore_enabled():  # [glm53-kv-offload-store]\n"
+
+ANCHOR_L2 = """        num_hit_tokens: int | None
+        if request.skip_reading_prefix_cache:
+            num_hit_tokens = 0
+        else:
+"""
+
+PATCHED_L2 = """        num_hit_tokens: int | None
+        if request.skip_reading_prefix_cache or not _glm53_kvo_restore_enabled():  # [glm53-kv-offload-store]
+            # Store-only stage 1: never report external hits, so no loads,
+            # no promotions and no WAITING_FOR_REMOTE_KVS can occur. Stores
+            # (below in build_connector_meta) are unaffected.
+            num_hit_tokens = 0
+        else:
+"""
+
+# L3 anchors on scope-patched S17 output.
+MARK_L3 = "            _glm53_store_meta_entries: list = []  # [glm53-kv-offload-store]\n"
+
+ANCHOR_L3 = """            group_sizes = [0] * self.config.num_kv_cache_groups  # [glm53-kv-offload-scope]
+            block_indices = [0] * self.config.num_kv_cache_groups
+"""
+
+PATCHED_L3 = """            group_sizes = [0] * self.config.num_kv_cache_groups  # [glm53-kv-offload-scope]
+            block_indices = [0] * self.config.num_kv_cache_groups
+            _glm53_store_meta_entries: list = []  # [glm53-kv-offload-store]
+"""
+
+MARK_L4 = "                        _glm53_store_meta_entries.append(  # [glm53-kv-offload-store]\n"
+
+ANCHOR_L4 = """                        if start_gpu_block_idx is None:
+                            start_gpu_block_idx = gpu_block_idx + i
+                        src_block_ids.append(block_id)
+                        num_group_blocks += 1
+"""
+
+PATCHED_L4 = """                        if start_gpu_block_idx is None:
+                            start_gpu_block_idx = gpu_block_idx + i
+                        src_block_ids.append(block_id)
+                        _glm53_store_meta_entries.append(  # [glm53-kv-offload-store]
+                            (offload_key, group_config.group_idx, chunk_idx)
+                        )
+                        num_group_blocks += 1
+"""
+
+MARK_L5 = "                glm53_store_meta=_glm53_build_store_meta(  # [glm53-kv-offload-store]\n"
+
+ANCHOR_L5 = """            store_jobs[job_id] = TransferJob(
+                req_id=req_id, src_spec=src_spec, dst_spec=dst_spec
+            )
+"""
+
+PATCHED_L5 = """            store_jobs[job_id] = TransferJob(
+                req_id=req_id,
+                src_spec=src_spec,
+                dst_spec=dst_spec,
+                glm53_store_meta=_glm53_build_store_meta(  # [glm53-kv-offload-store]
+                    self.config, req, _glm53_store_meta_entries
+                ),
+            )
+"""
+
+SITES_SCHED = (
+    ("L1 scheduler helpers", MARK_L1, ANCHOR_L1, PATCHED_L1),
+    ("L2 restore-off short-circuit", MARK_L2, ANCHOR_L2, PATCHED_L2),
+    ("L3 store-meta list init", MARK_L3, ANCHOR_L3, PATCHED_L3),
+    ("L4 store-meta entry append", MARK_L4, ANCHOR_L4, PATCHED_L4),
+    ("L5 TransferJob store meta", MARK_L5, ANCHOR_L5, PATCHED_L5),
+)
+
+
+# ===========================================================================
+# File 3: offloading/worker.py — capture, delay acks, write locally
+# ===========================================================================
+MARK_W1 = "# [glm53-kv-offload-store] worker-local store writer\n"
+
+ANCHOR_W1 = """class OffloadingConnectorWorker:
+"""
+
+PATCHED_W1 = MODE_HELPERS_SRC + CODEC_SRC + WRITER_SRC + ANCHOR_W1
+
+MARK_W2 = "        self._glm53_store_writer = None  # [glm53-kv-offload-store] lazy\n"
+
+ANCHOR_W2 = """        self._unsubmitted_store_jobs: list[
+            tuple[int, GPULoadStoreSpec, LoadStoreSpec]
+        ] = []
+        self._connector_worker_meta = OffloadingWorkerMetadata()
+"""
+
+PATCHED_W2 = """        self._unsubmitted_store_jobs: list[
+            tuple[int, GPULoadStoreSpec, LoadStoreSpec]
+        ] = []
+        self._connector_worker_meta = OffloadingWorkerMetadata()
+        self._glm53_store_writer = None  # [glm53-kv-offload-store] lazy
+        self._glm53_job_meta: dict[int, tuple] = {}
+"""
+
+MARK_W3 = "                    _glm53_meta = getattr(entry, \"glm53_store_meta\", None)  # [glm53-kv-offload-store] flush path\n"
+
+ANCHOR_W3 = """                entry = kv_connector_metadata.store_jobs.pop(job_id, None)
+                if entry is not None:
+                    if not self._is_store_writer:
+                        self._connector_worker_meta.mark_completed(job_id)
+                        continue
+                    assert isinstance(entry.src_spec, GPULoadStoreSpec)
+"""
+
+PATCHED_W3 = """                entry = kv_connector_metadata.store_jobs.pop(job_id, None)
+                if entry is not None:
+                    if not self._is_store_writer:
+                        self._connector_worker_meta.mark_completed(job_id)
+                        continue
+                    _glm53_meta = getattr(entry, \"glm53_store_meta\", None)  # [glm53-kv-offload-store] flush path
+                    if _glm53_meta is not None:
+                        self._glm53_job_meta[job_id] = (_glm53_meta, entry.dst_spec)
+                    assert isinstance(entry.src_spec, GPULoadStoreSpec)
+"""
+
+MARK_W4 = "            _glm53_meta = getattr(entry, \"glm53_store_meta\", None)  # [glm53-kv-offload-store]\n"
+
+ANCHOR_W4 = """        for job_id, entry in metadata.store_jobs.items():
+            if not self._is_store_writer:
+                # Gate before queueing: no _unsubmitted_store_jobs entry.
+                self._connector_worker_meta.mark_completed(job_id)
+                continue
+"""
+
+PATCHED_W4 = """        for job_id, entry in metadata.store_jobs.items():
+            if not self._is_store_writer:
+                # Gate before queueing: no _unsubmitted_store_jobs entry.
+                self._connector_worker_meta.mark_completed(job_id)
+                continue
+            _glm53_meta = getattr(entry, \"glm53_store_meta\", None)  # [glm53-kv-offload-store]
+            if _glm53_meta is not None:
+                self._glm53_job_meta[job_id] = (_glm53_meta, entry.dst_spec)
+"""
+
+MARK_W5 = "        _glm53_drain_finished_disk_writes(self)  # [glm53-kv-offload-store]\n"
+
+ANCHOR_W5 = """        assert self.worker is not None
+        finished_recving: set[str] = set()
+        for transfer_result in self.worker.get_finished():
+"""
+
+PATCHED_W5 = """        assert self.worker is not None
+        finished_recving: set[str] = set()
+        _glm53_drain_finished_disk_writes(self)  # [glm53-kv-offload-store]
+        for transfer_result in self.worker.get_finished():
+"""
+
+MARK_W5B = "            if _glm53_intercept_store_completion(self, job_id):  # [glm53-kv-offload-store]\n"
+
+ANCHOR_W5B = """            self._connector_worker_meta.mark_completed(job_id)
+            req_id = self._load_jobs.pop(job_id, None)
+"""
+
+PATCHED_W5B = """            if _glm53_intercept_store_completion(self, job_id):  # [glm53-kv-offload-store]
+                # DMA done; the ack is deferred until this rank's disk write
+                # finishes (staging stays pinned by the store protocol, so
+                # the bytes cannot be evicted under the writer).
+                continue
+            self._connector_worker_meta.mark_completed(job_id)
+            req_id = self._load_jobs.pop(job_id, None)
+"""
+
+MARK_W6 = "        if self._glm53_store_writer is not None:  # [glm53-kv-offload-store]\n"
+
+ANCHOR_W6 = """    def shutdown(self) -> None:
+        self._unsubmitted_store_jobs.clear()
+"""
+
+PATCHED_W6 = """    def shutdown(self) -> None:
+        if self._glm53_store_writer is not None:  # [glm53-kv-offload-store]
+            self._glm53_store_writer.shutdown()
+        self._unsubmitted_store_jobs.clear()
+"""
+
+SITES_WORKER = (
+    ("W1 writer classes", MARK_W1, ANCHOR_W1, PATCHED_W1),
+    ("W2 worker state", MARK_W2, ANCHOR_W2, PATCHED_W2),
+    ("W3 flush-path meta capture", MARK_W3, ANCHOR_W3, PATCHED_W3),
+    ("W4 store meta capture", MARK_W4, ANCHOR_W4, PATCHED_W4),
+    ("W5 drain finished writes", MARK_W5, ANCHOR_W5, PATCHED_W5),
+    ("W5B intercept completion", MARK_W5B, ANCHOR_W5B, PATCHED_W5B),
+    ("W6 shutdown drain", MARK_W6, ANCHOR_W6, PATCHED_W6),
+)
+
+
+TARGETS = (
+    ("offloading/common.py", TARGET_COMMON, SITES_COMMON),
+    ("offloading/scheduler.py", TARGET_SCHED, SITES_SCHED),
+    ("offloading/worker.py", TARGET_WORKER, SITES_WORKER),
+)
+
+# The scheduler anchors L3/L5 pin patch_kv_offload_scope.py output; refuse to
+# run against an unscoped tree with a clear message instead of anchor drift.
+SCOPE_MARK = "[glm53-kv-offload-scope]"
+
+
+def verified_state(text: str, sites) -> bool:
+    return all(
+        text.count(mark) == 1
+        and text.count(patched) == 1
+        and text.count(anchor) == patched.count(anchor)
+        for _name, mark, anchor, patched in sites
+    )
+
+
+def prepare(source: str, sites, label: str) -> tuple[str, str]:
+    marks = sum(source.count(mark) for _n, mark, _a, _p in sites)
+    if marks:
+        # Marks-only already-present check (same rationale as the scope
+        # patcher: a later overlay may edit inside patched regions; full
+        # verification is enforced on this patcher's own output below).
+        if marks != len(sites) or any(
+            source.count(mark) != 1 for _n, mark, _a, _p in sites
+        ):
+            raise ValueError(
+                f"partial/inconsistent kv-offload-store patch in {label} "
+                f"(marks={marks}, expected {len(sites)}) -- refusing to touch "
+                "a half-patched file"
+            )
+        return source, "already present"
+    for name, _mark, anchor, _patched in sites:
+        n = source.count(anchor)
+        if n != 1:
+            raise ValueError(
+                f"pinned kv-offload-store anchor '{name}' drifted in {label} "
+                f"(found {n}, expected 1)"
+            )
+    out = source
+    for _name, _mark, anchor, patched in sites:
+        out = out.replace(anchor, patched, 1)
+    if not verified_state(out, sites):
+        raise ValueError(f"kv-offload-store post-patch verification failed in {label}")
+    return out, "patched"
+
+
+def replace_file(target: Path, source: str) -> None:
+    tmp = target.with_name(f".{target.name}.glm53-kv-offload-store.tmp")
+    try:
+        tmp.write_text(source)
+        os.chmod(tmp, stat.S_IMODE(target.stat().st_mode))
+        os.replace(tmp, target)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def clear_pyc(target: Path) -> None:
+    cache = target.parent / "__pycache__"
+    if not cache.is_dir():
+        return
+    for pyc in cache.glob(f"{target.stem}*.pyc"):
+        pyc.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv if argv is None else argv
+    preflight_only = "--preflight" in argv[1:]
+
+    sched_source = TARGET_SCHED.read_text() if TARGET_SCHED.is_file() else ""
+    if SCOPE_MARK not in sched_source:
+        raise SystemExit(
+            "kv-offload-store preflight failed: scheduler.py is not "
+            "scope-patched -- run patch_kv_offload_scope.py first "
+            "(GLM53_OVERLAY_ORDER pins this)"
+        )
+
+    prepared: list[tuple[Path, str, str, str]] = []
+    for label, target, sites in TARGETS:
+        if not target.is_file():
+            raise SystemExit(f"missing {target}")
+        source = target.read_text()
+        try:
+            patched, action = prepare(source, sites, label)
+        except ValueError as exc:
+            raise SystemExit(f"kv-offload-store preflight failed: {exc}") from exc
+        compile(patched, str(target), "exec")
+        prepared.append((target, source, patched, action))
+        if preflight_only:
+            print(f"{target.name}: kv-offload-store preflight OK ({action})")
+
+    if preflight_only:
+        return 0
+
+    for target, source, patched, action in prepared:
+        if patched != source:
+            replace_file(target, patched)
+            clear_pyc(target)
+    print(
+        f"kv-offload-store {prepared[0][3]} "
+        f"({ENV_ENABLE}={os.environ.get(ENV_ENABLE, '0 (unset)')!r})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/overlay/patch_kv_offload_store_local.py
+++ b/overlay/patch_kv_offload_store_local.py
@@ -539,13 +539,20 @@ class Glm53LocalStoreWriter:
         self._namespace_hash = _glm53_hashlib.sha256(
             canonical.encode("utf-8")
         ).hexdigest()[:12]
-        # keep_boundaries is retention POLICY, not byte semantics: it rides
-        # the on-disk namespace record for operators but must NOT fence the
-        # namespace hash (changing K must not orphan the whole store).
-        namespace_fields["keep_boundaries"] = self._keep_boundaries
-        namespace_fields["rank_source"] = rank_source
-        canonical = _glm53_json.dumps(
-            namespace_fields, sort_keys=True, separators=(",", ":")
+        # The on-disk record separates the FENCED fields (exact-compared and
+        # hashed) from informational ones: retention K and rank provenance are
+        # policy/diagnostics, not byte semantics -- changing them must neither
+        # fork the namespace nor disable the writer on the next boot.
+        record = _glm53_json.dumps(
+            {
+                "fenced": namespace_fields,
+                "info": {
+                    "keep_boundaries": self._keep_boundaries,
+                    "rank_source": rank_source,
+                },
+            },
+            sort_keys=True,
+            separators=(",", ":"),
         )
         safe_model = spec.config.model.name.replace("/", "_")
         self._base = (
@@ -554,12 +561,21 @@ class Glm53LocalStoreWriter:
         _os.makedirs(self._base, exist_ok=True)
         ns_path = f"{root}/glm53kv_{safe_model}_{self._namespace_hash}.json"
         if _os.path.exists(ns_path):
-            with open(ns_path, encoding="utf-8") as f:
-                existing = f.read()
-            if existing != canonical:
-                # Same 12-hex namespace, different canonical record: either a
-                # truncated write or a hash collision -- both disqualify the
-                # store (fail closed rather than mixing semantics).
+            # Compare the FENCED portion only (info fields may legitimately
+            # differ across boots). An unparseable or mismatched record is a
+            # truncated write or hash collision: fail closed.
+            try:
+                with open(ns_path, encoding="utf-8") as f:
+                    existing = _glm53_json.load(f)
+                existing_fenced = _glm53_json.dumps(
+                    existing["fenced"], sort_keys=True, separators=(",", ":")
+                )
+            except (OSError, ValueError, KeyError, TypeError) as exc:
+                raise ValueError(
+                    f"namespace record unreadable at {ns_path} ({exc}) -- "
+                    "refusing to write into an unverifiable store"
+                ) from exc
+            if existing_fenced != canonical:
                 raise ValueError(
                     f"namespace record mismatch at {ns_path} -- refusing to "
                     "write into a store whose recorded config differs"
@@ -567,7 +583,7 @@ class Glm53LocalStoreWriter:
         else:
             tmp = ns_path + f".tmp.r{rank}.{_os.getpid()}"
             with open(tmp, "w", encoding="utf-8") as f:
-                f.write(canonical)
+                f.write(record)
                 f.flush()
                 _os.fsync(f.fileno())
             _os.replace(tmp, ns_path)

--- a/overlay/patch_kv_offload_store_local.py
+++ b/overlay/patch_kv_offload_store_local.py
@@ -44,16 +44,19 @@ manifest-aggregating lookup replaces it on the read side.
 3. ``offloading/worker.py`` — the worker-local writer:
    - store-job metadata is captured per job (both the ``prepare_store_kv``
      and the ``handle_preemptions`` flush path);
-   - when a store job's GPU->CPU DMA completes, the job is NOT acked to the
-     scheduler yet; a small writer pool (2 threads) writes one file per
-     (block-hash, group): real (unpadded) bytes only, gathered from the
-     worker's own CPU staging tensors via the same CanonicalKVCacheRef layout
-     the DMA used, with a §4 chunk header (format v1: magic, versioned JSON
-     header with namespace hash, ORIGINAL group index, per-layer segment
-     table incl. the KDA conv/temporal split, payload CRC, header CRC);
-   - the job is acked only after its writes finish — staging blocks stay
-     pinned by the store protocol until every worker acks, so the bytes
-     cannot be evicted or rewritten under the disk writer;
+   - when a store job's GPU->CPU DMA completes, the job's bytes are
+     SNAPSHOTTED synchronously out of the staging mmap (capture-then-write;
+     Codex OFFLOAD1-REVIEW finding 1) — at get_finished before this rank's
+     ack (rows pinned until complete_store) or right after worker.wait() on
+     the flush/reset path, before any new DMA can reuse the rows: staging
+     reuse after reset_cache()/preemption/shutdown can never tear a payload.
+     A small writer pool (2 threads) then writes one file per (block-hash,
+     group) from PRIVATE buffers (budget-capped, drop-over-budget = lost
+     store): real (unpadded) bytes only, via the same CanonicalKVCacheRef
+     layout the DMA used, with a §4 chunk header (format v1: magic,
+     versioned JSON header with namespace hash, ORIGINAL group index,
+     per-layer segment table incl. the KDA conv/temporal split, payload
+     CRC, header CRC); acks are never deferred;
    - after a job's payloads are durable (write+fsync+rename+parent-dir
      fsync, unique pid-suffixed temp names), boundary manifests are
      published (existence-verified cumulative references, tmp+rename with
@@ -397,6 +400,7 @@ class Glm53LocalStoreWriter:
         self._lock = _glm53_threading.Lock()
         self._files_written = 0
         self._files_dropped = 0
+        self._outstanding_bytes = 0
         # Keys whose write failed THIS boot: a manifest must never reference
         # them even if a stale file appears on disk later (plan §8).
         self._failed_keys: set = set()
@@ -437,14 +441,23 @@ class Glm53LocalStoreWriter:
         # config's parallel.rank must agree; disagreement disables the
         # writer rather than risking cross-rank mixing.
         rank = None
+        rank_source = "tp-group"
         try:
             from vllm.distributed.parallel_state import (
                 get_tensor_model_parallel_rank as _glm53_tp_rank,
             )
 
             rank = int(_glm53_tp_rank())
-        except Exception:  # noqa: BLE001 - group not initialized: fall back
+        except Exception as exc:  # noqa: BLE001 - group not initialized
             rank = None
+            rank_source = f"config-fallback ({type(exc).__name__})"
+            self._log.warning(
+                "%s TP rank unavailable (%s); falling back to "
+                "OffloadingParallelConfig.rank -- the two-node R0 receipt is "
+                "the live check for this path",
+                _GLM53_KVO_STORE_TAG,
+                exc,
+            )
         cfg_rank = parallel.rank
         if rank is None:
             rank = cfg_rank
@@ -467,6 +480,7 @@ class Glm53LocalStoreWriter:
         self._keep_boundaries = int(keep_raw)
 
         self._rank = rank
+        self._rank_source = rank_source
         self._world = world
         self._cpu_tensors = handler.dst_tensors
         self._refs_per_group = handler.layer_refs_per_group
@@ -529,6 +543,7 @@ class Glm53LocalStoreWriter:
         # the on-disk namespace record for operators but must NOT fence the
         # namespace hash (changing K must not orphan the whole store).
         namespace_fields["keep_boundaries"] = self._keep_boundaries
+        namespace_fields["rank_source"] = rank_source
         canonical = _glm53_json.dumps(
             namespace_fields, sort_keys=True, separators=(",", ":")
         )
@@ -538,10 +553,23 @@ class Glm53LocalStoreWriter:
         )
         _os.makedirs(self._base, exist_ok=True)
         ns_path = f"{root}/glm53kv_{safe_model}_{self._namespace_hash}.json"
-        if not _os.path.exists(ns_path):
+        if _os.path.exists(ns_path):
+            with open(ns_path, encoding="utf-8") as f:
+                existing = f.read()
+            if existing != canonical:
+                # Same 12-hex namespace, different canonical record: either a
+                # truncated write or a hash collision -- both disqualify the
+                # store (fail closed rather than mixing semantics).
+                raise ValueError(
+                    f"namespace record mismatch at {ns_path} -- refusing to "
+                    "write into a store whose recorded config differs"
+                )
+        else:
             tmp = ns_path + f".tmp.r{rank}.{_os.getpid()}"
             with open(tmp, "w", encoding="utf-8") as f:
                 f.write(canonical)
+                f.flush()
+                _os.fsync(f.fileno())
             _os.replace(tmp, ns_path)
         for _ in range(2):
             t = _glm53_threading.Thread(
@@ -576,11 +604,27 @@ class Glm53LocalStoreWriter:
         return abi
 
     # ---- job intake ----------------------------------------------------
-    def submit_job(self, job_id: int, meta: dict, dst_block_ids) -> bool:
-        """Queue a completed-DMA store job for disk writing. Returns True when
-        the ack must be deferred until the writes finish."""
+    # CAPTURE-THEN-WRITE (Codex OFFLOAD1-REVIEW finding 1, BLOCKER): payload
+    # bytes are SNAPSHOTTED OUT of the staging mmap synchronously at capture
+    # time -- while the job's rows are still guaranteed live (normal path:
+    # before this rank's ack, rows pinned until complete_store; flush/reset
+    # path: immediately after worker.wait(), before any new DMA is submitted).
+    # The async writer threads then work on private buffers only, so staging
+    # reuse after reset_cache(), preemption fencing, or shutdown/mmap cleanup
+    # can never tear a payload. Bounded by _BUFFER_BUDGET (drop-oldest-style:
+    # new captures over budget are dropped as lost stores, plan §7).
+    _BUFFER_BUDGET_BYTES = 512 * 1024 * 1024
+
+    def capture_job(self, job_id: int, meta: dict, dst_block_ids) -> None:
+        """Snapshot a completed-DMA store job's bytes and queue disk writes.
+
+        Synchronous copy, asynchronous write. Idempotent per job_id. Never
+        defers the job's ack: correctness no longer depends on ack timing."""
         if self._disabled_reason is not None:
-            return False
+            return
+        with self._lock:
+            if job_id in self._pending_jobs:
+                return
         keys = meta.get("keys") or []
         rows = [int(b) for b in dst_block_ids]
         if len(keys) != len(rows):
@@ -592,22 +636,60 @@ class Glm53LocalStoreWriter:
                 len(keys),
                 len(rows),
             )
-            return False
+            return
         job = {
             "job_id": job_id,
             "meta": meta,
-            "remaining": len(keys),
+            "remaining": 0,
             "written": [],
         }
+        tasks = []
+        for (hash_hex, group_idx, chunk_idx, n_tokens), row in zip(keys, rows):
+            group_idx = int(group_idx)
+            if self._paused_reason is not None:
+                self._files_dropped += 1
+                continue
+            try:
+                if group_idx not in self._eligible_groups:
+                    raise ValueError(
+                        f"ineligible group {group_idx} reached the writer"
+                    )
+                payload, segments = self._gather_payload(group_idx, row)
+            except Exception as exc:  # noqa: BLE001 - lost store only
+                self._on_write_error(hash_hex, group_idx, exc)
+                continue
+            with self._lock:
+                if (
+                    self._outstanding_bytes + len(payload)
+                    > self._BUFFER_BUDGET_BYTES
+                ):
+                    over_budget = True
+                else:
+                    over_budget = False
+                    self._outstanding_bytes += len(payload)
+            if over_budget:
+                # Lost store, not a failure: the key may be re-stored later
+                # and stays manifest-eligible if a durable file appears.
+                self._files_dropped += 1
+                continue
+            tasks.append(
+                (
+                    job,
+                    hash_hex,
+                    group_idx,
+                    int(chunk_idx),
+                    int(n_tokens),
+                    payload,
+                    segments,
+                )
+            )
+        job["remaining"] = len(tasks)
         with self._lock:
             self._pending_jobs[job_id] = job
-        for (hash_hex, group_idx, chunk_idx, n_tokens), row in zip(keys, rows):
-            self._task_queue.put(
-                (job, hash_hex, int(group_idx), int(chunk_idx), int(n_tokens), row)
-            )
-        if not keys:
+        for task in tasks:
+            self._task_queue.put(task)
+        if not tasks:
             self._finish_job(job)
-        return True
 
     def drain_done(self):
         done = []
@@ -637,15 +719,18 @@ class Glm53LocalStoreWriter:
 
     def _writer_loop(self) -> None:
         while True:
-            job, hash_hex, group_idx, chunk_idx, n_tokens, row = (
+            job, hash_hex, group_idx, chunk_idx, n_tokens, payload, segments = (
                 self._task_queue.get()
             )
             try:
-                self._write_one(job, hash_hex, group_idx, chunk_idx, n_tokens, row)
+                self._write_one(
+                    job, hash_hex, group_idx, chunk_idx, n_tokens, payload, segments
+                )
             except Exception as exc:  # noqa: BLE001 - lost store only
                 self._on_write_error(hash_hex, group_idx, exc)
             finally:
                 with self._lock:
+                    self._outstanding_bytes -= len(payload)
                     job["remaining"] -= 1
                     finished = job["remaining"] <= 0
                 if finished:
@@ -675,21 +760,10 @@ class Glm53LocalStoreWriter:
             exc,
         )
 
-    def _write_one(self, job, hash_hex, group_idx, chunk_idx, n_tokens, row):
-        import os as _os
-
-        if self._paused_reason is not None or self._disabled_reason is not None:
-            self._files_dropped += 1
-            return
-        if group_idx not in self._eligible_groups:
-            raise ValueError(f"ineligible group {group_idx} reached the writer")
-        path = self._file_path(hash_hex, group_idx)
-        if _os.path.exists(path):
-            _os.utime(path)  # dedup refresh, mtime stays meaningful
-            with self._lock:
-                job["written"].append((hash_hex, group_idx))
-            return
-
+    def _gather_payload(self, group_idx: int, row: int):
+        """Copy one (group, staging-row) chunk OUT of the mmap: real bytes
+        per CanonicalKVCacheRef, in group layer order. Runs synchronously at
+        capture time (rows guaranteed live); returns (payload, segments)."""
         refs = self._refs_per_group[group_idx]
         group = self._kv_groups[group_idx]
         layer_names = list(group.layer_names)
@@ -705,8 +779,50 @@ class Glm53LocalStoreWriter:
                 self._layer_segments(group, layer, offset, ref.page_size_bytes)
             )
             offset += ref.page_size_bytes
-        payload = b"".join(parts)
+        return b"".join(parts), segments
 
+    def _write_one(
+        self, job, hash_hex, group_idx, chunk_idx, n_tokens, payload, segments
+    ):
+        import os as _os
+
+        if self._paused_reason is not None or self._disabled_reason is not None:
+            self._files_dropped += 1
+            return
+        path = self._file_path(hash_hex, group_idx)
+        if _os.path.exists(path):
+            # Dedup ONLY when the existing file verifies as ours (header
+            # identity: namespace + hash + group). A corrupt or foreign file
+            # under our name is unlinked and rewritten (Codex OFFLOAD1-REVIEW
+            # finding 3: existence alone must not certify).
+            try:
+                h = glm53_read_chunk_header(path)
+                if (
+                    h.get("namespace_hash") == self._namespace_hash
+                    and h.get("hash") == hash_hex
+                    and h.get("group_idx") == group_idx
+                ):
+                    _os.utime(path)  # dedup refresh, mtime stays meaningful
+                    with self._lock:
+                        job["written"].append((hash_hex, group_idx))
+                    return
+                raise ValueError("header identity mismatch")
+            except (OSError, ValueError) as exc:
+                self._log.warning(
+                    "%s existing chunk %s g%d failed verification (%s) -- "
+                    "rewriting",
+                    _GLM53_KVO_STORE_TAG,
+                    hash_hex[:12],
+                    group_idx,
+                    exc,
+                )
+                try:
+                    _os.unlink(path)
+                except OSError:
+                    pass
+
+        group = self._kv_groups[group_idx]
+        refs = self._refs_per_group[group_idx]
         inner = _glm53_unwrap_kv_spec(group.kv_cache_spec)
         header = {
             "namespace_hash": self._namespace_hash,
@@ -727,7 +843,10 @@ class Glm53LocalStoreWriter:
         blob = glm53_encode_chunk(header, payload)
 
         _os.makedirs(_os.path.dirname(path), exist_ok=True)
-        tmp = f"{path}.tmp.r{self._rank}.{_os.getpid()}"
+        tmp = (
+            f"{path}.tmp.r{self._rank}.{_os.getpid()}"
+            f".{_glm53_threading.get_ident()}"
+        )
         try:
             with open(tmp, "wb") as f:
                 f.write(blob)
@@ -852,6 +971,13 @@ class Glm53LocalStoreWriter:
                 except (OSError, ValueError):
                     complete = False
                     break
+                if (
+                    fheader.get("namespace_hash") != self._namespace_hash
+                    or fheader.get("hash") != boundary_hash
+                    or fheader.get("group_idx") != gidx
+                ):
+                    complete = False
+                    break
                 groups_entry[str(gidx)] = {
                     "hash": boundary_hash,
                     "payload_len": fheader["payload_len"],
@@ -859,15 +985,29 @@ class Glm53LocalStoreWriter:
                 }
             if not complete:
                 continue
+            full_entry = {}
             for gidx in full_groups:
+                chunks = []
                 for h in chunk_hashes:
-                    if (h, gidx) in failed or not _os.path.exists(
-                        self._file_path(h, gidx)
+                    if (h, gidx) in failed:
+                        complete = False
+                        break
+                    try:
+                        fh = glm53_read_chunk_header(self._file_path(h, gidx))
+                    except (OSError, ValueError):
+                        complete = False
+                        break
+                    if (
+                        fh.get("namespace_hash") != self._namespace_hash
+                        or fh.get("hash") != h
+                        or fh.get("group_idx") != gidx
                     ):
                         complete = False
                         break
+                    chunks.append([h, fh["payload_len"], fh["payload_crc32"]])
                 if not complete:
                     break
+                full_entry[str(gidx)] = chunks
             if not complete:
                 continue
             manifest = {
@@ -876,12 +1016,17 @@ class Glm53LocalStoreWriter:
                 "boundary_token_index": cand["boundary_token_index"],
                 "chunk_hashes": chunk_hashes,
                 "cow_groups": groups_entry,
-                "full_groups": {str(g): len(chunk_hashes) for g in full_groups},
+                # Per-chunk [hash, payload_len, payload_crc32], cumulative
+                # 0..boundary (plan §4: hashes + sizes + crcs per group).
+                "full_groups": full_entry,
                 "rank": self._rank,
                 "created_at": _glm53_time.time(),
             }
             _os.makedirs(_os.path.dirname(mpath), exist_ok=True)
-            tmp = f"{mpath}.tmp.r{self._rank}.{_os.getpid()}"
+            tmp = (
+                f"{mpath}.tmp.r{self._rank}.{_os.getpid()}"
+                f".{_glm53_threading.get_ident()}"
+            )
             try:
                 with open(tmp, "w", encoding="utf-8") as f:
                     _glm53_json.dump(manifest, f, sort_keys=True)
@@ -974,32 +1119,33 @@ def _glm53_get_store_writer(connector_worker):
     return writer
 
 
-def _glm53_drain_finished_disk_writes(connector_worker) -> None:
-    writer = connector_worker._glm53_store_writer
-    if writer is None:
-        return
-    for job_id in writer.drain_done():
-        connector_worker._connector_worker_meta.mark_completed(job_id)
+def _glm53_capture_store_job(connector_worker, job_id: int) -> None:
+    """Snapshot a DMA-complete store job's bytes out of the staging mmap.
 
-
-def _glm53_intercept_store_completion(connector_worker, job_id: int) -> bool:
-    """Route a DMA-complete store job into the local disk writer. Returns True
-    when the ack is deferred until the disk write finishes."""
+    Called at the two points where the job's rows are guaranteed still live:
+    get_finished (before this rank's ack -- staging pinned until
+    complete_store) and immediately after worker.wait() on the flush/reset
+    path (before any new DMA can reuse the rows). Never defers the ack; the
+    disk write proceeds on private buffers."""
     captured = connector_worker._glm53_job_meta.pop(job_id, None)
     if captured is None:
-        return False
+        return
     meta, dst_spec = captured
     try:
         writer = _glm53_get_store_writer(connector_worker)
-        return writer.submit_job(job_id, meta, dst_spec.block_ids)
+        writer.capture_job(job_id, meta, dst_spec.block_ids)
     except Exception as exc:  # noqa: BLE001 - never block serving on the tier
         logger.error(
-            "%s store interception failed (job acked, store lost): %s: %s",
+            "%s store capture failed (store lost, serving unaffected): %s: %s",
             _GLM53_KVO_STORE_TAG,
             type(exc).__name__,
             exc,
         )
-        return False
+
+
+def _glm53_capture_flushed_store_jobs(connector_worker, job_ids) -> None:
+    for job_id in list(job_ids or ()):
+        _glm53_capture_store_job(connector_worker, job_id)
 
 
 '''
@@ -1200,32 +1346,31 @@ PATCHED_W4 = """        for job_id, entry in metadata.store_jobs.items():
                 self._glm53_job_meta[job_id] = (_glm53_meta, entry.dst_spec)
 """
 
-MARK_W5 = "        _glm53_drain_finished_disk_writes(self)  # [glm53-kv-offload-store]\n"
-
-ANCHOR_W5 = """        assert self.worker is not None
-        finished_recving: set[str] = set()
-        for transfer_result in self.worker.get_finished():
-"""
-
-PATCHED_W5 = """        assert self.worker is not None
-        finished_recving: set[str] = set()
-        _glm53_drain_finished_disk_writes(self)  # [glm53-kv-offload-store]
-        for transfer_result in self.worker.get_finished():
-"""
-
-MARK_W5B = "            if _glm53_intercept_store_completion(self, job_id):  # [glm53-kv-offload-store]\n"
+MARK_W5B = "            _glm53_capture_store_job(self, job_id)  # [glm53-kv-offload-store]\n"
 
 ANCHOR_W5B = """            self._connector_worker_meta.mark_completed(job_id)
             req_id = self._load_jobs.pop(job_id, None)
 """
 
-PATCHED_W5B = """            if _glm53_intercept_store_completion(self, job_id):  # [glm53-kv-offload-store]
-                # DMA done; the ack is deferred until this rank's disk write
-                # finishes (staging stays pinned by the store protocol, so
-                # the bytes cannot be evicted under the writer).
-                continue
+PATCHED_W5B = """            _glm53_capture_store_job(self, job_id)  # [glm53-kv-offload-store]
             self._connector_worker_meta.mark_completed(job_id)
             req_id = self._load_jobs.pop(job_id, None)
+"""
+
+# Flush/reset path: reset_cache() frees ALL staging rows and the very next
+# step may DMA new stores into them -- capture the flushed jobs' bytes
+# synchronously right after their DMA wait, before returning to the step.
+MARK_W5C = "            _glm53_capture_flushed_store_jobs(  # [glm53-kv-offload-store]\n"
+
+ANCHOR_W5C = """        if kv_connector_metadata.jobs_to_flush:
+            self.worker.wait(kv_connector_metadata.jobs_to_flush)
+"""
+
+PATCHED_W5C = """        if kv_connector_metadata.jobs_to_flush:
+            self.worker.wait(kv_connector_metadata.jobs_to_flush)
+            _glm53_capture_flushed_store_jobs(  # [glm53-kv-offload-store]
+                self, kv_connector_metadata.jobs_to_flush
+            )
 """
 
 MARK_W6 = "        if self._glm53_store_writer is not None:  # [glm53-kv-offload-store]\n"
@@ -1245,8 +1390,8 @@ SITES_WORKER = (
     ("W2 worker state", MARK_W2, ANCHOR_W2, PATCHED_W2),
     ("W3 flush-path meta capture", MARK_W3, ANCHOR_W3, PATCHED_W3),
     ("W4 store meta capture", MARK_W4, ANCHOR_W4, PATCHED_W4),
-    ("W5 drain finished writes", MARK_W5, ANCHOR_W5, PATCHED_W5),
-    ("W5B intercept completion", MARK_W5B, ANCHOR_W5B, PATCHED_W5B),
+    ("W5B capture at completion", MARK_W5B, ANCHOR_W5B, PATCHED_W5B),
+    ("W5C capture at flush", MARK_W5C, ANCHOR_W5C, PATCHED_W5C),
     ("W6 shutdown drain", MARK_W6, ANCHOR_W6, PATCHED_W6),
 )
 
@@ -1323,6 +1468,21 @@ def clear_pyc(target: Path) -> None:
 def main(argv: list[str] | None = None) -> int:
     argv = sys.argv if argv is None else argv
     preflight_only = "--preflight" in argv[1:]
+
+    if "--check-injected" in argv[1:]:
+        # Host-side gate mode: compile every injected source standalone (no
+        # target access) so a truncated/corrupted string literal inside this
+        # file fails BEFORE the launcher stops a healthy pair.
+        for name, src in (
+            ("mode helpers", MODE_HELPERS_SRC),
+            ("codec", CODEC_SRC),
+            ("meta builder", META_BUILDER_SRC),
+            ("writer", WRITER_SRC),
+        ):
+            compile(src, f"<glm53-kv-offload-store {name}>", "exec")
+        load_helpers()
+        print("patch_kv_offload_store_local.py: injected sources compile OK")
+        return 0
 
     sched_source = TARGET_SCHED.read_text() if TARGET_SCHED.is_file() else ""
     if SCOPE_MARK not in sched_source:

--- a/start.sh
+++ b/start.sh
@@ -73,11 +73,26 @@ _cli_ablit_direction="${ABLIT_DIRECTION-}"
 _cli_ablit_layers="${ABLIT_LAYERS-}"
 _cli_ablit_alpha="${ABLIT_ALPHA-}"
 _cli_ablit_mtp="${ABLIT_INCLUDE_MTP-}"
+_cli_kvoffload_set="${GLM53_KV_OFFLOAD+1}"
+_cli_kvoffload="${GLM53_KV_OFFLOAD-}"
+_cli_kvoffload_dir_set="${GLM53_KV_OFFLOAD_DIR+1}"
+_cli_kvoffload_dir="${GLM53_KV_OFFLOAD_DIR-}"
+_cli_kvoffload_cpu_set="${GLM53_KV_OFFLOAD_CPU_GB+1}"
+_cli_kvoffload_cpu="${GLM53_KV_OFFLOAD_CPU_GB-}"
+_cli_kvoffload_restore_set="${GLM53_KV_OFFLOAD_RESTORE+1}"
+_cli_kvoffload_restore="${GLM53_KV_OFFLOAD_RESTORE-}"
+_cli_kvoffload_drafter_set="${GLM53_KV_OFFLOAD_DRAFTER+1}"
+_cli_kvoffload_drafter="${GLM53_KV_OFFLOAD_DRAFTER-}"
 set -a
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/.env"
 set +a
 [ -n "${_cli_mtp}" ] && MTP_TOKENS="$_cli_mtp"
+[ -n "${_cli_kvoffload_set}" ] && GLM53_KV_OFFLOAD="$_cli_kvoffload"
+[ -n "${_cli_kvoffload_dir_set}" ] && GLM53_KV_OFFLOAD_DIR="$_cli_kvoffload_dir"
+[ -n "${_cli_kvoffload_cpu_set}" ] && GLM53_KV_OFFLOAD_CPU_GB="$_cli_kvoffload_cpu"
+[ -n "${_cli_kvoffload_restore_set}" ] && GLM53_KV_OFFLOAD_RESTORE="$_cli_kvoffload_restore"
+[ -n "${_cli_kvoffload_drafter_set}" ] && GLM53_KV_OFFLOAD_DRAFTER="$_cli_kvoffload_drafter"
 [ -n "${_cli_spec}" ] && SPEC_METHOD="$_cli_spec"
 [ -n "${_cli_eager}" ] && ENFORCE_EAGER="$_cli_eager"
 [ -n "${_cli_fused}" ] && EXL3_FUSED_MOE="$_cli_fused"
@@ -173,6 +188,8 @@ STOP_PATCH_HOST="${STOP_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_suppress_stops_in_
 SCHED_PATCH_HOST="${SCHED_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_scheduler_decode_floor.py}"
 DRAFTER_PATCH_HOST="${DRAFTER_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm5_drafter_group.py}"
 APC_PATCH_HOST="${APC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_hybrid_prefix_hit.py}"
+KVOFFLOAD_SCOPE_PATCH_HOST="${KVOFFLOAD_SCOPE_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kv_offload_scope.py}"
+KVOFFLOAD_STORE_PATCH_HOST="${KVOFFLOAD_STORE_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kv_offload_store_local.py}"
 XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_xgrammar_termination.py}"
 KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kpool_tail_slotmap.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
@@ -227,6 +244,29 @@ GLM53_SUPPRESS_STOPS_IN_REASONING="${GLM53_SUPPRESS_STOPS_IN_REASONING:-1}"
 # Mixed-step prefill policy when a peer is already decoding (issue #6).
 # skip = do not mix; N>0 = cap tokens; 0 = off.
 GLM53_MIXED_PREFILL_CHUNK="${GLM53_MIXED_PREFILL_CHUNK:-skip}"
+# --- disk KV-offload store tier (stage 1: store-only) -----------------------
+# 1 = enable the OffloadingConnector (CPU staging + worker-local per-rank disk
+# writes under overlay patch_kv_offload_scope.py + patch_kv_offload_store_local.py).
+# 0 (default) = OFF: no --kv-transfer-config, no store mount — serving is
+# byte-identical to a build without the tier. Exactly 0 or 1.
+GLM53_KV_OFFLOAD="${GLM53_KV_OFFLOAD-0}"
+# Host directory for the store (local NVMe on EACH Spark; same path on both;
+# per-rank namespaced subdirs are created by the writer). Mounted rw at
+# $GLM53_KV_OFFLOAD_DIR_CTR in both containers when the knob is 1.
+GLM53_KV_OFFLOAD_DIR="${GLM53_KV_OFFLOAD_DIR:-$HOME/glm53-kv-offload}"
+GLM53_KV_OFFLOAD_DIR_CTR="/data/glm53-kv-offload"
+# CPU staging bounce-buffer size in GiB (cpu_bytes_to_use). Staging only —
+# never a capacity tier (plan non-goal); 4 GiB ≈ 15 aligned boundaries.
+GLM53_KV_OFFLOAD_CPU_GB="${GLM53_KV_OFFLOAD_CPU_GB:-4}"
+# Stage-1 hard rule: restore stays OFF. The launcher REFUSES 1 (stage 2
+# flips this default after the restore plumbing lands + receipts).
+GLM53_KV_OFFLOAD_RESTORE="${GLM53_KV_OFFLOAD_RESTORE-0}"
+# 1 = include the DFlash2 drafter group in the offload eligible set
+# (stage-4 experiment); 0 (default) = policy-excluded (plan §3.2).
+GLM53_KV_OFFLOAD_DRAFTER="${GLM53_KV_OFFLOAD_DRAFTER-0}"
+# Inline manifest retention: keep the K most recent boundary manifests per
+# chain (plan §7; 0 = dense, no inline supersede).
+GLM53_KV_OFFLOAD_KEEP_BOUNDARIES="${GLM53_KV_OFFLOAD_KEEP_BOUNDARIES:-2}"
 # EngineCore stock timeout is 300s; mid-serve Triton/TileLang JIT on TP=2 can
 # exceed that without being a true hang. NCCL watchdog is still 600s.
 VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS="${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-1800}"
@@ -291,6 +331,19 @@ _glm53_canonical_positive_int() {
     export "$name"
 }
 
+# Kill switches are exactly 0 or 1. Not "non-empty means on", not `[ "$v" = 0 ]`
+# with everything else treated as on: a typo'd knob must not silently pick a
+# serving/storage mode. The overlays re-validate in-container
+# (_glm53_kvo_bool_env), so catching it here turns a container boot failure
+# into a launcher error with the healthy pair left serving.
+_glm53_validate_bool_flag() {
+    local name="$1" value="$2"
+    if [ "$value" != 0 ] && [ "$value" != 1 ]; then
+        echo "$name must be exactly 0 or 1 (got: $value)" >&2
+        return 2
+    fi
+}
+
 validate_numeric_config() {
     if ! [[ "$GPU_MEM_UTIL" =~ ^(0([.][0-9]+)?|[.][0-9]+|1([.]0+)?)$ ]] \
        || ! awk -v u="$GPU_MEM_UTIL" 'BEGIN { exit !(u > 0 && u <= 1) }'; then
@@ -300,8 +353,87 @@ validate_numeric_config() {
     _glm53_canonical_positive_int MAX_MODEL_LEN "$MAX_MODEL_LEN" 1000000 || return
     _glm53_canonical_positive_int MAX_NUM_SEQS "$MAX_NUM_SEQS" 4096 || return
     _glm53_canonical_positive_int MAX_NUM_BATCHED_TOKENS "$MAX_NUM_BATCHED_TOKENS" 8388608 || return
+    _glm53_validate_bool_flag GLM53_KV_OFFLOAD "${GLM53_KV_OFFLOAD-0}" || return
+    _glm53_validate_bool_flag GLM53_KV_OFFLOAD_RESTORE "${GLM53_KV_OFFLOAD_RESTORE-0}" || return
+    _glm53_validate_bool_flag GLM53_KV_OFFLOAD_DRAFTER "${GLM53_KV_OFFLOAD_DRAFTER-0}" || return
+    # Stage-1 hard rule: the restore path is not built yet; refusing here is
+    # fail-closed (the flag exists so stage 2 flips exactly one default).
+    if [ "${GLM53_KV_OFFLOAD_RESTORE-0}" = 1 ]; then
+        echo "GLM53_KV_OFFLOAD_RESTORE=1 is refused: stage 1 is store-only (restore lands in stage 2)" >&2
+        return 2
+    fi
+    if [ "${GLM53_KV_OFFLOAD-0}" = 1 ]; then
+        _glm53_canonical_positive_int GLM53_KV_OFFLOAD_CPU_GB "${GLM53_KV_OFFLOAD_CPU_GB-}" 64 || return
+        if ! [[ "${GLM53_KV_OFFLOAD_KEEP_BOUNDARIES-}" =~ ^[0-9]+$ ]] \
+           || [ "${GLM53_KV_OFFLOAD_KEEP_BOUNDARIES-}" -gt 1024 ]; then
+            echo "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES must be an integer 0..1024 (got: ${GLM53_KV_OFFLOAD_KEEP_BOUNDARIES-})" >&2
+            return 2
+        fi
+        case "${GLM53_KV_OFFLOAD_DIR-}" in
+            /*) ;;
+            *)
+                echo "GLM53_KV_OFFLOAD_DIR must be an absolute path (got: ${GLM53_KV_OFFLOAD_DIR-})" >&2
+                return 2
+                ;;
+        esac
+        case "${GLM53_KV_OFFLOAD_DIR-}" in
+            *"'"*|*'"'*|*[$' \t\n']*)
+                echo "GLM53_KV_OFFLOAD_DIR must not contain quotes or whitespace (got: $GLM53_KV_OFFLOAD_DIR)" >&2
+                return 2
+                ;;
+        esac
+    fi
 }
 # GLM53 numeric config guard (end)
+
+# GLM53 kv-offload artifact guard (begin)
+# The two kv-offload overlays + the GC tool, validated BEFORE `restart` stops
+# anything: a missing, empty, mis-pointed, truncated or syntactically broken
+# artifact is a launcher error with the healthy pair left serving, not a
+# container that dies at boot after the old one is gone. Identity string +
+# exact last non-blank line + ast.parse, per artifact (same technique as the
+# overlay artifact guard on the capacity-log branch; scoped to this PR's
+# artifacts so the two guards merge cleanly).
+validate_kv_offload_artifacts() {
+    local main_guard='    sys.exit(main())'
+    local gc_guard='    sys.exit(main())'
+    local -a artifacts=(
+        "$KVOFFLOAD_SCOPE_PATCH_HOST|[glm53-kv-offload-scope]|$main_guard"
+        "$KVOFFLOAD_STORE_PATCH_HOST|[glm53-kv-offload-store]|$main_guard"
+        "$SCRIPT_DIR/overlay/kv_offload_store_gc.py|glm53kv_<model>_<ns>_r<rank>|$gc_guard"
+    )
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "python3 is required on the head to verify kv-offload artifacts before launch" >&2
+        return 2
+    fi
+    local entry path rest tag tail last
+    for entry in "${artifacts[@]}"; do
+        path="${entry%%|*}"
+        rest="${entry#*|}"
+        tag="${rest%%|*}"
+        tail="${rest#*|}"
+        if [ ! -f "$path" ] || [ ! -r "$path" ] || [ ! -s "$path" ]; then
+            echo "kv-offload artifact missing, unreadable or empty: $path" >&2
+            return 2
+        fi
+        if ! grep -qF -- "$tag" "$path"; then
+            echo "kv-offload artifact $path does not carry its identity string '$tag' (wrong file?)" >&2
+            return 2
+        fi
+        # `|| true`: under pipefail a whitespace-only file makes grep exit 1,
+        # which must surface as the rc=2 diagnostic below, not a bare exit 1.
+        last="$(grep -v '^[[:space:]]*$' "$path" | tail -n 1 || true)"
+        if [ "$last" != "$tail" ]; then
+            echo "kv-offload artifact $path does not end with '$tail' (truncated copy? last line: '$last')" >&2
+            return 2
+        fi
+        if ! python3 -c 'import ast, sys; ast.parse(open(sys.argv[1], encoding="utf-8").read(), sys.argv[1])' "$path" 2>/dev/null; then
+            echo "kv-offload artifact does not parse as Python: $path" >&2
+            return 2
+        fi
+    done
+}
+# GLM53 kv-offload artifact guard (end)
 
 banner() {
     local label="${1:-start.sh}"
@@ -435,6 +567,8 @@ preflight() {
     [ -f "$SCHED_PATCH_HOST" ] || die "$SCHED_PATCH_HOST missing"
     [ -f "$DRAFTER_PATCH_HOST" ] || die "$DRAFTER_PATCH_HOST missing"
     [ -f "$APC_PATCH_HOST" ] || die "$APC_PATCH_HOST missing"
+    [ -f "$KVOFFLOAD_SCOPE_PATCH_HOST" ] || die "$KVOFFLOAD_SCOPE_PATCH_HOST missing"
+    [ -f "$KVOFFLOAD_STORE_PATCH_HOST" ] || die "$KVOFFLOAD_STORE_PATCH_HOST missing"
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "$XGRAMMAR_PATCH_HOST missing"
     [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "$KPOOL_TAIL_PATCH_HOST missing"
     [ -f "$SCRIPT_DIR/overlay/patch_ablit.py" ] || die "$SCRIPT_DIR/overlay/patch_ablit.py missing"
@@ -822,6 +956,43 @@ sync_weights() {
 }
 
 # ------------------------ inner container scripts --------------------------
+# Overlay application order inside BOTH rank containers. write_inner_scripts
+# emits this one list verbatim into the head and the worker inner script, so
+# the two ranks cannot drift apart. Pinned segments:
+#   - the prefix-cache overlays share the kv_cache_coordinator.py helper
+#     insert point: patch_hybrid_prefix_hit -> patch_apc_per_group_retention
+#     -> patch_apc_fine_grained_hits (per-group = PR #83, fine-grained =
+#     PR #84 — [ -f ]-guarded no-ops unless those branches' artifacts are
+#     mounted);
+#   - the kv-offload pair is order-dependent: patch_kv_offload_scope MUST
+#     precede patch_kv_offload_store_local (the store overlay anchors on the
+#     scope overlay's scheduler output and refuses an unscoped tree).
+# Entries that are not mounted are skipped in-container (`[ -f ]`); which ones
+# MUST exist is decided by the artifact guards above, not here.
+GLM53_OVERLAY_ORDER=(
+    patch_glm_video_placeholders.py
+    patch_suppress_stops_in_reasoning.py
+    patch_scheduler_decode_floor.py
+    patch_glm5_drafter_group.py
+    patch_hybrid_prefix_hit.py
+    patch_apc_per_group_retention.py
+    patch_apc_fine_grained_hits.py
+    patch_kv_offload_scope.py
+    patch_kv_offload_store_local.py
+    patch_xgrammar_termination.py
+    patch_kpool_tail_slotmap.py
+    patch_ablit.py
+)
+
+# Emits the in-container apply block for GLM53_OVERLAY_ORDER (same bytes for
+# both ranks).
+emit_overlay_block() {
+    local p
+    for p in "${GLM53_OVERLAY_ORDER[@]}"; do
+        printf 'if [ -f /opt/glm53/%s ]; then\n    python3 /opt/glm53/%s\nfi\n' "$p" "$p"
+    done
+}
+
 write_inner_scripts() {
     cat > "$HEAD_SCRIPT" <<'EOF'
 #!/bin/bash
@@ -851,6 +1022,16 @@ ARGS=(
 [ -n "${MAX_NUM_SEQS:-}" ] && ARGS+=(--max-num-seqs "${MAX_NUM_SEQS}")
 [ -n "${MAX_NUM_BATCHED_TOKENS:-}" ] && ARGS+=(--max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}")
 [ -n "${KV_CACHE_DTYPE:-}" ] && ARGS+=(--kv-cache-dtype "${KV_CACHE_DTYPE}")
+if [ "${GLM53_KV_OFFLOAD:-0}" = "1" ]; then
+    # Stage-1 store tier: CPU staging only (TieringOffloadingSpec, NO
+    # secondary tiers -- the worker-local writer in
+    # patch_kv_offload_store_local.py is the disk tier; the scheduler-side fs
+    # tier is byte-invalid on 2-node TP, see the overlay header).
+    ARGS+=(--kv-transfer-config "$(python3 -S -c 'import json,os
+gb=int(os.environ["GLM53_KV_OFFLOAD_CPU_GB"])
+cfg={"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":gb*(1<<30),"blocks_per_chunk":1}}
+print(json.dumps(cfg,separators=(",",":")))')")
+fi
 if [ "${SPEC_METHOD:-mtp}" = "dflash" ]; then
     ARGS+=(--speculative-config "$(python3 -S -c 'import json,os
 spec={"method":"dflash","model":os.environ["DFLASH_MODEL_DIR"],"num_speculative_tokens":int(os.environ.get("DFLASH_TOKENS","7")),"kv_cache_dtype":"auto","draft_sample_method":"probabilistic","rejection_sample_method":"standard"}
@@ -881,30 +1062,9 @@ if [ -n "${EXTRA_ARGS:-}" ]; then
 fi
 
 [ -f "${MODEL_DIR}/config.json" ] || { say "FATAL: ${MODEL_DIR}/config.json missing"; ls -la "${MODEL_DIR}" | head; exit 1; }
-if [ -f /opt/glm53/patch_glm_video_placeholders.py ]; then
-    python3 /opt/glm53/patch_glm_video_placeholders.py
-fi
-if [ -f /opt/glm53/patch_suppress_stops_in_reasoning.py ]; then
-    python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
-fi
-if [ -f /opt/glm53/patch_scheduler_decode_floor.py ]; then
-    python3 /opt/glm53/patch_scheduler_decode_floor.py
-fi
-if [ -f /opt/glm53/patch_glm5_drafter_group.py ]; then
-    python3 /opt/glm53/patch_glm5_drafter_group.py
-fi
-if [ -f /opt/glm53/patch_hybrid_prefix_hit.py ]; then
-    python3 /opt/glm53/patch_hybrid_prefix_hit.py
-fi
-if [ -f /opt/glm53/patch_xgrammar_termination.py ]; then
-    python3 /opt/glm53/patch_xgrammar_termination.py
-fi
-if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
-    python3 /opt/glm53/patch_kpool_tail_slotmap.py
-fi
-if [ -f /opt/glm53/patch_ablit.py ]; then
-    python3 /opt/glm53/patch_ablit.py
-fi
+EOF
+    emit_overlay_block >> "$HEAD_SCRIPT"
+    cat >> "$HEAD_SCRIPT" <<'EOF'
 if [ "${ABLIT:-0}" = "1" ]; then
     say "ablit: o_proj orthogonalization ON (method=${ABLIT_METHOD:-auto} direction=${ABLIT_DIRECTION:-dealign} layers=${ABLIT_LAYERS:-15-45} alpha=${ABLIT_ALPHA:-3.0})"
 else
@@ -943,6 +1103,16 @@ ARGS=(
 [ -n "${MAX_NUM_SEQS:-}" ] && ARGS+=(--max-num-seqs "${MAX_NUM_SEQS}")
 [ -n "${MAX_NUM_BATCHED_TOKENS:-}" ] && ARGS+=(--max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}")
 [ -n "${KV_CACHE_DTYPE:-}" ] && ARGS+=(--kv-cache-dtype "${KV_CACHE_DTYPE}")
+if [ "${GLM53_KV_OFFLOAD:-0}" = "1" ]; then
+    # Stage-1 store tier: CPU staging only (TieringOffloadingSpec, NO
+    # secondary tiers -- the worker-local writer in
+    # patch_kv_offload_store_local.py is the disk tier; the scheduler-side fs
+    # tier is byte-invalid on 2-node TP, see the overlay header).
+    ARGS+=(--kv-transfer-config "$(python3 -S -c 'import json,os
+gb=int(os.environ["GLM53_KV_OFFLOAD_CPU_GB"])
+cfg={"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":gb*(1<<30),"blocks_per_chunk":1}}
+print(json.dumps(cfg,separators=(",",":")))')")
+fi
 if [ "${SPEC_METHOD:-mtp}" = "dflash" ]; then
     ARGS+=(--speculative-config "$(python3 -S -c 'import json,os
 spec={"method":"dflash","model":os.environ["DFLASH_MODEL_DIR"],"num_speculative_tokens":int(os.environ.get("DFLASH_TOKENS","7")),"kv_cache_dtype":"auto","draft_sample_method":"probabilistic","rejection_sample_method":"standard"}
@@ -971,30 +1141,9 @@ if [ -n "${EXTRA_ARGS:-}" ]; then
 fi
 
 [ -f "${MODEL_DIR}/config.json" ] || { say "FATAL: ${MODEL_DIR}/config.json missing"; ls -la "${MODEL_DIR}" | head; exit 1; }
-if [ -f /opt/glm53/patch_glm_video_placeholders.py ]; then
-    python3 /opt/glm53/patch_glm_video_placeholders.py
-fi
-if [ -f /opt/glm53/patch_suppress_stops_in_reasoning.py ]; then
-    python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
-fi
-if [ -f /opt/glm53/patch_scheduler_decode_floor.py ]; then
-    python3 /opt/glm53/patch_scheduler_decode_floor.py
-fi
-if [ -f /opt/glm53/patch_glm5_drafter_group.py ]; then
-    python3 /opt/glm53/patch_glm5_drafter_group.py
-fi
-if [ -f /opt/glm53/patch_hybrid_prefix_hit.py ]; then
-    python3 /opt/glm53/patch_hybrid_prefix_hit.py
-fi
-if [ -f /opt/glm53/patch_xgrammar_termination.py ]; then
-    python3 /opt/glm53/patch_xgrammar_termination.py
-fi
-if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
-    python3 /opt/glm53/patch_kpool_tail_slotmap.py
-fi
-if [ -f /opt/glm53/patch_ablit.py ]; then
-    python3 /opt/glm53/patch_ablit.py
-fi
+EOF
+    emit_overlay_block >> "$WORKER_SCRIPT"
+    cat >> "$WORKER_SCRIPT" <<'EOF'
 if [ "${ABLIT:-0}" = "1" ]; then
     say "ablit: o_proj orthogonalization ON (method=${ABLIT_METHOD:-auto} direction=${ABLIT_DIRECTION:-dealign} layers=${ABLIT_LAYERS:-15-45} alpha=${ABLIT_ALPHA:-3.0})"
 else
@@ -1013,6 +1162,18 @@ launch_cluster() {
 
     mkdir -p "$CACHE_ROOT" "$TRITON_HOST_CACHE" "$TILELANG_HOST_CACHE"
     worker_ssh "mkdir -p '$WORKER_VLLM_CACHE' '$WORKER_TRITON_CACHE' '$WORKER_TILELANG_CACHE'"
+
+    # Disk KV-offload store: mount + dir only when the knob is 1 (knob=0 adds
+    # NOTHING to the containers beyond the replayed env — byte-identical boot).
+    local -a head_offload_mount=()
+    local worker_offload_mount=""
+    if [ "$GLM53_KV_OFFLOAD" = 1 ]; then
+        mkdir -p "$GLM53_KV_OFFLOAD_DIR"
+        worker_ssh "mkdir -p '$GLM53_KV_OFFLOAD_DIR'"
+        head_offload_mount=(-v "$GLM53_KV_OFFLOAD_DIR:$GLM53_KV_OFFLOAD_DIR_CTR")
+        worker_offload_mount="-v '$GLM53_KV_OFFLOAD_DIR:$GLM53_KV_OFFLOAD_DIR_CTR'"
+        log "kv-offload store tier ON: $GLM53_KV_OFFLOAD_DIR (both ranks, rw) staging=${GLM53_KV_OFFLOAD_CPU_GB}GiB keep_boundaries=$GLM53_KV_OFFLOAD_KEEP_BOUNDARIES restore=$GLM53_KV_OFFLOAD_RESTORE"
+    fi
     scp -q -o BatchMode=yes "$WORKER_SCRIPT" "${WORKER_SSH}:/tmp/${CONTAINER_WORKER}.sh"
     [ -f "$CHAT_TEMPLATE_HOST" ] || die "missing chat template: $CHAT_TEMPLATE_HOST"
     scp -q -o BatchMode=yes "$CHAT_TEMPLATE_HOST" "${WORKER_SSH}:/tmp/glm53-chat_template.jinja"
@@ -1026,6 +1187,10 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$DRAFTER_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_glm5_drafter_group.py"
     [ -f "$APC_PATCH_HOST" ] || die "missing $APC_PATCH_HOST"
     scp -q -o BatchMode=yes "$APC_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_hybrid_prefix_hit.py"
+    [ -f "$KVOFFLOAD_SCOPE_PATCH_HOST" ] || die "missing $KVOFFLOAD_SCOPE_PATCH_HOST"
+    scp -q -o BatchMode=yes "$KVOFFLOAD_SCOPE_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kv_offload_scope.py"
+    [ -f "$KVOFFLOAD_STORE_PATCH_HOST" ] || die "missing $KVOFFLOAD_STORE_PATCH_HOST"
+    scp -q -o BatchMode=yes "$KVOFFLOAD_STORE_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kv_offload_store_local.py"
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "missing $XGRAMMAR_PATCH_HOST"
     scp -q -o BatchMode=yes "$XGRAMMAR_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_xgrammar_termination.py"
     [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "missing $KPOOL_TAIL_PATCH_HOST"
@@ -1053,6 +1218,12 @@ launch_cluster() {
         -e VLLM_CACHE_ROOT=/root/.cache/vllm
         -e "GLM53_SUPPRESS_STOPS_IN_REASONING=$GLM53_SUPPRESS_STOPS_IN_REASONING"
         -e "GLM53_MIXED_PREFILL_CHUNK=$GLM53_MIXED_PREFILL_CHUNK"
+        -e "GLM53_KV_OFFLOAD=$GLM53_KV_OFFLOAD"
+        -e "GLM53_KV_OFFLOAD_DIR=$GLM53_KV_OFFLOAD_DIR_CTR"
+        -e "GLM53_KV_OFFLOAD_CPU_GB=$GLM53_KV_OFFLOAD_CPU_GB"
+        -e "GLM53_KV_OFFLOAD_RESTORE=$GLM53_KV_OFFLOAD_RESTORE"
+        -e "GLM53_KV_OFFLOAD_DRAFTER=$GLM53_KV_OFFLOAD_DRAFTER"
+        -e "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES=$GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"
         -e "TRITON_CACHE_DIR=$TRITON_CACHE_DIR"
         -e "TILELANG_CACHE_DIR=$TILELANG_CACHE_DIR"
         -e "VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=$VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS"
@@ -1123,11 +1294,14 @@ launch_cluster() {
         -v '/tmp/patch_scheduler_decode_floor.py:/opt/glm53/patch_scheduler_decode_floor.py:ro' \
         -v '/tmp/patch_glm5_drafter_group.py:/opt/glm53/patch_glm5_drafter_group.py:ro' \
         -v '/tmp/patch_hybrid_prefix_hit.py:/opt/glm53/patch_hybrid_prefix_hit.py:ro' \
+        -v '/tmp/patch_kv_offload_scope.py:/opt/glm53/patch_kv_offload_scope.py:ro' \
+        -v '/tmp/patch_kv_offload_store_local.py:/opt/glm53/patch_kv_offload_store_local.py:ro' \
         -v '/tmp/patch_xgrammar_termination.py:/opt/glm53/patch_xgrammar_termination.py:ro' \
         -v '/tmp/patch_kpool_tail_slotmap.py:/opt/glm53/patch_kpool_tail_slotmap.py:ro' \
         -v '/tmp/glm53-ablit:/opt/glm53/ablit:ro' \
         -v '/tmp/glm53-ablit_runtime.py:/opt/glm53/ablit_runtime.py:ro' \
         -v '/tmp/patch_ablit.py:/opt/glm53/patch_ablit.py:ro' \
+        ${worker_offload_mount} \
         ${worker_preload} \
         ${worker_nccl} \
         -e NCCL_SOCKET_IFNAME='$WORKER_CX7_IF' \
@@ -1154,11 +1328,14 @@ launch_cluster() {
         -v "$SCHED_PATCH_HOST:/opt/glm53/patch_scheduler_decode_floor.py:ro" \
         -v "$DRAFTER_PATCH_HOST:/opt/glm53/patch_glm5_drafter_group.py:ro" \
         -v "$APC_PATCH_HOST:/opt/glm53/patch_hybrid_prefix_hit.py:ro" \
+        -v "$KVOFFLOAD_SCOPE_PATCH_HOST:/opt/glm53/patch_kv_offload_scope.py:ro" \
+        -v "$KVOFFLOAD_STORE_PATCH_HOST:/opt/glm53/patch_kv_offload_store_local.py:ro" \
         -v "$XGRAMMAR_PATCH_HOST:/opt/glm53/patch_xgrammar_termination.py:ro" \
         -v "$KPOOL_TAIL_PATCH_HOST:/opt/glm53/patch_kpool_tail_slotmap.py:ro" \
         -v "$SCRIPT_DIR/ablit:/opt/glm53/ablit:ro" \
         -v "$SCRIPT_DIR/overlay/ablit_runtime.py:/opt/glm53/ablit_runtime.py:ro" \
         -v "$SCRIPT_DIR/overlay/patch_ablit.py:/opt/glm53/patch_ablit.py:ro" \
+        ${head_offload_mount[@]+"${head_offload_mount[@]}"} \
         "${head_preload[@]}" \
         "${nccl_common[@]}" \
         -e NCCL_SOCKET_IFNAME="$HEAD_CX7_IF" \
@@ -1391,7 +1568,7 @@ logs() {
 main() {
     local cmd="${1:-start}"
     case "$cmd" in
-        start|restart) validate_numeric_config ;;
+        start|restart) validate_numeric_config; validate_kv_offload_artifacts ;;
     esac
     case "$cmd" in
         stop)     banner stop.sh ;;

--- a/start.sh
+++ b/start.sh
@@ -1214,18 +1214,20 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$SCRIPT_DIR/overlay/ablit_runtime.py" "${WORKER_SSH}:/tmp/glm53-ablit_runtime.py"
     scp -q -o BatchMode=yes "$SCRIPT_DIR/overlay/patch_ablit.py" "${WORKER_SSH}:/tmp/patch_ablit.py"
 
-    # OffloadingConnector (GLM53_KV_OFFLOAD=1) is refused by vLLM when
-    # PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True: the VMM allocator can
-    # remap KV-cache virtual addresses onto different physical pages under
-    # pinned/registered KV memory (VllmConfig validation refuses the pair at
-    # boot; found live in the #99 receipt window — the check is unreachable
-    # from host stubs). knob=1 boots therefore DROP the env on both ranks
+    # OffloadingConnector (GLM53_KV_OFFLOAD=1) is refused by vLLM under
+    # PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True unless
+    # enable_cumem_allocator is also on (not on this deployment): the VMM
+    # allocator can remap KV-cache virtual addresses onto different physical
+    # pages under pinned/registered KV memory (VllmConfig rejects the pair on
+    # the non-CuMem path at boot; found live in the #99 receipt window — the
+    # check is unreachable from host stubs). knob=1 boots therefore DROP the
+    # env on both ranks
     # (torch default allocator); knob=0 boots keep the stock entry, container
     # env byte-identical to a build without the tier.
     local -a alloc_conf_env=(-e PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True)
     if [ "${GLM53_KV_OFFLOAD-0}" = 1 ]; then
         alloc_conf_env=()
-        log "kv-offload: PYTORCH_CUDA_ALLOC_CONF (expandable_segments:True) dropped on both ranks (OffloadingConnector incompatibility, vllm config validation)"
+        log "kv-offload: PYTORCH_CUDA_ALLOC_CONF (expandable_segments:True) dropped on both ranks (vllm rejects OffloadingConnector with it unless CuMem allocator is enabled)"
     fi
     local -a nccl_common=(
         -e NCCL_IB_DISABLE=0

--- a/start.sh
+++ b/start.sh
@@ -190,6 +190,7 @@ DRAFTER_PATCH_HOST="${DRAFTER_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm5_drafter
 APC_PATCH_HOST="${APC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_hybrid_prefix_hit.py}"
 KVOFFLOAD_SCOPE_PATCH_HOST="${KVOFFLOAD_SCOPE_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kv_offload_scope.py}"
 KVOFFLOAD_STORE_PATCH_HOST="${KVOFFLOAD_STORE_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kv_offload_store_local.py}"
+KVOFFLOAD_RESTORE_PATCH_HOST="${KVOFFLOAD_RESTORE_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kv_offload_restore_g0.py}"
 XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_xgrammar_termination.py}"
 KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kpool_tail_slotmap.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
@@ -360,10 +361,11 @@ validate_numeric_config() {
     _glm53_validate_bool_flag GLM53_KV_OFFLOAD "${GLM53_KV_OFFLOAD-0}" || return
     _glm53_validate_bool_flag GLM53_KV_OFFLOAD_RESTORE "${GLM53_KV_OFFLOAD_RESTORE-0}" || return
     _glm53_validate_bool_flag GLM53_KV_OFFLOAD_DRAFTER "${GLM53_KV_OFFLOAD_DRAFTER-0}" || return
-    # Stage-1 hard rule: the restore path is not built yet; refusing here is
-    # fail-closed (the flag exists so stage 2 flips exactly one default).
-    if [ "${GLM53_KV_OFFLOAD_RESTORE-0}" = 1 ]; then
-        echo "GLM53_KV_OFFLOAD_RESTORE=1 is refused: stage 1 is store-only (restore lands in stage 2)" >&2
+    # Stage-2 rule: restore reads the store tier, so RESTORE=1 without the
+    # store knob is meaningless (a lookup with nothing behind it) and is
+    # refused fail-closed pre-stop.
+    if [ "${GLM53_KV_OFFLOAD_RESTORE-0}" = 1 ] && [ "${GLM53_KV_OFFLOAD-0}" != 1 ]; then
+        echo "GLM53_KV_OFFLOAD_RESTORE=1 requires GLM53_KV_OFFLOAD=1 (the restore path reads the store tier)" >&2
         return 2
     fi
     if [ "${GLM53_KV_OFFLOAD-0}" = 1 ]; then
@@ -404,6 +406,7 @@ validate_kv_offload_artifacts() {
     local -a artifacts=(
         "$KVOFFLOAD_SCOPE_PATCH_HOST|[glm53-kv-offload-scope]|$main_guard"
         "$KVOFFLOAD_STORE_PATCH_HOST|[glm53-kv-offload-store]|$main_guard"
+        "$KVOFFLOAD_RESTORE_PATCH_HOST|[glm53-kv-offload-restore]|$main_guard"
         "$SCRIPT_DIR/overlay/kv_offload_store_gc.py|glm53kv_<model>_<ns>_r<rank>|$gc_guard"
     )
     if ! command -v python3 >/dev/null 2>&1; then
@@ -439,7 +442,7 @@ validate_kv_offload_artifacts() {
     # The two patchers embed their in-container code as string literals; a
     # file that parses can still carry a truncated literal. --check-injected
     # compiles every injected source standalone (no image access needed).
-    for entry in "$KVOFFLOAD_SCOPE_PATCH_HOST" "$KVOFFLOAD_STORE_PATCH_HOST"; do
+    for entry in "$KVOFFLOAD_SCOPE_PATCH_HOST" "$KVOFFLOAD_STORE_PATCH_HOST" "$KVOFFLOAD_RESTORE_PATCH_HOST"; do
         if ! python3 "$entry" --check-injected >/dev/null 2>&1; then
             echo "kv-offload artifact failed its injected-source self-check: $entry" >&2
             return 2
@@ -977,9 +980,11 @@ sync_weights() {
 #     -> patch_apc_fine_grained_hits (per-group = PR #83, fine-grained =
 #     PR #84 — [ -f ]-guarded no-ops unless those branches' artifacts are
 #     mounted);
-#   - the kv-offload pair is order-dependent: patch_kv_offload_scope MUST
+#   - the kv-offload trio is order-dependent: patch_kv_offload_scope MUST
 #     precede patch_kv_offload_store_local (the store overlay anchors on the
-#     scope overlay's scheduler output and refuses an unscoped tree).
+#     scope overlay's scheduler output and refuses an unscoped tree), and
+#     patch_kv_offload_restore_g0 MUST come last of the three (it anchors on
+#     BOTH overlays' output and refuses a tree missing either mark).
 # Entries that are not mounted are skipped in-container (`[ -f ]`); which ones
 # MUST exist is decided by the artifact guards above, not here.
 GLM53_OVERLAY_ORDER=(
@@ -992,6 +997,7 @@ GLM53_OVERLAY_ORDER=(
     patch_apc_fine_grained_hits.py
     patch_kv_offload_scope.py
     patch_kv_offload_store_local.py
+    patch_kv_offload_restore_g0.py
     patch_xgrammar_termination.py
     patch_kpool_tail_slotmap.py
     patch_ablit.py
@@ -1204,6 +1210,8 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$KVOFFLOAD_SCOPE_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kv_offload_scope.py"
     [ -f "$KVOFFLOAD_STORE_PATCH_HOST" ] || die "missing $KVOFFLOAD_STORE_PATCH_HOST"
     scp -q -o BatchMode=yes "$KVOFFLOAD_STORE_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kv_offload_store_local.py"
+    [ -f "$KVOFFLOAD_RESTORE_PATCH_HOST" ] || die "missing $KVOFFLOAD_RESTORE_PATCH_HOST"
+    scp -q -o BatchMode=yes "$KVOFFLOAD_RESTORE_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kv_offload_restore_g0.py"
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "missing $XGRAMMAR_PATCH_HOST"
     scp -q -o BatchMode=yes "$XGRAMMAR_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_xgrammar_termination.py"
     [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "missing $KPOOL_TAIL_PATCH_HOST"
@@ -1310,6 +1318,7 @@ launch_cluster() {
         -v '/tmp/patch_hybrid_prefix_hit.py:/opt/glm53/patch_hybrid_prefix_hit.py:ro' \
         -v '/tmp/patch_kv_offload_scope.py:/opt/glm53/patch_kv_offload_scope.py:ro' \
         -v '/tmp/patch_kv_offload_store_local.py:/opt/glm53/patch_kv_offload_store_local.py:ro' \
+        -v '/tmp/patch_kv_offload_restore_g0.py:/opt/glm53/patch_kv_offload_restore_g0.py:ro' \
         -v '/tmp/patch_xgrammar_termination.py:/opt/glm53/patch_xgrammar_termination.py:ro' \
         -v '/tmp/patch_kpool_tail_slotmap.py:/opt/glm53/patch_kpool_tail_slotmap.py:ro' \
         -v '/tmp/glm53-ablit:/opt/glm53/ablit:ro' \
@@ -1344,6 +1353,7 @@ launch_cluster() {
         -v "$APC_PATCH_HOST:/opt/glm53/patch_hybrid_prefix_hit.py:ro" \
         -v "$KVOFFLOAD_SCOPE_PATCH_HOST:/opt/glm53/patch_kv_offload_scope.py:ro" \
         -v "$KVOFFLOAD_STORE_PATCH_HOST:/opt/glm53/patch_kv_offload_store_local.py:ro" \
+        -v "$KVOFFLOAD_RESTORE_PATCH_HOST:/opt/glm53/patch_kv_offload_restore_g0.py:ro" \
         -v "$XGRAMMAR_PATCH_HOST:/opt/glm53/patch_xgrammar_termination.py:ro" \
         -v "$KPOOL_TAIL_PATCH_HOST:/opt/glm53/patch_kpool_tail_slotmap.py:ro" \
         -v "$SCRIPT_DIR/ablit:/opt/glm53/ablit:ro" \

--- a/start.sh
+++ b/start.sh
@@ -267,6 +267,10 @@ GLM53_KV_OFFLOAD_DRAFTER="${GLM53_KV_OFFLOAD_DRAFTER-0}"
 # Inline manifest retention: keep the K most recent boundary manifests per
 # chain (plan §7; 0 = dense, no inline supersede).
 GLM53_KV_OFFLOAD_KEEP_BOUNDARIES="${GLM53_KV_OFFLOAD_KEEP_BOUNDARIES:-2}"
+# Build identity for the store namespace fence: the recipe checkout SHA (an
+# overlay change that alters byte semantics forks the store). "unpinned"
+# when the checkout is not a git repo.
+GLM53_KV_OFFLOAD_BUILD_ID="${GLM53_KV_OFFLOAD_BUILD_ID:-$(git -C "$SCRIPT_DIR" rev-parse --short=12 HEAD 2>/dev/null || echo unpinned)}"
 # EngineCore stock timeout is 300s; mid-serve Triton/TileLang JIT on TP=2 can
 # exceed that without being a true hang. NCCL watchdog is still 600s.
 VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS="${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-1800}"
@@ -429,6 +433,15 @@ validate_kv_offload_artifacts() {
         fi
         if ! python3 -c 'import ast, sys; ast.parse(open(sys.argv[1], encoding="utf-8").read(), sys.argv[1])' "$path" 2>/dev/null; then
             echo "kv-offload artifact does not parse as Python: $path" >&2
+            return 2
+        fi
+    done
+    # The two patchers embed their in-container code as string literals; a
+    # file that parses can still carry a truncated literal. --check-injected
+    # compiles every injected source standalone (no image access needed).
+    for entry in "$KVOFFLOAD_SCOPE_PATCH_HOST" "$KVOFFLOAD_STORE_PATCH_HOST"; do
+        if ! python3 "$entry" --check-injected >/dev/null 2>&1; then
+            echo "kv-offload artifact failed its injected-source self-check: $entry" >&2
             return 2
         fi
     done
@@ -1029,7 +1042,7 @@ if [ "${GLM53_KV_OFFLOAD:-0}" = "1" ]; then
     # tier is byte-invalid on 2-node TP, see the overlay header).
     ARGS+=(--kv-transfer-config "$(python3 -S -c 'import json,os
 gb=int(os.environ["GLM53_KV_OFFLOAD_CPU_GB"])
-cfg={"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":gb*(1<<30),"blocks_per_chunk":1}}
+cfg={"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":gb*(1<<30),"blocks_per_chunk":1,"offload_prompt_only":False}}
 print(json.dumps(cfg,separators=(",",":")))')")
 fi
 if [ "${SPEC_METHOD:-mtp}" = "dflash" ]; then
@@ -1110,7 +1123,7 @@ if [ "${GLM53_KV_OFFLOAD:-0}" = "1" ]; then
     # tier is byte-invalid on 2-node TP, see the overlay header).
     ARGS+=(--kv-transfer-config "$(python3 -S -c 'import json,os
 gb=int(os.environ["GLM53_KV_OFFLOAD_CPU_GB"])
-cfg={"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":gb*(1<<30),"blocks_per_chunk":1}}
+cfg={"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":gb*(1<<30),"blocks_per_chunk":1,"offload_prompt_only":False}}
 print(json.dumps(cfg,separators=(",",":")))')")
 fi
 if [ "${SPEC_METHOD:-mtp}" = "dflash" ]; then
@@ -1224,6 +1237,7 @@ launch_cluster() {
         -e "GLM53_KV_OFFLOAD_RESTORE=$GLM53_KV_OFFLOAD_RESTORE"
         -e "GLM53_KV_OFFLOAD_DRAFTER=$GLM53_KV_OFFLOAD_DRAFTER"
         -e "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES=$GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"
+        -e "GLM53_KV_OFFLOAD_BUILD_ID=$GLM53_KV_OFFLOAD_BUILD_ID"
         -e "TRITON_CACHE_DIR=$TRITON_CACHE_DIR"
         -e "TILELANG_CACHE_DIR=$TILELANG_CACHE_DIR"
         -e "VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=$VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS"

--- a/start.sh
+++ b/start.sh
@@ -1214,6 +1214,19 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$SCRIPT_DIR/overlay/ablit_runtime.py" "${WORKER_SSH}:/tmp/glm53-ablit_runtime.py"
     scp -q -o BatchMode=yes "$SCRIPT_DIR/overlay/patch_ablit.py" "${WORKER_SSH}:/tmp/patch_ablit.py"
 
+    # OffloadingConnector (GLM53_KV_OFFLOAD=1) is refused by vLLM when
+    # PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True: the VMM allocator can
+    # remap KV-cache virtual addresses onto different physical pages under
+    # pinned/registered KV memory (VllmConfig validation refuses the pair at
+    # boot; found live in the #99 receipt window — the check is unreachable
+    # from host stubs). knob=1 boots therefore DROP the env on both ranks
+    # (torch default allocator); knob=0 boots keep the stock entry, container
+    # env byte-identical to a build without the tier.
+    local -a alloc_conf_env=(-e PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True)
+    if [ "${GLM53_KV_OFFLOAD-0}" = 1 ]; then
+        alloc_conf_env=()
+        log "kv-offload: PYTORCH_CUDA_ALLOC_CONF (expandable_segments:True) dropped on both ranks (OffloadingConnector incompatibility, vllm config validation)"
+    fi
     local -a nccl_common=(
         -e NCCL_IB_DISABLE=0
         -e NCCL_IB_ROCE_VERSION_NUM=2
@@ -1244,7 +1257,7 @@ launch_cluster() {
         -e "TORCH_CUDA_ARCH_LIST=$TORCH_CUDA_ARCH_LIST"
         -e "FLASHINFER_CUDA_ARCH_LIST=$FLASHINFER_CUDA_ARCH_LIST"
         -e FLASHINFER_DISABLE_VERSION_CHECK=1
-        -e PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+        ${alloc_conf_env[@]+"${alloc_conf_env[@]}"}
         -e "VLLM_ENGINE_READY_TIMEOUT_S=$READY_TIMEOUT"
         # py-cpuinfo JSON-parses empty output on Grace/aarch64; the usage
         # thread then dumps JSONDecodeError. Stats are off on this private kit.

--- a/tests/_kv_offload_stub_env.py
+++ b/tests/_kv_offload_stub_env.py
@@ -1,0 +1,683 @@
+#!/usr/bin/env python3
+"""Stubbed-vllm exec environment for the kv-offload overlay tests.
+
+Applies the overlay patchers to the pinned image fixtures
+(tests/fixtures/image_487ecf187_*.py) and executes the PATCHED module text
+under a minimal fake ``vllm`` namespace, so the tests drive the exact code the
+container will run — not a replica (Codex OFFLOAD1 finding 6).
+
+Only what the patched modules import is stubbed; everything else raises on
+first touch. The 7-group GLM-5.3-Flash boot layout (stage-0 receipts) is the
+canonical fake config: g0 mixed MLA+indexer (block 3584), g1 KpoolTail scratch
+(block 4, not prefix-cacheable), g2-5 MambaSpec align (block 3584), g6 exact
+SlidingWindowSpec drafter (block 64, EAGLE).
+"""
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass, field
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+FIXTURES = HERE / "fixtures"
+
+sys.path.insert(0, str(ROOT / "overlay"))
+
+import patch_kv_offload_scope as scope_mod  # noqa: E402
+import patch_kv_offload_store_local as store_mod  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Patched module text
+# ---------------------------------------------------------------------------
+def patched_texts(with_store: bool = True) -> dict[str, str]:
+    """Apply the patchers (prepare only, no writes) to the pinned fixtures."""
+    kvo_cfg = (FIXTURES / "image_487ecf187_kv_offload_config.py").read_text()
+    conn_cfg = (FIXTURES / "image_487ecf187_offloading_config.py").read_text()
+    sched = (FIXTURES / "image_487ecf187_offloading_scheduler.py").read_text()
+    common = (FIXTURES / "image_487ecf187_offloading_common.py").read_text()
+    worker = (FIXTURES / "image_487ecf187_offloading_worker.py").read_text()
+
+    kvo_cfg, _ = scope_mod.prepare(kvo_cfg, scope_mod.SITES_KVO_CONFIG, "t")
+    conn_cfg, _ = scope_mod.prepare(conn_cfg, scope_mod.SITES_CONN_CONFIG, "t")
+    sched, _ = scope_mod.prepare(sched, scope_mod.SITES_SCHED, "t")
+    if with_store:
+        common, _ = store_mod.prepare(common, store_mod.SITES_COMMON, "t")
+        sched, _ = store_mod.prepare(sched, store_mod.SITES_SCHED, "t")
+        worker, _ = store_mod.prepare(worker, store_mod.SITES_WORKER, "t")
+    return {
+        "kv_offload_config": kvo_cfg,
+        "offloading_config": conn_cfg,
+        "scheduler": sched,
+        "common": common,
+        "worker": worker,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fake spec classes (names are load-bearing: the overlays key on them)
+# ---------------------------------------------------------------------------
+class KVCacheSpec:
+    """[I] naming: the cacheability flag is the participates_in_prefix_caching
+    PROPERTY (no prefix_cacheable attribute exists) — the stub mirrors that so
+    the overlays' dual-name check is exercised against the fork name."""
+
+    def __init__(self, block_size, prefix_cacheable=True):
+        self.block_size = block_size
+        self._cacheable = prefix_cacheable
+
+    @property
+    def participates_in_prefix_caching(self) -> bool:
+        return self._cacheable
+
+
+class AttentionSpec(KVCacheSpec):
+    pass
+
+
+class FullAttentionSpec(AttentionSpec):
+    pass
+
+
+class MLAAttentionSpec(FullAttentionSpec):
+    pass
+
+
+class ChunkedLocalAttentionSpec(AttentionSpec):
+    pass
+
+
+class SlidingWindowSpec(AttentionSpec):
+    def __init__(self, block_size, sliding_window, **kw):
+        super().__init__(block_size, **kw)
+        self.sliding_window = sliding_window
+
+
+class MambaSpec(KVCacheSpec):
+    def __init__(self, block_size, mamba_cache_mode="align", shapes=None, dtypes=None):
+        super().__init__(block_size)
+        self.mamba_cache_mode = mamba_cache_mode
+        # Stage-0 R13 KDA ABI at num_spec=7, TP=2.
+        self.shapes = shapes if shapes is not None else ((10, 12288), (32, 128, 128))
+        self.dtypes = (
+            dtypes if dtypes is not None else ("torch.bfloat16", "torch.float32")
+        )
+
+
+class KpoolTailSpec(AttentionSpec):
+    pass
+
+
+class UniformTypeKVCacheSpecs(KVCacheSpec):
+    """[I]'s wrapper: subclasses KVCacheSpec ONLY (not FullAttentionSpec),
+    aggregates member cacheability — kv_cache_interface.py:920-937."""
+
+    def __init__(self, block_size, kv_cache_specs):
+        super().__init__(block_size)
+        self.kv_cache_specs = kv_cache_specs
+
+    @property
+    def participates_in_prefix_caching(self) -> bool:
+        return all(
+            s.participates_in_prefix_caching for s in self.kv_cache_specs.values()
+        )
+
+
+@dataclass
+class FakeKVCacheGroup:
+    kv_cache_spec: object
+    layer_names: tuple
+    is_eagle_group: bool = False
+
+
+@dataclass
+class FakeKVCacheConfig:
+    kv_cache_groups: list
+    num_blocks: int = 804
+
+
+def boot_layout() -> FakeKVCacheConfig:
+    """The 7-group GLM-5.3-Flash layout (stage-0 receipts §C)."""
+    g0_layers = tuple(f"mla.{i}" for i in range(11)) + tuple(
+        f"idx.{i}" for i in range(11)
+    )
+    g0 = FakeKVCacheGroup(
+        UniformTypeKVCacheSpecs(
+            3584, {n: MLAAttentionSpec(3584) for n in g0_layers}
+        ),
+        g0_layers,
+    )
+    g1_layers = tuple(f"kpool.{i}" for i in range(11))
+    g1 = FakeKVCacheGroup(
+        UniformTypeKVCacheSpecs(
+            4, {n: KpoolTailSpec(4, prefix_cacheable=False) for n in g1_layers}
+        ),
+        g1_layers,
+    )
+    mamba_groups = []
+    for g, n in ((2, 9), (3, 9), (4, 8), (5, 8)):
+        names = tuple(f"kda{g}.{i}" for i in range(n))
+        mamba_groups.append(
+            FakeKVCacheGroup(
+                UniformTypeKVCacheSpecs(3584, {nm: MambaSpec(3584) for nm in names}),
+                names,
+            )
+        )
+    g6_layers = tuple(f"draft.{i}" for i in range(5))
+    g6 = FakeKVCacheGroup(
+        UniformTypeKVCacheSpecs(
+            64, {n: SlidingWindowSpec(64, 2048) for n in g6_layers}
+        ),
+        g6_layers,
+    )
+    return FakeKVCacheConfig([g0, g1] + mamba_groups + [g6])
+
+
+@dataclass
+class FakeSpeculativeConfig:
+    num_speculative_tokens: int = 7
+
+    def use_eagle(self) -> bool:
+        return True
+
+
+@dataclass
+class FakeParallelConfig:
+    rank: int = 0
+    world_size: int = 2
+    tensor_parallel_size: int = 2
+    pipeline_parallel_size: int = 1
+    prefill_context_parallel_size: int = 1
+    decode_context_parallel_size: int = 1
+    data_parallel_index: int = 0
+    data_parallel_size: int = 1
+    data_parallel_rank_local: int | None = 0
+    nnodes_within_dp: int = 2
+    distributed_executor_backend: str = "mp"
+
+
+@dataclass
+class FakeCacheConfig:
+    enable_prefix_caching: bool = True
+    prefix_caching_hash_algo: str = "sha256"
+    cache_dtype: str = "fp8"
+
+
+@dataclass
+class FakeModelConfig:
+    model: str = "Mia-AiLab/GLM-5.3-Flash-EXL3-TR3-4bpw"
+    dtype: str = "bfloat16"
+    use_mla: bool = True
+
+    def get_total_num_kv_heads(self) -> int:
+        return 1
+
+
+@dataclass
+class FakeVllmConfig:
+    parallel_config: FakeParallelConfig = field(default_factory=FakeParallelConfig)
+    speculative_config: FakeSpeculativeConfig | None = field(
+        default_factory=FakeSpeculativeConfig
+    )
+    cache_config: FakeCacheConfig = field(default_factory=FakeCacheConfig)
+    model_config: FakeModelConfig = field(default_factory=FakeModelConfig)
+    kv_transfer_config: object | None = None
+    kv_events_config: object | None = None
+    use_v2_model_runner: bool = False
+
+
+# ---------------------------------------------------------------------------
+# The fake vllm module tree
+# ---------------------------------------------------------------------------
+class _RecordingLogger:
+    def __init__(self):
+        self.lines: list[str] = []
+
+    def _fmt(self, msg, *args):
+        try:
+            self.lines.append(msg % args if args else str(msg))
+        except TypeError:
+            self.lines.append(str(msg))
+
+    info = info_once = debug = warning = warning_once = error = exception = _fmt
+
+
+def _mod(name: str) -> types.ModuleType:
+    m = types.ModuleType(name)
+    sys.modules[name] = m
+    return m
+
+
+def install_fake_vllm() -> dict:
+    """Install a minimal fake vllm namespace; returns handles for tests."""
+    logger = _RecordingLogger()
+
+    vllm = _mod("vllm")
+    vllm.__version__ = "0.1.dev20051+g487ecf187"
+
+    m = _mod("vllm.config")
+    m.VllmConfig = FakeVllmConfig
+
+    m = _mod("vllm.logger")
+    m.init_logger = lambda name: logger
+
+    m = _mod("vllm.utils.math_utils")
+    m.cdiv = lambda a, b: -(-a // b)
+    m.round_down = lambda x, y: (x // y) * y
+    sys.modules["vllm.utils"] = types.ModuleType("vllm.utils")
+
+    m = _mod("vllm.distributed.kv_events")
+    m.KVCacheEvent = object
+
+    m = _mod("vllm.distributed.parallel_state")
+
+    def _tp_rank():
+        raise RuntimeError("TP group not initialized in the stub env")
+
+    m.get_tensor_model_parallel_rank = _tp_rank
+
+    m = _mod("vllm.distributed.kv_transfer.kv_connector.utils")
+
+    def yield_req_data(scheduler_output):
+        for req_id, (blocks, preempted) in scheduler_output.req_data.items():
+            yield req_id, blocks, preempted
+
+    m.yield_req_data = yield_req_data
+
+    m = _mod("vllm.distributed.kv_transfer.kv_connector.v1.base")
+
+    class KVConnectorMetadata:
+        pass
+
+    class KVConnectorWorkerMetadata:
+        pass
+
+    m.KVConnectorMetadata = KVConnectorMetadata
+    m.KVConnectorWorkerMetadata = KVConnectorWorkerMetadata
+
+    m = _mod("vllm.v1.kv_cache_interface")
+    for cls in (
+        AttentionSpec,
+        FullAttentionSpec,
+        MLAAttentionSpec,
+        ChunkedLocalAttentionSpec,
+        SlidingWindowSpec,
+        MambaSpec,
+        KVCacheSpec,
+        UniformTypeKVCacheSpecs,
+    ):
+        setattr(m, cls.__name__, cls)
+    m.KVCacheConfig = FakeKVCacheConfig
+    m.KVCacheTensor = object
+
+    m = _mod("vllm.v1.core.kv_cache_manager")
+
+    @dataclass
+    class KVCacheBlocks:
+        blocks: tuple
+
+    m.KVCacheBlocks = KVCacheBlocks
+
+    m = _mod("vllm.v1.core.sched.output")
+    m.SchedulerOutput = object
+
+    m = _mod("vllm.v1.core.kv_cache_utils")
+    m.resolve_kv_cache_block_sizes = lambda kv_cache_config, vllm_config: (
+        [3584],
+        64,
+    )
+
+    m = _mod("vllm.v1.outputs")
+
+    @dataclass
+    class KVConnectorOutput:
+        kv_connector_stats: object = None
+        invalid_block_ids: frozenset = frozenset()
+        finished_sending: set | None = None
+        finished_recving: set | None = None
+
+    m.KVConnectorOutput = KVConnectorOutput
+
+    m = _mod("vllm.v1.request")
+
+    class RequestStatus:
+        FINISHED_ABORTED = "aborted"
+
+    class Request:
+        pass
+
+    m.RequestStatus = RequestStatus
+    m.Request = Request
+
+    m = _mod("vllm.v1.attention.backend")
+    m.AttentionBackend = object
+
+    # --- vllm.v1.kv_offload.base: real key packing, minimal everything else
+    m = _mod("vllm.v1.kv_offload.base")
+
+    def make_offload_key(block_hash: bytes, group_idx: int):
+        return block_hash + group_idx.to_bytes(4, "big", signed=False)
+
+    m.make_offload_key = make_offload_key
+    m.get_offload_block_hash = lambda key: key[:-4]
+    m.get_offload_group_idx = lambda key: int.from_bytes(key[-4:], "big")
+    m.OffloadKey = bytes
+
+    import enum
+
+    class Medium(enum.Enum):
+        CPU = "CPU"
+        STORAGE = "STORAGE"
+
+    class Locality(enum.Enum):
+        LOCAL = "LOCAL"
+        REMOTE = "REMOTE"
+
+    class LookupResult(enum.Enum):
+        HIT = 1
+        HIT_PENDING = 2
+        RETRY = 3
+        MISS = 4
+
+    class OffloadPolicy(enum.Enum):
+        BLOCK_LEVEL = 1
+        REQUEST_LEVEL = 2
+
+    @dataclass
+    class TierMatcher:
+        medium: object = None
+        locality: object = None
+
+    class TierFilter:
+        ALL = None
+
+        def __init__(self, matchers=()):
+            self.matchers = matchers
+
+    TierFilter.ALL = TierFilter()
+
+    @dataclass
+    class ReqContext:
+        req_id: str
+        kv_transfer_params: dict | None = None
+        load_tier_filter: object = None
+
+    @dataclass
+    class RequestOffloadingContext:
+        policy: object = OffloadPolicy.BLOCK_LEVEL
+
+    @dataclass
+    class ScheduleEndContext:
+        pass
+
+    import numpy as np
+
+    class LoadStoreSpec:
+        pass
+
+    class BlockIDsLoadStoreSpec(LoadStoreSpec):
+        def __init__(self, block_ids):
+            self.block_ids = np.array(block_ids, dtype=np.int64)
+
+    class GPULoadStoreSpec(BlockIDsLoadStoreSpec):
+        def __init__(self, block_ids, group_sizes, block_indices):
+            super().__init__(block_ids)
+            assert sum(group_sizes) == len(block_ids)
+            assert len(block_indices) == len(group_sizes)
+            self.group_sizes = group_sizes
+            self.block_indices = block_indices
+
+    class CPULoadStoreSpec(BlockIDsLoadStoreSpec):
+        pass
+
+    class OffloadingManager:
+        pass
+
+    class OffloadingWorker:
+        pass
+
+    class OffloadingSpec:
+        def __init__(self, config):
+            self.config = config
+            self.extra_config = config.extra_config
+            self.tokens_per_block = tuple(
+                g.tokens_per_block for g in config.groups
+            )
+            self.tokens_per_hash = config.cache.tokens_per_hash
+            self.blocks_per_chunk = config.cache.blocks_per_chunk
+            self.offload_prompt_only = False
+
+    for name, obj in dict(
+        Medium=Medium,
+        Locality=Locality,
+        LookupResult=LookupResult,
+        OffloadPolicy=OffloadPolicy,
+        TierMatcher=TierMatcher,
+        TierFilter=TierFilter,
+        ReqContext=ReqContext,
+        RequestOffloadingContext=RequestOffloadingContext,
+        ScheduleEndContext=ScheduleEndContext,
+        LoadStoreSpec=LoadStoreSpec,
+        BlockIDsLoadStoreSpec=BlockIDsLoadStoreSpec,
+        GPULoadStoreSpec=GPULoadStoreSpec,
+        CPULoadStoreSpec=CPULoadStoreSpec,
+        OffloadingManager=OffloadingManager,
+        OffloadingWorker=OffloadingWorker,
+        OffloadingSpec=OffloadingSpec,
+        CanonicalKVCaches=object,
+        CanonicalKVCacheRef=object,
+        CanonicalKVCacheTensor=object,
+        OffloadingCounterMetadata=object,
+        OffloadingGaugeMetadata=object,
+        OffloadingHistogramMetadata=object,
+        OffloadingMetricMetadata=object,
+    ).items():
+        setattr(m, name, obj)
+
+    # --- offloading sibling modules the scheduler/worker import
+    m = _mod("vllm.distributed.kv_transfer.kv_connector.v1.offloading.events")
+
+    @dataclass
+    class OffloadingEventGroupSpec:
+        name: str = "g"
+
+    class OffloadingEventsTracker:
+        def __init__(self, kv_events_config):
+            self.records = []
+
+        def record_lookup(self, *a, **k):
+            self.records.append(("lookup", a))
+
+        def record_partial_lookup(self, *a, **k):
+            self.records.append(("partial_lookup", a))
+
+        def record_store(self, *a, **k):
+            self.records.append(("store", a))
+
+        def record_partial_store(self, *a, **k):
+            self.records.append(("partial_store", a))
+
+        def take_events(self):
+            return ()
+
+    m.OffloadingEventGroupSpec = OffloadingEventGroupSpec
+    m.OffloadingEventsTracker = OffloadingEventsTracker
+    m.get_offloading_event_group_spec = lambda group: OffloadingEventGroupSpec()
+
+    m = _mod("vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics")
+
+    class OffloadingConnectorStats:
+        def __init__(self):
+            self.hist = []
+
+        def observe_histogram(self, *a, **k):
+            self.hist.append(a)
+
+        def increase_counter(self, *a, **k):
+            pass
+
+    class _ConnectorMetricName:
+        LOOKUP_ASYNC_DELAY = "lookup_async"
+        LOOKUP_SYNC_DELAY = "lookup_sync"
+        ALLOCATION_FAILURE = "alloc_failure"
+
+    class _TransferMetricName:
+        pass
+
+    m.OffloadingConnectorStats = OffloadingConnectorStats
+    m._ConnectorMetricName = _ConnectorMetricName
+    m._TransferMetricName = _TransferMetricName
+
+    m = _mod(
+        "vllm.distributed.kv_transfer.kv_connector.v1.offloading.canonical_mapping"
+    )
+    m.derive_canonical_mappings = lambda *a, **k: {}
+    m.canonical_format_id = lambda: "v1-nhd"
+
+    # --- exec the PATCHED overlay outputs as the real module names
+    texts = patched_texts(with_store=True)
+
+    kvo_cfg = _mod("vllm.v1.kv_offload.config")
+    exec(compile(texts["kv_offload_config"], "kv_offload/config.py", "exec"), kvo_cfg.__dict__)
+
+    common = _mod("vllm.distributed.kv_transfer.kv_connector.v1.offloading.common")
+    exec(compile(texts["common"], "offloading/common.py", "exec"), common.__dict__)
+
+    conn_cfg = _mod("vllm.distributed.kv_transfer.kv_connector.v1.offloading.config")
+    exec(compile(texts["offloading_config"], "offloading/config.py", "exec"), conn_cfg.__dict__)
+
+    sched = _mod("vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler")
+    exec(compile(texts["scheduler"], "offloading/scheduler.py", "exec"), sched.__dict__)
+
+    # worker.py imports torch at module level; provide a named stub only if
+    # torch is genuinely absent (the writer path never touches it).
+    if "torch" not in sys.modules:
+        try:
+            import torch  # noqa: F401
+        except ImportError:
+            t = _mod("torch")
+            t.Tensor = object
+            t.Event = object
+
+    worker = _mod("vllm.distributed.kv_transfer.kv_connector.v1.offloading.worker")
+    exec(compile(texts["worker"], "offloading/worker.py", "exec"), worker.__dict__)
+
+    return {
+        "logger": logger,
+        "kv_offload_config": kvo_cfg,
+        "offloading_config": conn_cfg,
+        "scheduler": sched,
+        "common": common,
+        "worker": worker,
+        "base": sys.modules["vllm.v1.kv_offload.base"],
+        "kv_cache_manager": sys.modules["vllm.v1.core.kv_cache_manager"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Convenience builders on top of the fake tree
+# ---------------------------------------------------------------------------
+@dataclass
+class FakeKVTransferConfig:
+    engine_id: str = "engine0"
+    kv_connector_extra_config: dict = field(default_factory=dict)
+
+
+def build_offloading_config(mods, vllm_config=None, kv_cache_config=None):
+    vllm_config = vllm_config or FakeVllmConfig(
+        kv_transfer_config=FakeKVTransferConfig()
+    )
+    kv_cache_config = kv_cache_config or boot_layout()
+    # worker_kv_bytes_per_block path needs kv_cache_tensors; keep it inert.
+    kv_cache_config.kv_cache_tensors = []
+    kv_cache_config.num_blocks = 0
+    return mods["offloading_config"].build_offloading_config(
+        vllm_config, kv_cache_config
+    )
+
+
+class FakeManager:
+    """Scheduler-side OffloadingManager stub that accepts every store."""
+
+    def __init__(self, mods):
+        self.base = mods["base"]
+        self.lookup_calls = []
+        self.prepare_load_calls = []
+        self.touched = []
+
+    def on_new_request(self, req_context):
+        return self.base.RequestOffloadingContext()
+
+    def lookup(self, key, req_context):
+        self.lookup_calls.append(key)
+        return self.base.LookupResult.MISS
+
+    def touch(self, keys, req_context):
+        self.touched.append(tuple(keys))
+
+    def prepare_load(self, keys, req_context):
+        self.prepare_load_calls.append(tuple(keys))
+        return self.base.CPULoadStoreSpec(list(range(len(list(keys)))))
+
+    def prepare_store(self, keys, req_context):
+        keys = list(keys)
+
+        class StoreOutput:
+            pass
+
+        out = StoreOutput()
+        out.keys_to_store = list(keys)
+        out.store_spec = self.base.CPULoadStoreSpec(
+            list(range(100, 100 + len(keys)))
+        )
+        return out
+
+    def on_request_finished(self, req_context):
+        pass
+
+    def take_events(self):
+        return ()
+
+    def get_stats(self):
+        return None
+
+
+class FakeSchedSpec:
+    """Duck-typed OffloadingSpec for the scheduler side."""
+
+    def __init__(self, mods, offloading_config, manager=None):
+        self.config = offloading_config
+        self.tokens_per_block = tuple(
+            g.tokens_per_block for g in offloading_config.groups
+        )
+        self.tokens_per_hash = offloading_config.cache.tokens_per_hash
+        self.blocks_per_chunk = offloading_config.cache.blocks_per_chunk
+        self.offload_prompt_only = False
+        self.kv_events_config = None
+        self._manager = manager or FakeManager(mods)
+
+    def get_manager(self):
+        return self._manager
+
+
+class FakeRequest:
+    def __init__(self, num_tokens, tokens_per_hash=64, req_id="req0", salt=b"s"):
+        import hashlib
+
+        self.request_id = req_id
+        self.num_tokens = num_tokens
+        self.num_prompt_tokens = num_tokens
+        self.num_computed_tokens = 0
+        self.kv_transfer_params = None
+        self.skip_reading_prefix_cache = False
+        self.status = None
+        n_hashes = num_tokens // tokens_per_hash
+        self.block_hashes = [
+            hashlib.sha256(salt + i.to_bytes(4, "big")).digest()
+            for i in range(n_hashes)
+        ]
+
+    def is_finished(self):
+        return False

--- a/tests/_kv_offload_stub_env.py
+++ b/tests/_kv_offload_stub_env.py
@@ -698,12 +698,21 @@ class FakeSchedSpec:
 
 
 class FakeRequest:
-    def __init__(self, num_tokens, tokens_per_hash=64, req_id="req0", salt=b"s"):
+    def __init__(
+        self,
+        num_tokens,
+        tokens_per_hash=64,
+        req_id="req0",
+        salt=b"s",
+        num_prompt_tokens=None,
+    ):
         import hashlib
 
         self.request_id = req_id
         self.num_tokens = num_tokens
-        self.num_prompt_tokens = num_tokens
+        self.num_prompt_tokens = (
+            num_tokens if num_prompt_tokens is None else num_prompt_tokens
+        )
         self.num_computed_tokens = 0
         self.kv_transfer_params = None
         self.skip_reading_prefix_cache = False

--- a/tests/_kv_offload_stub_env.py
+++ b/tests/_kv_offload_stub_env.py
@@ -447,7 +447,11 @@ def install_fake_vllm() -> dict:
             )
             self.tokens_per_hash = config.cache.tokens_per_hash
             self.blocks_per_chunk = config.cache.blocks_per_chunk
-            self.offload_prompt_only = False
+            # Mirror upstream: DEFAULT TRUE — the launcher must explicitly
+            # pass offload_prompt_only=false or decoded tokens are not stored.
+            self.offload_prompt_only = bool(
+                config.extra_config.get("offload_prompt_only", True)
+            )
 
     for name, obj in dict(
         Medium=Medium,
@@ -654,7 +658,9 @@ class FakeSchedSpec:
         )
         self.tokens_per_hash = offloading_config.cache.tokens_per_hash
         self.blocks_per_chunk = offloading_config.cache.blocks_per_chunk
-        self.offload_prompt_only = False
+        self.offload_prompt_only = bool(
+            offloading_config.extra_config.get("offload_prompt_only", True)
+        )
         self.kv_events_config = None
         self._manager = manager or FakeManager(mods)
 

--- a/tests/_kv_offload_stub_env.py
+++ b/tests/_kv_offload_stub_env.py
@@ -27,12 +27,15 @@ sys.path.insert(0, str(ROOT / "overlay"))
 
 import patch_kv_offload_scope as scope_mod  # noqa: E402
 import patch_kv_offload_store_local as store_mod  # noqa: E402
+import patch_kv_offload_restore_g0 as restore_mod  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
 # Patched module text
 # ---------------------------------------------------------------------------
-def patched_texts(with_store: bool = True) -> dict[str, str]:
+def patched_texts(
+    with_store: bool = True, with_restore: bool = False
+) -> dict[str, str]:
     """Apply the patchers (prepare only, no writes) to the pinned fixtures."""
     kvo_cfg = (FIXTURES / "image_487ecf187_kv_offload_config.py").read_text()
     conn_cfg = (FIXTURES / "image_487ecf187_offloading_config.py").read_text()
@@ -47,6 +50,11 @@ def patched_texts(with_store: bool = True) -> dict[str, str]:
         common, _ = store_mod.prepare(common, store_mod.SITES_COMMON, "t")
         sched, _ = store_mod.prepare(sched, store_mod.SITES_SCHED, "t")
         worker, _ = store_mod.prepare(worker, store_mod.SITES_WORKER, "t")
+    if with_restore:
+        assert with_store, "the restore overlay stacks on the store overlay"
+        common, _ = restore_mod.prepare(common, restore_mod.SITES_COMMON, "t")
+        sched, _ = restore_mod.prepare(sched, restore_mod.SITES_SCHED, "t")
+        worker, _ = restore_mod.prepare(worker, restore_mod.SITES_WORKER, "t")
     return {
         "kv_offload_config": kvo_cfg,
         "offloading_config": conn_cfg,
@@ -250,7 +258,7 @@ def _mod(name: str) -> types.ModuleType:
     return m
 
 
-def install_fake_vllm() -> dict:
+def install_fake_vllm(with_restore: bool = False) -> dict:
     """Install a minimal fake vllm namespace; returns handles for tests."""
     logger = _RecordingLogger()
 
@@ -410,7 +418,8 @@ def install_fake_vllm() -> dict:
 
     @dataclass
     class ScheduleEndContext:
-        pass
+        new_req_ids: list = None
+        preempted_req_ids: object = ()
 
     import numpy as np
 
@@ -506,6 +515,9 @@ def install_fake_vllm() -> dict:
         def take_events(self):
             return ()
 
+        def reset(self):
+            self.records.clear()
+
     m.OffloadingEventGroupSpec = OffloadingEventGroupSpec
     m.OffloadingEventsTracker = OffloadingEventsTracker
     m.get_offloading_event_group_spec = lambda group: OffloadingEventGroupSpec()
@@ -541,7 +553,7 @@ def install_fake_vllm() -> dict:
     m.canonical_format_id = lambda: "v1-nhd"
 
     # --- exec the PATCHED overlay outputs as the real module names
-    texts = patched_texts(with_store=True)
+    texts = patched_texts(with_store=True, with_restore=with_restore)
 
     kvo_cfg = _mod("vllm.v1.kv_offload.config")
     exec(compile(texts["kv_offload_config"], "kv_offload/config.py", "exec"), kvo_cfg.__dict__)
@@ -638,7 +650,24 @@ class FakeManager:
         )
         return out
 
+    def complete_load(self, keys, req_context):
+        self.completed_loads = getattr(self, "completed_loads", [])
+        self.completed_loads.append(tuple(keys))
+
+    def complete_store(self, keys, req_context):
+        self.completed_stores = getattr(self, "completed_stores", [])
+        self.completed_stores.append(tuple(keys))
+
     def on_request_finished(self, req_context):
+        pass
+
+    def on_schedule_end(self, schedule_end_context):
+        pass
+
+    def has_pending_work(self) -> bool:
+        return False
+
+    def reset_cache(self):
         pass
 
     def take_events(self):

--- a/tests/_mamba_differential.py
+++ b/tests/_mamba_differential.py
@@ -118,7 +118,14 @@ def write_park_fixture(
     """Write one boot's park-at-boundary-k fixture: the four mamba group
     chunk files + the boundary manifest, in the stage-1 on-disk format
     (format v1 headers, real bytes only, tmp-free direct writes — this is a
-    fixture generator, not the durable writer)."""
+    fixture generator, not the durable writer).
+
+    Deliberate fixture scope (review f12 note): only the TERMINAL boundary's
+    mamba chunks are materialized even though the manifest chain lists
+    earlier boundary hashes — mamba restore needs exactly ONE state block
+    per group at the target boundary (plan §3), and this harness compares
+    states at that boundary; earlier boundaries would be separate park
+    fixtures of their own."""
     base = root / f"glm53kv_test_model_{namespace}_r{rank}"
     bhash = boundary_hash(chain, boundary_k)
     cow_entries: dict[str, dict] = {}
@@ -191,17 +198,38 @@ def check_state_abi(base: Path, boundary_k: int, chain: str = "chainA") -> list[
         if len(segs) != 2 * n_layers:
             problems.append(f"g{group}: {len(segs)} segments != {2 * n_layers}")
             continue
+        run = 0
         for i, seg in enumerate(segs):
-            want = (
-                (list(KDA_CONV_SHAPE), KDA_CONV_DTYPE, KDA_CONV_BYTES)
-                if i % 2 == 0
-                else (list(KDA_TEMPORAL_SHAPE), KDA_TEMPORAL_DTYPE, KDA_TEMPORAL_BYTES)
-            )
-            if (seg.get("shape"), seg.get("dtype"), seg.get("length")) != want:
-                problems.append(
-                    f"g{group} seg{i}: {seg.get('shape')}/{seg.get('dtype')}"
-                    f"/{seg.get('length')} != {want}"
+            layer_idx = i // 2
+            if i % 2 == 0:
+                want_shape, want_dtype, want_len, want_kind = (
+                    list(KDA_CONV_SHAPE), KDA_CONV_DTYPE, KDA_CONV_BYTES,
+                    "conv_state",
                 )
+            else:
+                want_shape, want_dtype, want_len, want_kind = (
+                    list(KDA_TEMPORAL_SHAPE), KDA_TEMPORAL_DTYPE,
+                    KDA_TEMPORAL_BYTES, "temporal_state",
+                )
+            want_strides = []
+            acc = 1
+            for d in reversed(want_shape):
+                want_strides.append(acc)
+                acc *= int(d)
+            want_strides.reverse()
+            got = (
+                seg.get("shape"), seg.get("dtype"), seg.get("length"),
+                seg.get("kind"), seg.get("layer"), seg.get("stride"),
+                seg.get("stride_provenance"), seg.get("offset"),
+            )
+            want = (
+                want_shape, want_dtype, want_len, want_kind,
+                f"kda{group}.{layer_idx}", want_strides,
+                "derived-contiguous", run,
+            )
+            if got != want:
+                problems.append(f"g{group} seg{i}: {got} != {want}")
+            run += want_len
     return problems
 
 

--- a/tests/_mamba_differential.py
+++ b/tests/_mamba_differential.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Stage-3 mamba cross-boot differential harness — fixture side.
+
+SCOPE (Codex OFFLOAD2 finding 14, adopted): this module is a **state-ABI /
+codec fixture comparator**, NOT stage-3 evidence. It builds park-at-boundary
+fixtures whose payloads are STUBBED KDA state tensors at the receipted ABI
+(STAGE0-RECEIPTS R13), and provides the exact bit-comparator stage 3 will run
+against REAL captures. The mamba state-index convention is still an OPEN
+stage-0 residual ("Strides: derived-contiguous, not observed live; the
+state-index convention remains stage-2/3" — STAGE0-RECEIPTS A2); nothing here
+proves that an align-mode snapshot restored on another boot is semantically
+sufficient. The live instrument is tests/stage3_mamba_differential_protocol.sh
+(guarded, not run in stage 2).
+
+The receipted KDA state ABI (deployed config: TP=2, heads 64, head_dim 128,
+conv kernel 4, num_spec 7):
+  conv_state     (10, 12288)   bfloat16  = 245,760 B   (width = kernel-1+num_spec)
+  temporal_state (32, 128, 128) float32  = 2,097,152 B
+  real per-layer page = 2,342,912 B  (logged mamba page 2,351,104 is PADDED
+  by +8,192 B/layer slot-share padding — padding must never hit disk)
+Groups 2/3/4/5 carry 9/9/8/8 KDA layers per rank.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent / "overlay"))
+
+import patch_kv_offload_store_local as store  # noqa: E402
+
+# The receipted ABI (stage-0 R13). num_spec is part of the ABI: it is baked
+# into the conv width, so it rides both the chunk headers and the namespace.
+KDA_CONV_SHAPE = (10, 12288)
+KDA_CONV_DTYPE = "torch.bfloat16"
+KDA_CONV_BYTES = 245_760
+KDA_TEMPORAL_SHAPE = (32, 128, 128)
+KDA_TEMPORAL_DTYPE = "torch.float32"
+KDA_TEMPORAL_BYTES = 2_097_152
+KDA_REAL_PAGE = KDA_CONV_BYTES + KDA_TEMPORAL_BYTES  # 2,342,912
+KDA_PADDED_PAGE = 2_351_104  # never on disk
+NUM_SPEC = 7
+MAMBA_GROUP_LAYERS = {2: 9, 3: 9, 4: 8, 5: 8}
+STATE_ABI_VERSION = "v0-kda-r13"
+TOKENS_PER_CHUNK = 3584
+
+
+def _tile(seed: str, n: int) -> bytes:
+    """Deterministic pseudo-random bytes: sha256 counter-mode tiling."""
+    out = bytearray()
+    counter = 0
+    base = seed.encode()
+    while len(out) < n:
+        out += hashlib.sha256(base + counter.to_bytes(8, "big")).digest() * 256
+        counter += 1
+    return bytes(out[:n])
+
+
+def kda_layer_state(boot: str, group: int, layer: int) -> tuple[bytes, bytes]:
+    """One layer's (conv, temporal) stubbed state bytes for a given boot."""
+    conv = _tile(f"{boot}:g{group}:l{layer}:conv", KDA_CONV_BYTES)
+    temporal = _tile(f"{boot}:g{group}:l{layer}:temporal", KDA_TEMPORAL_BYTES)
+    return conv, temporal
+
+
+def group_payload_and_segments(boot: str, group: int) -> tuple[bytes, list]:
+    """The chunk payload (all layers, real bytes only) + its segment table,
+    exactly as the stage-1 writer lays them out."""
+    n_layers = MAMBA_GROUP_LAYERS[group]
+    parts: list[bytes] = []
+    segments: list[dict] = []
+    offset = 0
+    for layer_idx in range(n_layers):
+        conv, temporal = kda_layer_state(boot, group, layer_idx)
+        layer = f"kda{group}.{layer_idx}"
+        for kind, blob, shape, dtype in (
+            ("conv_state", conv, KDA_CONV_SHAPE, KDA_CONV_DTYPE),
+            ("temporal_state", temporal, KDA_TEMPORAL_SHAPE, KDA_TEMPORAL_DTYPE),
+        ):
+            strides = []
+            acc = 1
+            for d in reversed(shape):
+                strides.append(acc)
+                acc *= int(d)
+            strides.reverse()
+            segments.append(
+                {
+                    "layer": layer,
+                    "kind": kind,
+                    "shape": list(shape),
+                    "dtype": dtype,
+                    "stride": strides,
+                    "stride_provenance": "derived-contiguous",
+                    "offset": offset,
+                    "length": len(blob),
+                }
+            )
+            parts.append(blob)
+            offset += len(blob)
+    return b"".join(parts), segments
+
+
+def boundary_hash(chain: str, k: int) -> str:
+    return hashlib.sha256(f"{chain}:boundary:{k}".encode()).hexdigest()
+
+
+def write_park_fixture(
+    root: Path,
+    boot: str,
+    rank: int = 0,
+    boundary_k: int = 1,
+    namespace: str = "mamba-diff-ns0",
+    chain: str = "chainA",
+) -> Path:
+    """Write one boot's park-at-boundary-k fixture: the four mamba group
+    chunk files + the boundary manifest, in the stage-1 on-disk format
+    (format v1 headers, real bytes only, tmp-free direct writes — this is a
+    fixture generator, not the durable writer)."""
+    base = root / f"glm53kv_test_model_{namespace}_r{rank}"
+    bhash = boundary_hash(chain, boundary_k)
+    cow_entries: dict[str, dict] = {}
+    for group in sorted(MAMBA_GROUP_LAYERS):
+        payload, segments = group_payload_and_segments(boot, group)
+        header = {
+            "namespace_hash": namespace,
+            "group_idx": group,
+            "spec_kind": "MambaSpec",
+            "layers": MAMBA_GROUP_LAYERS[group],
+            "block_size_tokens": TOKENS_PER_CHUNK,
+            "n_tokens_valid": TOKENS_PER_CHUNK,
+            "boundary_token_index": (boundary_k + 1) * TOKENS_PER_CHUNK,
+            "tp_rank": rank,
+            "tp_world": 2,
+            "segment_table": segments,
+            "hash": bhash,
+            "state_abi_version": STATE_ABI_VERSION,
+            "num_speculative_tokens": NUM_SPEC,
+        }
+        blob = store.encode_chunk(header, payload)
+        path = base / bhash[:3] / f"{bhash[3:5]}_g{group}" / f"{bhash}.bin"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(blob)
+        h = store.read_chunk_header(str(path))
+        cow_entries[str(group)] = {
+            "hash": bhash,
+            "payload_len": h["payload_len"],
+            "payload_crc32": h["payload_crc32"],
+        }
+    manifest = {
+        "format_version": 1,
+        "namespace_hash": namespace,
+        "boundary_token_index": (boundary_k + 1) * TOKENS_PER_CHUNK,
+        "chunk_hashes": [boundary_hash(chain, j) for j in range(boundary_k + 1)],
+        "cow_groups": cow_entries,
+        "full_groups": {},
+        "rank": rank,
+        "created_at": 0,
+    }
+    mpath = base / "manifests" / bhash[:3] / f"{bhash}.json"
+    mpath.parent.mkdir(parents=True, exist_ok=True)
+    mpath.write_text(json.dumps(manifest, sort_keys=True))
+    return base
+
+
+def check_state_abi(base: Path, boundary_k: int, chain: str = "chainA") -> list[str]:
+    """Field checks against the receipted ABI. Returns a list of violations
+    (empty = pass): shapes, dtypes, per-tensor sizes, num_spec in the header,
+    real (unpadded) payload sizes — the padding must never be on disk."""
+    problems: list[str] = []
+    bhash = boundary_hash(chain, boundary_k)
+    for group, n_layers in MAMBA_GROUP_LAYERS.items():
+        path = base / bhash[:3] / f"{bhash[3:5]}_g{group}" / f"{bhash}.bin"
+        try:
+            h = store.read_chunk_header(str(path), verify_payload=True)
+        except (OSError, ValueError) as exc:
+            problems.append(f"g{group}: unreadable chunk: {exc}")
+            continue
+        if h.get("state_abi_version") != STATE_ABI_VERSION:
+            problems.append(f"g{group}: state_abi_version {h.get('state_abi_version')!r}")
+        if h.get("num_speculative_tokens") != NUM_SPEC:
+            problems.append(f"g{group}: num_spec {h.get('num_speculative_tokens')!r}")
+        if h.get("payload_len") != n_layers * KDA_REAL_PAGE:
+            problems.append(
+                f"g{group}: payload {h.get('payload_len')} != "
+                f"{n_layers}x{KDA_REAL_PAGE} (padded bytes on disk?)"
+            )
+        segs = h.get("segment_table") or []
+        if len(segs) != 2 * n_layers:
+            problems.append(f"g{group}: {len(segs)} segments != {2 * n_layers}")
+            continue
+        for i, seg in enumerate(segs):
+            want = (
+                (list(KDA_CONV_SHAPE), KDA_CONV_DTYPE, KDA_CONV_BYTES)
+                if i % 2 == 0
+                else (list(KDA_TEMPORAL_SHAPE), KDA_TEMPORAL_DTYPE, KDA_TEMPORAL_BYTES)
+            )
+            if (seg.get("shape"), seg.get("dtype"), seg.get("length")) != want:
+                problems.append(
+                    f"g{group} seg{i}: {seg.get('shape')}/{seg.get('dtype')}"
+                    f"/{seg.get('length')} != {want}"
+                )
+    return problems
+
+
+def compare_state_bits(
+    base_a: Path, base_b: Path, boundary_k: int, chain: str = "chainA"
+) -> dict[tuple[int, str, str], int]:
+    """The stage-3 comparator: per-(group, layer, tensor-kind) mismatching
+    byte counts between two boots' parked states at the same boundary.
+    Walks the VALIDATED segment tables (never raw offsets)."""
+    bhash = boundary_hash(chain, boundary_k)
+    result: dict[tuple[int, str, str], int] = {}
+    for group in sorted(MAMBA_GROUP_LAYERS):
+        payloads = []
+        tables = []
+        for base in (base_a, base_b):
+            path = base / bhash[:3] / f"{bhash[3:5]}_g{group}" / f"{bhash}.bin"
+            h = store.read_chunk_header(str(path), verify_payload=True)
+            raw = path.read_bytes()
+            hlen = int.from_bytes(raw[8:12], "little")
+            payloads.append(raw[16 + hlen :])
+            tables.append(h["segment_table"])
+        if tables[0] != tables[1]:
+            result[(group, "*", "segment-table")] = -1
+            continue
+        for seg in tables[0]:
+            a = payloads[0][seg["offset"] : seg["offset"] + seg["length"]]
+            b = payloads[1][seg["offset"] : seg["offset"] + seg["length"]]
+            n = sum(x != y for x, y in zip(a, b)) + abs(len(a) - len(b))
+            if n:
+                result[(group, seg["layer"], seg["kind"])] = n
+    return result

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -10,3 +10,14 @@ sha256 (as captured; `shasum -a 256` these files to compare against a future
 image):
 - offloading/config.py    d400d0b0fadc06f2ad60a1356a6fee730a187dbcc4e48656da523de813419ec9
 - offloading/scheduler.py 616e7fd4cb0d09064cbc4d5735f607b37964c6be3b81e26de00d5913e0a9a3e3
+
+Stage-2 captures (2026-09-01, read-only from the live next3 container — same
+vllm tree 0.1.dev20051+g487ecf187, verified: the four offloading fixtures'
+sha256s match that container byte-exact):
+- offloading_connector.py            b5ddf7c1c8c50f6183dcdc4247759865b88e2b1b415e605c7993f615534912e0
+- single_type_kv_cache_manager.py    41043976d1d5e38e0465c8004fc04e01f35f66b39a40099c62d79b3756337d00
+- core sched/scheduler.py            ec94d3271351b1f4ddb2d3aca5117f8428168855c9a24c2716b73f9987582b7d
+  (image_487ecf187_core_sched_scheduler.py — pinned as the RECEIPT for the
+  single-group invalid-block path: `(req_block_ids,) =
+  self.kv_cache_manager.get_block_ids(req_id)` under the hybrid-allocator
+  TODO at lines 2954-2955; it is not a patch target)

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,12 @@
+# Pinned image fixtures (vllm 0.1.dev20051+g487ecf187, image ad0cdd86)
+
+Byte-exact copies of the in-image vLLM sources the kv-offload overlays patch,
+captured read-only from the deployed container on 2026-09-01 (Apache-2.0,
+SPDX headers retained). The kv-offload patcher tests preflight/apply against
+these and exec the patched result under a stubbed vllm namespace, so anchor
+drift or a broken port fails on the host before any server is touched.
+
+sha256 (as captured; `shasum -a 256` these files to compare against a future
+image):
+- offloading/config.py    d400d0b0fadc06f2ad60a1356a6fee730a187dbcc4e48656da523de813419ec9
+- offloading/scheduler.py 616e7fd4cb0d09064cbc4d5735f607b37964c6be3b81e26de00d5913e0a9a3e3

--- a/tests/fixtures/image_487ecf187_core_sched_scheduler.py
+++ b/tests/fixtures/image_487ecf187_core_sched_scheduler.py
@@ -1,0 +1,3084 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import itertools
+import os
+import time
+from collections import defaultdict, deque
+from collections.abc import Iterable
+from dataclasses import replace
+from typing import Any
+
+
+_GLM53_GATE_CFG = None
+_GLM53_FIRST_SEEN_FALLBACK = None   # WeakKeyDictionary used only if Request rejects attribute assignment
+
+
+def _glm53_gate_config():
+    """Parse the v2 gate knobs once (validated; bad values fall back to defaults and are reported once).  [glm53-decode-floor-v2]"""
+    global _GLM53_GATE_CFG
+    if _GLM53_GATE_CFG is not None:
+        return _GLM53_GATE_CFG
+
+    def _int(name, default, lo, hi):
+        raw = os.environ.get(name)
+        if raw is None or raw.strip() == "":
+            return default
+        try:
+            v = int(raw.strip(), 10)
+        except ValueError:
+            print(f"[glm53-decode-floor-v2] {name}={raw!r} is not an integer; using {default}", flush=True)
+            return default
+        if v < lo or v > hi:
+            print(f"[glm53-decode-floor-v2] {name}={v} outside [{lo}, {hi}]; using {default}", flush=True)
+            return default
+        return v
+
+    cfg = {
+        "warm_tokens": _int("GLM53_MIXED_PREFILL_WARM_TOKENS", 3584, 0, 1_000_000),
+        "max_wait_ms": _int("GLM53_MIXED_PREFILL_MAX_WAIT_MS", 1500, 0, 600_000),
+        "late_cap": _int("GLM53_MIXED_PREFILL_LATE_CAP", 512, 64, 8192),
+    }
+    print(f"[glm53-decode-floor-v2] gate config: {cfg}", flush=True)
+    _GLM53_GATE_CFG = cfg
+    return cfg
+
+
+def _glm53_mixed_prefill_gate(running, current, num_computed_tokens):
+    """Return (cap|None) for this prefill step: remaining-prefill threshold bypass + deadline.  [glm53-decode-floor-v2]
+
+    Bypass: remaining uncached prefill <= GLM53_MIXED_PREFILL_WARM_TOKENS (default 3584 = one hybrid block) -> no policy
+            (typically <= 2 MNBT steps). This is a size heuristic: it admits cached follow-up tails, short cold prompts
+            (the 30-token chat that used to wait 15 s), and the last block of a late-capped prefill alike.
+    Late:   waited >= GLM53_MIXED_PREFILL_MAX_WAIT_MS (default 1500) -> proceed under GLM53_MIXED_PREFILL_LATE_CAP
+            (default 512) tokens per step -- a bound on time-to-first-service, NOT on TTFT or completion: the request
+            then crawls like cap:N and slows running decodes for its duration. 0 ms = wait forever (v1 / issue #6).
+    Mutates the Request (first-seen stamp); the decision itself has no other side effects.
+    Remainder uses ``num_tokens`` (prompt + generated so far) like the base scheduler, so a preempted request that
+    resumes with its prompt cached still replays its output under the policy.
+    """
+    import time as _t
+    cfg = _glm53_gate_config()
+    remaining = current.num_tokens - num_computed_tokens
+    if remaining <= 0:
+        return None
+    if remaining <= cfg["warm_tokens"]:
+        return None
+    cap = _glm53_mixed_prefill_policy(running, current)
+    if cap is None or cap > 0:
+        return cap
+    max_wait_ms = cfg["max_wait_ms"]
+    if max_wait_ms <= 0:
+        return cap
+    # First time this gate saw the request (monotonic; kept on the Request object so it survives chunking, preemption
+    # and requeue). If the Request class ever rejects attribute assignment, fall back to a WeakKeyDictionary (entries
+    # vanish with the request) and say so once -- never silently degrade to "never late".
+    global _GLM53_FIRST_SEEN_FALLBACK
+    first_seen = getattr(current, "_glm53_gate_first_seen", None)
+    if first_seen is None and _GLM53_FIRST_SEEN_FALLBACK is not None:
+        first_seen = _GLM53_FIRST_SEEN_FALLBACK.get(current)
+    if first_seen is None:
+        first_seen = _t.monotonic()
+        try:
+            current._glm53_gate_first_seen = first_seen
+        except AttributeError:
+            import weakref
+            if _GLM53_FIRST_SEEN_FALLBACK is None:
+                _GLM53_FIRST_SEEN_FALLBACK = weakref.WeakKeyDictionary()
+                print("[glm53-decode-floor-v2] Request rejects attributes; using a weak-keyed first-seen map", flush=True)
+            _GLM53_FIRST_SEEN_FALLBACK[current] = first_seen
+    if (_t.monotonic() - first_seen) * 1000.0 >= max_wait_ms:
+        return max(min(cfg["late_cap"], remaining), 1)
+    return cap
+
+
+def _glm53_mixed_prefill_policy(running, current):
+    """Mixed-step prefill policy when a peer in `running` is decoding.
+
+    None = no extra policy. 0 = skip this prefill this step. N>0 = cap.
+    """
+    raw = os.environ.get("GLM53_MIXED_PREFILL_CHUNK", "skip").strip().lower()
+    if raw in ("0", "off", "no"):
+        return None
+    if raw in ("skip", "-1"):
+        cap = 0
+    else:
+        try:
+            cap = int(raw)
+        except ValueError:
+            cap = 0
+        if cap <= 0:
+            return None
+    cur_id = getattr(current, "request_id", None)
+    for r in running:
+        if r is current or getattr(r, "request_id", None) == cur_id:
+            continue
+        if r.num_computed_tokens >= r.num_prompt_tokens:
+            return cap
+    return None
+
+
+from vllm.compilation.cuda_graph import CUDAGraphStat
+from vllm.config import KVEventsConfig, VllmConfig
+from vllm.distributed.ec_transfer.ec_connector.base import (
+    ECConnectorBase,
+    ECConnectorMetadata,
+    ECConnectorRole,
+)
+from vllm.distributed.ec_transfer.ec_connector.factory import ECConnectorFactory
+from vllm.distributed.kv_events import EventPublisherFactory, KVEventBatch
+from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
+from vllm.distributed.kv_transfer.kv_connector.v1 import (
+    KVConnectorBase_V1,
+    KVConnectorRole,
+    SupportsHMA,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
+    RoutedExpertsManager,
+)
+from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
+from vllm.multimodal.encoder_budget import MultiModalBudget
+from vllm.multimodal.utils import get_mm_features_in_window
+from vllm.v1.core.encoder_cache_manager import (
+    EncoderCacheManager,
+    EncoderDecoderCacheManager,
+)
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
+from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
+from vllm.v1.core.kv_cache_utils import KVCacheBlock
+from vllm.v1.core.sched.interface import PauseState, SchedulerInterface
+from vllm.v1.core.sched.output import (
+    CachedRequestData,
+    GrammarOutput,
+    NewRequestData,
+    ScheduledEncoderInputStats,
+    SchedulerOutput,
+)
+from vllm.v1.core.sched.request_queue import (
+    RequestQueue,
+    SchedulingPolicy,
+    create_request_queue,
+)
+from vllm.v1.core.sched.utils import check_stop, remove_all
+from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutputs
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.metrics.perf import ModelMetrics, PerfStats
+from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
+from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
+from vllm.v1.request import Request, RequestStatus, StreamingUpdate
+from vllm.v1.spec_decode.dynamic.utils import build_dynamic_sd_schedule_lookup
+from vllm.v1.spec_decode.metrics import SpecDecodingStats
+from vllm.v1.structured_output import StructuredOutputGrammar, StructuredOutputManager
+from vllm.v1.utils import record_function_or_nullcontext
+
+logger = init_logger(__name__)
+
+
+class Scheduler(SchedulerInterface):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        kv_cache_config: KVCacheConfig,
+        structured_output_manager: StructuredOutputManager,
+        block_size: int,
+        hash_block_size: int | None = None,
+        mm_registry: MultiModalRegistry = MULTIMODAL_REGISTRY,
+        include_finished_set: bool = False,
+        log_stats: bool = False,
+    ) -> None:
+        self.vllm_config = vllm_config
+        self.scheduler_config = vllm_config.scheduler_config
+        self.cache_config = vllm_config.cache_config
+        self.lora_config = vllm_config.lora_config
+        self.kv_cache_config = kv_cache_config
+        self.kv_events_config = vllm_config.kv_events_config
+        self.parallel_config = vllm_config.parallel_config
+        self.log_stats = log_stats
+        self.observability_config = vllm_config.observability_config
+        self.kv_metrics_collector: KVCacheMetricsCollector | None = None
+        if self.observability_config.kv_cache_metrics:
+            self.kv_metrics_collector = KVCacheMetricsCollector(
+                self.observability_config.kv_cache_metrics_sample,
+            )
+        self.structured_output_manager = structured_output_manager
+        self.is_encoder_decoder = vllm_config.model_config.is_encoder_decoder
+        self.is_encoder_only = vllm_config.is_encoder_only
+
+        # include_finished_set controls whether a separate set of finished
+        # request ids should be included in the EngineCoreOutputs returned
+        # by update_from_outputs(). This is currently used in the multi-engine
+        # case to track request lifetimes efficiently.
+        self.finished_req_ids_dict: dict[int, set[str]] | None = (
+            defaultdict(set) if include_finished_set else None
+        )
+        # Track requests scheduled in prior step (MRV1-only).
+        self.prev_step_scheduled_req_ids: set[str] = set()
+
+        # Scheduling constraints.
+        self.max_num_running_reqs = self.scheduler_config.max_num_seqs
+        self.max_num_scheduled_tokens = (
+            self.scheduler_config.max_num_scheduled_tokens
+            if self.scheduler_config.max_num_scheduled_tokens is not None
+            else self.scheduler_config.max_num_batched_tokens
+        )
+        self.max_model_len = vllm_config.model_config.max_model_len
+        self.enable_kv_cache_events = (
+            self.kv_events_config is not None
+            and self.kv_events_config.enable_kv_cache_events
+        )
+        # Diffusion models may not sample any tokens for a denoising step.
+        self.num_sampled_tokens_per_step = (
+            1 if not vllm_config.model_config.is_diffusion else 0
+        )
+
+        # Create KVConnector for the Scheduler. Note that each Worker
+        # will have a corresponding KVConnector with Role=WORKER.
+        # KV Connector pushes/pull of remote KVs for P/D and offloading.
+        self.connector = None
+        self.connector_prefix_cache_stats: PrefixCacheStats | None = None
+        self.recompute_kv_load_failures = True
+        self.defer_block_free = False
+        # Whether a preempted request's in-flight output must be dropped; see
+        # KVConnectorBase_V1.requires_kv_delivery.
+        self.requires_kv_delivery = False
+        kv_transfer_config = self.vllm_config.kv_transfer_config
+        if kv_transfer_config is not None:
+            assert not self.is_encoder_decoder, (
+                "Encoder-decoder models are not currently supported with KV connectors"
+            )
+            self.connector = KVConnectorFactory.create_connector(
+                config=self.vllm_config,
+                role=KVConnectorRole.SCHEDULER,
+                kv_cache_config=self.kv_cache_config,
+            )
+            if self.log_stats:
+                self.connector_prefix_cache_stats = PrefixCacheStats()
+            kv_load_failure_policy = kv_transfer_config.kv_load_failure_policy
+            self.recompute_kv_load_failures = kv_load_failure_policy == "recompute"
+
+            # With overlapping batches (async scheduling or PP), a step may
+            # still be writing a freed request's KV blocks. A consumer KV
+            # Connector can reallocate and fill those blocks via a load that
+            # isn't ordered against that write, so defer freeing them.
+            multiple_inflight_batches = self.vllm_config.max_concurrent_batches > 1
+            if multiple_inflight_batches and kv_transfer_config.is_kv_consumer:
+                self.defer_block_free = True
+
+            self.requires_kv_delivery = self.connector.requires_kv_delivery
+
+        self.kv_event_publisher = EventPublisherFactory.create(
+            self.kv_events_config,
+            self.parallel_config.data_parallel_index,
+        )
+        self.ec_connector = None
+        if self.vllm_config.ec_transfer_config is not None:
+            self.ec_connector = ECConnectorFactory.create_connector(
+                config=self.vllm_config, role=ECConnectorRole.SCHEDULER
+            )
+
+        num_gpu_blocks = self.cache_config.num_gpu_blocks
+        assert num_gpu_blocks is not None and num_gpu_blocks > 0
+
+        self.block_size = block_size
+        self.dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size
+        self.pcp_world_size = vllm_config.parallel_config.prefill_context_parallel_size
+
+        # req_id -> Request
+        self.requests: dict[str, Request] = {}
+        # Scheduling policy
+        try:
+            self.policy = SchedulingPolicy(self.scheduler_config.policy)
+        except ValueError as e:
+            raise ValueError(
+                f"Unknown scheduling policy: {self.scheduler_config.policy}"
+            ) from e
+        # Priority queues for requests.
+        self.waiting = create_request_queue(self.policy)
+        # requests skipped in waiting flow due async deps or constraints.
+        self.skipped_waiting = create_request_queue(self.policy)
+        self.running: list[Request] = []
+
+        # The request IDs that are finished in between the previous and the
+        # current steps. This is used to notify the workers about the finished
+        # requests so that they can free the cached states for those requests.
+        # This is flushed at the end of each scheduling step.
+        self.finished_req_ids: set[str] = set()
+
+        # IDs of requests preempted since the last call to schedule().
+        self.reset_preempted_req_ids: set[str] = set()
+
+        # Counter for requests waiting for streaming input. Used to calculate
+        # number of unfinished requests
+        self.num_waiting_for_streaming_input: int = 0
+
+        # KV Connector: requests in process of async KV loading or recving
+        self.finished_recving_kv_req_ids: set[str] = set()
+        self.failed_recving_kv_req_ids: set[str] = set()
+
+        # Grammar compilation failures to finish as per-request errors in
+        # update_from_output.
+        self.grammar_compile_error_reqs: set[str] = set()
+
+        # Encoder-related.
+        # Calculate encoder cache size if applicable
+        supports_mm_inputs = mm_registry.supports_multimodal_inputs(
+            vllm_config.model_config
+        )
+        mm_budget = (
+            MultiModalBudget(vllm_config, mm_registry) if supports_mm_inputs else None
+        )
+
+        # NOTE: Text-only encoder-decoder models are implemented as
+        # multi-modal models for convenience
+        # Example: https://github.com/vllm-project/bart-plugin
+        if self.is_encoder_decoder:
+            assert mm_budget and len(mm_budget.mm_max_toks_per_item) <= 1, (
+                "Encoder-decoder models are expected to implement the "
+                "multimodal interface with at most one modality."
+            )
+
+        self.max_num_encoder_input_tokens = (
+            mm_budget.encoder_compute_budget if mm_budget else 0
+        )
+        encoder_cache_size = mm_budget.encoder_cache_size if mm_budget else 0
+        manager_cls_obj = vllm_config.ec_manager_config.get_encoder_cache_manager_obj()
+        if manager_cls_obj is not None:
+            self.encoder_cache_manager = manager_cls_obj(cache_size=encoder_cache_size)
+        else:
+            self.encoder_cache_manager = (
+                EncoderDecoderCacheManager(cache_size=encoder_cache_size)
+                if self.is_encoder_decoder
+                else EncoderCacheManager(cache_size=encoder_cache_size)
+            )
+        speculative_config = vllm_config.speculative_config
+        self.use_eagle = False
+        self.num_spec_tokens = vllm_config.num_speculative_tokens
+        self.num_lookahead_tokens = vllm_config.num_lookahead_tokens
+        self.dynamic_sd_lookup: list[int] | None = None
+        if speculative_config is not None:
+            if speculative_config.num_speculative_tokens_per_batch_size:
+                self.dynamic_sd_lookup = build_dynamic_sd_schedule_lookup(
+                    speculative_config.num_speculative_tokens_per_batch_size,
+                    vllm_max_batch_size=self.scheduler_config.max_num_seqs,
+                    vllm_num_speculative_tokens=self.num_spec_tokens,
+                )
+            self.use_eagle = speculative_config.use_eagle()
+
+        # Create the KV cache manager.
+        if hash_block_size is None:
+            hash_block_size = block_size
+        self.hash_block_size = hash_block_size
+        self.kv_cache_manager = KVCacheManager(
+            kv_cache_config=kv_cache_config,
+            max_model_len=self.max_model_len,
+            max_in_flight_tokens=vllm_config.max_in_flight_tokens,
+            enable_caching=self.cache_config.enable_prefix_caching,
+            use_eagle=self.use_eagle,
+            log_stats=self.log_stats,
+            enable_kv_cache_events=self.enable_kv_cache_events,
+            dcp_world_size=self.dcp_world_size,
+            pcp_world_size=1,
+            scheduler_block_size=self.block_size,
+            hash_block_size=hash_block_size,
+            metrics_collector=self.kv_metrics_collector,
+            watermark=self.scheduler_config.watermark,
+        )
+        # Bind GPU block pool to the KV connector. This must happen after
+        # kv_cache_manager is constructed so block_pool is available.
+        if self.connector is not None:
+            self.connector.bind_gpu_block_pool(self.kv_cache_manager.block_pool)
+
+        self.use_pp = self.parallel_config.pipeline_parallel_size > 1
+        self.use_v2_model_runner = vllm_config.use_v2_model_runner
+        # Scheduler iteration counter. Drives the V2+PP+async decode-throttle
+        # cadence (`next_decode_eligible_step`).
+        self.current_step = 0
+        # DP prefill balancing: Flag to track whether the last cadence-aligned
+        # prefill batch fully drained the waiting queue. Prefill throttling
+        # is disabled in this case.
+        self.prefill_capacity_bound = False
+        self.scheduler_reserve_full_isl = (
+            self.scheduler_config.scheduler_reserve_full_isl
+        )
+
+        self.has_mamba_layers = kv_cache_config.has_mamba_layers
+        self.needs_kv_cache_zeroing = kv_cache_config.needs_kv_cache_zeroing
+        # Blocks that async KV loads will overwrite this step, skipped from
+        # zeroing since the zeroing could race the out-of-band write.
+        self._skip_zero_block_ids: set[int] = set()
+        self.need_mamba_block_aligned_split = (
+            self.has_mamba_layers and self.cache_config.mamba_cache_mode == "align"
+        )
+        # A finer prefix_match_unit is configured: a mamba partial tail entry
+        # can only be registered by a step ending exactly at the prompt's last
+        # hash boundary, so the split adds that stop.
+        self.mamba_partial_cache_hit = (
+            self.need_mamba_block_aligned_split
+            and self.hash_block_size < self.block_size
+            and self.kv_cache_manager.coordinator.enable_partial_hash_hits
+        )
+
+        # Counts of non-empty steps scheduled / processed. update_from_output
+        # is called once per scheduled step in FIFO order, so these stay in sync.
+        self.sched_step_seq = 0
+        self.processed_step_seq = 0
+        # FIFO of (fence_seq, blocks): blocks become safe to free once
+        # processed_step_seq >= fence_seq.
+        self.deferred_frees: deque[tuple[int, list[KVCacheBlock]]] = deque()
+
+        self.perf_metrics: ModelMetrics | None = None
+        if self.log_stats and vllm_config.observability_config.enable_mfu_metrics:
+            self.perf_metrics = ModelMetrics(vllm_config)
+
+        self.enable_return_routed_experts = (
+            vllm_config.model_config.enable_return_routed_experts
+        )
+
+        if self.enable_return_routed_experts:
+            assert self.dcp_world_size == 1 and self.pcp_world_size == 1, (
+                "enable_return_routed_experts does not support context parallelism "
+                "(dcp_world_size > 1 or pcp_world_size > 1)"
+            )
+
+            self.routed_experts_mgr = RoutedExpertsManager(
+                vllm_config=vllm_config,
+                kv_cache_config=kv_cache_config,
+            )
+            # Block-ID snapshot taken at schedule time (before forward),
+            # so update_from_output can read slot data even if a later
+            # schedule() frees the blocks (async scheduling race).
+            self._re_block_ids: dict[str, list[int]] = {}
+
+        self._pause_state: PauseState = PauseState.UNPAUSED
+
+        # In-flight requests still prefilling (prefill chunks + in-progress
+        # async KV loads). Their remaining-block reservation gates async loads.
+        self._inflight_prefills: set[Request] = set()
+
+    def _mamba_block_aligned_split(
+        self,
+        request: Request,
+        num_new_tokens: int,
+        num_new_local_computed_tokens: int = 0,
+        num_external_computed_tokens: int = 0,
+    ) -> int:
+        """Clip a prefill chunk so it ends where Mamba state must be cached.
+
+        In "align" cache mode reusable SSM states are materialized at block
+        boundaries, plus mandatory early stops (the prompt's partial-tail hash
+        boundary, a detected shared-prefix junction). If a block is larger
+        than the configured prefill chunk limit, intermediate chunks keep
+        private running state until they reach the next cacheable position.
+        """
+        start = (
+            request.num_computed_tokens
+            + num_new_local_computed_tokens
+            + num_external_computed_tokens
+        )
+        # Split only during prefill: `request.num_tokens - 1` extends this to
+        # resumed requests replaying their output tokens.
+        prefill_end = max(request.num_prompt_tokens, request.num_tokens - 1)
+        if start >= prefill_end:
+            return num_new_tokens
+
+        block_size = self.cache_config.block_size
+        # The last block-aligned position whose state can be cached. With
+        # Eagle, FullAttn prunes the last matching block, so back off one
+        # block to avoid a Mamba cache miss.
+        last_cache_position = request.num_tokens - request.num_tokens % block_size
+        if self.use_eagle:
+            last_cache_position = max(last_cache_position - block_size, 0)
+
+        end = start + num_new_tokens
+        # Invariant: slot p holds the state after exactly (p + 1) * block_size
+        # tokens. State is written at chunk ends, so chunk ends must be block
+        # aligned. Exempt: the prompt's last chunk, whose slot decode advances
+        # to the boundary. A block too wide for one chunk advances sub-block
+        # and re-aligns at the next boundary.
+        if end < prefill_end:
+            max_prefill_tokens = self.max_num_scheduled_tokens
+            long_prefill_threshold = self.scheduler_config.long_prefill_token_threshold
+            if long_prefill_threshold > 0:
+                max_prefill_tokens = min(max_prefill_tokens, long_prefill_threshold)
+            aligned_end = end // block_size * block_size
+            if aligned_end > start or block_size <= max_prefill_tokens:
+                end = aligned_end
+
+        next_block_boundary = (start // block_size + 1) * block_size
+        tail_boundary = (
+            request.num_prompt_tokens // self.hash_block_size * self.hash_block_size
+            if self.mamba_partial_cache_hit
+            else 0
+        )
+        stops = (
+            # Same invariant: a chunk starting mid-block stops at the boundary
+            # rather than running past it.
+            next_block_boundary if start % block_size != 0 else 0,
+            # Never run past the last cacheable block boundary mid-chunk.
+            last_cache_position,
+            # Fine-grained hits: the prompt's partial-tail entry can only be
+            # registered by a chunk ending exactly at its last hash boundary.
+            tail_boundary
+            if last_cache_position < tail_boundary < request.num_prompt_tokens
+            else 0,
+            # Marconi shared-prefix junction, block-floored (a sub-block
+            # junction's state is not separately cacheable): cache its state
+            # so sibling requests sharing the prefix can reuse it.
+            start + (request.shared_prefix_boundary - start) // block_size * block_size
+            if start < request.shared_prefix_boundary < end
+            else 0,
+        )
+        # Stop at the earliest mandatory position strictly inside the chunk.
+        end = min((s for s in stops if start < s < end), default=end)
+        return max(end - start, 0)
+
+    def _get_local_prefix_cache_hit(
+        self, request: Request
+    ) -> tuple[KVCacheBlocks, int, int, bool]:
+        connector = self.connector
+        if connector is not None and connector.supports_divergent_local_hybrid_hits:
+            return self.kv_cache_manager.get_computed_blocks_for_connector(request)
+
+        blocks, num_local, shared_prefix_boundary = (
+            self.kv_cache_manager.get_computed_blocks(request)
+        )
+        return blocks, num_local, shared_prefix_boundary, False
+
+    def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
+        self.current_step += 1
+        # NOTE(woosuk) on the scheduling algorithm:
+        # There's no "decoding phase" nor "prefill phase" in the scheduler.
+        # Each request just has the num_computed_tokens and
+        # num_tokens_with_spec. num_tokens_with_spec =
+        # len(prompt_token_ids) + len(output_token_ids) + len(spec_token_ids).
+        # At each step, the scheduler tries to assign tokens to the requests
+        # so that each request's num_computed_tokens can catch up its
+        # num_tokens_with_spec. This is general enough to cover
+        # chunked prefills, prefix caching, speculative decoding,
+        # and the "jump decoding" optimization in the future.
+
+        scheduled_new_reqs: list[Request] = []
+        scheduled_resumed_reqs: list[Request] = []
+        scheduled_running_reqs: list[Request] = []
+        preempted_reqs: list[Request] = []
+
+        req_to_new_blocks: dict[str, KVCacheBlocks] = {}
+        num_scheduled_tokens: dict[str, int] = {}
+        token_budget = self.max_num_scheduled_tokens
+        spec = self.vllm_config.speculative_config
+        draft_slots = spec.max_num_new_slots_for_drafting if spec is not None else 0
+        input_budget = self.scheduler_config.max_num_batched_tokens
+        if self._pause_state == PauseState.PAUSED_ALL:
+            # Do not schedule any requests when paused.
+            token_budget = 0
+
+        # Encoder-related.
+        scheduled_encoder_inputs: dict[str, list[int]] = {}
+        encoder_compute_budget = self.max_num_encoder_input_tokens
+        # Spec decode-related.
+        scheduled_spec_decode_tokens: dict[str, list[int]] = {}
+        # Whether the running batch contains any prefill requests.
+        prefill_scheduled = False
+
+        # For logging.
+        scheduled_timestamp = time.monotonic()
+
+        self.kv_cache_manager.new_step_starts()
+
+        # DP prefill balancing: on a throttled (non-cadence-aligned) step, defer
+        # all prefill compute unless saturated.
+        defer_prefills = (
+            throttle_prefills and not self.prefill_capacity_bound
+        ) and any(not r.is_prefill_chunk for r in self.running)
+
+        # First, schedule the RUNNING requests.
+        req_index = 0
+        while req_index < len(self.running) and token_budget > 0:
+            request = self.running[req_index]
+            if input_budget <= draft_slots:
+                break
+
+            if (
+                request.num_output_placeholders > 0
+                # This is (num_computed_tokens + 1) - (num_output_placeholders - 1).
+                # Since output placeholders are also included in the computed tokens
+                # count, we subtract (num_output_placeholders - 1) to remove any draft
+                # tokens, so that we can be sure no further steps are needed even if
+                # they are all rejected.
+                and request.num_computed_tokens + 2 - request.num_output_placeholders
+                >= request.num_prompt_tokens + request.max_tokens
+            ):
+                # Async scheduling: Avoid scheduling an extra step when we are sure that
+                # the previous step has reached request.max_tokens. We don't schedule
+                # partial draft tokens since this prevents uniform decode optimizations.
+                req_index += 1
+                continue
+
+            if self.current_step < request.next_decode_eligible_step:
+                # V2+PP+async: enforce `pp_size` steps between same-req decodes
+                # to match worker-side sampled-tokens broadcast slot ring cadence.
+                req_index += 1
+                continue
+
+            if defer_prefills and request.is_prefill_chunk:
+                # DP prefill balancing: defer this in-progress prefill chunk to a
+                # cadence-aligned step; decodes still run to fill this step.
+                req_index += 1
+                continue
+
+            num_new_tokens = (
+                request.num_tokens_with_spec
+                + request.num_output_placeholders
+                - request.num_computed_tokens
+            )
+            if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:
+                num_new_tokens = self.scheduler_config.long_prefill_token_threshold
+            num_new_tokens = min(
+                num_new_tokens, token_budget, input_budget - draft_slots
+            )
+            mixed_cap = _glm53_mixed_prefill_gate(self.running, request, request.num_computed_tokens)  # [glm53-decode-floor] [glm53-decode-floor-v2]
+            if mixed_cap is not None:
+                num_new_tokens = min(num_new_tokens, mixed_cap)
+
+            # Make sure the input position does not exceed the max model len.
+            # This is necessary when using spec decoding.
+            num_new_tokens = min(
+                num_new_tokens,
+                self.max_model_len
+                - request.num_computed_tokens
+                - self.num_sampled_tokens_per_step,
+            )
+
+            # Apply Mamba alignment before encoder caps.
+            if self.need_mamba_block_aligned_split:
+                num_new_tokens = self._mamba_block_aligned_split(
+                    request, num_new_tokens
+                )
+
+            # Schedule encoder inputs.
+            encoder_inputs_to_schedule = None
+            external_load_encoder_input: list[int] = []
+            new_encoder_compute_budget = encoder_compute_budget
+            if request.has_encoder_inputs:
+                (
+                    encoder_inputs_to_schedule,
+                    num_new_tokens,
+                    new_encoder_compute_budget,
+                    external_load_encoder_input,
+                ) = self._try_schedule_encoder_inputs(
+                    request,
+                    request.num_computed_tokens,
+                    num_new_tokens,
+                    encoder_compute_budget,
+                    shift_computed_tokens=1 if self.use_eagle else 0,
+                )
+
+            if num_new_tokens == 0:
+                # The request cannot be scheduled because one of the following
+                # reasons:
+                # 1. No new tokens to schedule. This may happen when
+                #    (1) PP>1 and we have already scheduled all prompt tokens
+                #    but they are not finished yet.
+                #    (2) Async scheduling and the request has reached to either
+                #    its max_total_tokens or max_model_len.
+                # 2. The encoder budget is exhausted.
+                # 3. The encoder cache is exhausted.
+                # 4. Insufficient budget for a block-aligned chunk in hybrid
+                #    models with mamba cache mode \"align\".
+                # NOTE(woosuk): Here, by doing `continue` instead of `break`,
+                # we do not strictly follow the FCFS scheduling policy and
+                # allow the lower-priority requests to be scheduled.
+                req_index += 1
+                continue
+
+            # Schedule newly needed KV blocks for the request.
+            with record_function_or_nullcontext("schedule: allocate_slots"):
+                while True:
+                    new_blocks = self.kv_cache_manager.allocate_slots(
+                        request,
+                        num_new_tokens,
+                        num_lookahead_tokens=self.num_lookahead_tokens,
+                    )
+
+                    if new_blocks is not None:
+                        # The request can be scheduled.
+                        break
+
+                    # The request cannot be scheduled.
+                    # Preempt the lowest-priority request.
+                    if self.policy == SchedulingPolicy.PRIORITY:
+                        preempted_req = max(
+                            self.running,
+                            key=lambda r: (r.priority, r.arrival_time),
+                        )
+                        # Record the index of the preemption victim to
+                        # maintain accurate loop state.
+                        victim_index = self.running.index(preempted_req)
+                        del self.running[victim_index]
+                        # Decrement the loop cursor if the removed request
+                        # preceded the current iteration, preventing the
+                        # silent omission of the subsequent request.
+                        if victim_index < req_index:
+                            req_index -= 1
+
+                        if preempted_req in scheduled_running_reqs:
+                            preempted_req_id = preempted_req.request_id
+                            scheduled_running_reqs.remove(preempted_req)
+                            restored = num_scheduled_tokens.pop(preempted_req_id)
+                            token_budget += restored
+                            input_budget += restored + draft_slots
+                            req_to_new_blocks.pop(preempted_req_id)
+                            scheduled_spec_decode_tokens.pop(preempted_req_id, None)
+                            preempted_encoder_inputs = scheduled_encoder_inputs.pop(
+                                preempted_req_id, None
+                            )
+                            if preempted_encoder_inputs:
+                                # Restore encoder compute budget if the preempted
+                                # request had encoder inputs scheduled in this step.
+                                num_embeds_to_restore = sum(
+                                    preempted_req.get_num_encoder_embeds(i)
+                                    for i in preempted_encoder_inputs
+                                )
+                                encoder_compute_budget += num_embeds_to_restore
+                    else:
+                        preempted_req = self.running.pop()
+
+                    self._preempt_request(
+                        preempted_req,
+                        scheduled_timestamp,
+                        drop_stale_output=self.requires_kv_delivery,
+                    )
+                    preempted_reqs.append(preempted_req)
+                    if preempted_req == request:
+                        # No more request to preempt. Cannot schedule this request.
+                        break
+
+            if new_blocks is None:
+                # Cannot schedule this request.
+                break
+
+            # Schedule the request.
+            scheduled_running_reqs.append(request)
+            prefill_scheduled |= request.is_prefill_chunk
+            request_id = request.request_id
+            req_to_new_blocks[request_id] = new_blocks
+            num_scheduled_tokens[request_id] = num_new_tokens
+            token_budget -= num_new_tokens
+            input_budget -= num_new_tokens + draft_slots
+            req_index += 1
+
+            # Speculative decode related.
+            if request.spec_token_ids:
+                num_scheduled_spec_tokens = (
+                    num_new_tokens
+                    + request.num_computed_tokens
+                    - request.num_tokens
+                    - request.num_output_placeholders
+                )
+                if num_scheduled_spec_tokens > 0:
+                    spec_token_ids = request.spec_token_ids
+                    if len(spec_token_ids) > num_scheduled_spec_tokens:
+                        spec_token_ids = spec_token_ids[:num_scheduled_spec_tokens]
+                    scheduled_spec_decode_tokens[request.request_id] = spec_token_ids
+
+                # New spec tokens will be set in `update_draft_token_ids` before the
+                # next step when applicable.
+                request.spec_token_ids = []
+
+            # Encoder-related.
+            if encoder_inputs_to_schedule:
+                scheduled_encoder_inputs[request_id] = encoder_inputs_to_schedule
+                # Allocate the encoder cache.
+                for i in encoder_inputs_to_schedule:
+                    self.encoder_cache_manager.allocate(request, i)
+                    if self.ec_connector is not None:
+                        self.ec_connector.update_state_after_alloc(request, i)
+                encoder_compute_budget = new_encoder_compute_budget
+            if external_load_encoder_input:
+                for i in external_load_encoder_input:
+                    self.encoder_cache_manager.allocate(request, i)
+                    if self.ec_connector is not None:
+                        self.ec_connector.update_state_after_alloc(request, i)
+
+        # Record the LoRAs in scheduled_running_reqs
+        scheduled_loras: set[int] = set()
+        if self.lora_config:
+            scheduled_loras = set(
+                req.lora_request.lora_int_id
+                for req in scheduled_running_reqs
+                if req.lora_request and req.lora_request.lora_int_id > 0
+            )
+            assert len(scheduled_loras) <= self.lora_config.max_loras
+
+        # Next, schedule the WAITING requests.
+        if not preempted_reqs and self._pause_state == PauseState.UNPAUSED:
+            step_skipped_waiting = create_request_queue(self.policy)
+
+            while (self.waiting or self.skipped_waiting) and token_budget > 0:
+                if input_budget <= draft_slots:
+                    break
+                # Paused streaming sessions (WAITING_FOR_STREAMING_REQ) are not
+                # in `running` but still hold a model-runner request slot.
+                num_running = len(self.running) + self.num_waiting_for_streaming_input
+                if num_running >= self.max_num_running_reqs:
+                    break
+
+                request_queue = self._select_waiting_queue_for_scheduling()
+                assert request_queue is not None
+
+                request = request_queue.peek_request()
+                request_id = request.request_id
+
+                # try to promote blocked statuses while traversing skipped queue.
+                if self._is_blocked_waiting_status(
+                    request.status
+                ) and not self._try_promote_blocked_waiting_request(request):
+                    if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+                        logger.debug(
+                            "%s is still in WAITING_FOR_REMOTE_KVS state.",
+                            request_id,
+                        )
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
+                    continue
+
+                if (
+                    request.num_stale_output_tokens > 0
+                    and not request.drop_stale_output
+                ):
+                    # Deliverable stale output still in flight: resuming now
+                    # could resample a position that output later delivers.
+                    # It drains within the pipeline depth.
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
+                    continue
+
+                # Check that adding the request still respects the max_loras
+                # constraint.
+                if (
+                    self.lora_config
+                    and request.lora_request
+                    and (
+                        len(scheduled_loras) == self.lora_config.max_loras
+                        and request.lora_request.lora_int_id not in scheduled_loras
+                    )
+                ):
+                    # Scheduling would exceed max_loras, skip.
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
+                    continue
+
+                num_external_computed_tokens = 0
+                load_kv_async = False
+                connector_prefix_cache_queries, connector_prefix_cache_hits = 0, 0
+                did_prefix_cache_lookup = False
+
+                # Get already-cached tokens.
+                if request.num_computed_tokens == 0:
+                    did_prefix_cache_lookup = True
+                    (
+                        new_computed_blocks,
+                        num_new_local_computed_tokens,
+                        request.shared_prefix_boundary,
+                        hit_diverged,
+                    ) = self._get_local_prefix_cache_hit(request)
+
+                    # Get externally-cached tokens if using a KVConnector.
+                    if self.connector is not None:
+                        # Present a block-aligned local hit to the connector so
+                        # a strictly longer remote hit can supersede a local
+                        # sub-block tail without racing its copy-on-write.
+                        partial_tail = num_new_local_computed_tokens % self.block_size
+                        block_aligned_local = (
+                            num_new_local_computed_tokens - partial_tail
+                        )
+                        ext_tokens, load_kv_async = (
+                            self.connector.get_num_new_matched_tokens(
+                                request, block_aligned_local
+                            )
+                        )
+
+                        if ext_tokens is None:
+                            # The request cannot be scheduled because
+                            # the KVConnector couldn't determine
+                            # the number of matched tokens.
+                            request_queue.pop_request()
+                            step_skipped_waiting.prepend_request(request)
+                            continue
+
+                        if partial_tail and ext_tokens > partial_tail:
+                            # Remote strictly exceeds the full local hit: drop the
+                            # sub-block tail so no CoW is needed, and let the load
+                            # cover it. Trim the partial block out of the local
+                            # computed blocks so it is not adopted from the cache.
+                            new_computed_blocks = (
+                                self.kv_cache_manager.truncate_computed_blocks(
+                                    new_computed_blocks, block_aligned_local
+                                )
+                            )
+                            num_new_local_computed_tokens = block_aligned_local
+                            num_external_computed_tokens = ext_tokens
+                        elif partial_tail:
+                            # Remote does not exceed the full local hit: keep the
+                            # local sub-block tail and load nothing external.
+                            num_external_computed_tokens = 0
+                            # Nothing to load remotely -> not an async-load step;
+                            # clearing avoids the `load_kv_async` assert below.
+                            load_kv_async = False
+                        else:
+                            num_external_computed_tokens = ext_tokens
+
+                        if hit_diverged and num_external_computed_tokens == 0:
+                            # No external tokens back the deeper local hit, so its
+                            # resume boundary would have no valid Mamba state.
+                            # Reconcile to the boundary every group agrees on.
+                            (
+                                new_computed_blocks,
+                                num_new_local_computed_tokens,
+                                request.shared_prefix_boundary,
+                            ) = self.kv_cache_manager.get_computed_blocks(request)
+
+                        connector_prefix_cache_queries = (
+                            request.num_tokens - num_new_local_computed_tokens
+                        )
+                        connector_prefix_cache_hits = num_external_computed_tokens
+
+                    # Total computed tokens (local + external).
+                    num_computed_tokens = (
+                        num_new_local_computed_tokens + num_external_computed_tokens
+                    )
+                    assert num_computed_tokens <= request.num_tokens
+
+                    # Skip request with pending mm encoding prefetches
+                    if (
+                        self.ec_connector is not None
+                        and request.mm_features
+                        and not self.ec_connector.ensure_cache_available(
+                            request, num_computed_tokens
+                        )
+                    ):
+                        request_queue.pop_request()
+                        step_skipped_waiting.prepend_request(request)
+                        continue
+
+                    # Track first scheduled prefill, not post-preemption repeat prefills
+                    if request.prefill_stats and request.num_preemptions <= 0:
+                        assert num_computed_tokens <= request.num_prompt_tokens
+                        request.prefill_stats.set(
+                            num_prompt_tokens=request.num_prompt_tokens,
+                            num_local_cached_tokens=num_new_local_computed_tokens,
+                            num_external_cached_tokens=num_external_computed_tokens,
+                        )
+                else:
+                    # KVTransfer: WAITING reqs have num_computed_tokens > 0
+                    # after async KV recvs are completed.
+                    new_computed_blocks = self.kv_cache_manager.empty_kv_cache_blocks
+                    num_new_local_computed_tokens = 0
+                    num_computed_tokens = request.num_computed_tokens
+
+                encoder_inputs_to_schedule = None
+                external_load_encoder_input = []
+                new_encoder_compute_budget = encoder_compute_budget
+                pad_spec_decode = False
+
+                if load_kv_async:
+                    # KVTransfer: loading remote KV, do not allocate for new work.
+                    assert num_external_computed_tokens > 0
+                    num_new_tokens = 0
+                elif defer_prefills and num_computed_tokens < request.num_tokens - 1:
+                    # DP prefill balancing: defer this step's local prefill
+                    # compute to a cadence-aligned step.
+                    break
+                else:
+                    request_token_budget = min(token_budget, input_budget - draft_slots)
+                    # Number of tokens to be scheduled.
+                    # We use `request.num_tokens` instead of
+                    # `request.num_prompt_tokens` to consider the resumed
+                    # requests, which have output tokens.
+                    num_new_tokens = request.num_tokens - num_computed_tokens
+
+                    # Pad new decode requests to uniform spec decoding size to
+                    # preserve full cudagraph for this step.
+                    # Not for diffusion where draft tokens can't be padded.
+                    if (
+                        (self.num_spec_tokens > 0 and self.dynamic_sd_lookup is None)
+                        and self.num_sampled_tokens_per_step > 0
+                        and num_new_tokens == 1
+                        and (scheduled_running_reqs and not prefill_scheduled)
+                    ):
+                        num_new_tokens = 1 + self.num_spec_tokens
+                        if (
+                            num_new_tokens > request_token_budget
+                            or num_computed_tokens + num_new_tokens > self.max_model_len
+                        ):
+                            # Prefer to not schedule than schedule un-padded here.
+                            break
+                        pad_spec_decode = True
+
+                    threshold = self.scheduler_config.long_prefill_token_threshold
+                    if 0 < threshold < num_new_tokens:
+                        num_new_tokens = threshold
+                    mixed_cap = _glm53_mixed_prefill_gate(self.running, request, num_computed_tokens)  # [glm53-decode-floor] [glm53-decode-floor-v2]
+                    if mixed_cap is not None:
+                        if mixed_cap <= 0:
+                            request_queue.pop_request()
+                            step_skipped_waiting.prepend_request(request)
+                            continue
+                        num_new_tokens = min(num_new_tokens, mixed_cap)
+
+                    # chunked prefill has to be enabled explicitly to allow
+                    # pooling requests to be chunked
+                    if (
+                        not self.scheduler_config.enable_chunked_prefill
+                        and num_new_tokens > request_token_budget
+                    ):
+                        # If chunked_prefill is disabled,
+                        # we can stop the scheduling here.
+                        break
+
+                    num_new_tokens = min(num_new_tokens, request_token_budget)
+                    assert num_new_tokens > 0
+
+                    # Apply Mamba alignment before encoder caps.
+                    if self.need_mamba_block_aligned_split:
+                        num_new_tokens = self._mamba_block_aligned_split(
+                            request,
+                            num_new_tokens,
+                            num_new_local_computed_tokens,
+                            num_external_computed_tokens,
+                        )
+                        if num_new_tokens == 0:
+                            break
+
+                    # Schedule encoder inputs.
+                    if request.has_encoder_inputs:
+                        (
+                            encoder_inputs_to_schedule,
+                            num_new_tokens,
+                            new_encoder_compute_budget,
+                            external_load_encoder_input,
+                        ) = self._try_schedule_encoder_inputs(
+                            request,
+                            num_computed_tokens,
+                            num_new_tokens,
+                            encoder_compute_budget,
+                            shift_computed_tokens=1 if self.use_eagle else 0,
+                        )
+                        if num_new_tokens == 0:
+                            # The request cannot be scheduled.
+                            break
+
+                # During async KV load, no forward pass is run yet.
+                # Allocate speculative lookahead slots later to avoid
+                # mismatching local and remote block counts.
+                limit_lookahead_tokens = load_kv_async and self.num_lookahead_tokens > 0
+                effective_lookahead_tokens = (
+                    0 if limit_lookahead_tokens else self.num_lookahead_tokens
+                )
+
+                # Determine if we need to allocate cross-attention blocks.
+                num_encoder_tokens = 0
+                if (
+                    self.is_encoder_decoder
+                    and request.has_encoder_inputs
+                    and encoder_inputs_to_schedule
+                ):
+                    num_encoder_tokens = sum(
+                        request.get_num_encoder_embeds(i)
+                        for i in encoder_inputs_to_schedule
+                    )
+
+                reserved_blocks = 0
+                if load_kv_async:
+                    # An async load holds its blocks for the whole transfer with
+                    # no forward progress and isn't preemptible here. Admit it
+                    # only if it fits in (free - other in-flight reservations), to
+                    # avoid deadlock and predictable preemptions.
+                    reserved_blocks = self._inflight_prefill_reserved_blocks()
+
+                new_blocks = self.kv_cache_manager.allocate_slots(
+                    request,
+                    num_new_tokens,
+                    num_new_computed_tokens=num_new_local_computed_tokens,
+                    new_computed_blocks=new_computed_blocks,
+                    num_lookahead_tokens=effective_lookahead_tokens,
+                    num_external_computed_tokens=num_external_computed_tokens,
+                    delay_cache_blocks=load_kv_async,
+                    num_encoder_tokens=num_encoder_tokens,
+                    full_sequence_must_fit=self.scheduler_reserve_full_isl,
+                    reserved_blocks=reserved_blocks,
+                    has_scheduled_reqs=bool(self.running),
+                )
+
+                if new_blocks is None:
+                    # The request cannot be scheduled.
+
+                    # NOTE: we need to untouch the request from the encode cache
+                    # manager
+                    if request.has_encoder_inputs:
+                        self.encoder_cache_manager.free(request)
+                    break
+
+                # KVTransfer: the connector uses this info to determine
+                # if a load is needed. Note that
+                # This information is used to determine if a load is
+                # needed for this request.
+                if self.connector is not None:
+                    self.connector.update_state_after_alloc(
+                        request,
+                        self.kv_cache_manager.get_blocks(request_id),
+                        num_external_computed_tokens,
+                    )
+                    if (
+                        self.connector_prefix_cache_stats is not None
+                        and connector_prefix_cache_queries != 0
+                    ):
+                        self.connector_prefix_cache_stats.record(
+                            num_tokens=connector_prefix_cache_queries,
+                            num_hits=connector_prefix_cache_hits,
+                            preempted=request.num_preemptions > 0,
+                        )
+
+                # Record at admission so unscheduled lookups are not counted.
+                if did_prefix_cache_lookup:
+                    self.kv_cache_manager.record_prefix_cache_stats(
+                        request, num_new_local_computed_tokens
+                    )
+
+                request = request_queue.pop_request()
+                if load_kv_async:
+                    # If loading async, allocate memory and put request
+                    # into the WAITING_FOR_REMOTE_KV state.
+                    request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+                    step_skipped_waiting.prepend_request(request)
+                    # Set num_computed_tokens even though KVs are not yet loaded.
+                    # request.num_computed_tokens will not be used anywhere until
+                    # the request finished the KV transfer.
+                    #
+                    # If a transfer error is reported by the connector,
+                    # request.num_computed_tokens will be re-set accordingly in
+                    # _update_requests_with_invalid_blocks.
+                    #
+                    # When the transfer is finished, either successfully or not,
+                    # request.num_computed_tokens will correctly reflect the number
+                    # of computed tokens.
+                    # _update_waiting_for_remote_kv will then cache
+                    # only the successfully loaded tokens.
+                    request.num_computed_tokens = num_computed_tokens
+                    self._inflight_prefills.add(request)
+                    if self.needs_kv_cache_zeroing:
+                        # Skip zeroing of the blocks the async load will
+                        # overwrite; the zeroing could race the write.
+                        self._skip_zero_block_ids.update(
+                            self.kv_cache_manager.get_zeroing_block_ids_in_range(
+                                request.request_id,
+                                num_new_local_computed_tokens,
+                                num_computed_tokens,
+                            )
+                        )
+                    continue
+
+                self.running.append(request)
+                if self.log_stats:
+                    request.record_event(
+                        EngineCoreEventType.SCHEDULED, scheduled_timestamp
+                    )
+                if request.status == RequestStatus.WAITING:
+                    scheduled_new_reqs.append(request)
+                elif request.status == RequestStatus.PREEMPTED:
+                    scheduled_resumed_reqs.append(request)
+                else:
+                    raise RuntimeError(f"Invalid request status: {request.status}")
+
+                if self.lora_config and request.lora_request:
+                    scheduled_loras.add(request.lora_request.lora_int_id)
+                req_to_new_blocks[request_id] = self.kv_cache_manager.get_blocks(
+                    request_id
+                )
+                num_scheduled_tokens[request_id] = num_new_tokens
+                token_budget -= num_new_tokens
+                input_budget -= num_new_tokens + draft_slots
+                request.status = RequestStatus.RUNNING
+                request.num_computed_tokens = num_computed_tokens
+                if pad_spec_decode:
+                    scheduled_spec_decode_tokens[request_id] = [
+                        -1
+                    ] * self.num_spec_tokens
+                # Only track requests that will still be prefilling after this chunk.
+                if num_computed_tokens + num_new_tokens < request.num_tokens:
+                    self._inflight_prefills.add(request)
+                # Encoder-related.
+                if encoder_inputs_to_schedule:
+                    scheduled_encoder_inputs[request_id] = encoder_inputs_to_schedule
+                    # Allocate the encoder cache.
+                    for i in encoder_inputs_to_schedule:
+                        self.encoder_cache_manager.allocate(request, i)
+                        if self.ec_connector is not None:
+                            self.ec_connector.update_state_after_alloc(request, i)
+                    encoder_compute_budget = new_encoder_compute_budget
+                # Allocate for external load encoder cache
+                if external_load_encoder_input:
+                    for i in external_load_encoder_input:
+                        self.encoder_cache_manager.allocate(request, i)
+                        if self.ec_connector is not None:
+                            self.ec_connector.update_state_after_alloc(request, i)
+
+            # re-queue requests skipped in this pass ahead of older skipped items.
+            if step_skipped_waiting:
+                self.skipped_waiting.prepend_requests(step_skipped_waiting)
+
+            # DP prefill balancing: on a step that admitted prefills (release),
+            # record whether it was capacity-bound.
+            if not defer_prefills:
+                self.prefill_capacity_bound = bool(self.waiting)
+
+        # Check if the scheduling constraints are satisfied.
+        total_num_scheduled_tokens = sum(num_scheduled_tokens.values())
+        assert total_num_scheduled_tokens <= self.max_num_scheduled_tokens
+
+        assert token_budget >= 0
+        assert input_budget >= 0
+        assert len(self.running) <= self.max_num_running_reqs
+        # Since some requests in the RUNNING queue may not be scheduled in
+        # this step, the total number of scheduled requests can be smaller than
+        # len(self.running).
+        assert len(scheduled_new_reqs) + len(scheduled_resumed_reqs) + len(
+            scheduled_running_reqs
+        ) <= len(self.running)
+
+        # Get the longest common prefix among all requests in the running queue.
+        # This can be potentially used for cascade attention.
+        num_common_prefix_blocks = [0] * len(self.kv_cache_config.kv_cache_groups)
+        with record_function_or_nullcontext("schedule: get_num_common_prefix_blocks"):
+            if self.running:
+                any_request_id = self.running[0].request_id
+                num_common_prefix_blocks = (
+                    self.kv_cache_manager.get_num_common_prefix_blocks(any_request_id)
+                )
+
+        # Construct the scheduler output.
+        if self.use_v2_model_runner:
+            scheduled_new_reqs.extend(scheduled_resumed_reqs)
+            scheduled_resumed_reqs.clear()
+            new_reqs_data = [
+                NewRequestData.from_request(
+                    req,
+                    req_to_new_blocks[req.request_id].get_block_ids(),
+                    req._all_token_ids,
+                )
+                for req in scheduled_new_reqs
+            ]
+        else:
+            new_reqs_data = [
+                NewRequestData.from_request(
+                    req, req_to_new_blocks[req.request_id].get_block_ids()
+                )
+                for req in scheduled_new_reqs
+            ]
+
+        with record_function_or_nullcontext("schedule: make_cached_request_data"):
+            cached_reqs_data = self._make_cached_request_data(
+                scheduled_running_reqs,
+                scheduled_resumed_reqs,
+                num_scheduled_tokens,
+                scheduled_spec_decode_tokens,
+                req_to_new_blocks,
+            )
+
+        # Record the request ids that were scheduled in this step (MRV1-only).
+        if not self.use_v2_model_runner:
+            self.prev_step_scheduled_req_ids.clear()
+            self.prev_step_scheduled_req_ids.update(num_scheduled_tokens.keys())
+
+        # Producer partial-tail hand-off for external KV connectors. Drained
+        # before the CoW retentions are released below, so the pin lands while
+        # the cow block still holds a retention ref. Without a producer-side
+        # connector nothing consumes the hand-off, so skip the drain (and its
+        # pin); the manager drops stale entries when the request's blocks are
+        # popped for free.
+        pending_partial_tail_offloads = None
+        if (
+            self.connector is not None
+            and self.vllm_config.kv_transfer_config is not None
+            and self.vllm_config.kv_transfer_config.is_kv_producer
+        ):
+            pending_partial_tail_offloads = (
+                self.kv_cache_manager.take_partial_tail_offloads() or None
+            )
+
+        kv_cache_block_copies, cow_retained_blocks = (
+            self.kv_cache_manager.take_kv_cache_block_copies()
+        )
+        if kv_cache_block_copies:
+            # The copies run with this step's execution; the first non-empty
+            # step at or after it gets seq `sched_step_seq + 1` (0-token steps
+            # do not advance the seq), and its completion implies the copies
+            # have run.
+            self._free_cow_retained_blocks(cow_retained_blocks, self.sched_step_seq + 1)
+        pending_kv_cache_block_copies = kv_cache_block_copies or None
+
+        # Dynamic speculative decoding: compute optimal K
+        num_spec_tokens_to_schedule = self.num_spec_tokens
+        if self.dynamic_sd_lookup is not None and len(num_scheduled_tokens) > 0:
+            num_spec_tokens_to_schedule = self.dynamic_sd_lookup[
+                len(num_scheduled_tokens)
+            ]
+
+        scheduled_encoder_input_stats = None
+        if (
+            self.log_stats
+            and self.observability_config.enable_logging_iteration_details
+        ):
+            scheduled_encoder_input_stats = self._make_scheduled_encoder_input_stats(
+                scheduled_encoder_inputs
+            )
+
+        scheduler_output = SchedulerOutput(
+            scheduled_new_reqs=new_reqs_data,
+            scheduled_cached_reqs=cached_reqs_data,
+            num_scheduled_tokens=num_scheduled_tokens,
+            total_num_scheduled_tokens=total_num_scheduled_tokens,
+            scheduled_spec_decode_tokens=scheduled_spec_decode_tokens,
+            scheduled_encoder_inputs=scheduled_encoder_inputs,
+            scheduled_encoder_input_stats=scheduled_encoder_input_stats,
+            num_common_prefix_blocks=num_common_prefix_blocks,
+            preempted_req_ids=self.reset_preempted_req_ids,
+            # finished_req_ids is an existing state in the scheduler,
+            # instead of being newly scheduled in this step.
+            # It contains the request IDs that are finished in between
+            # the previous and the current steps.
+            finished_req_ids=self.finished_req_ids,
+            free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
+            new_block_ids_to_zero=self._get_new_block_ids_to_zero(),
+            kv_cache_block_copies=pending_kv_cache_block_copies,
+            partial_tail_offloads=pending_partial_tail_offloads,
+            num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
+            ec_manager_metadata=self.encoder_cache_manager.get_manager_metadata(),
+        )
+
+        # NOTE(Kuntai): this function is designed for multiple purposes:
+        # 1. Plan the KV cache store
+        # 2. Wrap up all the KV cache load / save ops into an opaque object
+        # 3. Clear the internal states of the connector
+        if self.connector is not None:
+            meta = self._build_kv_connector_meta(self.connector, scheduler_output)
+            scheduler_output.kv_connector_metadata = meta
+
+        # Build the connector meta for ECConnector
+        if self.ec_connector is not None:
+            ec_meta: ECConnectorMetadata = self.ec_connector.build_connector_meta(
+                scheduler_output
+            )
+            scheduler_output.ec_connector_metadata = ec_meta
+
+        # Advance the fence only for non-empty steps (those that actually
+        # write KV and have their output processed later in update_from_output).
+        if self.defer_block_free and total_num_scheduled_tokens > 0:
+            self.sched_step_seq += 1
+
+        with record_function_or_nullcontext("schedule: update_after_schedule"):
+            self._update_after_schedule(scheduler_output)
+        return scheduler_output
+
+    def _build_kv_connector_meta(
+        self, connector: KVConnectorBase_V1, scheduler_output: SchedulerOutput
+    ) -> KVConnectorMetadata:
+        return connector.build_connector_meta(scheduler_output)
+
+    def _get_new_block_ids_to_zero(self) -> list[int] | None:
+        # Drain new attention block ids every step so the manager-side list
+        # does not grow unbounded; only kv-cache zeroing consumes them.
+        new_block_ids_to_zero = self.kv_cache_manager.take_new_block_ids()
+        if not self.needs_kv_cache_zeroing:
+            return None
+
+        if self._skip_zero_block_ids:
+            skip = self._skip_zero_block_ids
+            new_block_ids_to_zero = [b for b in new_block_ids_to_zero if b not in skip]
+            skip.clear()
+
+        return new_block_ids_to_zero or None
+
+    def _preempt_request(
+        self, request: Request, timestamp: float, drop_stale_output: bool = False
+    ) -> None:
+        """Preempt a request and put it back to the waiting queue.
+
+        NOTE: The request should be popped from the running queue outside of this
+        method.
+
+        drop_stale_output: drop (rather than deliver) any in-flight output; used
+        by reset_prefix_cache, whose same-step resume would otherwise deliver
+        tokens out of order, and for connectors with a pending KV hand-off,
+        which the preemption's block free would leave without valid KV.
+        """
+        assert request.status == RequestStatus.RUNNING, (
+            "Only running requests can be preempted"
+        )
+        self._free_request_blocks(request)
+        self.encoder_cache_manager.free(request)
+        self._inflight_prefills.discard(request)
+        request.status = RequestStatus.PREEMPTED
+        request.num_computed_tokens = 0
+        if request.spec_token_ids:
+            request.spec_token_ids = []
+        # Async scheduling: mark all in-flight output as stale. Its tokens are
+        # still delivered on return (dropping them would perturb spec-decode
+        # acceptance) but must not mutate the reset counters; each step drains
+        # its share in update_from_output. num_in_flight_tokens already
+        # includes any undrained stale share, so assign rather than accumulate.
+        # An undrained drop-mode share stays dropped: its positions have
+        # already been resampled.
+        request.drop_stale_output = drop_stale_output or (
+            request.drop_stale_output and request.num_stale_output_tokens > 0
+        )
+        request.num_stale_output_tokens = request.num_in_flight_tokens
+        request.num_output_placeholders = 0
+        request.num_preemptions += 1
+        if self.log_stats:
+            request.record_event(EngineCoreEventType.PREEMPTED, timestamp)
+
+        # Put the request back to the waiting queue.
+        self.waiting.prepend_request(request)
+        self.reset_preempted_req_ids.add(request.request_id)
+
+    def _update_after_schedule(self, scheduler_output: SchedulerOutput) -> None:
+        # Advance the number of computed tokens for the request AFTER
+        # the request is scheduled.
+        # 1. The scheduler_output of the current step has to include the
+        #    original number of scheduled tokens to determine input IDs.
+        # 2. Advance the number of computed tokens here allowing us to
+        #    schedule the prefill request again immediately in the next
+        #    scheduling step.
+        # 3. If some tokens (e.g. spec tokens) are rejected later, the number of
+        #    computed tokens will be adjusted in update_from_output.
+        num_scheduled_tokens = scheduler_output.num_scheduled_tokens
+        for req_id, num_scheduled_token in num_scheduled_tokens.items():
+            request = self.requests[req_id]
+            request.num_computed_tokens += num_scheduled_token
+            request.num_in_flight_tokens += num_scheduled_token
+            if self.defer_block_free:
+                # Record the in-flight step, to fence deferred block freeing.
+                request.last_sched_seq = self.sched_step_seq
+            request.is_prefill_chunk = request.num_computed_tokens < (
+                request.num_tokens + request.num_output_placeholders
+            )
+            scheduler_output.has_structured_output_requests |= (
+                request.use_structured_output and not request.is_prefill_chunk
+            )
+            # Drop from the in-flight-prefill set once it's no longer prefilling.
+            if not request.is_prefill_chunk:
+                self._inflight_prefills.discard(request)
+
+        # Snapshot block IDs for routed experts before forward starts.
+        # A concurrent schedule() may preempt requests and free blocks
+        # before update_from_output runs; the snapshot survives that.
+        # Use update() to preserve entries from the previous step that
+        # have not yet been consumed by update_from_output (async
+        # scheduling may call _update_after_schedule again before the
+        # prior update_from_output runs).
+        if self.enable_return_routed_experts:
+            gid = self.routed_experts_mgr.attn_gid
+            self._re_block_ids.update(
+                {
+                    rid: self.kv_cache_manager.get_blocks(rid).get_block_ids()[gid]
+                    for rid in num_scheduled_tokens
+                }
+            )
+
+        # Clear the finished and preempted request IDs.
+        # NOTE: We shouldn't just clear() here because it will also affect
+        # the scheduler output.
+        self.finished_req_ids = set()
+        self.reset_preempted_req_ids = set()
+
+    def _update_request_as_session(
+        self, session: Request, update: StreamingUpdate
+    ) -> None:
+        """
+        Updates the waiting session with the next streaming update.
+
+        Discards the last sampled output token from the prior input chunk.
+        """
+
+        # Current streaming input behaviour: Keep only computed output tokens
+        # (discard final sampled output token).
+        num_computed_tokens = session.num_computed_tokens
+        kept_output_tokens = session._all_token_ids[
+            session.num_prompt_tokens : num_computed_tokens
+        ]
+        del session._all_token_ids[num_computed_tokens:]
+        session._output_token_ids.clear()
+        assert session.prompt_token_ids is not None
+        # Extend prompt with kept output tokens.
+        session.prompt_token_ids.extend(kept_output_tokens)
+
+        if update.mm_features:
+            base = session.num_tokens
+            for mm_feature in update.mm_features:
+                mm_feature.mm_position = replace(
+                    mm_feature.mm_position, offset=mm_feature.mm_position.offset + base
+                )
+            session.mm_features.extend(update.mm_features)
+
+        session._all_token_ids.extend(update.prompt_token_ids or ())
+        session.prompt_token_ids.extend(update.prompt_token_ids or ())
+        # Update block hashes for the new tokens.
+        session.update_block_hashes()
+        session.num_prompt_tokens = len(session.prompt_token_ids)
+        session.arrival_time = update.arrival_time
+        session.sampling_params = update.sampling_params
+        if session.status == RequestStatus.WAITING_FOR_STREAMING_REQ:
+            self.num_waiting_for_streaming_input -= 1
+        session.status = RequestStatus.WAITING
+
+        if self.log_stats:
+            session.record_event(EngineCoreEventType.QUEUED)
+
+    def _make_cached_request_data(
+        self,
+        running_reqs: list[Request],
+        resumed_reqs: list[Request],
+        num_scheduled_tokens: dict[str, int],
+        spec_decode_tokens: dict[str, list[int]],
+        req_to_new_blocks: dict[str, KVCacheBlocks],
+    ) -> CachedRequestData:
+        req_ids: list[str] = []
+        new_token_ids: list[list[int]] = []
+        new_block_ids: list[tuple[list[int], ...] | None] = []
+        all_token_ids: dict[str, list[int]] = {}
+        num_computed_tokens: list[int] = []
+        num_output_tokens: list[int] = []
+        resumed_req_ids = set()
+
+        num_running_reqs = len(running_reqs)
+        for idx, req in enumerate(itertools.chain(running_reqs, resumed_reqs)):
+            req_id = req.request_id
+            req_ids.append(req_id)
+            # NOTE: In PP+async scheduling, we consume token ids via a direct GPU
+            # broadcast path (`input_batch.prev_sampled_token_ids`), so we can
+            # omit this payload.
+            if self.use_pp and not self.scheduler_config.async_scheduling:
+                # When using PP, the scheduler sends the sampled tokens back,
+                # because there's no direct communication between the first-
+                # stage worker and the last-stage worker. Otherwise, we don't
+                # need to send the sampled tokens back because the model runner
+                # will cache them.
+                num_tokens = num_scheduled_tokens[req_id] - len(
+                    spec_decode_tokens.get(req_id, ())
+                )
+                token_ids = req.all_token_ids[
+                    req.num_computed_tokens : req.num_computed_tokens + num_tokens
+                ]
+                new_token_ids.append(token_ids)
+            if idx >= num_running_reqs:
+                resumed_req_ids.add(req_id)
+            if not self.use_v2_model_runner:  # noqa: SIM102
+                if req_id not in self.prev_step_scheduled_req_ids:
+                    all_token_ids[req_id] = req.all_token_ids.copy()
+            new_block_ids.append(
+                req_to_new_blocks[req_id].get_block_ids(allow_none=True)
+            )
+            num_computed_tokens.append(req.num_computed_tokens)
+            num_output_tokens.append(
+                req.num_output_tokens + req.num_output_placeholders
+            )
+
+        return CachedRequestData(
+            req_ids=req_ids,
+            resumed_req_ids=resumed_req_ids,
+            new_token_ids=new_token_ids,
+            all_token_ids=all_token_ids,
+            new_block_ids=new_block_ids,
+            num_computed_tokens=num_computed_tokens,
+            num_output_tokens=num_output_tokens,
+        )
+
+    def _try_schedule_encoder_inputs(
+        self,
+        request: Request,
+        num_computed_tokens: int,
+        num_new_tokens: int,
+        encoder_compute_budget: int,
+        shift_computed_tokens: int = 0,
+    ) -> tuple[list[int], int, int, list[int]]:
+        """
+        Determine which encoder inputs need to be scheduled in the current step,
+        and update `num_new_tokens` and encoder token budget accordingly.
+
+        An encoder input will be scheduled if:
+        - Its output tokens overlap with the range of tokens being computed
+        in this step, i.e.,
+        [num_computed_tokens, num_computed_tokens + num_new_tokens).
+        - It is not already computed and stored in the encoder cache.
+        - It is not exist on remote encoder cache (via ECConnector)
+        - There is sufficient encoder token budget to process it.
+        - The encoder cache has space to store it.
+
+        If an encoder input cannot be scheduled due to cache or budget
+        limitations, the method adjusts `num_new_tokens` to schedule only the
+        decoder tokens up to just before the unschedulable encoder input.
+
+        Note that num_computed_tokens includes both locally cached
+        blocks and externally cached blocks (via KVConnector).
+        """
+        if num_new_tokens == 0 or not request.has_encoder_inputs:
+            return [], num_new_tokens, encoder_compute_budget, []
+        encoder_inputs_to_schedule: list[int] = []
+        mm_features = request.mm_features
+        assert mm_features is not None
+        assert len(mm_features) > 0
+        external_load_encoder_input = []
+
+        # NOTE: since scheduler operates on the request level (possibly with
+        # multiple encoder inputs per request), we need to create temporary
+        # trackers for accounting at the encoder input level.
+        mm_hashes_to_schedule = set()
+        num_embeds_to_schedule = 0
+
+        encoder_window_end = (
+            num_computed_tokens + num_new_tokens + shift_computed_tokens
+        )
+        lo, hi = get_mm_features_in_window(
+            mm_features,
+            start=num_computed_tokens,
+            end=encoder_window_end,
+        )
+        # For encoder-decoder, all inputs sit at start_pos=0, so lo=0 always.
+        if self.is_encoder_decoder:
+            lo = 0
+
+        for i in range(lo, hi):
+            mm_feature = mm_features[i]
+            start_pos = mm_feature.mm_position.offset
+            num_encoder_tokens = mm_feature.mm_position.length
+            num_encoder_embeds = mm_feature.mm_position.get_num_embeds()
+            item_identifier = mm_feature.identifier
+
+            if self.is_encoder_decoder and num_computed_tokens > 0:
+                assert start_pos == 0, (
+                    "Encoder input should be processed at the beginning of "
+                    "the sequence when encoder-decoder models are used."
+                )
+                # Encoder input has already been computed
+                # The calculation here is a bit different. We don't turn encoder
+                # output into tokens that get processed by the decoder and
+                # reflected in num_computed_tokens. Instead, start_pos reflects
+                # the position where we need to ensure we calculate encoder
+                # inputs. This should always be 0 to ensure we calculate encoder
+                # inputs before running the decoder.  Once we've calculated some
+                # decoder tokens (num_computed_tokens > 0), then we know we
+                # already calculated encoder inputs and can skip here.
+                continue
+
+            if not self.is_encoder_decoder:
+                # We are not using the encoder cache for encoder-decoder models,
+                # yet.
+                if item_identifier in mm_hashes_to_schedule:
+                    # The same encoder input has already been scheduled in the
+                    # current step.
+                    continue
+
+                if self.encoder_cache_manager.check_and_update_cache(request, i):
+                    # The encoder input is already computed and cached from a
+                    # previous step.
+                    continue
+
+            # If no encoder input chunking is allowed, we do not want to
+            # partially schedule a multimodal item. If the scheduled range would
+            # only cover part of the mm input, roll back to before the mm item.
+            if (
+                self.scheduler_config.disable_chunked_mm_input
+                and num_computed_tokens < start_pos
+                and (num_computed_tokens + num_new_tokens)
+                < (start_pos + num_encoder_tokens)
+            ):
+                # Account for EAGLE shift when rolling back to avoid
+                # encoder cache miss. This ensures the scheduled range
+                # stops before start_pos even with the shift.
+                num_new_tokens = max(
+                    0, start_pos - (num_computed_tokens + shift_computed_tokens)
+                )
+                break
+            if not self.encoder_cache_manager.can_allocate(
+                request, i, encoder_compute_budget, num_embeds_to_schedule
+            ):
+                # The encoder cache is full or the encoder budget is exhausted.
+                # NOTE(woosuk): We assume that the encoder input tokens should
+                # be processed altogether, as the encoder usually uses
+                # bidirectional attention.
+                if num_computed_tokens + shift_computed_tokens < start_pos:
+                    # We only schedule the decoder tokens just before the
+                    # encoder input.
+                    num_new_tokens = start_pos - (
+                        num_computed_tokens + shift_computed_tokens
+                    )
+                else:
+                    # Because of prefix caching, num_computed_tokens is greater
+                    # than start_pos even though its encoder input is not
+                    # available. In this case, we can't schedule any token for
+                    # the request in this step.
+                    num_new_tokens = 0
+                break
+
+            # Calculate the number of embeddings to schedule in the current range
+            # of scheduled encoder placeholder tokens.
+            start_idx_rel = max(0, num_computed_tokens - start_pos)
+            end_idx_rel = min(num_encoder_tokens, encoder_window_end - start_pos)
+            curr_embeds_start, curr_embeds_end = (
+                mm_feature.mm_position.get_embeds_indices_in_range(
+                    start_idx_rel, end_idx_rel
+                )
+            )
+            # There's no embeddings in the current range of encoder placeholder tokens
+            # so we can skip the encoder input.
+            if curr_embeds_end - curr_embeds_start == 0:
+                continue
+
+            if self.ec_connector is not None and self.ec_connector.has_cache_item(
+                item_identifier
+            ):
+                mm_hashes_to_schedule.add(item_identifier)
+                external_load_encoder_input.append(i)
+                num_embeds_to_schedule += num_encoder_embeds
+                continue
+
+            num_embeds_to_schedule += num_encoder_embeds
+            encoder_compute_budget -= num_encoder_embeds
+            mm_hashes_to_schedule.add(item_identifier)
+            encoder_inputs_to_schedule.append(i)
+
+        return (
+            encoder_inputs_to_schedule,
+            num_new_tokens,
+            encoder_compute_budget,
+            external_load_encoder_input,
+        )
+
+    def _make_scheduled_encoder_input_stats(
+        self, scheduled_encoder_inputs: dict[str, list[int]]
+    ) -> ScheduledEncoderInputStats | None:
+        stats = ScheduledEncoderInputStats()
+
+        for req_id, input_ids in scheduled_encoder_inputs.items():
+            request = self.requests.get(req_id)
+            if request is None:
+                continue
+
+            for input_id in input_ids:
+                mm_feature = request.mm_features[input_id]
+                stats.num_inputs += 1
+                stats.output_tokens += mm_feature.mm_position.get_num_embeds()
+
+        return stats if stats.num_inputs else None
+
+    def get_grammar_bitmask(
+        self, scheduler_output: SchedulerOutput
+    ) -> GrammarOutput | None:
+        # Collect list of scheduled request ids that use structured output.
+        # The corresponding rows of the bitmask will be in this order.
+        if not scheduler_output.has_structured_output_requests:
+            return None
+
+        structured_output_request_ids = [
+            req_id
+            for req_id in scheduler_output.num_scheduled_tokens
+            if (req := self.requests.get(req_id))
+            and (req.use_structured_output and not req.is_prefill_chunk)
+        ]
+        if not structured_output_request_ids:
+            return None
+
+        bitmask = self.structured_output_manager.grammar_bitmask(
+            self.requests,
+            structured_output_request_ids,
+            scheduler_output.scheduled_spec_decode_tokens,
+        )
+        return GrammarOutput(structured_output_request_ids, bitmask)
+
+    def update_from_output(
+        self,
+        scheduler_output: SchedulerOutput,
+        model_runner_output: ModelRunnerOutput,
+    ) -> dict[int, EngineCoreOutputs]:
+        sampled_token_ids = model_runner_output.sampled_token_ids
+        logprobs = model_runner_output.logprobs
+        prompt_logprobs_dict = model_runner_output.prompt_logprobs_dict
+        num_scheduled_tokens = scheduler_output.num_scheduled_tokens
+        pooler_outputs = model_runner_output.pooler_output
+        num_nans_in_logits = model_runner_output.num_nans_in_logits
+        kv_connector_output = model_runner_output.kv_connector_output
+        ec_connector_output = model_runner_output.ec_connector_output
+        cudagraph_stats = model_runner_output.cudagraph_stats
+
+        # Every GPU write enqueued by this and earlier steps has completed, so it is
+        # safe to return deferred-free blocks to the pool.
+        if self.defer_block_free and scheduler_output.total_num_scheduled_tokens > 0:
+            self.processed_step_seq += 1
+            self._drain_deferred_frees()
+
+        perf_stats: PerfStats | None = None
+        if self.perf_metrics and self.perf_metrics.is_enabled():
+            perf_stats = self.perf_metrics.get_step_perf_stats_per_gpu(scheduler_output)
+
+        outputs: dict[int, list[EngineCoreOutput]] = defaultdict(list)
+        spec_decoding_stats: SpecDecodingStats | None = None
+
+        failed_kv_load_req_ids = None
+        if kv_connector_output and kv_connector_output.invalid_block_ids:
+            # These blocks contain externally computed tokens that failed to
+            # load. Identify affected requests and adjust their computed token
+            # count to trigger recomputation of the invalid blocks.
+            failed_kv_load_req_ids = self._handle_invalid_blocks(
+                kv_connector_output.invalid_block_ids,
+                num_scheduled_tokens,
+            )
+
+        # Persist per-step routed experts into the scheduler-side slot
+        # buffer (CPU->CPU fancy-index assign; ~few MB per step).
+        # MUST precede the per-request routing reads below: stopped
+        # requests may terminate on tokens generated in this very step,
+        # whose routing was just D2H'd into model_runner_output.
+        routing_data = None
+        routing_offsets: dict[str, int] = {}
+        if model_runner_output.routed_experts is not None:
+            re = model_runner_output.routed_experts
+            self.routed_experts_mgr.store_batch(re.routing_data, re.slot_mapping)
+            routing_data = re.routing_data.astype(
+                self.routed_experts_mgr.routed_experts_by_slot.dtype,
+                copy=False,
+            )
+            # Build offset map using model runner's request order
+            # (input_batch ordering), NOT scheduler dict order.
+            offset = 0
+            for rid in model_runner_output.req_ids:
+                routing_offsets[rid] = offset
+                offset += num_scheduled_tokens[rid]
+
+        # NOTE(woosuk): As len(num_scheduled_tokens) can be up to 1K or more,
+        # the below loop can be a performance bottleneck. We should do our best
+        # to avoid expensive operations inside the loop.
+        stopped_running_reqs: set[Request] = set()
+        stopped_preempted_reqs: set[Request] = set()
+        for req_id, num_tokens_scheduled in num_scheduled_tokens.items():
+            assert num_tokens_scheduled > 0
+            request = self.requests.get(req_id)
+            output_is_stale = False
+            if request is not None:
+                request.num_in_flight_tokens -= num_tokens_scheduled
+                # Drain any stale share (see _preempt_request) in lockstep.
+                if request.num_stale_output_tokens > 0:
+                    output_is_stale = True
+                    request.num_stale_output_tokens -= num_tokens_scheduled
+                    assert request.num_stale_output_tokens >= 0
+            if failed_kv_load_req_ids and req_id in failed_kv_load_req_ids:
+                # skip failed or rescheduled requests from KV load failure
+                continue
+            if request is None or request.is_finished():
+                # The request is already finished. This can happen if the
+                # request is aborted while the model is executing it (e.g.,
+                # in pipeline parallelism or in async scheduling).
+                # NOTE(Kuntai): When delay_free_blocks=True (for async KV
+                # cache transfer in KV connector), the aborted request will not
+                # be set to None (in order to finish async KV transfer).
+                # In this case, we use is_finished() to check.
+                continue
+
+            # Drop-mode stale output (same-step resume) is discarded entirely.
+            if output_is_stale and request.drop_stale_output:
+                continue
+
+            req_index = model_runner_output.req_id_to_index[req_id]
+            generated_token_ids = (
+                sampled_token_ids[req_index] if sampled_token_ids else []
+            )
+
+            scheduled_spec_token_ids = (
+                scheduler_output.scheduled_spec_decode_tokens.get(req_id)
+            )
+            if scheduled_spec_token_ids and (
+                generated_token_ids or self.num_sampled_tokens_per_step == 0
+            ):
+                num_draft_tokens = len(scheduled_spec_token_ids)
+                num_sampled = self.num_sampled_tokens_per_step
+                num_accepted = max(len(generated_token_ids) - num_sampled, 0)
+                num_rejected = num_draft_tokens - num_accepted
+                # Rejections roll back num_computed_tokens (and, under async
+                # scheduling, num_output_placeholders, which covers the spec
+                # tokens). A stale rejection count predates the preemption
+                # rollback and must not apply.
+                if not output_is_stale:
+                    if request.num_computed_tokens > 0:
+                        request.num_computed_tokens -= num_rejected
+                    if request.num_output_placeholders > 0:
+                        request.num_output_placeholders -= num_rejected
+                spec_decoding_stats = self.make_spec_decoding_stats(
+                    spec_decoding_stats,
+                    num_draft_tokens=num_draft_tokens,
+                    num_accepted_tokens=num_accepted,
+                    num_invalid_spec_tokens=scheduler_output.num_invalid_spec_tokens,
+                    request_id=req_id,
+                )
+
+            # Free encoder inputs only after the step has actually executed.
+            if request.has_encoder_inputs:
+                self._free_encoder_inputs(request)
+
+            stopped = False
+            new_logprobs = None
+            new_token_ids = generated_token_ids
+            pooler_output = pooler_outputs[req_index] if pooler_outputs else None
+            kv_transfer_params = None
+            ec_transfer_params = None
+            prefill_stats = None
+            status_before_stop = request.status
+            num_output_tokens_before = len(request._output_token_ids)
+
+            # Check for stop and update request status.
+            if new_token_ids:
+                new_token_ids, stopped = self._update_request_with_output(
+                    request, new_token_ids, is_stale=output_is_stale
+                )
+            elif request.pooling_params and pooler_output is not None:
+                # Pooling stops as soon as there is output.
+                request.status = RequestStatus.FINISHED_STOPPED
+                stopped = True
+            elif (
+                self.is_encoder_only
+                and request.num_computed_tokens >= request.num_prompt_tokens
+            ):
+                # An encoder instance runs the encoder and publishes the
+                # embeddings instead of sampling, so it stops as soon as the
+                # whole prompt is consumed. Encoder inputs are never scheduled
+                # past a multi-modal item the encoder cache could not admit, so
+                # a consumed prompt also means every item in it was encoded.
+                request.status = RequestStatus.FINISHED_STOPPED
+                stopped = True
+
+            if new_token_ids and self.structured_output_manager.should_advance(
+                request, new_token_ids=new_token_ids
+            ):
+                struct_output_request = request.structured_output_request
+                assert struct_output_request is not None
+                grammar = struct_output_request.grammar
+                assert isinstance(grammar, StructuredOutputGrammar)
+                # new_token_ids can be a mixed block of reasoning content, then
+                # the reasoning end marker, then the start of the grammar content.
+                # Trim the reasoning content so the grammar only sees grammar content.
+                advance_token_ids = (
+                    self.structured_output_manager.trim_reasoning_for_advance(
+                        request, new_token_ids
+                    )
+                )
+                if advance_token_ids and not grammar.accept_tokens(
+                    req_id, advance_token_ids
+                ):
+                    logger.error(
+                        "Unexpected: grammar rejected tokens %s for request %s. "
+                        "Terminating request.",
+                        advance_token_ids,
+                        req_id,
+                    )
+                    request.status = RequestStatus.FINISHED_ERROR
+                    request.resumable = False
+                    stopped = True
+
+            routed_experts = None
+            if (
+                self.enable_return_routed_experts
+                and routing_data is not None
+                and new_token_ids
+            ):
+                req_offset = routing_offsets[req_id]
+                end = req_offset + num_tokens_scheduled
+                block_ids = self._re_block_ids.pop(req_id, [])
+                if num_output_tokens_before == 0:
+                    # Prefill completed: read full prompt routing from
+                    # slot buffer using the block-ID snapshot taken at
+                    # schedule time (immune to async preemption).
+                    if (
+                        request.sampling_params is not None
+                        and request.sampling_params.routed_experts_prompt_start
+                        is not None
+                    ):
+                        prompt_start = (
+                            request.sampling_params.routed_experts_prompt_start
+                        )
+                        assert prompt_start < request.num_prompt_tokens
+                    else:
+                        prompt_start = 0
+                    routed_experts = self.routed_experts_mgr.get(
+                        block_ids,
+                        request.num_prompt_tokens,
+                        token_start=prompt_start,
+                    )
+                else:
+                    if scheduled_spec_token_ids:
+                        # Spec decode: accepted tokens at the START of
+                        # the scheduled range, rejected at the end.
+                        routed_experts = routing_data[
+                            req_offset : req_offset + len(new_token_ids)
+                        ]
+                    else:
+                        # Normal decode / re-prefill: token(s) at the END.
+                        routed_experts = routing_data[end - len(new_token_ids) : end]
+
+            should_emit_output = bool(
+                new_token_ids or pooler_output is not None or stopped
+            )
+            if should_emit_output:
+                prefill_stats = request.take_prefill_stats()
+                if prefill_stats is not None:
+                    prefill_stats.finalize(
+                        self.kv_cache_manager.estimate_cached_tokens(request)
+                    )
+
+            finish_reason = None
+            if stopped:
+                # Capture finish_reason BEFORE _handle_stopped_request, which may
+                # reset the status to WAITING for streaming requests that continue.
+                finish_reason = request.get_finished_reason()
+                finished = self._handle_stopped_request(request)
+                if finished:
+                    kv_transfer_params, ec_transfer_params = self._free_request(request)
+
+                if status_before_stop == RequestStatus.RUNNING:
+                    stopped_running_reqs.add(request)
+                else:
+                    stopped_preempted_reqs.add(request)
+
+            # Extract sample logprobs if needed.
+            if (
+                request.sampling_params is not None
+                and request.sampling_params.num_logprobs is not None
+                and logprobs
+            ):
+                new_logprobs = logprobs.slice_request(req_index, len(new_token_ids))
+
+            if num_nans_in_logits is not None and req_id in num_nans_in_logits:
+                request.num_nans_in_logits = num_nans_in_logits[req_id]
+
+            # Get prompt logprobs for this request.
+            prompt_logprobs_tensors = prompt_logprobs_dict.get(req_id)
+            if should_emit_output:
+                # Add EngineCoreOutput for this Request.
+                outputs[request.client_index].append(
+                    EngineCoreOutput(
+                        request_id=req_id,
+                        new_token_ids=new_token_ids,
+                        finish_reason=finish_reason,
+                        new_logprobs=new_logprobs,
+                        new_prompt_logprobs_tensors=prompt_logprobs_tensors,
+                        pooling_output=pooler_output,
+                        stop_reason=request.stop_reason,
+                        events=request.take_events(),
+                        prefill_stats=prefill_stats,
+                        kv_transfer_params=kv_transfer_params,
+                        ec_transfer_params=ec_transfer_params,
+                        trace_headers=request.trace_headers,
+                        routed_experts=routed_experts,
+                        num_nans_in_logits=request.num_nans_in_logits,
+                    )
+                )
+            else:
+                # Invariant: EngineCore returns no partial prefill outputs.
+                assert not prompt_logprobs_tensors
+
+        # Remove the stopped requests from the running and waiting queues.
+        if stopped_running_reqs:
+            self.running = remove_all(self.running, stopped_running_reqs)
+        if stopped_preempted_reqs:
+            # This is a rare case and unlikely to impact performance.
+            self.waiting.remove_requests(stopped_preempted_reqs)
+            self.skipped_waiting.remove_requests(stopped_preempted_reqs)
+
+        error_req_ids = set(self.grammar_compile_error_reqs)
+        self.grammar_compile_error_reqs.clear()
+        if failed_kv_load_req_ids and not self.recompute_kv_load_failures:
+            error_req_ids.update(failed_kv_load_req_ids)
+
+        if error_req_ids:
+            error_reqs = self.finish_requests(
+                error_req_ids, RequestStatus.FINISHED_ERROR
+            )
+            for request in error_reqs:
+                outputs[request.client_index].append(
+                    EngineCoreOutput(
+                        request_id=request.request_id,
+                        new_token_ids=[],
+                        finish_reason=request.get_finished_reason(),
+                        events=request.take_events(),
+                        trace_headers=request.trace_headers,
+                    )
+                )
+
+        # KV Connector: update state for finished KV Transfers.
+        if kv_connector_output:
+            self._update_from_kv_xfer_finished(kv_connector_output)
+
+        # EC Connector: update state from worker-side EC connector output.
+        if self.ec_connector is not None and ec_connector_output:
+            self.ec_connector.update_connector_output(ec_connector_output)
+
+        # Worker-side KV connector stats from the model runner output.
+        kv_connector_stats: KVConnectorStats | None = (
+            kv_connector_output.kv_connector_stats if kv_connector_output else None
+        )
+        if self.connector:
+            # Scheduler-side KV connector stats collected after connector update.
+            scheduler_kv_connector_stats = self.connector.get_kv_connector_stats()
+            if (
+                scheduler_kv_connector_stats is not None
+                and not scheduler_kv_connector_stats.is_empty()
+            ):
+                kv_connector_stats = (
+                    kv_connector_stats.aggregate(scheduler_kv_connector_stats)
+                    if kv_connector_stats is not None
+                    else scheduler_kv_connector_stats
+                )
+
+        # collect KV cache events from KV cache manager
+        events = self.kv_cache_manager.take_events()
+
+        # collect KV cache events from connector
+        if self.connector is not None:
+            connector_events = self.connector.take_events()
+            if connector_events:
+                if events is None:
+                    events = list(connector_events)
+                else:
+                    events.extend(connector_events)
+
+        # publish collected KV cache events
+        if events:
+            batch = KVEventBatch(ts=time.time(), events=events)
+            self.kv_event_publisher.publish(batch)
+
+        # Create EngineCoreOutputs for all clients that have requests with
+        # outputs in this step.
+        engine_core_outputs = {
+            client_index: EngineCoreOutputs(outputs=outs)
+            for client_index, outs in outputs.items()
+        }
+
+        finished_req_ids = self.finished_req_ids_dict
+        if finished_req_ids:
+            # Include ids of requests that finished since last outputs
+            # were sent.
+            for client_index, finished_set in finished_req_ids.items():
+                # Set finished request set in EngineCoreOutputs for this client.
+                if (eco := engine_core_outputs.get(client_index)) is not None:
+                    eco.finished_requests = finished_set
+                else:
+                    engine_core_outputs[client_index] = EngineCoreOutputs(
+                        finished_requests=finished_set
+                    )
+            finished_req_ids.clear()
+
+        if (
+            stats := self.make_stats(
+                spec_decoding_stats,
+                kv_connector_stats,
+                cudagraph_stats,
+                perf_stats,
+            )
+        ) is not None:
+            # Return stats to only one of the front-ends.
+            if (eco := next(iter(engine_core_outputs.values()), None)) is None:
+                # We must return the stats even if there are no request
+                # outputs this step.
+                engine_core_outputs[0] = eco = EngineCoreOutputs()
+            eco.scheduler_stats = stats
+
+        return engine_core_outputs
+
+    @staticmethod
+    def _is_blocked_waiting_status(status: RequestStatus) -> bool:
+        return status in (
+            RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR,
+            RequestStatus.WAITING_FOR_REMOTE_KVS,
+            RequestStatus.WAITING_FOR_STREAMING_REQ,
+        )
+
+    def _enqueue_waiting_request(self, request: Request) -> None:
+        if self._is_blocked_waiting_status(request.status):
+            self.skipped_waiting.add_request(request)
+        else:
+            self.waiting.add_request(request)
+
+    def _select_waiting_queue_for_scheduling(self) -> RequestQueue | None:
+        if self.policy == SchedulingPolicy.FCFS:
+            return self.skipped_waiting or self.waiting or None
+
+        # PRIORITY mode: compare queue heads when both queues are non-empty.
+        if self.waiting and self.skipped_waiting:
+            waiting_req = self.waiting.peek_request()
+            skipped_req = self.skipped_waiting.peek_request()
+            return self.waiting if waiting_req < skipped_req else self.skipped_waiting
+
+        return self.waiting or self.skipped_waiting or None
+
+    def _handle_stopped_request(self, request: Request) -> bool:
+        """Return True if finished (can be False for resumable requests)."""
+        if not request.resumable:
+            return True
+
+        if request.streaming_queue:
+            update = request.streaming_queue.popleft()
+            if update is None:
+                # Streaming request finished.
+                return True
+            self._update_request_as_session(request, update)
+        else:
+            request.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+            self.num_waiting_for_streaming_input += 1
+
+        self._enqueue_waiting_request(request)
+        return False
+
+    def _update_request_with_output(
+        self, request: Request, new_token_ids: list[int], is_stale: bool = False
+    ) -> tuple[list[int], bool]:
+        # is_stale is only used by the AsyncScheduler override.
+        # Append generated tokens and check for stop. Note that if
+        # a request is still being prefilled, we expect the model runner
+        # to return empty token ids for the request.
+        stopped = False
+        for num_new, output_token_id in enumerate(new_token_ids, 1):
+            request.append_output_token_ids(output_token_id)
+
+            # Check for stop and update request state.
+            # This must be called before we make the EngineCoreOutput.
+            stopped = check_stop(request, self.max_model_len)
+            if stopped:
+                del new_token_ids[num_new:]  # Trim new tokens if needed.
+                break
+        return new_token_ids, stopped
+
+    def _free_encoder_inputs(self, request: Request) -> None:
+        cached_encoder_input_ids = self.encoder_cache_manager.get_cached_input_ids(
+            request
+        )
+        # OPTIMIZATION: Avoid list(set) if the set is empty.
+        if not cached_encoder_input_ids:
+            return
+
+        # Defer the free by the drafter's look-ahead so an entry stays
+        # referenced until the drafter's +1 read has also passed it, mirroring
+        # the shift the encoder scheduling path applies.
+        spec_lookahead = 1 if self.use_eagle else 0
+
+        # Here, we use list(set) to avoid modifying the set while iterating
+        # over it.
+        for input_id in list(cached_encoder_input_ids):
+            mm_feature = request.mm_features[input_id]
+            start_pos = mm_feature.mm_position.offset
+            num_tokens = mm_feature.mm_position.length
+            if self.is_encoder_decoder and request.num_computed_tokens > 0:
+                # With Whisper, as soon as we've generated a single token,
+                # we know we're done with the encoder input. Cross Attention
+                # KVs have been calculated and cached already.
+                self.encoder_cache_manager.free_encoder_input(request, input_id)
+            elif (
+                start_pos + num_tokens + spec_lookahead
+                <= request.num_computed_tokens - request.num_output_placeholders
+            ):
+                # Processed, stored in the decoder KV cache, and far enough past
+                # the placeholder range (plus the drafter's look-ahead) that no
+                # rejection or drafter gather can reference it.
+                self.encoder_cache_manager.free_encoder_input(request, input_id)
+
+    def update_draft_token_ids(self, draft_token_ids: DraftTokenIds) -> None:
+        for req_id, spec_token_ids in zip(
+            draft_token_ids.req_ids,
+            draft_token_ids.draft_token_ids,
+        ):
+            request = self.requests.get(req_id)
+            if request is None or request.is_finished():
+                # The request may have been finished. Skip.
+                continue
+
+            if request.is_prefill_chunk:
+                # Ignore draft tokens for prefill chunks.
+                if request.spec_token_ids:
+                    request.spec_token_ids = []
+                continue
+
+            # Add newly generated spec token ids to the request.
+            if self.structured_output_manager.should_advance(request):
+                metadata = request.structured_output_request
+                spec_token_ids = metadata.grammar.validate_tokens(spec_token_ids)  # type: ignore[union-attr]
+            request.spec_token_ids = spec_token_ids
+
+    def update_draft_token_ids_in_output(
+        self, draft_token_ids: DraftTokenIds, scheduler_output: SchedulerOutput
+    ) -> None:
+        num_invalid_spec_tokens: dict[str, int] = {}
+
+        sched_spec_tokens = scheduler_output.scheduled_spec_decode_tokens
+        for req_id, spec_token_ids in zip(
+            draft_token_ids.req_ids,
+            draft_token_ids.draft_token_ids,
+        ):
+            request = self.requests.get(req_id)
+            if request is None or request.is_finished():
+                # The request may have been finished. Skip.
+                continue
+
+            placeholder_spec_tokens = sched_spec_tokens.get(req_id)
+            if not placeholder_spec_tokens:
+                continue
+
+            orig_num_spec_tokens = len(placeholder_spec_tokens)
+            # Trim drafts to scheduled number of spec tokens
+            # (needed for chunked prefill case for example).
+            del spec_token_ids[orig_num_spec_tokens:]
+            # Filter out spec tokens which do not adhere to the grammar.
+            if self.structured_output_manager.should_advance(request):
+                metadata = request.structured_output_request
+                spec_token_ids = metadata.grammar.validate_tokens(spec_token_ids)  # type: ignore[union-attr]
+            # Pad to original number of spec tokens.
+            num_invalid_tokens = orig_num_spec_tokens - len(spec_token_ids)
+            if num_invalid_tokens:
+                spec_token_ids.extend([-1] * num_invalid_tokens)
+                num_invalid_spec_tokens[req_id] = num_invalid_tokens
+
+            sched_spec_tokens[req_id] = spec_token_ids
+
+        scheduler_output.num_invalid_spec_tokens = num_invalid_spec_tokens
+
+    def get_request_counts(self) -> tuple[int, int]:
+        """Returns (num_running_reqs, num_waiting_reqs)."""
+        return len(self.running), len(self.waiting) + len(self.skipped_waiting)
+
+    def get_kv_cache_usage(self) -> float:
+        """Returns the fraction of the KV cache currently in use (0.0-1.0)."""
+        return self.kv_cache_manager.usage
+
+    def add_request(self, request: Request) -> None:
+        existing = self.requests.get(request.request_id)
+        if existing is not None:
+            update = StreamingUpdate.from_request(request)
+            if existing.status != RequestStatus.WAITING_FOR_STREAMING_REQ:
+                assert existing.streaming_queue is not None, "duplicate request id"
+                # Queue next input chunk (or finished sentinel).
+                existing.streaming_queue.append(update)
+            elif update is not None:
+                # Commence next input chunk.
+                self._update_request_as_session(existing, update)
+            else:
+                # Streaming-input session finished.
+                self.finish_requests(request.request_id, RequestStatus.FINISHED_ABORTED)
+        else:
+            if request.resumable:
+                request.streaming_queue = deque()
+            self._enqueue_waiting_request(request)
+            self.requests[request.request_id] = request
+            if self.connector is not None:
+                self.connector.on_new_request(request)
+            if self.log_stats:
+                request.record_event(EngineCoreEventType.QUEUED)
+
+    def finish_requests(
+        self, request_ids: str | Iterable[str] | None, finished_status: RequestStatus
+    ) -> list[Request]:
+        """Handles the finish signal from outside the scheduler.
+
+        For example, the API server can abort a request when the client
+        disconnects.
+
+        If request_ids is None, all requests will be finished.
+
+        Returns:
+            List of requests that were aborted. Will not include any that were
+            already finished.
+        """
+        assert RequestStatus.is_finished(finished_status)
+        if isinstance(request_ids, str):
+            request_ids = (request_ids,)
+        elif request_ids is not None:
+            request_ids = set(request_ids)
+        else:
+            request_ids = self.requests.keys()
+
+        running_requests_to_remove = set()
+        waiting_requests_to_remove = []
+        valid_requests = []
+
+        # First pass: collect requests to remove from queues
+        for req_id in request_ids:
+            request = self.requests.get(req_id)
+            if request is None or request.is_finished():
+                # Invalid request ID.
+                continue
+
+            valid_requests.append(request)
+            if request.status == RequestStatus.RUNNING:
+                running_requests_to_remove.add(request)
+            else:
+                if request.status == RequestStatus.WAITING_FOR_STREAMING_REQ:
+                    self.num_waiting_for_streaming_input -= 1
+                waiting_requests_to_remove.append(request)
+
+        # Remove all requests from queues at once for better efficiency
+        if running_requests_to_remove:
+            self.running = remove_all(self.running, running_requests_to_remove)
+        if waiting_requests_to_remove:
+            self.waiting.remove_requests(waiting_requests_to_remove)
+            self.skipped_waiting.remove_requests(waiting_requests_to_remove)
+
+        # Second pass: set status and free requests
+        for request in valid_requests:
+            delay_free_blocks = False
+            if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+                delay_free_blocks = (
+                    request.request_id not in self.finished_recving_kv_req_ids
+                )
+                self.finished_recving_kv_req_ids.discard(request.request_id)
+                self.failed_recving_kv_req_ids.discard(request.request_id)
+
+            request.status = finished_status
+            self._free_request(request, delay_free_blocks=delay_free_blocks)
+
+        return valid_requests
+
+    def _free_request(
+        self, request: Request, delay_free_blocks: bool = False
+    ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+        assert request.is_finished()
+
+        self._inflight_prefills.discard(request)
+        connector_delay_free_blocks, kv_xfer_params = self._connector_finished(request)
+
+        # EC Connector: mirror the KV hook. The contract requires firing
+        # before the encoder cache is freed so the connector can inspect
+        # per-request state (e.g. which mm_hashes it recorded during
+        # save_caches()) and emit ec_transfer_params for the response body.
+        ec_xfer_params: dict[str, Any] | None = None
+        if self.ec_connector is not None:
+            ec_delay_free, ec_xfer_params = self.ec_connector.request_finished(request)
+            connector_delay_free_blocks |= ec_delay_free
+
+        self.encoder_cache_manager.free(request)
+        request_id = request.request_id
+        self.finished_req_ids.add(request_id)
+        if self.finished_req_ids_dict is not None:
+            self.finished_req_ids_dict[request.client_index].add(request_id)
+
+        delay_free_blocks |= connector_delay_free_blocks
+        if not delay_free_blocks:
+            self._free_blocks(request)
+
+        return kv_xfer_params, ec_xfer_params
+
+    def _free_blocks(self, request: Request):
+        assert request.is_finished()
+        self._free_request_blocks(request)
+        del self.requests[request.request_id]
+
+    @property
+    def pause_state(self) -> PauseState:
+        return self._pause_state
+
+    def set_pause_state(self, pause_state: PauseState) -> None:
+        self._pause_state = pause_state
+
+    def _free_request_blocks(self, request: Request):
+        """Free the request's KV blocks, deferring the return to the block
+        pool when an in-flight GPU step may still write them.
+        """
+        if not self.defer_block_free or (
+            # Last scheduled step already processed: no in-flight write remains
+            # (always the case for a normal finish), so free now.
+            request.last_sched_seq <= self.processed_step_seq
+        ):
+            self.kv_cache_manager.free(request)
+            return
+        blocks = self.kv_cache_manager.pop_blocks_for_free(request)
+        if blocks:
+            self.deferred_frees.append((self.sched_step_seq, blocks))
+
+    def _free_cow_retained_blocks(
+        self, blocks: list[KVCacheBlock], fence_seq: int
+    ) -> None:
+        """Release CoW copy retentions, deferring their return to the block
+        pool while the step that runs the copy may still be in flight.
+        """
+        if not self.defer_block_free or fence_seq <= self.processed_step_seq:
+            self.kv_cache_manager.block_pool.free_blocks(blocks)
+            return
+        self.deferred_frees.append((fence_seq, blocks[::-1]))
+
+    def _drain_deferred_frees(self):
+        """Return deferred blocks whose fence step has completed.
+
+        Fences are appended in near-monotonic order (a CoW retention fence
+        can lead request-free fences by one step), so stop at the first
+        pending one; any satisfied entry behind it is merely freed later.
+        """
+        while self.deferred_frees:
+            fence, _ = self.deferred_frees[0]
+            if fence > self.processed_step_seq:
+                break
+            _, blocks = self.deferred_frees.popleft()
+            # Free in reverse order so that the tail blocks are evicted first.
+            self.kv_cache_manager.block_pool.free_blocks(reversed(blocks))
+
+    def get_num_unfinished_requests(self) -> int:
+        if self._pause_state == PauseState.PAUSED_ALL:
+            return 0
+        if self._pause_state == PauseState.PAUSED_NEW:
+            return len(self.running)
+        num_waiting = (
+            len(self.waiting)
+            + len(self.skipped_waiting)
+            - self.num_waiting_for_streaming_input
+        )
+        return num_waiting + len(self.running)
+
+    def has_finished_requests(self) -> bool:
+        if self.finished_req_ids:
+            return True
+        if self.connector is None:
+            return False
+        # Finished requests waiting on delayed connector cleanup remain in
+        # self.requests after they have been removed from scheduling queues.
+        num_in_queues = (
+            len(self.waiting) + len(self.skipped_waiting) + len(self.running)
+        )
+        return len(self.requests) > num_in_queues
+
+    def has_requests(self) -> bool:
+        # Override the interface default to also keep the engine alive while a
+        # connector still has pending push work (e.g. push-mode WRITE transfers
+        # in flight after all "live" requests have finished). Without this hook
+        # the engine would quiesce before the connector can drain completions.
+        # TODO: replace with a more general mechanism for connectors to keep
+        # the scheduler alive.
+        return (
+            self.has_unfinished_requests()
+            or self.has_finished_requests()
+            or (self.connector is not None and self.connector.has_pending_push_work())
+            or (
+                self.ec_connector is not None
+                and self.ec_connector.has_pending_push_work()
+            )
+        )
+
+    def reset_prefix_cache(
+        self, reset_running_requests: bool = False, reset_connector: bool = False
+    ) -> bool:
+        """Reset the KV prefix cache.
+
+        If reset_running_requests is True, all the running requests will be
+        preempted and moved to the waiting queue.
+        Otherwise, this method will only reset the KV prefix cache when there
+        is no running requests taking KV cache.
+        """
+        if reset_running_requests:
+            # For logging.
+            timestamp = time.monotonic()
+            # Invalidate all the current running requests KV's by pushing them to
+            # the waiting queue. In this case, we can reduce the ref count of all
+            # the kv blocks to 0 and thus we can make sure the reset is successful.
+            # Preempt in reverse order so the requests will be added back to the
+            # running queue in FIFO order.
+            while self.running:
+                request = self.running.pop()
+                self._preempt_request(request, timestamp, drop_stale_output=True)
+
+            # Clear scheduled request ids cache. Since we are forcing preemption
+            # + resumption in the same step, we must act as if these requests were
+            # not scheduled in the prior step. They will be flushed from the
+            # persistent batch in the model runner.
+            self.prev_step_scheduled_req_ids.clear()
+
+        reset_successful = self.kv_cache_manager.reset_prefix_cache()
+        if reset_running_requests and not reset_successful:
+            raise RuntimeError(
+                "Failed to reset KV cache even when all the running requests are "
+                "preempted and moved to the waiting queue. This is likely due to "
+                "the presence of running requests waiting for remote KV transfer, "
+                "which is not supported yet."
+            )
+
+        if reset_connector:
+            reset_successful = self.reset_connector_cache() and reset_successful
+
+        return reset_successful
+
+    def reset_connector_cache(self) -> bool:
+        if self.connector is None:
+            # No connector attached -> nothing to reset, treat as success so
+            # callers that unconditionally request a connector reset (e.g. as
+            # part of a cache-clearing cascade after a weight update) don't
+            # see reset_prefix_cache() flip to False purely because they
+            # didn't configure a connector.
+            logger.debug(
+                "reset_connector requested but no KV connector is configured; "
+                "treating as no-op success."
+            )
+            return True
+
+        if self.connector.reset_cache() is False:
+            return False
+
+        if self.log_stats:
+            assert self.connector_prefix_cache_stats is not None
+            self.connector_prefix_cache_stats.reset = True
+
+        return True
+
+    def reset_encoder_cache(self) -> None:
+        """Reset the encoder cache to invalidate all cached encoder outputs.
+
+        This should be called when model weights are updated to ensure
+        stale vision embeddings are not reused.
+        """
+        self.encoder_cache_manager.reset()
+
+    def make_stats(
+        self,
+        spec_decoding_stats: SpecDecodingStats | None = None,
+        kv_connector_stats: KVConnectorStats | None = None,
+        cudagraph_stats: CUDAGraphStat | None = None,
+        perf_stats: PerfStats | None = None,
+    ) -> SchedulerStats | None:
+        if not self.log_stats:
+            return None
+        prefix_cache_stats = self.kv_cache_manager.make_prefix_cache_stats()
+        assert prefix_cache_stats is not None
+        connector_prefix_cache_stats: PrefixCacheStats | None = None
+        if self.connector_prefix_cache_stats is not None:
+            connector_prefix_cache_stats = self.connector_prefix_cache_stats
+            self.connector_prefix_cache_stats = PrefixCacheStats()
+        eviction_events = (
+            self.kv_metrics_collector.drain_events()
+            if self.kv_metrics_collector is not None
+            else []
+        )
+        spec_stats = spec_decoding_stats
+        connector_stats_payload = (
+            kv_connector_stats.data if kv_connector_stats else None
+        )
+        return SchedulerStats(
+            num_running_reqs=len(self.running),
+            num_waiting_reqs=len(self.waiting),
+            num_skipped_waiting_reqs=len(self.skipped_waiting),
+            kv_cache_usage=self.kv_cache_manager.usage,
+            prefix_cache_stats=prefix_cache_stats,
+            connector_prefix_cache_stats=connector_prefix_cache_stats,
+            kv_cache_eviction_events=eviction_events,
+            spec_decoding_stats=spec_stats,
+            kv_connector_stats=connector_stats_payload,
+            cudagraph_stats=cudagraph_stats,
+            perf_stats=perf_stats,
+        )
+
+    def make_spec_decoding_stats(
+        self,
+        spec_decoding_stats: SpecDecodingStats | None,
+        num_draft_tokens: int,
+        num_accepted_tokens: int,
+        num_invalid_spec_tokens: dict[str, int] | None,
+        request_id: str,
+    ) -> SpecDecodingStats | None:
+        if not self.log_stats or not num_draft_tokens:
+            return None
+        if spec_decoding_stats is None:
+            spec_decoding_stats = SpecDecodingStats.new(self.num_spec_tokens)
+        if num_invalid_spec_tokens:
+            num_draft_tokens -= num_invalid_spec_tokens.get(request_id, 0)
+        spec_decoding_stats.observe_draft(
+            num_draft_tokens=num_draft_tokens, num_accepted_tokens=num_accepted_tokens
+        )
+        return spec_decoding_stats
+
+    def shutdown(self) -> None:
+        logger.debug_once("[shutdown] Scheduler: start")
+        if self.kv_event_publisher:
+            self.kv_event_publisher.shutdown()
+        if self.connector is not None:
+            self.connector.shutdown()
+
+        if self.ec_connector is not None:
+            self.ec_connector.shutdown()
+
+        logger.debug_once("[shutdown] Scheduler: complete")
+
+    ########################################################################
+    # KV Connector Related Methods
+    ########################################################################
+
+    def get_kv_connector(self) -> KVConnectorBase_V1 | None:
+        return self.connector
+
+    def get_ec_connector(self) -> ECConnectorBase | None:
+        return self.ec_connector
+
+    def get_kv_event_publisher_config(self) -> KVEventsConfig | None:
+        return self.kv_event_publisher.get_publisher_config()
+
+    def _connector_finished(
+        self, request: Request
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """
+        Invoke the KV connector request_finished() method if applicable.
+
+        Returns optional kv transfer parameters to be included with the
+        request outputs.
+        """
+        if self.connector is None:
+            return False, None
+
+        # Free any out-of-window prefix blocks before we hand the block table to
+        # the connector, on the processed-token basis (see `allocate_slots`).
+        self.kv_cache_manager.remove_skipped_blocks(
+            request_id=request.request_id,
+            processed_computed_tokens=max(
+                0, request.num_computed_tokens - request.num_in_flight_tokens
+            ),
+            num_prompt_tokens=request.num_prompt_tokens,
+        )
+
+        block_ids = self.kv_cache_manager.get_block_ids_for_computed_tokens(
+            request_id=request.request_id,
+            num_computed_tokens=request.num_computed_tokens,
+        )
+
+        if not isinstance(self.connector, SupportsHMA):
+            # NOTE(Kuntai): We should deprecate this code path after we enforce
+            # all connectors to support HMA.
+            # Hybrid memory allocator should be already turned off for this
+            # code path, but let's double-check here.
+            assert len(self.kv_cache_config.kv_cache_groups) == 1
+            return self.connector.request_finished(request, block_ids[0])
+
+        return self.connector.request_finished_all_groups(request, block_ids)
+
+    def _request_remaining_blocks(self, request: Request) -> int:
+        """Blocks `request` still needs to allocate to hold its full sequence."""
+        full_num_tokens = min(request.num_tokens, self.max_model_len)
+        return self.kv_cache_manager.coordinator.get_num_blocks_to_allocate(
+            request_id=request.request_id,
+            num_tokens=full_num_tokens,
+            new_computed_blocks=self.kv_cache_manager.empty_kv_cache_blocks.blocks,
+            num_encoder_tokens=0,
+            total_computed_tokens=request.num_computed_tokens,
+            num_local_computed_tokens=request.num_computed_tokens,
+            num_tokens_main_model=full_num_tokens,
+            apply_admission_cap=True,
+        )
+
+    def _inflight_prefill_reserved_blocks(self) -> int:
+        """Num blocks in-flight prefills still need to finish (their reservation)."""
+
+        return sum(
+            self._request_remaining_blocks(req) for req in self._inflight_prefills
+        )
+
+    def _update_waiting_for_remote_kv(self, request: Request) -> None:
+        """
+        KV Connector: update request state after async recv is finished.
+
+        When the kv transfer is ready, we cache the blocks
+        and the request state will be moved back to WAITING from
+        WAITING_FOR_REMOTE_KV.
+        """
+        assert self.connector is not None
+
+        if request.request_id in self.failed_recving_kv_req_ids:
+            # Request had KV load failures; num_computed_tokens was already
+            # updated in _update_requests_with_invalid_blocks
+            if request.num_computed_tokens:
+                # Cache any valid computed tokens.
+                self.kv_cache_manager.cache_blocks(request, request.num_computed_tokens)
+                if self.needs_kv_cache_zeroing:
+                    # The failed load left the blocks beyond the valid
+                    # prefix unwritten and their zeroing was skipped; zero
+                    # them before they are recomputed locally.
+                    self.kv_cache_manager.record_blocks_for_zeroing(
+                        request.request_id, request.num_computed_tokens
+                    )
+            else:
+                # No valid computed tokens, release allocated blocks.
+                # There may be a local cache hit on retry.
+                # (Freed blocks are re-recorded for zeroing when
+                # reallocated, so the skipped blocks need no handling.)
+                self.kv_cache_manager.free(request)
+
+            self.failed_recving_kv_req_ids.remove(request.request_id)
+        else:
+            # Now that the blocks are ready, actually cache them.
+            # This will cache the blocks iff caching is enabled.
+            self.kv_cache_manager.cache_blocks(request, request.num_computed_tokens)
+
+            # on a full prompt hit, we need to re-compute the last token
+            # in order to be able to sample the next token
+            if request.num_computed_tokens == request.num_tokens:
+                request.num_computed_tokens = request.num_tokens - 1
+
+        self.finished_recving_kv_req_ids.remove(request.request_id)
+
+    def _try_promote_blocked_waiting_request(self, request: Request) -> bool:
+        """
+        Try to promote a blocked waiting request back to schedulable states.
+        """
+        if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+            # finished_recving_kv_req_ids is populated during
+            # update_from_output(), based on worker-side connector signals
+            # in KVConnectorOutput.finished_recving
+            if request.request_id not in self.finished_recving_kv_req_ids:
+                return False
+            self._update_waiting_for_remote_kv(request)
+            if request.num_preemptions:
+                request.status = RequestStatus.PREEMPTED
+            else:
+                request.status = RequestStatus.WAITING
+            return True
+
+        if request.status == RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR:
+            structured_output_req = request.structured_output_request
+            if not structured_output_req or structured_output_req.grammar is None:
+                return False
+            if isinstance(structured_output_req.grammar, Exception):
+                self.grammar_compile_error_reqs.add(request.request_id)
+                return False
+            request.status = RequestStatus.WAITING
+            return True
+
+        if request.status == RequestStatus.WAITING_FOR_STREAMING_REQ:
+            assert not request.streaming_queue
+            return False
+
+        raise AssertionError(
+            "Unexpected blocked waiting status in promotion: "
+            f"{request.status.name} for request {request.request_id}"
+        )
+
+    def _update_from_kv_xfer_finished(self, kv_connector_output: KVConnectorOutput):
+        """
+        KV Connector: update the scheduler state based on the output.
+
+        The Worker side connectors add finished_recving and
+        finished_sending reqs to the output.
+        * if finished_sending: free the blocks
+        # if finished_recving: add to state so we can
+            schedule the request during the next step.
+        """
+
+        if self.connector is not None:
+            self.connector.update_connector_output(kv_connector_output)
+
+        # KV Connector:: update recv and send status from last step.
+        for req_id in kv_connector_output.finished_recving or ():
+            logger.debug("Finished recving KV transfer for request %s", req_id)
+            req = self.requests.get(req_id)
+            if req is None:
+                # The request was already removed (e.g. aborted after a
+                # failed/late KV transfer). Drop the stale completion instead
+                # of crashing the engine.
+                logger.warning(
+                    "Finished recving KV transfer for request %s, but it is "
+                    "no longer tracked (likely aborted). Ignoring.",
+                    req_id,
+                )
+                continue
+            if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+                self.finished_recving_kv_req_ids.add(req_id)
+            elif RequestStatus.is_finished(req.status):
+                self._free_blocks(req)
+            else:
+                logger.warning(
+                    "Finished recving KV transfer for request %s in "
+                    "unexpected status %s; ignoring.",
+                    req_id,
+                    req.status,
+                )
+        for req_id in kv_connector_output.finished_sending or ():
+            logger.debug("Finished sending KV transfer for request %s", req_id)
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.warning(
+                    "Finished sending KV transfer for request %s, but it is "
+                    "no longer tracked (likely aborted). Ignoring.",
+                    req_id,
+                )
+                continue
+            self._free_blocks(req)
+
+    def _update_requests_with_invalid_blocks(
+        self,
+        requests: Iterable[Request],
+        invalid_block_ids: set[int],
+        num_scheduled_tokens: dict[str, int],
+        evict_blocks: bool = True,
+    ) -> tuple[set[str], int, set[int]]:
+        """
+        Identify and update requests affected by invalid KV cache blocks.
+
+        This method scans the given requests, detects those with invalid blocks
+        and adjusts their `num_computed_tokens` to the longest valid prefix.
+        For observability, it also accumulates the total number of tokens that
+        will need to be recomputed across all affected requests.
+
+        Args:
+            requests: The set of requests to scan for invalid blocks.
+            invalid_block_ids: IDs of invalid blocks.
+            num_scheduled_tokens: req_id -> number of scheduled tokens.
+            evict_blocks: Whether to collect blocks for eviction (False for
+                async requests which aren't cached yet).
+
+        Returns:
+            tuple:
+                - affected_req_ids (set[str]): IDs of requests impacted by
+                invalid blocks.
+                - total_affected_tokens (int): Total number of tokens that must
+                be recomputed across all affected requests.
+                - blocks_to_evict (set[int]): Block IDs to evict from cache,
+                including invalid blocks and downstream dependent blocks.
+        """
+        affected_req_ids: set[str] = set()
+        total_affected_tokens = 0
+        blocks_to_evict: set[int] = set()
+        # If a block is invalid and shared by multiple requests in the batch,
+        # these requests must be rescheduled, but only the first will recompute
+        # it. This set tracks blocks already marked for recomputation.
+        marked_invalid_block_ids: set[int] = set()
+        for request in requests:
+            is_affected = False
+            marked_invalid_block = False
+            req_id = request.request_id
+            # TODO (davidb): add support for hybrid memory allocator
+            (req_block_ids,) = self.kv_cache_manager.get_block_ids(req_id)
+            # We iterate only over blocks that may contain externally computed
+            # tokens
+            req_num_computed_tokens = (
+                request.num_computed_tokens - num_scheduled_tokens.get(req_id, 0)
+            )
+
+            req_num_computed_blocks = (
+                req_num_computed_tokens + self.block_size - 1
+            ) // self.block_size
+            for idx, block_id in zip(range(req_num_computed_blocks), req_block_ids):
+                if block_id not in invalid_block_ids:
+                    continue
+
+                is_affected = True
+
+                if block_id in marked_invalid_block_ids:
+                    # This invalid block is shared with a previous request
+                    # and was already marked for recomputation.
+                    # This means this request can still consider this block
+                    # as computed when rescheduled.
+                    # Currently this only applies to sync loading; Async
+                    # loading does not yet support block sharing
+                    continue
+
+                marked_invalid_block_ids.add(block_id)
+
+                if marked_invalid_block:
+                    # This request has already marked an invalid block for
+                    # recomputation and updated its num_computed_tokens.
+                    continue
+
+                marked_invalid_block = True
+                # Truncate the computed tokens at the first failed block
+                request.num_computed_tokens = idx * self.block_size
+                num_affected_tokens = (
+                    req_num_computed_tokens - request.num_computed_tokens
+                )
+                total_affected_tokens += num_affected_tokens
+
+                # collect invalid block and all downstream dependent blocks
+                if evict_blocks:
+                    blocks_to_evict.update(req_block_ids[idx:])
+
+            if is_affected:
+                if not marked_invalid_block:
+                    # All invalid blocks of this request are shared with
+                    # previous requests and will be recomputed by them.
+                    # Revert to considering only cached tokens as computed.
+                    # Currently this only applies to sync loading; Async
+                    # loading does not yet support block sharing
+                    total_affected_tokens += (
+                        request.num_computed_tokens - req_num_computed_tokens
+                    )
+                    request.num_computed_tokens = req_num_computed_tokens
+
+                affected_req_ids.add(request.request_id)
+
+        return affected_req_ids, total_affected_tokens, blocks_to_evict
+
+    def _handle_invalid_blocks(
+        self, invalid_block_ids: set[int], num_scheduled_tokens: dict[str, int]
+    ) -> set[str]:
+        """
+        Handle requests affected by invalid KV cache blocks.
+
+        Returns:
+            Set of affected request IDs to skip in update_from_output main loop.
+        """
+        should_fail = not self.recompute_kv_load_failures
+
+        # handle async KV loads (not cached yet, evict_blocks=False)
+        async_load_reqs = (
+            req
+            for req in self.skipped_waiting
+            if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+        )
+        async_failed_req_ids, num_failed_tokens, _ = (
+            self._update_requests_with_invalid_blocks(
+                async_load_reqs,
+                invalid_block_ids,
+                num_scheduled_tokens,
+                evict_blocks=False,
+            )
+        )
+
+        total_failed_requests = len(async_failed_req_ids)
+        total_failed_tokens = num_failed_tokens
+
+        # handle sync loads (may be cached, collect blocks for eviction)
+        sync_failed_req_ids, num_failed_tokens, sync_blocks_to_evict = (
+            self._update_requests_with_invalid_blocks(
+                self.running, invalid_block_ids, num_scheduled_tokens, evict_blocks=True
+            )
+        )
+
+        total_failed_requests += len(sync_failed_req_ids)
+        total_failed_tokens += num_failed_tokens
+
+        if not total_failed_requests:
+            return set()
+
+        # evict invalid blocks and downstream dependent blocks from cache
+        # only when not using recompute policy (where blocks will be recomputed
+        # and reused by other requests sharing them)
+        if sync_blocks_to_evict and not self.recompute_kv_load_failures:
+            self.kv_cache_manager.evict_blocks(sync_blocks_to_evict)
+
+        if should_fail:
+            all_failed_req_ids = async_failed_req_ids | sync_failed_req_ids
+            logger.error(
+                "Failing %d request(s) due to KV load failure "
+                "(failure_policy=fail, %d tokens affected). Request IDs: %s",
+                total_failed_requests,
+                total_failed_tokens,
+                all_failed_req_ids,
+            )
+            return all_failed_req_ids
+
+        logger.warning(
+            "Recovered from KV load failure: "
+            "%d request(s) rescheduled (%d tokens affected).",
+            total_failed_requests,
+            total_failed_tokens,
+        )
+
+        # Mark async requests with KV load failures for retry once loading completes
+        self.failed_recving_kv_req_ids |= async_failed_req_ids
+        # Return sync affected IDs to skip in update_from_output
+        return sync_failed_req_ids

--- a/tests/fixtures/image_487ecf187_kv_offload_config.py
+++ b/tests/fixtures/image_487ecf187_kv_offload_config.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Normalized configuration consumed by native offloading backends."""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class OffloadingGroupConfig:
+    # Total token span covered by one block across all workers
+    # (accounts for context parallelism).
+    tokens_per_block: int
+    # Layer names belonging to this group.
+    layer_names: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class OffloadingModelConfig:
+    # Model identifier (e.g. HuggingFace model path).
+    name: str
+    # KV cache data type (e.g. "float16").
+    dtype: str
+
+
+@dataclass(frozen=True)
+class OffloadingCacheConfig:
+    # Tokens per block hash.
+    tokens_per_hash: int
+    # Blocks coalesced into one offload chunk.
+    blocks_per_chunk: int
+
+
+@dataclass(frozen=True)
+class OffloadingParallelConfig:
+    # Worker index in [0, world_size). 0 on the scheduler side.
+    rank: int
+    # Total number of workers.
+    world_size: int
+    # Tensor parallel size.
+    tp_size: int
+    # Pipeline parallel size.
+    pp_size: int
+    # Prefill context parallel size.
+    pcp_size: int
+    # Decode context parallel size.
+    dcp_size: int
+    # Data parallel replica index of this engine.
+    data_parallel_index: int
+    # Number of data parallel replicas.
+    data_parallel_size: int
+    # Local rank of the data parallel group, set only in SPMD mode.
+    data_parallel_rank_local: int | None
+    # True when the bytes that will be persisted for a block are portable
+    # across parallelism configurations: for the direct layout, concatenating
+    # the block's data across all workers in rank order yields the same bytes
+    # under any topology; for the canonical layout, the canonical page itself
+    # is topology-free.
+    is_parallelism_agnostic: bool
+
+
+@dataclass(frozen=True)
+class OffloadingConfig:
+    groups: tuple[OffloadingGroupConfig, ...]
+    # KV bytes stored by one worker per block.
+    worker_kv_bytes_per_block: int
+    # Whether the scheduler emits KV cache events. When true,
+    # the offloading backend should emit events as well.
+    enable_kv_cache_events: bool
+    # Offloading-specific configuration from kv_connector_extra_config.
+    extra_config: Mapping[str, Any]
+    # Unique identifier for this engine, distinct per DP rank.
+    engine_id: str
+    model: OffloadingModelConfig
+    cache: OffloadingCacheConfig
+    parallel: OffloadingParallelConfig
+    # True when the offloaded bytes of every worker are expected to be
+    # byte-identical per block (pure-MLA model, single-node TP-only
+    # parallelism), enabling a single-copy host layout in backends that
+    # support it. Aggregate layout decision; per-layer replication metadata
+    # is planned for CanonicalKVCacheRef (#48408).
+    replicated_layout: bool = False
+    # True when the canonical per-layer host byte layout was requested via
+    # kv_connector_extra_config; certified per-layer at worker registration.
+    canonical_layout: bool = False

--- a/tests/fixtures/image_487ecf187_offloading_common.py
+++ b/tests/fixtures/image_487ecf187_offloading_common.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from dataclasses import dataclass, field
+
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorMetadata,
+    KVConnectorWorkerMetadata,
+)
+from vllm.v1.kv_offload.base import LoadStoreSpec
+
+ReqId = str
+
+
+@dataclass(slots=True)
+class DirectionalTransferStats:
+    bytes: int = 0
+    time: float = 0.0
+    sizes: list[int | float] = field(default_factory=list)
+
+    def aggregate(
+        self, other: "DirectionalTransferStats"
+    ) -> "DirectionalTransferStats":
+        return DirectionalTransferStats(
+            bytes=self.bytes + other.bytes,
+            time=self.time + other.time,
+            sizes=[*self.sizes, *other.sizes],
+        )
+
+    def record(self, num_bytes: int, time: float) -> None:
+        self.bytes += num_bytes
+        self.time += time
+        self.sizes.append(num_bytes)
+
+    def is_empty(self) -> bool:
+        return self.bytes == 0 and self.time == 0.0 and not self.sizes
+
+
+@dataclass(slots=True)
+class TransferStats:
+    load: DirectionalTransferStats = field(default_factory=DirectionalTransferStats)
+    store: DirectionalTransferStats = field(default_factory=DirectionalTransferStats)
+
+    def aggregate(self, other: "TransferStats") -> "TransferStats":
+        return TransferStats(
+            load=self.load.aggregate(other.load),
+            store=self.store.aggregate(other.store),
+        )
+
+    def is_empty(self) -> bool:
+        return self.load.is_empty() and self.store.is_empty()
+
+
+@dataclass
+class TransferJob:
+    """A transfer job bundling request context with transfer spec.
+
+    Used for both loads and stores, keyed by scheduler-assigned job ID.
+    The worker reports the job ID back when the transfer finishes,
+    and the scheduler processes the completion.
+    """
+
+    req_id: ReqId
+    src_spec: LoadStoreSpec
+    dst_spec: LoadStoreSpec
+
+
+@dataclass
+class OffloadingConnectorMetadata(KVConnectorMetadata):
+    # Keyed by scheduler-assigned job IDs.
+    load_jobs: dict[int, TransferJob]
+    store_jobs: dict[int, TransferJob]
+    jobs_to_flush: set[int] | None = None
+
+
+@dataclass
+class OffloadingWorkerMetadata(KVConnectorWorkerMetadata):
+    """Worker -> Scheduler metadata for completed transfer jobs.
+
+    Each worker reports {job_id: 1} for newly completed transfer jobs
+    (load or store). aggregate() sums counts across workers within a step.
+    The scheduler accumulates across steps and processes
+    a transfer completion only when count reaches num_workers.
+    """
+
+    completed_jobs: dict[int, int] = field(default_factory=dict)
+    transfer_stats: TransferStats = field(default_factory=TransferStats)
+
+    def mark_completed(self, job_id: int) -> None:
+        """Record a transfer job completion from this worker."""
+        self.completed_jobs[job_id] = 1
+
+    def aggregate(
+        self, other: "KVConnectorWorkerMetadata"
+    ) -> "KVConnectorWorkerMetadata":
+        assert isinstance(other, OffloadingWorkerMetadata)
+
+        merged = dict(self.completed_jobs)
+        for job_id, v in other.completed_jobs.items():
+            merged[job_id] = merged.get(job_id, 0) + v
+
+        return OffloadingWorkerMetadata(
+            completed_jobs=merged,
+            transfer_stats=self.transfer_stats.aggregate(other.transfer_stats),
+        )

--- a/tests/fixtures/image_487ecf187_offloading_config.py
+++ b/tests/fixtures/image_487ecf187_offloading_config.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Translate vLLM KV cache metadata for native offloading backends."""
+
+from typing import TYPE_CHECKING
+
+from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    FullAttentionSpec,
+    MLAAttentionSpec,
+)
+from vllm.v1.kv_offload.config import (
+    OffloadingCacheConfig,
+    OffloadingConfig,
+    OffloadingGroupConfig,
+    OffloadingModelConfig,
+    OffloadingParallelConfig,
+)
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheTensor
+
+
+def is_kv_cache_tensor_packed(kv_cache_tensor: "KVCacheTensor") -> bool:
+    """Return whether a KV cache tensor uses a packed block stride."""
+    return bool(kv_cache_tensor.block_stride)
+
+
+def build_offloading_config(
+    vllm_config: "VllmConfig",
+    kv_cache_config: "KVCacheConfig",
+) -> OffloadingConfig:
+    """Translate vLLM configuration into the native offloading boundary."""
+    kv_transfer_config = vllm_config.kv_transfer_config
+    assert kv_transfer_config is not None
+    extra_config = kv_transfer_config.kv_connector_extra_config
+    assert kv_transfer_config.engine_id is not None
+    engine_id = kv_transfer_config.engine_id
+
+    parallel_config = vllm_config.parallel_config
+    groups = tuple(
+        OffloadingGroupConfig(
+            tokens_per_block=(
+                group.kv_cache_spec.block_size
+                * (
+                    parallel_config.decode_context_parallel_size
+                    if isinstance(group.kv_cache_spec, AttentionSpec)
+                    else 1
+                )
+            ),
+            layer_names=tuple(group.layer_names),
+        )
+        for group in kv_cache_config.kv_cache_groups
+    )
+
+    _, tokens_per_hash = resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)
+    for group in groups:
+        assert group.tokens_per_block % tokens_per_hash == 0, (
+            f"tokens_per_block={group.tokens_per_block} not divisible by "
+            f"tokens_per_hash={tokens_per_hash}. "
+            f"Hybrid models (e.g. Mamba+Attention) need "
+            f"--enable-prefix-caching to align block sizes."
+        )
+
+    blocks_per_chunk = 1
+    blocks_per_chunk_config = extra_config.get("blocks_per_chunk")
+    tokens_per_chunk = extra_config.get("block_size")
+
+    if blocks_per_chunk_config is not None and tokens_per_chunk is not None:
+        raise ValueError(
+            "Specify only one of 'block_size' or 'blocks_per_chunk' "
+            "in kv_connector_extra_config."
+        )
+
+    if blocks_per_chunk_config is not None:
+        blocks_per_chunk = int(blocks_per_chunk_config)
+
+        if blocks_per_chunk <= 0:
+            raise ValueError("'blocks_per_chunk' must be greater than 0.")
+
+    elif tokens_per_chunk is not None:
+        tokens_per_chunk_int = int(tokens_per_chunk)
+
+        unique_tokens_per_block = {group.tokens_per_block for group in groups}
+
+        assert len(unique_tokens_per_block) == 1, (
+            "If 'block_size' is specified in kv_connector_extra_config, "
+            "there must be at least one KV cache group, "
+            "and all groups must have the same block size."
+        )
+
+        tokens_per_block = unique_tokens_per_block.pop()
+        assert tokens_per_chunk_int % tokens_per_block == 0
+        blocks_per_chunk = tokens_per_chunk_int // tokens_per_block
+
+    worker_kv_bytes_per_block = 0
+    if kv_cache_config.num_blocks > 0:
+        packed_tensors = tuple(
+            is_kv_cache_tensor_packed(tensor)
+            for tensor in kv_cache_config.kv_cache_tensors
+        )
+        is_packed = any(packed_tensors)
+        assert not is_packed or all(packed_tensors)
+        total_gpu_kv_bytes = (
+            kv_cache_config.kv_cache_tensors[0].size
+            if is_packed
+            else sum(tensor.size for tensor in kv_cache_config.kv_cache_tensors)
+        )
+        worker_kv_bytes_per_block = total_gpu_kv_bytes // kv_cache_config.num_blocks
+
+    single_group_spec = (
+        kv_cache_config.kv_cache_groups[0].kv_cache_spec
+        if len(kv_cache_config.kv_cache_groups) == 1
+        else None
+    )
+    replicated_layout = (
+        vllm_config.model_config.use_mla
+        # Exact type: fail closed on wrappers and sliding-window variants.
+        and type(single_group_spec) is MLAAttentionSpec
+        # Page accounting: one MLA page per layer, no packed/mixed rows.
+        and worker_kv_bytes_per_block > 0
+        and worker_kv_bytes_per_block
+        == single_group_spec.page_size_bytes
+        * len(kv_cache_config.kv_cache_groups[0].layer_names)
+        # Safe MVP boundary: TP-only, no other parallel axes.
+        and parallel_config.tensor_parallel_size > 1
+        and parallel_config.pipeline_parallel_size == 1
+        and parallel_config.prefill_context_parallel_size == 1
+        and parallel_config.decode_context_parallel_size == 1
+        and parallel_config.world_size == parallel_config.tensor_parallel_size
+        # Shared /dev/shm mmap layout is single-node mp only.
+        and parallel_config.distributed_executor_backend == "mp"
+        and parallel_config.nnodes_within_dp == 1
+    )
+
+    canonical_layout = bool(extra_config.get("canonical_layout", False))
+
+    # Only a single non-MLA full-attention group with genuinely head-sharded
+    # pages is parallelism-invariant: replicated latent or GQA heads,
+    # per-token-head scales, CP token sharding, and the V2 model runner's
+    # layout are all excluded.
+    is_parallelism_agnostic = (
+        not vllm_config.use_v2_model_runner
+        and single_group_spec is not None
+        and isinstance(single_group_spec, FullAttentionSpec)
+        and not isinstance(single_group_spec, MLAAttentionSpec)
+        and single_group_spec.num_kv_heads * parallel_config.tensor_parallel_size
+        == vllm_config.model_config.get_total_num_kv_heads()
+        and not single_group_spec.kv_quant_mode.is_per_token_head
+        and parallel_config.decode_context_parallel_size == 1
+        and parallel_config.prefill_context_parallel_size == 1
+    )
+    # Canonical pages are topology-free by construction, so the canonical
+    # layout widens the gate to every config whose mappings derive portable:
+    # exactly-sharded or replicated GQA heads (writer rotation) and the
+    # TP-replicated MLA latent (one canonical copy for all replicas). The
+    # model-runner version is irrelevant here — certification happens per
+    # layer against live tensor strides at registration, and create_worker
+    # fails closed against this flag if any layer cannot be certified.
+    if canonical_layout and not is_parallelism_agnostic:
+        tp_size = parallel_config.tensor_parallel_size
+        if isinstance(single_group_spec, FullAttentionSpec):
+            if type(single_group_spec) is MLAAttentionSpec:
+                spec_certifiable = (
+                    single_group_spec.compress_ratio == 1
+                    and single_group_spec.real_page_size_bytes
+                    % single_group_spec.block_size
+                    == 0
+                )
+            else:
+                total_kv_heads = vllm_config.model_config.get_total_num_kv_heads()
+                spec_certifiable = (
+                    total_kv_heads % tp_size == 0 or tp_size % total_kv_heads == 0
+                )
+            is_parallelism_agnostic = (
+                spec_certifiable
+                and not single_group_spec.kv_quant_mode.is_per_token_head
+                and parallel_config.decode_context_parallel_size == 1
+                and parallel_config.prefill_context_parallel_size == 1
+                and parallel_config.world_size == tp_size
+            )
+
+    kv_events_config = vllm_config.kv_events_config
+    cache_dtype = (
+        vllm_config.model_config.dtype
+        if vllm_config.cache_config.cache_dtype == "auto"
+        else vllm_config.cache_config.cache_dtype
+    )
+
+    return OffloadingConfig(
+        groups=groups,
+        worker_kv_bytes_per_block=worker_kv_bytes_per_block,
+        enable_kv_cache_events=(
+            kv_events_config is not None and kv_events_config.enable_kv_cache_events
+        ),
+        extra_config=extra_config,
+        engine_id=engine_id,
+        model=OffloadingModelConfig(
+            name=vllm_config.model_config.model,
+            dtype=str(cache_dtype).removeprefix("torch."),
+        ),
+        cache=OffloadingCacheConfig(
+            tokens_per_hash=tokens_per_hash,
+            blocks_per_chunk=blocks_per_chunk,
+        ),
+        parallel=OffloadingParallelConfig(
+            rank=parallel_config.rank,
+            world_size=parallel_config.world_size,
+            tp_size=parallel_config.tensor_parallel_size,
+            pp_size=parallel_config.pipeline_parallel_size,
+            pcp_size=parallel_config.prefill_context_parallel_size,
+            dcp_size=parallel_config.decode_context_parallel_size,
+            data_parallel_index=parallel_config.data_parallel_index,
+            data_parallel_size=parallel_config.data_parallel_size,
+            data_parallel_rank_local=parallel_config.data_parallel_rank_local,
+            is_parallelism_agnostic=is_parallelism_agnostic,
+        ),
+        replicated_layout=replicated_layout,
+        canonical_layout=canonical_layout,
+    )

--- a/tests/fixtures/image_487ecf187_offloading_connector.py
+++ b/tests/fixtures/image_487ecf187_offloading_connector.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_events import KVCacheEvent
+from vllm.distributed.kv_transfer.kv_connector.v1 import (
+    KVConnectorBase_V1,
+    KVConnectorRole,
+    SupportsHMA,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+    KVConnectorPromMetrics,
+    KVConnectorStats,
+    PromMetric,
+    PromMetricT,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
+    OffloadingConnectorMetadata,
+    OffloadingWorkerMetadata,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.config import (
+    build_offloading_config,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
+    OffloadingConnectorStats,
+    OffloadPromMetrics,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
+    OffloadingConnectorScheduler,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.worker import (
+    OffloadingConnectorWorker,
+)
+from vllm.forward_context import ForwardContext
+from vllm.v1.attention.backend import AttentionBackend, AttentionMetadata
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.kv_offload.factory import OffloadingSpecFactory
+from vllm.v1.outputs import KVConnectorOutput
+from vllm.v1.request import Request
+
+
+class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
+    @property
+    def prefer_cross_layer_blocks(self) -> bool:
+        # Cross-layer slabs have no per-layer refs to certify canonical mappings
+        return not self._canonical_layout
+
+    @property
+    def requires_kv_delivery(self) -> bool:
+        # Runs as kv_both, but is a best-effort cache: a dropped save is just a
+        # future cache miss, so opt out of the producer-role default.
+        return False
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        role: KVConnectorRole,
+        kv_cache_config: KVCacheConfig,
+    ):
+        super().__init__(vllm_config, role, kv_cache_config)
+
+        offloading_config = build_offloading_config(vllm_config, kv_cache_config)
+        self._canonical_layout = offloading_config.canonical_layout
+        spec = OffloadingSpecFactory.create_spec(offloading_config)
+
+        self.connector_scheduler: OffloadingConnectorScheduler | None = None
+        self.connector_worker: OffloadingConnectorWorker | None = None
+        if role == KVConnectorRole.SCHEDULER:
+            self.connector_scheduler = OffloadingConnectorScheduler(
+                spec, vllm_config, kv_cache_config
+            )
+        elif role == KVConnectorRole.WORKER:
+            self.connector_worker = OffloadingConnectorWorker(
+                spec, vllm_config, kv_cache_config
+            )
+
+    def shutdown(self) -> None:
+        if self.connector_worker is not None:
+            self.connector_worker.shutdown()
+        if self.connector_scheduler is not None:
+            self.connector_scheduler.shutdown()
+
+    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
+        assert self.connector_worker is not None
+        self.connector_worker.register_kv_caches(kv_caches)
+
+    def register_cross_layers_kv_cache(
+        self, kv_cache: torch.Tensor, attn_backend: type[AttentionBackend]
+    ):
+        assert self.connector_worker is not None
+        self.connector_worker.register_cross_layers_kv_cache(kv_cache, attn_backend)
+
+    def handle_preemptions(self, kv_connector_metadata: KVConnectorMetadata):
+        assert self.connector_worker is not None
+        assert isinstance(kv_connector_metadata, OffloadingConnectorMetadata)
+        self.connector_worker.handle_preemptions(kv_connector_metadata)
+
+    def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
+        assert self.connector_worker is not None
+        assert isinstance(self._connector_metadata, OffloadingConnectorMetadata)
+        self.connector_worker.start_kv_transfers(self._connector_metadata)
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        pass
+
+    def save_kv_layer(
+        self,
+        layer_name: str,
+        kv_layer: torch.Tensor,
+        attn_metadata: "AttentionMetadata",
+        **kwargs,
+    ) -> None:
+        pass
+
+    def wait_for_save(self):
+        # Store deferral is handled in get_finished(), which always runs even
+        # when wait_for_save() is skipped (e.g. kv_connector_no_forward).
+        pass
+
+    def get_finished(self, finished_req_ids: set[str]) -> tuple[set[str], set[str]]:
+        assert self.connector_worker is not None
+        assert isinstance(self._connector_metadata, OffloadingConnectorMetadata)
+
+        # Defer store jobs to the next step's start_kv_transfers. Done here
+        # (rather than wait_for_save) so stores are queued even on steps where
+        # wait_for_save is skipped.
+        self.connector_worker.prepare_store_kv(self._connector_metadata)
+
+        return self.connector_worker.get_finished(finished_req_ids)
+
+    def build_connector_worker_meta(self) -> OffloadingWorkerMetadata | None:
+        if self.connector_worker is not None:
+            return self.connector_worker.build_connector_worker_meta()
+        return None
+
+    def on_new_request(self, request: "Request") -> None:
+        assert self.connector_scheduler is not None
+        self.connector_scheduler.on_new_request(request)
+
+    def get_num_new_matched_tokens(
+        self, request: "Request", num_computed_tokens: int
+    ) -> tuple[int | None, bool]:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.get_num_new_matched_tokens(
+            request, num_computed_tokens
+        )
+
+    def update_state_after_alloc(
+        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+    ):
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.update_state_after_alloc(
+            request, blocks, num_external_tokens
+        )
+
+    def build_connector_meta(
+        self, scheduler_output: SchedulerOutput
+    ) -> KVConnectorMetadata:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.build_connector_meta(scheduler_output)
+
+    def has_pending_push_work(self) -> bool:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.has_pending_push_work()
+
+    def update_connector_output(self, connector_output: KVConnectorOutput):
+        assert self.connector_scheduler is not None
+        self.connector_scheduler.update_connector_output(connector_output)
+
+    def request_finished(
+        self,
+        request: "Request",
+        block_ids: list[int],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.request_finished(request)
+
+    def request_finished_all_groups(
+        self,
+        request: "Request",
+        block_ids: tuple[list[int], ...],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.request_finished(request)
+
+    def take_events(self) -> Iterable[KVCacheEvent]:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.take_events()
+
+    @classmethod
+    def get_required_kvcache_layout(cls, vllm_config: VllmConfig) -> str | None:
+        return "HND"
+
+    def reset_cache(self) -> bool | None:
+        assert self.connector_scheduler is not None
+        self.connector_scheduler.reset_cache()
+        return True
+
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
+        if self.connector_scheduler is not None:
+            return self.connector_scheduler.get_stats()
+        return None
+
+    @classmethod
+    def build_kv_connector_stats(
+        cls, data: dict[str, Any] | None = None
+    ) -> KVConnectorStats | None:
+        return (
+            OffloadingConnectorStats(data=data)
+            if data is not None
+            else OffloadingConnectorStats()
+        )
+
+    @classmethod
+    def build_prom_metrics(
+        cls,
+        vllm_config: VllmConfig,
+        metric_types: dict[type[PromMetric], type[PromMetricT]],
+        labelnames: list[str],
+        per_engine_labelvalues: dict[int, list[object]],
+    ) -> KVConnectorPromMetrics:
+        return OffloadPromMetrics(
+            vllm_config, metric_types, labelnames, per_engine_labelvalues
+        )

--- a/tests/fixtures/image_487ecf187_offloading_scheduler.py
+++ b/tests/fixtures/image_487ecf187_offloading_scheduler.py
@@ -1,0 +1,1698 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import time
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from itertools import chain, islice
+from typing import Any, NamedTuple
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_events import KVCacheEvent
+from vllm.distributed.kv_transfer.kv_connector.utils import yield_req_data
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
+    OffloadingConnectorMetadata,
+    OffloadingWorkerMetadata,
+    ReqId,
+    TransferJob,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.events import (
+    OffloadingEventGroupSpec,
+    OffloadingEventsTracker,
+    get_offloading_event_group_spec,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
+    OffloadingConnectorStats,
+    _ConnectorMetricName,
+    _TransferMetricName,
+)
+from vllm.logger import init_logger
+from vllm.utils.math_utils import cdiv, round_down
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheSpec,
+    MambaSpec,
+    SlidingWindowSpec,
+)
+from vllm.v1.kv_offload.base import (
+    GPULoadStoreSpec,
+    Locality,
+    LookupResult,
+    Medium,
+    OffloadingManager,
+    OffloadingSpec,
+    OffloadKey,
+    OffloadPolicy,
+    ReqContext,
+    RequestOffloadingContext,
+    ScheduleEndContext,
+    TierFilter,
+    TierMatcher,
+    make_offload_key,
+)
+from vllm.v1.outputs import KVConnectorOutput
+from vllm.v1.request import Request, RequestStatus
+
+logger = init_logger(__name__)
+
+KV_LOAD_TIERS_KEY = "kv_load_tiers"
+MATCHER_MEDIUM_KEY = "medium"
+MATCHER_LOCALITY_KEY = "locality"
+
+
+@dataclass(slots=True)
+class TransferJobStatus:
+    """Tracks scheduler-side state for a single transfer job."""
+
+    req_id: ReqId
+    # Number of workers still pending. Starts at num_workers,
+    # decremented as each worker reports completion. Job is done at 0.
+    pending_count: int
+    # Offload keys this job covers; passed to manager.complete_*().
+    keys: set[OffloadKey]
+    is_store: bool
+    # Store source blocks fenced after the request finishes.
+    deferred_fence_block_ids: list[int] | None = None
+    # Store source blocks fenced when the transfer is created.
+    fenced_block_ids: list[int] | None = None
+
+
+class GroupOffloadConfig(NamedTuple):
+    group_idx: int
+    tokens_per_block: int
+    tokens_per_chunk: int
+    hashes_per_chunk: int
+    # KV cache spec metadata propagated onto emitted BlockStored events so
+    # KV-aware consumers can classify and filter the group.
+    kv_event_group_spec: OffloadingEventGroupSpec
+    # None below means full attention
+    sliding_window_size_in_chunks: int | None
+    # Partial-tail data for this group comes from the scheduler's CoW hand-off
+    # rather than the request block table.
+    requires_cow_source: bool = False
+    # Number of this group's offloaded chunks per full-attention alignment
+    # segment. Used to skip storing SWA chunks that can never serve a load
+    # hit (e.g. DeepSeek V4 where SWA groups have much smaller block sizes
+    # than the MLA full-attention group).
+    # None for full-attention groups or when the optimization doesn't apply.
+    alignment_chunk_count: int | None = None
+    # True for EAGLE/MTP draft-model attention groups. The trailing chunk
+    # of these groups is volatile and lacks a stable hash, so it must
+    # be excluded from store and load scheduling.
+    is_eagle_group: bool = False
+
+
+def get_sliding_window_size_in_chunks(
+    kv_cache_spec: KVCacheSpec, tokens_per_chunk: int
+) -> int | None:
+    if isinstance(kv_cache_spec, SlidingWindowSpec):
+        assert kv_cache_spec.sliding_window > 0
+        return cdiv(kv_cache_spec.sliding_window, tokens_per_chunk)
+
+    if isinstance(kv_cache_spec, ChunkedLocalAttentionSpec):
+        # Attention never reaches back past one chunk
+        assert kv_cache_spec.attention_chunk_size > 0
+        return cdiv(kv_cache_spec.attention_chunk_size, tokens_per_chunk)
+
+    if isinstance(kv_cache_spec, MambaSpec):
+        # Mamba depends on a single state
+        return 1
+
+    assert isinstance(kv_cache_spec, FullAttentionSpec)
+    return None
+
+
+def is_store_reachable_swa_chunk(
+    absolute_chunk_index: int,
+    storable_chunk_count: int,
+    alignment_chunk_count: int | None,
+    sliding_window_chunks: int | None,
+    is_eagle_group: bool,
+) -> bool:
+    """Return whether an SWA chunk can participate in an external-cache hit."""
+    if alignment_chunk_count is None:
+        return True
+    assert sliding_window_chunks is not None
+    position_in_segment = absolute_chunk_index % alignment_chunk_count
+    segment_start = absolute_chunk_index - position_in_segment
+    actual_segment_length = min(
+        alignment_chunk_count, storable_chunk_count - segment_start
+    )
+    reachable_tail = sliding_window_chunks + int(is_eagle_group)
+    return position_in_segment >= actual_segment_length - reachable_tail
+
+
+def resolve_mamba_align_size(
+    spec: "OffloadingSpec", kv_cache_config: KVCacheConfig
+) -> int | None:
+    """Scan all KV cache groups in *spec* and return the single mamba alignment
+    size, or None if no group requires mamba alignment.
+
+    For MambaSpec groups in "align" or "all" cache mode the hit window must be
+    rounded down to a multiple of the offloaded chunk size. Asserts that all
+    such groups agree on the same value.
+    """
+    mamba_align_size: int | None = None
+    for idx, tokens_per_block in enumerate(spec.tokens_per_block):
+        kv_spec = kv_cache_config.kv_cache_groups[idx].kv_cache_spec
+        if isinstance(kv_spec, MambaSpec) and kv_spec.mamba_cache_mode in (
+            "align",
+            "all",
+        ):
+            tokens_per_chunk = tokens_per_block * spec.blocks_per_chunk
+            assert mamba_align_size is None or mamba_align_size == tokens_per_chunk
+            mamba_align_size = tokens_per_chunk
+    return mamba_align_size
+
+
+class SchedulerOffloadConfig(NamedTuple):
+    kv_group_configs: tuple[GroupOffloadConfig, ...]
+    blocks_per_chunk: int
+    tokens_per_hash: int
+    num_workers: int
+    offload_prompt_only: bool
+    supports_partial_tail: bool
+
+    @classmethod
+    def from_spec(
+        cls,
+        spec: OffloadingSpec,
+        vllm_config: VllmConfig,
+        kv_cache_config: KVCacheConfig,
+    ) -> "SchedulerOffloadConfig":
+        # Determine the alignment token count from the full-attention group(s).
+        # This is the tokens_per_chunk of the full-attention group; load
+        # hits are always aligned to this boundary, so SWA blocks earlier in
+        # each segment can never serve a load hit. Relevant for hybrid
+        # architectures like DeepSeek V4 (MLA + SWA groups).
+        full_attn_tokens_per_chunk: set[int] = set()
+        for idx, tokens_per_block in enumerate(spec.tokens_per_block):
+            kv_spec = kv_cache_config.kv_cache_groups[idx].kv_cache_spec
+            sw = get_sliding_window_size_in_chunks(
+                kv_spec, tokens_per_block * spec.blocks_per_chunk
+            )
+            if sw is None:
+                full_attn_tokens_per_chunk.add(tokens_per_block * spec.blocks_per_chunk)
+
+        # Only apply the optimization if there's a single consistent
+        # full-attention alignment size.
+        alignment_tokens: int | None = None
+        if len(full_attn_tokens_per_chunk) == 1:
+            alignment_tokens = full_attn_tokens_per_chunk.pop()
+
+        def _alignment_chunk_count(
+            tokens_per_chunk: int,
+            sliding_window_size_in_chunks: int | None,
+        ) -> int | None:
+            if alignment_tokens is None or sliding_window_size_in_chunks is None:
+                return None
+            if alignment_tokens <= tokens_per_chunk:
+                return None
+            per_segment = alignment_tokens // tokens_per_chunk
+            if sliding_window_size_in_chunks >= per_segment:
+                return None
+            return per_segment
+
+        eagle_groups = {
+            idx
+            for idx, g in enumerate(kv_cache_config.kv_cache_groups)
+            if g.is_eagle_group
+        }
+
+        use_eagle = (
+            vllm_config.speculative_config is not None
+            and vllm_config.speculative_config.use_eagle()
+        )
+        if use_eagle and not eagle_groups:
+            eagle_groups = set(range(len(kv_cache_config.kv_cache_groups)))
+
+        if eagle_groups:
+            logger.info(
+                "KV offloading: EAGLE/MTP draft attention groups %s "
+                "detected. The trailing chunk of these groups will be "
+                "excluded from offloading due to volatility.",
+                sorted(eagle_groups),
+            )
+
+        kv_group_configs_list: list[GroupOffloadConfig] = []
+        for idx, tokens_per_block in enumerate(spec.tokens_per_block):
+            kv_cache_group = kv_cache_config.kv_cache_groups[idx]
+            kv_spec = kv_cache_group.kv_cache_spec
+            sw = get_sliding_window_size_in_chunks(
+                kv_spec, tokens_per_block * spec.blocks_per_chunk
+            )
+            kv_group_configs_list.append(
+                GroupOffloadConfig(
+                    group_idx=idx,
+                    tokens_per_block=tokens_per_block,
+                    tokens_per_chunk=tokens_per_block * spec.blocks_per_chunk,
+                    hashes_per_chunk=(
+                        (tokens_per_block * spec.blocks_per_chunk)
+                        // spec.tokens_per_hash
+                    ),
+                    sliding_window_size_in_chunks=sw,
+                    alignment_chunk_count=_alignment_chunk_count(
+                        tokens_per_block * spec.blocks_per_chunk, sw
+                    ),
+                    kv_event_group_spec=get_offloading_event_group_spec(kv_cache_group),
+                    is_eagle_group=idx in eagle_groups,
+                    requires_cow_source=(
+                        isinstance(kv_spec, MambaSpec)
+                        and kv_spec.mamba_cache_mode == "align"
+                    ),
+                )
+            )
+        kv_group_configs = tuple(kv_group_configs_list)
+        group_block_sizes = {config.tokens_per_block for config in kv_group_configs}
+        has_partial_recurrent_group = any(
+            config.requires_cow_source
+            and config.tokens_per_block > spec.tokens_per_hash
+            for config in kv_group_configs
+        )
+        # Partial tails currently require one physical block per offload chunk
+        # and uniform, non-windowed groups so one boundary identifies every
+        # group's source. EAGLE and DCP need additional hand-off semantics.
+        supports_partial_tail = (
+            spec.blocks_per_chunk == 1
+            and len(group_block_sizes) == 1
+            and has_partial_recurrent_group
+            and all(
+                config.sliding_window_size_in_chunks is None
+                or config.requires_cow_source
+                for config in kv_group_configs
+            )
+            and not any(config.is_eagle_group for config in kv_group_configs)
+            and vllm_config.parallel_config.decode_context_parallel_size == 1
+        )
+
+        return cls(
+            num_workers=vllm_config.parallel_config.world_size,
+            kv_group_configs=kv_group_configs,
+            blocks_per_chunk=spec.blocks_per_chunk,
+            tokens_per_hash=spec.tokens_per_hash,
+            offload_prompt_only=spec.offload_prompt_only,
+            supports_partial_tail=supports_partial_tail,
+        )
+
+
+@dataclass
+class RequestGroupState:
+    offload_keys: list[OffloadKey] = field(default_factory=list)
+    block_ids: list[int] = field(default_factory=list)
+    # Index of the next chunk to offload.
+    next_stored_chunk_idx: int = 0
+    # Number of offloaded chunks hit (including GPU prefix cache)
+    # when the request first started
+    num_hit_chunks: int = 0
+
+
+@dataclass(slots=True)
+class RequestOffloadState:
+    config: SchedulerOffloadConfig
+    req: Request
+    req_context: ReqContext
+    offloading_context: RequestOffloadingContext
+    group_states: tuple[RequestGroupState, ...] = field(init=False)
+    # upper bound on tokens to offload for this request; None means no cap
+    max_offload_tokens: int | None = None
+    # number of hits in the GPU cache
+    num_locally_computed_tokens: int = 0
+    # In-flight job IDs. Per the connector's invariant, at any given time
+    # this contains either a single load job, or one or more store jobs.
+    transfer_jobs: set[int] = field(default_factory=set)
+    # time.monotonic() of this request's first deferred offload lookup;
+    # None once consumed (observed) or while no lookup is pending.
+    deferred_lookup_start_time: float | None = None
+    # Fine-grained token boundary selected beyond the last complete offload
+    # chunk. It is consumed when the corresponding load is scheduled.
+    partial_tail_boundary: int | None = None
+    # True once on_request_finished has been signaled to the manager.
+    finished_signaled: bool = False
+
+    def __post_init__(self) -> None:
+        self.group_states = tuple(
+            RequestGroupState() for _ in self.config.kv_group_configs
+        )
+        params = self.req.kv_transfer_params
+
+        # NOTE: This field is experimental and subject to change in the future.
+        raw = params.get("max_offload_tokens") if params else None
+        if type(raw) is int and raw >= 0:
+            self.max_offload_tokens = raw
+            logger.debug(
+                "Request %s: max_offload_tokens set to %d",
+                self.req.request_id,
+                raw,
+            )
+        elif raw is not None:
+            logger.warning(
+                "max_offload_tokens must be a non-negative int, got %r; ignoring", raw
+            )
+
+    def update_offload_keys(self) -> None:
+        for group_config, group_state in zip(
+            self.config.kv_group_configs, self.group_states
+        ):
+            for req_block_hash in islice(
+                self.req.block_hashes,
+                group_config.hashes_per_chunk * len(group_state.offload_keys)
+                + group_config.hashes_per_chunk
+                - 1,
+                None,
+                group_config.hashes_per_chunk,
+            ):
+                group_state.offload_keys.append(
+                    make_offload_key(req_block_hash, group_config.group_idx)
+                )
+
+    def update_block_id_groups(
+        self, new_block_id_groups: tuple[list[int], ...] | None
+    ) -> None:
+        if new_block_id_groups is None:
+            return
+
+        assert len(new_block_id_groups) == len(self.group_states)
+        for group_state, new_blocks in zip(self.group_states, new_block_id_groups):
+            group_state.block_ids.extend(new_blocks)
+
+    def storable_chunks(
+        self,
+        group_config: "GroupOffloadConfig",
+        group_state: RequestGroupState,
+        num_offloadable_tokens: int,
+    ) -> int:
+        """Number of allocated leading offloaded chunks eligible for store.
+
+        For eagle/MTP groups the volatile trailing chunk of the offloadable
+        range is excluded while decoding: the draft-layer KV of the last
+        accepted position may be rewritten after spec-token rejection. During
+        prefill the trailing chunk is stable (the draft input for a chunk's
+        last position is the next prompt token), so it is stored immediately.
+        The exclusion must be applied consistently everywhere
+        ``next_stored_chunk_idx`` is derived: otherwise the trailing chunk of
+        each step is skipped on collection but jumped over by
+        ``next_stored_chunk_idx``, so it is never re-considered and a
+        permanent hole breaks prefix-reuse lookup.
+        """
+        num_chunks = num_offloadable_tokens // group_config.tokens_per_chunk
+        is_decoding = num_offloadable_tokens > self.req.num_prompt_tokens
+        if group_config.is_eagle_group and is_decoding:
+            num_chunks = max(0, num_chunks - 1)
+        num_allocated_chunks = (
+            len(group_state.block_ids) // self.config.blocks_per_chunk
+        )
+        return min(num_chunks, num_allocated_chunks)
+
+    def advance_stored_idx(self, num_offloadable_tokens: int) -> None:
+        # max(): at the prefill->decode transition of a chunk-aligned prompt,
+        # storable_chunks drops by one (the eagle exclusion kicks in), and the
+        # index must not move backwards past already-stored chunks.
+        for group_config, group_state in zip(
+            self.config.kv_group_configs, self.group_states
+        ):
+            group_state.next_stored_chunk_idx = max(
+                group_state.next_stored_chunk_idx,
+                self.storable_chunks(group_config, group_state, num_offloadable_tokens),
+            )
+
+    def update_num_hit_chunks(self, num_cached_tokens: int) -> None:
+        for group_config, group_state in zip(
+            self.config.kv_group_configs, self.group_states
+        ):
+            group_state.num_hit_chunks = (
+                num_cached_tokens // group_config.tokens_per_chunk
+            )
+
+
+def _parse_tier_filter(raw: Any) -> TierFilter:
+    """Parse raw kv_transfer_params tier matchers into a TierFilter."""
+    if not isinstance(raw, list):
+        logger.warning(
+            "_parse_tier_filter: expected list, got %s; ignoring",
+            type(raw).__name__,
+        )
+        return TierFilter.ALL
+    matchers: list[TierMatcher] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            logger.warning("_parse_tier_filter: entry is not a dict; skipping")
+            continue
+        medium: Medium | None = None
+        locality: Locality | None = None
+        raw_medium = entry.get(MATCHER_MEDIUM_KEY)
+        if raw_medium is not None:
+            try:
+                medium = Medium(raw_medium.upper())
+            except (ValueError, AttributeError):
+                logger.warning(
+                    "_parse_tier_filter: unknown medium %r; skipping entry",
+                    raw_medium,
+                )
+                continue
+        raw_locality = entry.get(MATCHER_LOCALITY_KEY)
+        if raw_locality is not None:
+            try:
+                locality = Locality(raw_locality.upper())
+            except (ValueError, AttributeError):
+                logger.warning(
+                    "_parse_tier_filter: unknown locality %r; skipping entry",
+                    raw_locality,
+                )
+                continue
+        matchers.append(TierMatcher(medium=medium, locality=locality))
+    if not matchers:
+        if not raw:  # input was [] — user explicitly wants nothing
+            return TierFilter(matchers=())
+        # all entries were invalid — fall back to ALL
+        return TierFilter.ALL
+    return TierFilter(matchers=tuple(matchers))
+
+
+def _create_req_context(req: Request) -> ReqContext:
+    params = req.kv_transfer_params
+    load_filter = TierFilter.ALL
+    if params:
+        raw = params.get(KV_LOAD_TIERS_KEY)
+        if raw is not None:
+            load_filter = _parse_tier_filter(raw)
+    return ReqContext(
+        req_id=req.request_id,
+        kv_transfer_params=params,
+        load_tier_filter=load_filter,
+    )
+
+
+class OffloadingConnectorScheduler:
+    """Implementation of Scheduler side methods"""
+
+    def __init__(
+        self,
+        spec: OffloadingSpec,
+        vllm_config: VllmConfig,
+        kv_cache_config: KVCacheConfig,
+    ):
+        self.config = SchedulerOffloadConfig.from_spec(
+            spec, vllm_config, kv_cache_config
+        )
+        self.manager: OffloadingManager = spec.get_manager()
+        self._connector_stats = OffloadingConnectorStats()
+
+        full_attention_groups: list[int] = []
+        sliding_window_groups: list[int] = []
+        for group_config in self.config.kv_group_configs:
+            if group_config.sliding_window_size_in_chunks is None:
+                full_attention_groups.append(group_config.group_idx)
+            else:
+                sliding_window_groups.append(group_config.group_idx)
+
+        # sort sliding window groups by window size in decreasing order
+        def _sliding_window_sort_key(i: int) -> int:
+            val = self.config.kv_group_configs[i].sliding_window_size_in_chunks
+            assert val is not None
+            return val
+
+        sliding_window_groups.sort(key=_sliding_window_sort_key, reverse=True)
+
+        # used by _lookup
+        self._sliding_window_groups: tuple[int, ...] = tuple(sliding_window_groups)
+        self._lookup_groups = tuple(full_attention_groups) + self._sliding_window_groups
+        self._mamba_align_size: int | None = resolve_mamba_align_size(
+            spec, kv_cache_config
+        )
+        self._partial_tail_block_size = (
+            self.config.kv_group_configs[0].tokens_per_block
+            if self.config.supports_partial_tail
+            else 0
+        )
+        self._cow_source_groups = frozenset(
+            config.group_idx
+            for config in self.config.kv_group_configs
+            if config.requires_cow_source
+        )
+
+        self._req_status: dict[ReqId, RequestOffloadState] = {}
+        self._current_batch_load_jobs: dict[int, TransferJob] = {}
+        self._current_batch_jobs_to_flush: set[int] = set()
+        # GPU block IDs allocated in the current engine step
+        self._current_batch_allocated_block_ids: set[int] = set()
+        # if GPU prefix caching is enabled,
+        # Track loaded chunks to avoid redundant loads.
+        self._chunks_being_loaded: set[OffloadKey] | None = (
+            set() if vllm_config.cache_config.enable_prefix_caching else None
+        )
+
+        # Job ID counter shared by loads and stores.
+        self._job_counter: int = 0
+        # Threshold value for stale jobs. All job ids >= _stale_job_threshold are
+        # active jobs.
+        self._stale_job_threshold: int = 0
+        self._jobs: dict[int, TransferJobStatus] = {}
+
+        # block_id -> pending store job_ids. Used to track jobs that needs
+        # flushing in case a block is re-allocated by the KV cache manager.
+        # Populated only for finished requests (running-request blocks are
+        # protected by their ref_cnt) and for sliding window blocks (which can
+        # be freed before a request finishes).
+        self._block_id_to_pending_jobs: dict[int, set[int]] = {}
+
+        self._events_tracker = OffloadingEventsTracker(spec.kv_events_config)
+
+    def _maybe_observe_lookup_async_delay(
+        self, req_status: RequestOffloadState
+    ) -> None:
+        start_time = req_status.deferred_lookup_start_time
+        if start_time is None:
+            return
+        req_status.deferred_lookup_start_time = None
+        self._connector_stats.observe_histogram(
+            _ConnectorMetricName.LOOKUP_ASYNC_DELAY,
+            time.monotonic() - start_time,
+        )
+
+    def _generate_job_id(self) -> int:
+        job_id = self._job_counter
+        self._job_counter += 1
+        return job_id
+
+    def _remove_pending_job(self, job_id: int, block_ids: list[int] | None) -> None:
+        for bid in block_ids or ():
+            pending = self._block_id_to_pending_jobs[bid]
+            pending.remove(job_id)
+            if not pending:
+                del self._block_id_to_pending_jobs[bid]
+
+    def _calc_num_offloadable_tokens(
+        self, req_status: RequestOffloadState, num_computed_tokens: int
+    ) -> int:
+        num = min(num_computed_tokens, req_status.req.num_tokens)
+        max_offload_tokens = req_status.max_offload_tokens
+        if max_offload_tokens is not None:
+            num = min(num, max_offload_tokens)
+        if self.config.offload_prompt_only:
+            num = min(num, req_status.req.num_prompt_tokens)
+        return num
+
+    def _maximal_prefix_lookup(
+        self,
+        keys: Iterable[OffloadKey],
+        req_context: ReqContext,
+        req: Request,
+        group_config: GroupOffloadConfig,
+        start_chunk_idx: int,
+    ) -> int | None:
+        """Return the number of consecutive offloaded chunks from the start,
+        or None if the backend deferred a lookup."""
+        hit_count = 0
+        defer_lookup = False
+        for local_idx, key in enumerate(keys):
+            result = self.manager.lookup(key, req_context)
+            match result:
+                case LookupResult.HIT:
+                    self._events_tracker.record_lookup(
+                        req,
+                        group_config,
+                        start_chunk_idx + local_idx,
+                        key,
+                    )
+                    hit_count += 1
+                case LookupResult.HIT_PENDING:
+                    defer_lookup = True
+                    hit_count += 1
+                case LookupResult.RETRY:
+                    # Don't break: keep scanning to let manager kick off
+                    # async lookups (until a miss is detected).
+                    defer_lookup = True
+                case LookupResult.MISS:
+                    break
+        return hit_count if not defer_lookup else None
+
+    def _sliding_window_lookup(
+        self,
+        keys: Sequence[OffloadKey],
+        sliding_window_size: int,
+        req_context: ReqContext,
+    ) -> int | None:
+        """Return the end index (in `keys`) of the last run of
+        `sliding_window_size` consecutive hits, scanning from the end.
+        Returns 0 on miss, None if the backend deferred a lookup."""
+        defer_lookup = False
+        consecutive_hits = 0
+        for idx in range(len(keys) - 1, -1, -1):
+            match self.manager.lookup(keys[idx], req_context):
+                case LookupResult.HIT:
+                    consecutive_hits += 1
+                case LookupResult.HIT_PENDING:
+                    # Block is in cache, just not readable yet — counts
+                    # as hit for the consecutive streak. Don't break:
+                    # keep scanning to let manager kick off async lookups.
+                    defer_lookup = True
+                    consecutive_hits += 1
+                case LookupResult.RETRY:
+                    # Block location uncertain — does not count as hit.
+                    # Don't break: keep scanning to let manager kick off
+                    # async lookups.
+                    defer_lookup = True
+                    consecutive_hits = 0
+                case LookupResult.MISS:
+                    consecutive_hits = 0
+            if consecutive_hits == sliding_window_size:
+                return idx + sliding_window_size if not defer_lookup else None
+        return consecutive_hits if not defer_lookup else None
+
+    def _touch(self, req_status: RequestOffloadState):
+        for group_config, group_state in zip(
+            self.config.kv_group_configs, req_status.group_states
+        ):
+            if group_config.sliding_window_size_in_chunks is None:
+                self.manager.touch(group_state.offload_keys, req_status.req_context)
+            else:
+                # Keep only chunks needed to hit the original request, plus
+                # decoded chunks.
+                chunks_to_skip = max(
+                    0,
+                    group_state.num_hit_chunks
+                    - group_config.sliding_window_size_in_chunks,
+                )
+                self.manager.touch(
+                    group_state.offload_keys[chunks_to_skip:],
+                    req_status.req_context,
+                )
+        if req_status.partial_tail_boundary is not None:
+            self.manager.touch(
+                tuple(
+                    self._make_boundary_key(
+                        req_status.req,
+                        group.group_idx,
+                        req_status.partial_tail_boundary,
+                    )
+                    for group in self.config.kv_group_configs
+                ),
+                req_status.req_context,
+            )
+
+    def _lookup_complete_chunks(self, req_status: RequestOffloadState) -> int | None:
+        """
+        Find how many tokens beyond num_locally_computed_tokens can be loaded.
+
+        Iterates full-attention groups first (prefix lookup), then sliding-window
+        groups (suffix lookup). Each group may tighten max_hit_size_tokens, which
+        can invalidate an earlier group's result, so the loop re-runs when that
+        happens until num_hit_tokens converges.
+        """
+        num_computed_tokens = req_status.num_locally_computed_tokens
+        max_hit_size_tokens: int = req_status.req.num_tokens
+        if self._sliding_window_groups:
+            # the last prompt token has to be recomputed to get the logprobs
+            # for sliding window attention, we must reduce by 1 to make sure
+            # we still have a hit after reduction
+            max_hit_size_tokens -= 1
+            if self._mamba_align_size is not None:
+                # Constrain hit-window to the mamba block size.
+                max_hit_size_tokens = round_down(
+                    max_hit_size_tokens, self._mamba_align_size
+                )
+
+        num_hit_tokens: int = 0
+        defer_lookup = False
+        lookup_groups = self._lookup_groups
+
+        # Tracks which eagle groups have already popped their volatile trailing chunk
+        # in the current convergence iteration. Reset when a non-eagle group
+        # tightens the hit boundary, requiring a fresh pop.
+        eagle_verified: set[int] = set()
+        while lookup_groups:
+            looked_up_sliding_window: bool = False
+            groups_iter = iter(lookup_groups)
+            lookup_groups = ()
+            for group_idx in groups_iter:
+                group_config: GroupOffloadConfig = self.config.kv_group_configs[
+                    group_idx
+                ]
+                group_state: RequestGroupState = req_status.group_states[group_idx]
+                tokens_per_chunk = group_config.tokens_per_chunk
+                offload_keys = group_state.offload_keys
+
+                assert (
+                    len(offload_keys) >= req_status.req.num_tokens // tokens_per_chunk
+                )
+
+                is_eagle_unverified = (
+                    group_config.is_eagle_group and group_idx not in eagle_verified
+                )
+
+                # Constrain to a chunk-aligned boundary for this group.
+                max_hit_size_tokens = min(
+                    max_hit_size_tokens, len(offload_keys) * tokens_per_chunk
+                )
+                if max_hit_size_tokens - num_computed_tokens < tokens_per_chunk:
+                    # We can only load less than a chunk, so skip.
+                    return 0
+
+                sliding_window_size_in_chunks = (
+                    group_config.sliding_window_size_in_chunks
+                )
+
+                # For eagle groups, query one extra chunk that will be popped.
+                # We only need to increase the query size for sliding window groups.
+                query_max = max_hit_size_tokens
+                if is_eagle_unverified and sliding_window_size_in_chunks is not None:
+                    query_max = min(
+                        max_hit_size_tokens + tokens_per_chunk,
+                        len(offload_keys) * tokens_per_chunk,
+                    )
+
+                num_chunks = min(cdiv(query_max, tokens_per_chunk), len(offload_keys))
+                start_chunk_idx = num_computed_tokens // tokens_per_chunk
+                offload_keys = offload_keys[start_chunk_idx:num_chunks]
+
+                # end index (in the sliced offload_keys) up to which we
+                # have backend-confirmed hits
+                num_hit_chunks: int | None
+                if sliding_window_size_in_chunks is None:
+                    num_hit_chunks = self._maximal_prefix_lookup(
+                        offload_keys,
+                        req_status.req_context,
+                        req_status.req,
+                        group_config,
+                        start_chunk_idx,
+                    )
+                else:
+                    required_window = sliding_window_size_in_chunks
+                    if is_eagle_unverified:
+                        required_window += 1
+                    num_hit_chunks = self._sliding_window_lookup(
+                        offload_keys,
+                        required_window,
+                        req_status.req_context,
+                    )
+                if num_hit_chunks == 0:
+                    return 0
+
+                if num_hit_chunks is None:
+                    defer_lookup = True
+                else:
+                    if is_eagle_unverified:
+                        num_hit_chunks -= 1
+                        eagle_verified.add(group_idx)
+
+                    max_hit_size_tokens = min(
+                        max_hit_size_tokens,
+                        tokens_per_chunk * (start_chunk_idx + num_hit_chunks),
+                    )
+
+                new_num_hit_tokens = max_hit_size_tokens - num_computed_tokens
+                if new_num_hit_tokens < tokens_per_chunk:
+                    # We can only load less than a chunk, so skip.
+                    return 0
+
+                if new_num_hit_tokens < num_hit_tokens:
+                    if not group_config.is_eagle_group:
+                        eagle_verified.clear()
+                    if defer_lookup:
+                        # make another iteration on all groups to check
+                        # if we still need to defer lookup
+                        defer_lookup = False
+                        lookup_groups = self._lookup_groups
+                    elif looked_up_sliding_window and not lookup_groups:
+                        # we need another iteration to confirm previously looked up
+                        # sliding window works with the new_num_hit_tokens
+                        lookup_groups = self._sliding_window_groups
+
+                looked_up_sliding_window |= sliding_window_size_in_chunks is not None
+                num_hit_tokens = new_num_hit_tokens
+
+        if defer_lookup:
+            logger.debug(
+                "Offloading manager delayed request %s as backend requested",
+                req_status.req.request_id,
+            )
+            return None
+
+        # Possibly delay the request if any hit chunk is already being loaded.
+        if self._chunks_being_loaded:
+            for group_config, group_state in zip(
+                self.config.kv_group_configs, req_status.group_states
+            ):
+                tokens_per_chunk = group_config.tokens_per_chunk
+                sliding_window_size_in_chunks = (
+                    group_config.sliding_window_size_in_chunks
+                )
+                offload_keys = group_state.offload_keys
+                num_chunks = cdiv(
+                    num_computed_tokens + num_hit_tokens, tokens_per_chunk
+                )
+                start_chunk_idx = num_computed_tokens // tokens_per_chunk
+                offload_keys = offload_keys[start_chunk_idx:num_chunks]
+                if sliding_window_size_in_chunks is not None:
+                    offload_keys = offload_keys[-sliding_window_size_in_chunks:]
+                if any(key in self._chunks_being_loaded for key in offload_keys):
+                    # Hit chunks are being loaded, so delay the request.
+                    logger.debug(
+                        "Delaying request %s since some of its"
+                        " chunks are already being loaded",
+                        req_status.req.request_id,
+                    )
+                    return None
+
+        logger.debug(
+            "Request %s hit %s offloaded tokens after %s GPU hit tokens",
+            req_status.req.request_id,
+            num_hit_tokens,
+            num_computed_tokens,
+        )
+
+        return num_hit_tokens
+
+    def _make_boundary_key(
+        self, request: Request, group_idx: int, boundary_tokens: int
+    ) -> OffloadKey:
+        hash_idx = boundary_tokens // self.config.tokens_per_hash - 1
+        return make_offload_key(request.block_hashes[hash_idx], group_idx)
+
+    def _lookup(self, req_status: RequestOffloadState) -> int | None:
+        complete_hit = self._lookup_complete_chunks(req_status)
+        req_status.partial_tail_boundary = None
+        if complete_hit is None or not self.config.supports_partial_tail:
+            return complete_hit
+
+        local_tokens = req_status.num_locally_computed_tokens
+        complete_boundary = local_tokens + complete_hit
+        tokens_per_hash = self.config.tokens_per_hash
+        block_end = complete_boundary + self._partial_tail_block_size
+        max_boundary = round_down(
+            min(req_status.req.num_prompt_tokens - 1, block_end - 1), tokens_per_hash
+        )
+        if max_boundary <= complete_boundary:
+            return complete_hit
+
+        pending = False
+        for boundary in range(max_boundary, complete_boundary, -tokens_per_hash):
+            boundary_pending = False
+            boundary_missed = False
+            boundary_keys = []
+            for group_config in self.config.kv_group_configs:
+                key = self._make_boundary_key(
+                    req_status.req, group_config.group_idx, boundary
+                )
+                boundary_keys.append(key)
+                result = self.manager.lookup(key, req_status.req_context)
+                if result is LookupResult.MISS:
+                    boundary_missed = True
+                    break
+                if result in (LookupResult.HIT_PENDING, LookupResult.RETRY):
+                    boundary_pending = True
+
+            pending |= boundary_pending
+            if not boundary_missed and not boundary_pending:
+                for group_config, key in zip(
+                    self.config.kv_group_configs, boundary_keys
+                ):
+                    self._events_tracker.record_partial_lookup(
+                        req_status.req, group_config, boundary, key
+                    )
+                req_status.partial_tail_boundary = boundary
+                return boundary - local_tokens
+
+        if pending and complete_hit == 0:
+            return None
+        return complete_hit
+
+    def on_new_request(self, request: Request) -> None:
+        """Called when a new request is added to the scheduler."""
+        req_context = _create_req_context(request)
+        offloading_context = self.manager.on_new_request(req_context)
+        req_status = RequestOffloadState(
+            config=self.config,
+            req=request,
+            req_context=req_context,
+            offloading_context=offloading_context,
+        )
+        self._req_status[request.request_id] = req_status
+
+    def get_num_new_matched_tokens(
+        self, request: Request, num_computed_tokens: int
+    ) -> tuple[int | None, bool]:
+        """
+        Get number of new tokens that can be loaded beyond the
+        num_computed_tokens.
+
+        Args:
+            request (Request): the request object.
+            num_computed_tokens (int): the number of locally
+                computed tokens for this request
+
+        Returns:
+            A tuple with the following elements:
+                - The number of tokens that can be loaded beyond what is
+                  already computed.
+                  If None, it means that the connector needs more time to
+                  determine the number of matched tokens, and the scheduler
+                  should query for this request again later.
+                - `True` if tokens will be loaded asynchronously
+                  (between scheduler steps).
+        """
+        req_status = self._req_status[request.request_id]
+        for group_state in req_status.group_states:
+            group_state.block_ids.clear()
+
+        if req_status.transfer_jobs:
+            logger.debug(
+                "Delaying request %s since it still has in-flight transfers",
+                request.request_id,
+            )
+            return None, False
+
+        req_status.update_offload_keys()
+        req_status.num_locally_computed_tokens = num_computed_tokens
+
+        num_hit_tokens: int | None
+        if request.skip_reading_prefix_cache:
+            num_hit_tokens = 0
+        else:
+            lookup_start = time.monotonic()
+            num_hit_tokens = self._lookup(req_status)
+            self._connector_stats.observe_histogram(
+                _ConnectorMetricName.LOOKUP_SYNC_DELAY,
+                time.monotonic() - lookup_start,
+            )
+            if num_hit_tokens is None:
+                if req_status.deferred_lookup_start_time is None:
+                    req_status.deferred_lookup_start_time = lookup_start
+            else:
+                self._maybe_observe_lookup_async_delay(req_status)
+        req_status.update_num_hit_chunks(num_computed_tokens + (num_hit_tokens or 0))
+
+        self._touch(req_status)
+
+        return num_hit_tokens, bool(num_hit_tokens)
+
+    def update_state_after_alloc(
+        self, request: Request, blocks: KVCacheBlocks, num_external_tokens: int
+    ):
+        if num_external_tokens == 0:
+            return
+
+        req_status = self._req_status[request.request_id]
+
+        num_locally_computed_tokens = req_status.num_locally_computed_tokens
+        num_cached_tokens = num_locally_computed_tokens + num_external_tokens
+        partial_tail_boundary = req_status.partial_tail_boundary
+        if partial_tail_boundary is not None:
+            assert partial_tail_boundary == num_cached_tokens
+
+        keys_to_load: list[OffloadKey] = []
+        dst_block_ids: list[int] = []
+        # per group
+        group_sizes: list[int] = []
+        block_indices: list[int] = []
+        for group_config, group_state, group_blocks in zip(
+            self.config.kv_group_configs,
+            req_status.group_states,
+            blocks.blocks,
+        ):
+            self._current_batch_allocated_block_ids.update(
+                block.block_id for block in group_blocks if block.block_id != 0
+            )
+
+            tokens_per_block = group_config.tokens_per_block
+            tokens_per_chunk = group_config.tokens_per_chunk
+            offload_keys = group_state.offload_keys
+            num_gpu_blocks = cdiv(num_cached_tokens, tokens_per_block)
+
+            assert len(group_blocks) >= num_gpu_blocks
+            num_locally_computed_gpu_blocks = num_gpu_blocks
+            # Skip null placeholder blocks (used for sliding window or mamba padding).
+            for i, block in enumerate(group_blocks[:num_gpu_blocks]):
+                if not block.is_null and block.block_hash is None:
+                    num_locally_computed_gpu_blocks = i
+                    break
+
+            assert (
+                num_locally_computed_tokens
+                <= num_locally_computed_gpu_blocks * tokens_per_block
+            )
+            num_pending_gpu_blocks = num_gpu_blocks - num_locally_computed_gpu_blocks
+
+            if group_config.sliding_window_size_in_chunks is not None:
+                assert (
+                    num_pending_gpu_blocks
+                    <= group_config.sliding_window_size_in_chunks
+                    * self.config.blocks_per_chunk
+                    + 1
+                )
+
+            num_chunks = cdiv(num_cached_tokens, tokens_per_chunk)
+            if num_pending_gpu_blocks:
+                start_chunk_idx = (
+                    num_locally_computed_gpu_blocks // self.config.blocks_per_chunk
+                )
+                end_chunk_idx = num_chunks - (partial_tail_boundary is not None)
+                assert len(offload_keys) >= end_chunk_idx
+                keys_to_load.extend(offload_keys[start_chunk_idx:end_chunk_idx])
+                if partial_tail_boundary is not None:
+                    keys_to_load.append(
+                        self._make_boundary_key(
+                            request, group_config.group_idx, partial_tail_boundary
+                        )
+                    )
+
+            dst_block_ids.extend(
+                block.block_id
+                for block in group_blocks[
+                    num_locally_computed_gpu_blocks:num_gpu_blocks
+                ]
+            )
+            group_sizes.append(num_pending_gpu_blocks)
+            block_indices.append(num_locally_computed_gpu_blocks)
+
+            # Skip prefix-hit chunks for block-level policy; for
+            # request-level, next_stored_chunk_idx stays at 0 so all
+            # chunks (including hits) are offloaded.
+            if req_status.offloading_context.policy == OffloadPolicy.BLOCK_LEVEL:
+                group_state.next_stored_chunk_idx = num_chunks
+
+        src_spec = self.manager.prepare_load(keys_to_load, req_status.req_context)
+        dst_spec = GPULoadStoreSpec(
+            dst_block_ids, group_sizes=group_sizes, block_indices=block_indices
+        )
+
+        load_job_id = self._generate_job_id()
+        self._current_batch_load_jobs[load_job_id] = TransferJob(
+            req_id=request.request_id,
+            src_spec=src_spec,
+            dst_spec=dst_spec,
+        )
+        # a load can only be issued when no other jobs are pending.
+        assert not req_status.transfer_jobs
+        req_status.transfer_jobs.add(load_job_id)
+        self._jobs[load_job_id] = TransferJobStatus(
+            req_id=request.request_id,
+            pending_count=self.config.num_workers,
+            keys=set(keys_to_load),
+            is_store=False,
+        )
+
+        if self._chunks_being_loaded is not None:
+            self._chunks_being_loaded.update(keys_to_load)
+        req_status.partial_tail_boundary = None
+
+    def _update_req_states(self, scheduler_output: SchedulerOutput) -> None:
+        """
+        Update request states from the Scheduler's output.
+        """
+
+        # new_block_ids_end[req_id][i] = end of pre-existing block_ids for
+        # the i-th sliding window group (before this step's extend).
+        # Used to detect sliding window blocks that got re-allocated.
+        new_block_ids_end: dict[str, tuple[int, ...]] = {}
+
+        for req_id, new_block_id_groups, preempted in yield_req_data(scheduler_output):
+            req_status = self._req_status[req_id]
+            req_status.update_offload_keys()
+
+            if preempted:
+                for group_state in req_status.group_states:
+                    group_state.block_ids.clear()
+
+            if new_block_id_groups:
+                if self._sliding_window_groups:
+                    new_block_ids_end[req_id] = tuple(
+                        len(req_status.group_states[grp_idx].block_ids)
+                        for grp_idx in self._sliding_window_groups
+                    )
+                req_status.update_block_id_groups(new_block_id_groups)
+                for new_blocks in new_block_id_groups:
+                    for bid in new_blocks:
+                        if bid != 0:
+                            self._current_batch_allocated_block_ids.add(bid)
+
+        # Zero out stale block_ids in sliding window groups' pending-store
+        # positions. Only sliding window groups can have stale entries (blocks
+        # freed by remove_skipped_blocks then reallocated). Only positions in
+        # [next_stored_chunk_idx * bsf, end) need checking where end is the
+        # pre-extend length: earlier positions were already offloaded, later
+        # ones are fresh allocations from this step.
+        if self._sliding_window_groups and self._current_batch_allocated_block_ids:
+            blocks_per_chunk = self.config.blocks_per_chunk
+            for req_id, req_status in self._req_status.items():
+                ends = new_block_ids_end.get(req_id)
+                for i, grp_idx in enumerate(self._sliding_window_groups):
+                    group_state = req_status.group_states[grp_idx]
+                    start = group_state.next_stored_chunk_idx * blocks_per_chunk
+                    end = ends[i] if ends is not None else len(group_state.block_ids)
+                    for j in range(start, end):
+                        if (
+                            group_state.block_ids[j]
+                            in self._current_batch_allocated_block_ids
+                        ):
+                            group_state.block_ids[j] = 0
+
+    def _build_partial_tail_store_jobs(
+        self, scheduler_output: SchedulerOutput
+    ) -> dict[int, TransferJob]:
+        handoffs = scheduler_output.partial_tail_offloads
+        if not self.config.supports_partial_tail or not handoffs:
+            return {}
+
+        store_jobs: dict[int, TransferJob] = {}
+        for req_id, entries in handoffs.items():
+            req_status = self._req_status.get(req_id)
+            assert req_status is not None
+            assert entries
+            boundaries = {boundary for _, _, boundary in entries}
+            assert len(boundaries) == 1
+            boundary = boundaries.pop()
+            req = req_status.req
+            max_boundary = min(
+                req.num_prompt_tokens,
+                req_status.max_offload_tokens or req.num_prompt_tokens,
+            )
+            assert boundary > 0
+            assert boundary % self.config.tokens_per_hash == 0
+            assert boundary <= max_boundary
+
+            cow_blocks = {group_idx: block_id for group_idx, block_id, _ in entries}
+            assert self._cow_source_groups.issubset(cow_blocks)
+
+            assert boundary % self._partial_tail_block_size != 0
+            block_idx = boundary // self._partial_tail_block_size
+            if any(
+                group.group_idx not in self._cow_source_groups
+                and block_idx >= len(req_status.group_states[group.group_idx].block_ids)
+                for group in self.config.kv_group_configs
+            ):
+                continue
+            keys = [
+                self._make_boundary_key(req, group.group_idx, boundary)
+                for group in self.config.kv_group_configs
+            ]
+            block_ids = [
+                cow_blocks[group.group_idx]
+                if group.group_idx in self._cow_source_groups
+                else req_status.group_states[group.group_idx].block_ids[block_idx]
+                for group in self.config.kv_group_configs
+            ]
+            assert all(block_id != 0 for block_id in block_ids)
+
+            store_output = self.manager.prepare_store(keys, req_status.req_context)
+            if store_output is None:
+                self._connector_stats.increase_counter(
+                    _ConnectorMetricName.ALLOCATION_FAILURE
+                )
+                continue
+            if not store_output.keys_to_store:
+                continue
+
+            for group_config, key in zip(self.config.kv_group_configs, keys):
+                if key in store_output.keys_to_store:
+                    self._events_tracker.record_partial_store(
+                        req, group_config, boundary, key
+                    )
+
+            group_by_key = {key: idx for idx, key in enumerate(keys)}
+            accepted_groups = [group_by_key[key] for key in store_output.keys_to_store]
+            group_sizes = [0] * len(self.config.kv_group_configs)
+            block_indices = [0] * len(self.config.kv_group_configs)
+            for group_idx in accepted_groups:
+                group_sizes[group_idx] = 1
+                block_indices[group_idx] = block_idx
+            source_blocks = [block_ids[group_idx] for group_idx in accepted_groups]
+
+            job_id = self._generate_job_id()
+            req_status.transfer_jobs.add(job_id)
+            for block_id in source_blocks:
+                self._block_id_to_pending_jobs.setdefault(block_id, set()).add(job_id)
+            self._jobs[job_id] = TransferJobStatus(
+                req_id=req_id,
+                pending_count=self.config.num_workers,
+                keys=set(store_output.keys_to_store),
+                is_store=True,
+                fenced_block_ids=source_blocks,
+            )
+            store_jobs[job_id] = TransferJob(
+                req_id=req_id,
+                src_spec=GPULoadStoreSpec(
+                    source_blocks,
+                    group_sizes=group_sizes,
+                    block_indices=block_indices,
+                ),
+                dst_spec=store_output.store_spec,
+            )
+
+        return store_jobs
+
+    def _build_store_jobs(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> dict[int, TransferJob]:
+        blocks_per_chunk = self.config.blocks_per_chunk
+        store_jobs: dict[int, TransferJob] = {}
+        for req_id in chain(
+            scheduler_output.num_scheduled_tokens,
+            scheduler_output.finished_req_ids or (),
+        ):
+            req_status = self._req_status.get(req_id)
+            if req_status is None:
+                continue
+            req = req_status.req
+
+            if req.status is RequestStatus.FINISHED_ABORTED:
+                num_tokens_after_batch = req.num_computed_tokens
+            elif req.is_finished():
+                num_tokens_after_batch = req.num_tokens
+            else:
+                num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
+                num_tokens_after_batch = req.num_computed_tokens + num_scheduled_tokens
+
+            num_offloadable_tokens = self._calc_num_offloadable_tokens(
+                req_status, num_tokens_after_batch
+            )
+
+            # Filter out chunks skipped due to sliding window attention / SSM
+            # or unreachable by the load path's alignment constraints.
+            new_offload_keys: list[OffloadKey] = []
+            for group_config, group_state in zip(
+                self.config.kv_group_configs, req_status.group_states
+            ):
+                num_chunks = req_status.storable_chunks(
+                    group_config, group_state, num_offloadable_tokens
+                )
+
+                start_chunk_idx = group_state.next_stored_chunk_idx
+                if num_chunks <= start_chunk_idx:
+                    continue
+                offload_keys = group_state.offload_keys[start_chunk_idx:num_chunks]
+                # For each chunk, take the last corresponding GPU block. For
+                # blocks_per_chunk=3 and GPU block IDs 1 5 6 7 2 4 9 3 8,
+                # this selects GPU blocks 6 4 8.
+                # A block_id of 0 means either a sliding window / SSM skip
+                # or a stale entry that was zeroed out — skip it either way.
+                offload_block_ids = group_state.block_ids[
+                    start_chunk_idx * blocks_per_chunk
+                    + blocks_per_chunk
+                    - 1 : num_chunks * blocks_per_chunk : blocks_per_chunk
+                ]
+                assert len(offload_keys) == len(offload_block_ids)
+
+                for key_idx, (offload_key, block_id) in enumerate(
+                    zip(offload_keys, offload_block_ids)
+                ):
+                    if block_id == 0:
+                        continue
+                    # Skip SWA chunks that can never serve a load hit:
+                    # within each full-attention alignment segment, only the
+                    # trailing chunks queried by _sliding_window_lookup are
+                    # reachable. EAGLE/MTP requires one additional chunk that
+                    # lookup later drops as its volatile draft tail.
+                    abs_chunk_idx = start_chunk_idx + key_idx
+                    if not is_store_reachable_swa_chunk(
+                        abs_chunk_idx,
+                        num_chunks,
+                        group_config.alignment_chunk_count,
+                        group_config.sliding_window_size_in_chunks,
+                        group_config.is_eagle_group,
+                    ):
+                        continue
+                    new_offload_keys.append(offload_key)
+
+            if not new_offload_keys:
+                req_status.advance_stored_idx(num_offloadable_tokens)
+                continue
+
+            store_output = self.manager.prepare_store(
+                new_offload_keys, req_status.req_context
+            )
+            if store_output is None:
+                self._connector_stats.increase_counter(
+                    _ConnectorMetricName.ALLOCATION_FAILURE
+                )
+                logger.warning("Request %s: cannot store chunks", req_id)
+                continue
+
+            if not store_output.keys_to_store:
+                req_status.advance_stored_idx(num_offloadable_tokens)
+                continue
+
+            self._touch(req_status)
+
+            keys_to_store = set(store_output.keys_to_store)
+
+            group_sizes: list[int] = []
+            block_indices: list[int] = []
+            src_block_ids: list[int] = []
+            fenced_block_ids: list[int] = []
+            deferred_fence_block_ids: list[int] = []
+            for group_config, group_state in zip(
+                self.config.kv_group_configs, req_status.group_states
+            ):
+                is_sliding_window = (
+                    group_config.sliding_window_size_in_chunks is not None
+                )
+                num_chunks = req_status.storable_chunks(
+                    group_config, group_state, num_offloadable_tokens
+                )
+                start_chunk_idx = group_state.next_stored_chunk_idx
+                block_ids = group_state.block_ids
+                num_group_blocks = 0
+                start_gpu_block_idx: int | None = None
+                for idx, offload_key in enumerate(
+                    group_state.offload_keys[start_chunk_idx:num_chunks]
+                ):
+                    if offload_key not in keys_to_store:
+                        continue
+
+                    chunk_idx = start_chunk_idx + idx
+
+                    self._events_tracker.record_store(
+                        req, group_config, chunk_idx, offload_key
+                    )
+
+                    gpu_block_idx = chunk_idx * blocks_per_chunk
+                    for i in range(blocks_per_chunk):
+                        block_id = block_ids[gpu_block_idx + i]
+                        if block_id == 0:
+                            continue
+                        if start_gpu_block_idx is None:
+                            start_gpu_block_idx = gpu_block_idx + i
+                        src_block_ids.append(block_id)
+                        num_group_blocks += 1
+                        if is_sliding_window:
+                            fenced_block_ids.append(block_id)
+                        else:
+                            deferred_fence_block_ids.append(block_id)
+
+                group_sizes.append(num_group_blocks)
+                block_indices.append(start_gpu_block_idx or 0)
+                group_state.next_stored_chunk_idx = max(
+                    group_state.next_stored_chunk_idx, num_chunks
+                )
+
+            src_spec = GPULoadStoreSpec(
+                src_block_ids, group_sizes=group_sizes, block_indices=block_indices
+            )
+            dst_spec = store_output.store_spec
+
+            job_id = self._generate_job_id()
+            # a store can only be issued when no load is pending.
+            if req_status.transfer_jobs:
+                any_jid = next(iter(req_status.transfer_jobs))
+                assert self._jobs[any_jid].is_store
+            req_status.transfer_jobs.add(job_id)
+
+            # Watch sliding window blocks as they may get evicted
+            # before the request finishes
+            for bid in fenced_block_ids:
+                self._block_id_to_pending_jobs.setdefault(bid, set()).add(job_id)
+
+            # the non-sliding window blocks will be watched only
+            # when the request finishes
+            self._jobs[job_id] = TransferJobStatus(
+                req_id=req_id,
+                pending_count=self.config.num_workers,
+                keys=set(keys_to_store),
+                is_store=True,
+                deferred_fence_block_ids=deferred_fence_block_ids,
+                fenced_block_ids=fenced_block_ids or None,
+            )
+
+            store_jobs[job_id] = TransferJob(
+                req_id=req_id, src_spec=src_spec, dst_spec=dst_spec
+            )
+
+            logger.debug(
+                "Request %s offloading %s chunks upto %d tokens (job %d)",
+                req_id,
+                len(keys_to_store),
+                num_offloadable_tokens,
+                job_id,
+            )
+
+            if req.is_finished():
+                # Register non-sliding-window blocks for flush detection.
+                for bid in deferred_fence_block_ids:
+                    self._block_id_to_pending_jobs.setdefault(bid, set()).add(job_id)
+                    if bid in self._current_batch_allocated_block_ids:
+                        self._current_batch_jobs_to_flush.add(job_id)
+
+        return store_jobs
+
+    def build_connector_meta(
+        self, scheduler_output: SchedulerOutput
+    ) -> KVConnectorMetadata:
+        self._update_req_states(scheduler_output)
+        schedule_end_context = ScheduleEndContext(
+            new_req_ids=[req.req_id for req in scheduler_output.scheduled_new_reqs],
+            preempted_req_ids=scheduler_output.preempted_req_ids or (),
+        )
+        self.manager.on_schedule_end(schedule_end_context)
+
+        # Flush jobs for preempted requests.
+        for req_id in scheduler_output.preempted_req_ids or ():
+            req_status = self._req_status.get(req_id)
+            if req_status is None or not req_status.transfer_jobs:
+                continue
+            any_jid = next(iter(req_status.transfer_jobs))
+            assert self._jobs[any_jid].is_store
+            self._current_batch_jobs_to_flush.update(req_status.transfer_jobs)
+
+        # Flush jobs that contain re-allocated blocks.
+        if (
+            self._block_id_to_pending_jobs
+            and not self._block_id_to_pending_jobs.keys().isdisjoint(
+                self._current_batch_allocated_block_ids
+            )
+        ):
+            self._current_batch_jobs_to_flush.update(
+                jid
+                for bid in self._current_batch_allocated_block_ids
+                if bid in self._block_id_to_pending_jobs
+                for jid in self._block_id_to_pending_jobs[bid]
+            )
+
+        partial_store_jobs = self._build_partial_tail_store_jobs(scheduler_output)
+        normal_store_jobs = self._build_store_jobs(scheduler_output)
+        meta = OffloadingConnectorMetadata(
+            load_jobs=self._current_batch_load_jobs,
+            store_jobs=partial_store_jobs | normal_store_jobs,
+            jobs_to_flush=self._current_batch_jobs_to_flush,
+        )
+
+        # All prepare_store calls for finished requests have been issued.
+        # Signal on_request_finished and clean up state where possible.
+        for req_id in scheduler_output.finished_req_ids or ():
+            req_status = self._req_status.get(req_id)
+            if req_status is None:
+                continue
+            req_status.finished_signaled = True
+            self.manager.on_request_finished(req_status.req_context)
+            if not req_status.transfer_jobs:
+                del self._req_status[req_id]
+        self._current_batch_load_jobs = {}
+        self._current_batch_jobs_to_flush = set()
+        self._current_batch_allocated_block_ids = set()
+        return meta
+
+    def has_pending_push_work(self) -> bool:
+        """Whether the engine must keep stepping.
+
+        While True, build_connector_meta() and update_connector_output()
+        continue to be called even when no requests are scheduled.
+        """
+        return bool(self._jobs) or self.manager.has_pending_work()
+
+    def update_connector_output(self, connector_output: KVConnectorOutput):
+        """
+        Update KVConnector state from worker-side connectors output.
+
+        Args:
+            connector_output (KVConnectorOutput): the worker-side
+                connectors output.
+        """
+        meta = connector_output.kv_connector_worker_meta
+        if not isinstance(meta, OffloadingWorkerMetadata):
+            assert meta is None
+            meta = OffloadingWorkerMetadata()
+        if not meta.transfer_stats.is_empty():
+            transfer_stats = OffloadingConnectorStats()
+            if not meta.transfer_stats.load.is_empty():
+                transfer_stats.increase_counter(
+                    _TransferMetricName.LOAD_BYTES,
+                    meta.transfer_stats.load.bytes,
+                )
+                transfer_stats.increase_counter(
+                    _TransferMetricName.LOAD_TIME,
+                    meta.transfer_stats.load.time,
+                )
+                for size in meta.transfer_stats.load.sizes:
+                    transfer_stats.observe_histogram(
+                        _TransferMetricName.LOAD_SIZE, size
+                    )
+            if not meta.transfer_stats.store.is_empty():
+                transfer_stats.increase_counter(
+                    _TransferMetricName.STORE_BYTES,
+                    meta.transfer_stats.store.bytes,
+                )
+                transfer_stats.increase_counter(
+                    _TransferMetricName.STORE_TIME,
+                    meta.transfer_stats.store.time,
+                )
+                for size in meta.transfer_stats.store.sizes:
+                    transfer_stats.observe_histogram(
+                        _TransferMetricName.STORE_SIZE, size
+                    )
+            self._connector_stats.aggregate(transfer_stats)
+
+        for job_id, count in meta.completed_jobs.items():
+            assert count > 0
+            if job_id < self._stale_job_threshold:
+                logger.debug(
+                    "Skipping stale completed job %d (pre-reset counter: %d)",
+                    job_id,
+                    self._stale_job_threshold,
+                )
+                continue
+            job_status = self._jobs[job_id]
+            job_status.pending_count -= count
+            if job_status.pending_count > 0:
+                continue
+            assert job_status.pending_count == 0
+
+            req_status = self._req_status[job_status.req_id]
+            if job_status.is_store:
+                self.manager.complete_store(job_status.keys, req_status.req_context)
+            else:
+                self.manager.complete_load(job_status.keys, req_status.req_context)
+                if self._chunks_being_loaded:
+                    self._chunks_being_loaded.difference_update(job_status.keys)
+            if self._block_id_to_pending_jobs:
+                # Sliding window blocks are tracked from store creation
+                # and must be cleaned up unconditionally.
+                self._remove_pending_job(job_id, job_status.fenced_block_ids)
+                # Non-sliding-window blocks are only tracked after
+                # request_finished, so only clean up for finished requests.
+                if req_status.req.is_finished():
+                    self._remove_pending_job(
+                        job_id, job_status.deferred_fence_block_ids
+                    )
+
+            del self._jobs[job_id]
+            req_status.transfer_jobs.remove(job_id)
+            if req_status.finished_signaled and not req_status.transfer_jobs:
+                del self._req_status[job_status.req_id]
+
+    def get_stats(self) -> OffloadingConnectorStats | None:
+        stats: OffloadingConnectorStats | None = None
+        if not self._connector_stats.is_empty():
+            stats = self._connector_stats
+            self._connector_stats = OffloadingConnectorStats()
+
+        manager_stats = self.manager.get_stats()
+        if manager_stats is not None:
+            if stats is None:
+                stats = manager_stats
+            else:
+                stats.aggregate(manager_stats)
+
+        return stats
+
+    def request_finished(
+        self,
+        request: Request,
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """
+        Called when a request has finished, before its blocks are freed.
+
+        Returns:
+            True if the request is being saved/sent asynchronously and blocks
+            should not be freed until the request_id is returned from
+            get_finished().
+            Optional KVTransferParams to be included in the request outputs
+            returned by the engine.
+        """
+        req_status = self._req_status.get(request.request_id)
+
+        if req_status is None:
+            # Untracked request (offloading never started): no in-flight jobs,
+            # nothing was deferred, so finalize immediately.
+            req_context = _create_req_context(request)
+            self.manager.on_new_request(req_context)
+            self.manager.on_request_finished(req_context)
+            return False, None
+
+        self._maybe_observe_lookup_async_delay(req_status)
+
+        # Update offload keys with final block hash so _build_store_jobs can
+        # create store jobs for the last block(s) on the next schedule step.
+        req_status.update_offload_keys()
+
+        # Keep req_status alive: _build_store_jobs will process finished_req_ids
+        # on the next step and handle cleanup after creating store jobs.
+        # Register deferred fences so future block reuse triggers a flush via
+        # _block_id_to_pending_jobs.
+        for job_id in req_status.transfer_jobs:
+            job_status = self._jobs[job_id]
+            for bid in job_status.deferred_fence_block_ids or ():
+                self._block_id_to_pending_jobs.setdefault(bid, set()).add(job_id)
+
+        return False, None
+
+    def take_events(self) -> Iterable[KVCacheEvent]:
+        """Drain pending KV cache events.
+
+        Complete metadata is available only when self-describing KV events
+        are enabled, and only for full-attention groups. Other shapes retain
+        the previous placeholder payload so consumers can ignore them.
+
+        Yields:
+            ``BlockStored`` or ``BlockRemoved`` events corresponding to
+            the underlying :class:`OffloadingEvent` stream.
+        """
+        yield from self._events_tracker.take_events(self.manager.take_events())
+
+    def reset_cache(self) -> None:
+        """Reset the offloading manager cache, evicting all stored chunks."""
+
+        # reset_cache cannot be called in the middle of a schedule step
+        assert not self._current_batch_load_jobs
+        assert not self._current_batch_jobs_to_flush
+        assert not self._current_batch_allocated_block_ids
+
+        # Flush all in-flight jobs
+        self._current_batch_jobs_to_flush.update(self._jobs.keys())
+
+        for req_id, status in list(self._req_status.items()):
+            if status.req.is_finished():
+                if not status.finished_signaled:
+                    self.manager.on_request_finished(status.req_context)
+                del self._req_status[req_id]
+
+        # Reset offloading manager cache
+        self.manager.reset_cache()
+
+        # Reset store progress so active requests re-offload from chunk 0.
+        for status in self._req_status.values():
+            for group_state in status.group_states:
+                group_state.next_stored_chunk_idx = 0
+            status.transfer_jobs.clear()
+            status.partial_tail_boundary = None
+
+        # Discard jobs and save job_counter to be able to discard worker responses
+        self._stale_job_threshold = self._job_counter
+        self._jobs.clear()
+        self._block_id_to_pending_jobs.clear()
+
+        # The manager pool is empty; pending event payloads and announced
+        # reference counts are stale.
+        self._events_tracker.reset()
+
+        # Note: _current_batch_jobs_to_flush is intentionally NOT cleared.
+        # The load flush IDs collected above must be delivered to workers.
+        if self._chunks_being_loaded is not None:
+            self._chunks_being_loaded.clear()
+
+    def shutdown(self) -> None:
+        self.manager.shutdown()

--- a/tests/fixtures/image_487ecf187_offloading_worker.py
+++ b/tests/fixtures/image_487ecf187_offloading_worker.py
@@ -1,0 +1,396 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections import defaultdict
+from dataclasses import replace
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.canonical_mapping import (
+    derive_canonical_mappings,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
+    OffloadingConnectorMetadata,
+    OffloadingWorkerMetadata,
+    ReqId,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.config import (
+    is_kv_cache_tensor_packed,
+)
+from vllm.logger import init_logger
+from vllm.v1.attention.backend import AttentionBackend
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    KVCacheConfig,
+    MambaSpec,
+    UniformTypeKVCacheSpecs,
+)
+from vllm.v1.kv_offload.base import (
+    CanonicalKVCacheRef,
+    CanonicalKVCaches,
+    CanonicalKVCacheTensor,
+    GPULoadStoreSpec,
+    LoadStoreSpec,
+    OffloadingSpec,
+    OffloadingWorker,
+)
+
+logger = init_logger(__name__)
+
+
+class OffloadingConnectorWorker:
+    """Implementation of Worker side methods"""
+
+    def __init__(
+        self,
+        spec: OffloadingSpec,
+        vllm_config: "VllmConfig",
+        kv_cache_config: KVCacheConfig,
+    ):
+        self.spec = spec
+        self.vllm_config = vllm_config
+        self.kv_cache_config = kv_cache_config
+        self.worker: OffloadingWorker | None = None
+        # Non-writers still ack: pending_count waits for world_size per job.
+        self._is_store_writer = (
+            not self.spec.replicated_layout or self.spec.config.parallel.rank == 0
+        )
+
+        # job_id -> req_id for in-flight loads.
+        self._load_jobs: dict[int, ReqId] = {}
+        self._unsubmitted_store_jobs: list[
+            tuple[int, GPULoadStoreSpec, LoadStoreSpec]
+        ] = []
+        self._connector_worker_meta = OffloadingWorkerMetadata()
+
+    def _init_worker(self, kv_caches: CanonicalKVCaches) -> None:
+        self.worker = self.spec.get_worker(kv_caches)
+
+    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
+        kv_cache_config = self.kv_cache_config
+        num_blocks = kv_cache_config.num_blocks
+        mappings = derive_canonical_mappings(
+            self.vllm_config, kv_cache_config, kv_caches
+        )
+
+        # Packed layouts (e.g. DSv4) set block_stride > 0; their tensors use
+        # stride(0) as the manager-block stride (equals total_num_bytes_per_block).
+        # General (non-packed) layouts size the tensor at page_size_bytes per
+        # manager block, so page_size_bytes is the correct offloading stride.
+        layer_is_packed: dict[str, bool] = {
+            ln: is_kv_cache_tensor_packed(kv_tensor)
+            for kv_tensor in kv_cache_config.kv_cache_tensors
+            for ln in kv_tensor.shared_by
+        }
+
+        # layer_name -> (num_blocks, page_size_bytes) tensor
+        tensors_per_block: dict[str, tuple[torch.Tensor, ...]] = {}
+        # layer_name -> size of (un-padded) page in bytes
+        unpadded_page_size_bytes: dict[str, int] = {}
+        # layer_name -> size of page in bytes
+        page_size_bytes: dict[str, int] = {}
+        for kv_cache_group in kv_cache_config.kv_cache_groups:
+            group_layer_names = kv_cache_group.layer_names
+            group_kv_cache_spec = kv_cache_group.kv_cache_spec
+            if isinstance(group_kv_cache_spec, UniformTypeKVCacheSpecs):
+                per_layer_specs = group_kv_cache_spec.kv_cache_specs
+            else:
+                per_layer_specs = {}
+            for layer_name in group_layer_names:
+                layer_kv_cache_spec = per_layer_specs.get(
+                    layer_name, group_kv_cache_spec
+                )
+                if isinstance(layer_kv_cache_spec, AttentionSpec):
+                    layer_kv_cache = kv_caches[layer_name]
+                    assert isinstance(layer_kv_cache, torch.Tensor)
+
+                    page = layer_kv_cache_spec.page_size_bytes
+                    elem_size = layer_kv_cache.element_size()
+                    byte_offset = layer_kv_cache.storage_offset() * elem_size
+                    block_stride_bytes = (
+                        layer_kv_cache.stride(0) * elem_size
+                        if layer_is_packed[layer_name]
+                        else page
+                    )
+                    raw = torch.empty(
+                        0,
+                        dtype=torch.int8,
+                        device=layer_kv_cache.device,
+                    ).set_(layer_kv_cache.untyped_storage())
+                    tensors_per_block[layer_name] = (
+                        torch.as_strided(
+                            raw,
+                            (num_blocks, page),
+                            (block_stride_bytes, 1),
+                            byte_offset,
+                        ),
+                    )
+                    page_size_bytes[layer_name] = layer_kv_cache_spec.page_size_bytes
+                    unpadded_page_size_bytes[layer_name] = (
+                        layer_kv_cache_spec.unpadded_page_size_bytes
+                    )
+
+                elif isinstance(layer_kv_cache_spec, MambaSpec):
+                    layer_kv_cache = kv_caches[layer_name]
+                    assert layer_kv_cache.dtype == torch.int8
+                    tensors_per_block[layer_name] = (
+                        layer_kv_cache.view(
+                            num_blocks, layer_kv_cache_spec.page_size_bytes
+                        ),
+                    )
+
+                    page_size_bytes[layer_name] = layer_kv_cache_spec.page_size_bytes
+                    unpadded_page_size_bytes[layer_name] = replace(
+                        layer_kv_cache_spec, page_size_padded=None
+                    ).page_size_bytes
+
+                else:
+                    raise NotImplementedError
+
+        packed_kv_cache_tensor = next(
+            (
+                t
+                for t in kv_cache_config.kv_cache_tensors
+                if is_kv_cache_tensor_packed(t) and t.shared_by
+            ),
+            None,
+        )
+        if packed_kv_cache_tensor is not None:
+            (tensor,) = tensors_per_block[packed_kv_cache_tensor.shared_by[0]]
+            block_stride = tensor.stride(0)
+            packed_tensor = tensor.as_strided(
+                (num_blocks, block_stride),
+                (block_stride, 1),
+                storage_offset=0,
+            )
+            self._init_worker(
+                CanonicalKVCaches(
+                    [CanonicalKVCacheTensor(packed_tensor, block_stride)],
+                    [
+                        [CanonicalKVCacheRef(0, block_stride)]
+                        for _ in kv_cache_config.kv_cache_groups
+                    ],
+                )
+            )
+            return
+
+        block_tensors: list[CanonicalKVCacheTensor] = []
+        block_data_refs: dict[str, list[CanonicalKVCacheRef]] = defaultdict(list)
+        for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
+            # Filter to layers that were actually processed above.
+            # Packed KV allocation emits KVCacheTensor entries for
+            # every (tuple_idx, page_size) slot; slots where no group has a
+            # layer at that index produce an empty shared_by (reserved memory
+            # with no corresponding model layer).
+            tensor_layer_names = [
+                n for n in kv_cache_tensor.shared_by if n in tensors_per_block
+            ]
+            if not tensor_layer_names:
+                continue
+
+            # verify all layers in the group reference the exact same tensors
+            assert len({len(tensors_per_block[n]) for n in tensor_layer_names}) == 1
+            assert (
+                len({tensors_per_block[n][0].data_ptr() for n in tensor_layer_names})
+                == 1
+            )
+            assert (
+                len({tensors_per_block[n][0].stride() for n in tensor_layer_names}) == 1
+            )
+
+            # pick the first layer to represent the group
+            first_layer_name = tensor_layer_names[0]
+            for tensor in tensors_per_block[first_layer_name]:
+                block_tensors.append(
+                    CanonicalKVCacheTensor(
+                        tensor=tensor,
+                        page_size_bytes=page_size_bytes[first_layer_name],
+                    )
+                )
+
+                curr_tensor_idx = len(block_tensors) - 1
+                for layer_name in tensor_layer_names:
+                    mapping = (
+                        mappings.get(layer_name)
+                        if len(tensors_per_block[first_layer_name]) == 1
+                        else None
+                    )
+                    assert (
+                        mapping is None
+                        or mapping.local_page_size_bytes
+                        == unpadded_page_size_bytes[layer_name]
+                    )
+                    block_data_refs[layer_name].append(
+                        CanonicalKVCacheRef(
+                            tensor_idx=curr_tensor_idx,
+                            page_size_bytes=(unpadded_page_size_bytes[layer_name]),
+                            mapping=mapping,
+                        )
+                    )
+
+        group_data_refs: list[list[CanonicalKVCacheRef]] = []
+        for kv_cache_group in kv_cache_config.kv_cache_groups:
+            group_refs: list[CanonicalKVCacheRef] = []
+            for layer_name in kv_cache_group.layer_names:
+                group_refs += block_data_refs[layer_name]
+            group_data_refs.append(group_refs)
+
+        canonical_kv_caches = CanonicalKVCaches(
+            tensors=block_tensors,
+            group_data_refs=group_data_refs,
+        )
+
+        self._init_worker(canonical_kv_caches)
+
+    def register_cross_layers_kv_cache(
+        self, kv_cache: torch.Tensor, attn_backend: type[AttentionBackend]
+    ):
+        # verify that num_blocks is at physical position 0 in the cross-layers
+        # tensor layout.
+        test_shape = attn_backend.get_kv_cache_shape(
+            num_blocks=1234, block_size=16, num_kv_heads=1, head_size=256
+        )
+        num_blocks_logical_dim = test_shape.index(1234) + 1
+        physical_to_logical = attn_backend.get_kv_cache_stride_order(
+            include_num_layers_dimension=True
+        )
+        num_blocks_physical_dim = physical_to_logical.index(num_blocks_logical_dim)
+        assert num_blocks_physical_dim == 0
+
+        kv_cache_groups = self.kv_cache_config.kv_cache_groups
+        assert len(kv_cache_groups) == 1
+        kv_cache_spec = kv_cache_groups[0].kv_cache_spec
+        num_layers = len(kv_cache_groups[0].layer_names)
+        page_size_bytes = kv_cache_spec.page_size_bytes * num_layers
+
+        assert kv_cache.storage_offset() == 0
+        storage = kv_cache.untyped_storage()
+        assert len(storage) % page_size_bytes == 0
+        num_blocks = len(storage) // page_size_bytes
+        tensor = (
+            torch.tensor(
+                [],
+                dtype=torch.int8,
+                device=kv_cache.device,
+            )
+            .set_(storage)
+            .view(num_blocks, page_size_bytes)
+        )
+        kv_cache_tensor = CanonicalKVCacheTensor(
+            tensor=tensor, page_size_bytes=page_size_bytes
+        )
+        # in cross layers layout, there's currently only a single group
+        kv_cache_data_ref = CanonicalKVCacheRef(
+            tensor_idx=0, page_size_bytes=page_size_bytes
+        )
+        canonical_kv_caches = CanonicalKVCaches(
+            tensors=[kv_cache_tensor], group_data_refs=[[kv_cache_data_ref]]
+        )
+
+        self._init_worker(canonical_kv_caches)
+
+    def handle_preemptions(self, kv_connector_metadata: OffloadingConnectorMetadata):
+        assert self.worker is not None
+
+        # Pop jobs_to_flush from store_jobs into _unsubmitted_store_jobs
+        # so the existing submission loop below submits them before wait().
+        if kv_connector_metadata.jobs_to_flush:
+            for job_id in kv_connector_metadata.jobs_to_flush:
+                entry = kv_connector_metadata.store_jobs.pop(job_id, None)
+                if entry is not None:
+                    if not self._is_store_writer:
+                        self._connector_worker_meta.mark_completed(job_id)
+                        continue
+                    assert isinstance(entry.src_spec, GPULoadStoreSpec)
+                    self._unsubmitted_store_jobs.append(
+                        (job_id, entry.src_spec, entry.dst_spec)
+                    )
+
+        # Submit deferred stores from previous step (and jobs_to_flush above).
+        for job_id, src_spec, dst_spec in self._unsubmitted_store_jobs:
+            assert isinstance(src_spec, GPULoadStoreSpec)
+            success = self.worker.submit_store(job_id, src_spec, dst_spec)
+            assert success
+        self._unsubmitted_store_jobs.clear()
+
+        if kv_connector_metadata.jobs_to_flush:
+            self.worker.wait(kv_connector_metadata.jobs_to_flush)
+
+    def start_kv_transfers(self, metadata: OffloadingConnectorMetadata):
+        assert self.worker is not None
+        for job_id, src_spec, dst_spec in self._unsubmitted_store_jobs:
+            success = self.worker.submit_store(job_id, src_spec, dst_spec)
+            assert success
+        self._unsubmitted_store_jobs.clear()
+
+        for job_id, entry in metadata.load_jobs.items():
+            self._load_jobs[job_id] = entry.req_id
+            assert isinstance(entry.dst_spec, GPULoadStoreSpec)
+            success = self.worker.submit_load(job_id, entry.src_spec, entry.dst_spec)
+            assert success
+
+    def prepare_store_kv(self, metadata: OffloadingConnectorMetadata):
+        for job_id, entry in metadata.store_jobs.items():
+            if not self._is_store_writer:
+                # Gate before queueing: no _unsubmitted_store_jobs entry.
+                self._connector_worker_meta.mark_completed(job_id)
+                continue
+            # NOTE(orozery): defer the store to the beginning of the next
+            # engine step, so that offloading starts AFTER transfers related
+            # to token sampling, thereby avoiding delays to token generation.
+            assert isinstance(entry.src_spec, GPULoadStoreSpec)
+            self._unsubmitted_store_jobs.append(
+                (job_id, entry.src_spec, entry.dst_spec)
+            )
+
+    def get_finished(self, finished_req_ids: set[str]) -> tuple[set[str], set[str]]:
+        """
+        Returns:
+            tuple of (finished_sending, finished_recving). Stores never
+            emit finished_sending — the scheduler tracks store completion
+            via kv_connector_worker_meta.completed_jobs and fences any
+            block reuse via jobs_to_flush. Loads still emit
+            finished_recving so the base scheduler can resume requests
+            blocked on remote KV (and free aborted-during-load reqs).
+        """
+        assert self.worker is not None
+        finished_recving: set[str] = set()
+        for transfer_result in self.worker.get_finished():
+            # we currently do not support job failures
+            job_id = transfer_result.job_id
+            assert transfer_result.success
+            is_load = job_id in self._load_jobs
+            if (
+                transfer_result.transfer_time is not None
+                and transfer_result.transfer_size is not None
+            ):
+                if is_load:
+                    stats = self._connector_worker_meta.transfer_stats.load
+                else:
+                    stats = self._connector_worker_meta.transfer_stats.store
+                stats.record(
+                    transfer_result.transfer_size,
+                    transfer_result.transfer_time,
+                )
+
+            self._connector_worker_meta.mark_completed(job_id)
+            req_id = self._load_jobs.pop(job_id, None)
+            if req_id is not None:
+                finished_recving.add(req_id)
+
+        return set(), finished_recving
+
+    def build_connector_worker_meta(self) -> OffloadingWorkerMetadata | None:
+        """Return completed transfer job IDs since the last call."""
+        if not self._connector_worker_meta.completed_jobs:
+            return None
+        meta = self._connector_worker_meta
+        self._connector_worker_meta = OffloadingWorkerMetadata()
+        return meta
+
+    def shutdown(self) -> None:
+        self._unsubmitted_store_jobs.clear()
+        self._load_jobs.clear()
+        self._connector_worker_meta = OffloadingWorkerMetadata()
+        if self.worker is not None:
+            self.worker.shutdown()

--- a/tests/fixtures/image_487ecf187_single_type_kv_cache_manager.py
+++ b/tests/fixtures/image_487ecf187_single_type_kv_cache_manager.py
@@ -1,0 +1,2076 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import itertools
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from collections.abc import Sequence
+from typing import ClassVar
+
+from vllm.logger import init_logger
+from vllm.utils.math_utils import cdiv
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import (
+    BlockHashList,
+    BlockHashListWithBlockSize,
+    BlockHashWithGroupId,
+    KVCacheBlock,
+    resolve_block_hashes,
+)
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    ChunkedLocalAttentionSpec,
+    CrossAttentionSpec,
+    FullAttentionSpec,
+    HiddenStateCacheSpec,
+    KpoolTailSpec,
+    KVCacheSpec,
+    MambaSpec,
+    MLAAttentionSpec,
+    RSWASpec,
+    SinkFullAttentionSpec,
+    SlidingWindowMLASpec,
+    SlidingWindowSpec,
+    TQFullAttentionSpec,
+)
+from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
+from vllm.v1.request import Request
+
+logger = init_logger(__name__)
+
+
+class SingleTypeKVCacheManager(ABC):
+    """
+    An abstract base class for a manager that handle the kv cache management
+    logic of one specific type of attention layer.
+    """
+
+    supports_fine_grained_hash_lookup: ClassVar[bool] = False
+
+    def __init__(
+        self,
+        kv_cache_spec: KVCacheSpec,
+        block_pool: BlockPool,
+        enable_caching: bool,
+        kv_cache_group_id: int,
+        scheduler_block_size: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+        needs_kv_cache_zeroing: bool = False,
+        max_admission_blocks_per_request: int | None = None,
+    ) -> None:
+        """
+        Initializes the SingleTypeKVCacheManager.
+        Args:
+            kv_cache_spec: The kv_cache_spec for this manager.
+            block_pool: The block pool.
+            kv_cache_group_id: The id of the kv cache group of this manager.
+            scheduler_block_size: The scheduling granularity (LCM of all group
+                block sizes); a multiple of this manager's ``block_size``.
+            needs_kv_cache_zeroing: Whether worker-side KV cache zeroing needs
+                newly allocated block IDs from this manager.
+            max_admission_blocks_per_request: Recycling-aware per-request
+                block cap used by `get_num_blocks_to_allocate`. Only set for
+                spec types that recycle blocks across chunks (SWA,
+                chunked-local); `None` (the default) means no cap, which is
+                correct for full-attention-style specs that hold every
+                block until the request finishes.
+        """
+        self.scheduler_block_size = scheduler_block_size
+        # The block size for this manager; used for actual block allocation.
+        self.block_size = kv_cache_spec.block_size
+        self.dcp_world_size = dcp_world_size
+        self.pcp_world_size = pcp_world_size
+        if dcp_world_size > 1:
+            self.block_size *= dcp_world_size
+        self.kv_cache_spec = kv_cache_spec
+        self.block_pool = block_pool
+        self.enable_caching = enable_caching
+        self._max_admission_blocks_per_request = max_admission_blocks_per_request
+        # Record newly allocated block ids only when worker-side zeroing will
+        # consume them and this manager holds a spec type that gets zeroed.
+        self._record_new_block_ids = needs_kv_cache_zeroing and isinstance(
+            kv_cache_spec, AttentionSpec
+        )
+        self.new_block_ids: list[int] = []
+
+        # Mapping from request ID to blocks to track the blocks allocated
+        # for each request, so that we can free the blocks when the request
+        # is finished.
+        self.req_to_blocks: defaultdict[str, list[KVCacheBlock]] = defaultdict(list)
+
+        # {req_id: The number of cached blocks for this given request}
+        # This is used to track the number of cached blocks for each request.
+        # This is only used to track the RUNNING requests, we do not track the
+        # data for preempted ones.
+        self.num_cached_block: dict[str, int] = {}
+
+        self.kv_cache_group_id = kv_cache_group_id
+        self._null_block = block_pool.null_block
+
+        # Whether this group's prefix-cache hits drop the EAGLE/MTP lookahead
+        # block. Only consulted by managers whose hit logic is sparse within an
+        # aligned segment (SWA). Initialized lazily by the coordinator after
+        # determining the attention groups.
+        self.use_eagle = False
+
+        # Partial-hit copy-on-write bookkeeping. Populated only by fine-grained
+        # managers (full attention, mamba "align"); harmlessly empty elsewhere.
+        self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
+        self._pending_cow_copies: list[tuple[KVCacheBlock, KVCacheBlock]] = []
+        # Partial-tail offload hand-off for external KV connectors: when a
+        # producer registers its last-prompt-boundary partial tail and the
+        # durable boundary block is not on the append-only request block table
+        # (mamba "align" CoW target), record the request, group, block, and
+        # exact token boundary so a connector can offload it under the right
+        # hash. Populated only by mamba "align".
+        self._pending_partial_tail_offloads: list[
+            tuple[str, int, KVCacheBlock, int]
+        ] = []
+
+    @classmethod
+    def _get_num_evictable_blocks(cls, blocks: Sequence[KVCacheBlock]):
+        return sum(blk.ref_cnt == 0 and not blk.is_null for blk in blocks)
+
+    def _has_partial_local_hit(
+        self,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        num_local_computed_tokens: int,
+    ) -> bool:
+        # The local prefix-cache hit ends inside one of this manager's
+        # blocks: the shared tail block needs CoW.
+        return (
+            len(new_computed_blocks) > 0
+            and num_local_computed_tokens % self.block_size != 0
+        )
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        total_computed_tokens: int,
+        num_local_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+    ) -> int:
+        """
+        Get the number of blocks needed to be allocated for the request.
+
+        Args:
+            request_id: The request ID.
+            num_tokens: The total number of tokens that need a slot (including
+                tokens that are already allocated).
+            new_computed_blocks: The new computed blocks just hitting the
+                prefix caching.
+            total_computed_tokens: Include both local and external computed
+                tokens.
+            num_local_computed_tokens: The number of local prefix-cache computed
+                tokens.
+            num_tokens_main_model: The number of tokens for the main model (aka target
+                model in spec decode). w/o spec decode, it is num_tokens;
+                with spec decode, it is num_tokens - num_lookahead_tokens.
+            apply_admission_cap: If True, clamp by `num_required_blocks` by
+                `_max_admission_blocks_per_request`for recycling-aware specs
+                (SWA, chunked-local).
+
+        Returns:
+            The number of blocks to allocate.
+        """
+
+        num_required_blocks = cdiv(num_tokens, self.block_size)
+        if apply_admission_cap and self._max_admission_blocks_per_request is not None:
+            # Recycling-aware specs (SWA, chunked-local) cap the per-request
+            # reservation here so admission matches the startup pool sizer
+            # (`SlidingWindowSpec.max_admission_blocks_per_request` / its
+            # chunked-local counterpart). `remove_skipped_blocks` runs from
+            # `allocate_slots` before each chunk's `get_num_blocks_to_allocate`,
+            # so per-request peak real-held blocks <= this cap, which keeps
+            # `sum(reservations) <= pool` <=> `sum(peak_real_held) <= pool`.
+            # Drift between the two would re-introduce the deadlock from
+            # issue #39734 or, worse, mid-prefill OOM.
+            num_required_blocks = min(
+                num_required_blocks, self._max_admission_blocks_per_request
+            )
+        num_req_blocks = len(self.req_to_blocks.get(request_id, ()))
+
+        if request_id in self.num_cached_block:
+            # Fast-path: a running request won't have any new prefix-cache hits.
+            assert len(new_computed_blocks) == 0
+            # NOTE: With speculative decoding, request's blocks may be allocated
+            # for draft tokens which are later rejected. In this case,
+            # num_required_blocks may be smaller than num_req_blocks.
+            return max(num_required_blocks - num_req_blocks, 0)
+
+        num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
+        num_local_computed_blocks = len(new_computed_blocks) + num_req_blocks
+        # Number of whole blocks that are skipped by the attention window.
+        # If nothing is skipped, this is 0.
+        num_skipped_blocks = num_skipped_tokens // self.block_size
+        # We need blocks for the non-skipped suffix. If there are still
+        # local-computed blocks inside the window, they contribute to the
+        # required capacity; otherwise, skipped blocks dominate.
+        num_new_blocks = max(
+            num_required_blocks - max(num_skipped_blocks, num_local_computed_blocks),
+            0,
+        )
+
+        # Among the `new_computed_blocks`, the first `num_skipped_blocks` worth
+        # of blocks are skipped; `num_req_blocks` of those may already be in
+        # `req_to_blocks`, so only skip the remainder from `new_computed_blocks`.
+        num_skipped_new_computed_blocks = max(0, num_skipped_blocks - num_req_blocks)
+
+        # If a computed block is an eviction candidate (in the free queue and
+        # ref_cnt == 0), it will be removed from the free queue when touched by
+        # the allocated request, so we must count it in the free-capacity check.
+        num_evictable_blocks = self._get_num_evictable_blocks(
+            new_computed_blocks[num_skipped_new_computed_blocks:]
+        )
+        if self._has_partial_local_hit(new_computed_blocks, num_local_computed_tokens):
+            # Reserve the extra block that allocate_new_blocks pulls for the
+            # partial-hit CoW redirect.
+            num_new_blocks += 1
+        return num_new_blocks + num_evictable_blocks
+
+    def add_local_computed_blocks(
+        self,
+        request_id: str,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        """
+        Add the locally cached (prefix-hit) blocks to the request:
+        1. Touch the computed blocks (paired with adding them to `req_blocks`)
+           so their ref_cnt exactly tracks the referencing requests.
+        1.5. (Optional) For sliding window, skipped blocks are padded with nulls.
+        2. Add the remaining computed blocks.
+
+        Args:
+            request_id: The request ID.
+            new_computed_blocks: The new computed blocks just hitting the
+                prefix cache.
+            num_local_computed_tokens: The number of local computed tokens.
+            num_external_computed_tokens: The number of external computed tokens.
+        """
+        # The coordinator only calls this for first-time allocations (running
+        # requests are short-circuited there), so the request has no blocks yet.
+        req_blocks = self.req_to_blocks[request_id]
+        assert len(req_blocks) == 0
+        num_total_computed_tokens = (
+            num_local_computed_tokens + num_external_computed_tokens
+        )
+        num_skipped_tokens = self.get_num_skipped_tokens(num_total_computed_tokens)
+        num_skipped_blocks = num_skipped_tokens // self.block_size
+        if num_skipped_blocks > 0:
+            # It is possible that all new computed blocks are skipped when
+            # num_skipped_blocks > len(new_computed_blocks).
+            new_computed_blocks = new_computed_blocks[num_skipped_blocks:]
+
+        # Touch the computed blocks to make sure they won't be evicted.
+        if self.enable_caching:
+            self.block_pool.touch(new_computed_blocks)
+        else:
+            assert not any(new_computed_blocks), (
+                "Computed blocks should be empty when prefix caching is disabled"
+            )
+
+        # Skip blocks are padded with null blocks.
+        req_blocks.extend([self._null_block] * num_skipped_blocks)
+        # Add the remaining computed blocks.
+        req_blocks.extend(new_computed_blocks)
+        # All cached hits (including skipped nulls) are already cached; mark
+        # them so cache_blocks() will not try to re-cache blocks that already
+        # have a block_hash set.
+        self.num_cached_block[request_id] = len(req_blocks)
+        if self._has_partial_local_hit(new_computed_blocks, num_local_computed_tokens):
+            # Record the partial tail for the CoW redirect in
+            # allocate_new_blocks; cap the cached count at the full blocks so
+            # cache_blocks() re-caches the private copy once full.
+            block_idx = num_local_computed_tokens // self.block_size
+            self._partial_hit_reqs[request_id] = (block_idx, new_computed_blocks[-1])
+            self.num_cached_block[request_id] = block_idx
+
+    def allocate_external_computed_blocks(
+        self,
+        request_id: str,
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        """
+        Allocate new blocks for external (KV-connector) computed tokens.
+
+        Must run only after every group's local blocks have been touched via
+        `add_local_computed_blocks`, so this group's `get_new_blocks` cannot
+        evict another group's cache-hit blocks (issue #33775).
+
+        Args:
+            request_id: The request ID.
+            num_local_computed_tokens: The number of local computed tokens.
+            num_external_computed_tokens: The number of external computed tokens.
+        """
+        num_total_computed_tokens = (
+            num_local_computed_tokens + num_external_computed_tokens
+        )
+        num_skipped_tokens = self.get_num_skipped_tokens(num_total_computed_tokens)
+        if num_skipped_tokens > 0:
+            # Some external computed tokens may be skipped too.
+            num_external_computed_tokens = min(
+                num_total_computed_tokens - num_skipped_tokens,
+                num_external_computed_tokens,
+            )
+        if num_external_computed_tokens <= 0:
+            return
+
+        req_blocks = self.req_to_blocks[request_id]
+        allocated_blocks = self.block_pool.get_new_blocks(
+            cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
+        )
+        req_blocks.extend(allocated_blocks)
+        if self._record_new_block_ids:
+            self.new_block_ids.extend(b.block_id for b in allocated_blocks)
+
+    def allocate_new_blocks(
+        self, request_id: str, num_tokens: int, num_tokens_main_model: int
+    ) -> list[KVCacheBlock]:
+        """
+        Allocate new blocks for the request to give it at least `num_tokens`
+        token slots.
+
+        Args:
+            request_id: The request ID.
+            num_tokens: The total number of tokens that need a slot (including
+                tokens that are already allocated).
+            num_tokens_main_model: The number of tokens for the main model (aka target
+                model in spec decode). w/o spec decode, it is num_tokens;
+                with spec decode, it is num_tokens - num_lookahead_tokens.
+        Returns:
+            The new allocated blocks.
+        """
+        cow_blocks: list[KVCacheBlock] = []
+        if request_id in self._partial_hit_reqs:
+            # Partial hit: redirect the shared tail to a private CoW block.
+            # Replacing in place keeps the length-based allocation below
+            # correct; the extra block was reserved by
+            # get_num_blocks_to_allocate.
+            block_idx, source_block = self._partial_hit_reqs.pop(request_id)
+            cow_block = self.block_pool.get_new_blocks(1)[0]
+            self._apply_cow(request_id, block_idx, source_block, cow_block)
+            self.new_block_ids.append(cow_block.block_id)
+            cow_blocks.append(cow_block)
+
+        req_blocks = self.req_to_blocks[request_id]
+        num_required_blocks = cdiv(num_tokens, self.block_size)
+        num_new_blocks = num_required_blocks - len(req_blocks)
+        if num_new_blocks <= 0:
+            return cow_blocks
+        else:
+            new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
+            req_blocks.extend(new_blocks)
+            if self._record_new_block_ids:
+                self.new_block_ids.extend(b.block_id for b in new_blocks)
+            return cow_blocks + new_blocks
+
+    @property
+    def records_new_block_ids(self) -> bool:
+        """Whether this manager's new blocks are zeroed by the worker."""
+        return self._record_new_block_ids
+
+    def take_new_block_ids(self) -> list[int]:
+        """Drain and return block IDs allocated since the last call."""
+        ids = self.new_block_ids
+        self.new_block_ids = []
+        return ids
+
+    def take_pending_cow_copies(
+        self,
+    ) -> list[tuple[KVCacheBlock, KVCacheBlock]]:
+        """Drain pending CoW source and destination block pairs."""
+        pending_copies = self._pending_cow_copies
+        self._pending_cow_copies = []
+        return pending_copies
+
+    def take_pending_partial_tail_offloads(
+        self,
+    ) -> list[tuple[str, int, KVCacheBlock, int]]:
+        """Drain producer partial-tail hand-offs.
+
+        Entries are ``(req_id, group_id, block, boundary_tokens)``.
+
+        Only mamba "align" populates this. The block lives off the request
+        block table, so the caller must pin it until the connector has read
+        it — nothing else keeps it alive once the CoW retention is released.
+        """
+        pending = self._pending_partial_tail_offloads
+        self._pending_partial_tail_offloads = []
+        return pending
+
+    def _apply_cow(
+        self,
+        request_id: str,
+        block_idx: int,
+        source_block: KVCacheBlock,
+        cow_block: KVCacheBlock,
+    ) -> None:
+        """Redirect a partial prefix-cache hit to a private CoW block.
+
+        Both copy endpoints stay retained until the copy has run on the worker,
+        so a same-step free cannot recycle them: ``source_block`` keeps its
+        hit-ref, ``cow_block`` takes an extra ref beyond the one handed to the
+        request.
+        """
+        req_blocks = self.req_to_blocks[request_id]
+        assert block_idx < len(req_blocks)
+        assert req_blocks[block_idx] is source_block
+        assert not source_block.is_null and source_block.ref_cnt > 0
+        req_blocks[block_idx] = cow_block
+        self._pending_cow_copies.append((source_block, cow_block))
+        cow_block.ref_cnt += 1
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        retention_interval: int | None = None,
+    ) -> None:
+        """
+        Cache the blocks for the request.
+
+        Args:
+            request: The request.
+            num_tokens: The total number of tokens that need to be cached
+                (including tokens that are already cached).
+            retention_interval: Sparse local-checkpoint granularity. ``None``
+                keeps dense checkpointing; ``0`` keeps only the latest replay
+                boundary; a positive multiple of ``scheduler_block_size`` keeps
+                a tail once per that-sized segment. Only SWA acts on it.
+        """
+        num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
+        num_full_blocks = num_tokens // self.block_size
+
+        if num_cached_blocks >= num_full_blocks:
+            return
+
+        # Token boundaries whose reachable tail must be retained under sparse
+        # retention: the replay boundary (``num_prompt - 1``, capped by
+        # ``get_computed_blocks``) and any detected shared-prefix junction.
+        reachable_boundaries = [request.num_prompt_tokens - 1]
+        if request.shared_prefix_boundary:
+            reachable_boundaries.append(request.shared_prefix_boundary)
+
+        block_mask = self.reachable_block_mask(
+            start_block=num_cached_blocks,
+            end_block=num_full_blocks,
+            alignment_tokens=self.scheduler_block_size,
+            kv_cache_spec=self.kv_cache_spec,
+            use_eagle=self.use_eagle,
+            retention_interval=retention_interval,
+            reachable_boundaries=reachable_boundaries,
+        )
+        self.block_pool.cache_full_blocks(
+            request=request,
+            blocks=self.req_to_blocks[request.request_id],
+            num_cached_blocks=num_cached_blocks,
+            num_full_blocks=num_full_blocks,
+            block_size=self.block_size,
+            kv_cache_group_id=self.kv_cache_group_id,
+            block_mask=block_mask,
+        )
+
+        self.num_cached_block[request.request_id] = num_full_blocks
+
+    @classmethod
+    def reachable_block_mask(
+        cls,
+        start_block: int,
+        end_block: int,
+        alignment_tokens: int | None,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        retention_interval: int | None = None,
+        reachable_boundaries: Sequence[int] = (),
+    ) -> list[bool] | None:
+        """Per-block mask for ``cache_full_blocks``. ``None`` means cache
+        every (non-null) block — the default for full attention.
+
+        Subclasses with sparse hit semantics (SWA / Mamba) override this to skip
+        blocks that can never serve a hit at any alignment-aligned prefix length.
+        ``reachable_boundaries`` are token positions whose reachable tail must be
+        retained; the base (dense) policy ignores them.
+        """
+        return None
+
+    def pop_blocks_for_free(self, request_id: str) -> list[KVCacheBlock]:
+        """
+        Pop the request's bookkeeping and return its blocks without yet
+        returning them to the block pool. The caller is responsible for
+        eventually passing the returned blocks to `block_pool.free_blocks`,
+        freeing them in reverse order (so that tail blocks are evicted first).
+
+        Args:
+            request_id: The request ID.
+
+        Returns:
+            The request's blocks in allocation order.
+        """
+        # Default to [] in case a request is freed (aborted) before alloc.
+        req_blocks = self.req_to_blocks.pop(request_id, [])
+        self.num_cached_block.pop(request_id, None)
+        self._partial_hit_reqs.pop(request_id, None)
+        return req_blocks
+
+    def free(self, request_id: str) -> None:
+        """
+        Free the blocks for the request.
+
+        Args:
+            request_id: The request ID.
+        """
+        # Free blocks in reverse order so that the tail blocks are freed first.
+        self.block_pool.free_blocks(reversed(self.pop_blocks_for_free(request_id)))
+
+    @abstractmethod
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        """
+        Get the number of common prefix blocks for all requests with allocated
+        KV cache.
+
+        Args:
+            running_request_id: The request ID.
+
+        Returns:
+            The number of common prefix blocks for all requests with allocated
+            KV cache.
+        """
+
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        drop_eagle_block: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        """
+        Get the longest cache hit prefix of the blocks that is not longer than
+        `max_length`. The prefix should be a common prefix hit for all the
+        kv cache groups in `kv_cache_group_ids`. If no cache hit is found,
+        return an empty list.
+        If eagle is enabled, drop the last matched block to force recompute the
+        last block to get the required hidden states for eagle drafting head.
+        Need to be customized for each attention type.
+
+        Args:
+            block_hashes: The block hashes of the request.
+            max_length: The maximum length of the cache hit prefix.
+            kv_cache_group_ids: The ids of the kv cache groups.
+            block_pool: The block pool.
+            kv_cache_spec: The kv cache spec.
+            drop_eagle_block: Whether to drop the last matched block for EAGLE/MTP.
+                Always False for non-EAGLE/MTP groups, but can be False for EAGLE/MTP
+                groups too if the last block is already dropped (e.g., in a
+                convergence loop in `find_longest_cache_hit`).
+            alignment_tokens: The returned cache hit length (in tokens) should
+                be a multiple of this value (in tokens). By default, it should
+                be set to the block_size.
+            dcp_world_size: The world size of decode context parallelism.
+            pcp_world_size: The world size of prefill context parallelism.
+
+        Returns:
+            A tuple containing cached blocks and the exact cache-hit length in
+            tokens. The cached block tuple has skipped blocks replaced by null
+            blocks for each kv cache group in `kv_cache_group_ids`.
+            For example, sliding window manager should return a list like
+            ([NULL, NULL, KVCacheBlock(7), KVCacheBlock(8)]) for block size 4
+            and sliding window 8 and len(kv_cache_group_ids) = 1.
+        """
+
+        raise NotImplementedError
+
+    def _remove_blocks_in_range(
+        self,
+        request_id: str,
+        first_block: int,
+        last_block: int,
+    ) -> None:
+        """Free blocks in ``[first_block, last_block)`` and replace with null_block.
+
+        Iterates backward so newly-evictable tail blocks are reached even after
+        earlier blocks in the range were nulled in a prior call.
+        """
+        if request_id not in self.req_to_blocks:
+            return
+        if first_block >= last_block:
+            return
+        blocks = self.req_to_blocks[request_id]
+        last_block = min(last_block, len(blocks))
+
+        freed: list[KVCacheBlock] = []
+        for i in range(last_block - 1, first_block - 1, -1):
+            if blocks[i] == self._null_block:
+                break
+            freed.append(blocks[i])
+            blocks[i] = self._null_block
+        if freed:
+            self.block_pool.free_blocks(freed)
+
+    def remove_skipped_blocks(
+        self,
+        request_id: str,
+        processed_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
+    ) -> None:
+        """
+        Remove and free the blocks that are no longer needed for attention computation.
+        The removed blocks should be replaced by null_block.
+
+        This function depends on `get_num_skipped_tokens`, which need to be implemented
+        differently for each attention type.
+
+        Args:
+            request_id: The request ID.
+            processed_computed_tokens: Computed-token prefix length covering
+                fully processed and committed tokens only (safe to free).
+            num_prompt_tokens: Optional prompt length for attention types (e.g.
+                R-SWA) that evict a middle gap rather than a head prefix. Ignored
+                by the default implementation.
+        """
+        del num_prompt_tokens
+        # Remove the blocks that will be skipped during attention computation.
+        num_skipped_tokens = self.get_num_skipped_tokens(processed_computed_tokens)
+        if num_skipped_tokens <= 0:
+            # This indicates that ALL tokens are inside attention window.
+            # Thus we do not need to free any blocks outside attention window.
+            # A typical case is full attention that we never free any token
+            # before the request is finished.
+            return
+        blocks = self.req_to_blocks[request_id]
+        num_skipped_blocks = num_skipped_tokens // self.block_size
+        # `num_skipped_tokens` may include tokens that haven't been allocated yet
+        # (e.g., when the attention window moves into the external computed tokens
+        # range), so we must cap to the number of blocks that currently exist for
+        # this request.
+        num_skipped_blocks = min(num_skipped_blocks, len(blocks))
+        self._remove_blocks_in_range(request_id, 0, num_skipped_blocks)
+
+    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+        """
+        Get the number of tokens that will be skipped for attention computation.
+
+        Args:
+            num_computed_tokens: The number of tokens that have been computed.
+
+        Returns:
+            The number of tokens that will be skipped for attention computation.
+        """
+        # The default behavior is to not skip any tokens.
+        return 0
+
+    def new_step_starts(self) -> None:
+        return None
+
+
+class FullAttentionManager(SingleTypeKVCacheManager):
+    supports_fine_grained_hash_lookup: ClassVar[bool] = True
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        drop_eagle_block: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        assert isinstance(
+            kv_cache_spec, FullAttentionSpec | ChunkedLocalAttentionSpec
+        ), (
+            "FullAttentionManager can only be used for full attention "
+            "and chunked local attention groups"
+        )
+        block_size = kv_cache_spec.block_size
+        if dcp_world_size > 1:
+            # DCP shards each block's KV across ranks; hashes must be viewed at
+            # the sharded block size.
+            block_size *= dcp_world_size
+        block_hashes = resolve_block_hashes(
+            block_hashes,
+            block_pool.hash_block_size,
+            block_size,
+            supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
+            alignment_tokens=alignment_tokens,
+        )
+
+        # Fine-grained mode (alignment_tokens == hash_block_size <
+        # block_size): resolve_block_hashes kept the raw hash-granularity
+        # list so interior boundaries can be probed.
+        fine_grained = (
+            alignment_tokens < block_size and block_size % alignment_tokens == 0
+        )
+        if fine_grained:
+            # list or lazy BlobBlockHashes view
+            assert isinstance(block_hashes, Sequence)
+            full_block_hashes: BlockHashList = BlockHashListWithBlockSize(
+                block_hashes, alignment_tokens, block_size
+            )
+        else:
+            full_block_hashes = block_hashes
+
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [] for _ in range(len(kv_cache_group_ids))
+        )
+        # Phase 1: longest run of cached full blocks from the start. A missing
+        # block implies every later block misses too (chained hashes).
+        for block_hash in itertools.islice(full_block_hashes, max_length // block_size):
+            cached_block = block_pool.get_cached_block(block_hash, kv_cache_group_ids)
+            if not cached_block:
+                break
+            for computed, cached in zip(computed_blocks, cached_block):
+                computed.append(cached)
+        hit_length = len(computed_blocks[0]) * block_size
+
+        # Phase 2 (fine-grained only): extend into the first non-full block by
+        # probing its interior hash boundaries high-to-low (longest hit first).
+        if fine_grained:
+            # list or lazy BlobBlockHashes view
+            assert isinstance(block_hashes, Sequence)
+            scale_factor = block_size // alignment_tokens
+            first_partial_idx = len(computed_blocks[0]) * scale_factor
+            max_partial_idx = min(
+                first_partial_idx + scale_factor - 1,
+                max_length // alignment_tokens,
+                len(block_hashes),
+            )
+            for fine_idx in range(max_partial_idx - 1, first_partial_idx - 1, -1):
+                cached_tail = block_pool.get_cached_block(
+                    block_hashes[fine_idx], kv_cache_group_ids
+                )
+                if not cached_tail:
+                    continue
+                for computed, cached in zip(computed_blocks, cached_tail):
+                    computed.append(cached)
+                hit_length = (fine_idx + 1) * alignment_tokens
+                break
+
+        # Eagle needs the tokens right before the generation point recomputed:
+        # drop one hash unit when fine-grained (the tail block's KV is
+        # append-only, so it still covers the reduced length), else one cache
+        # block.
+        if drop_eagle_block and hit_length > 0:
+            hit_length -= min(alignment_tokens, block_size)
+        # Round down to the alignment; a no-op when fine-grained (hits land on
+        # hash boundaries by construction) and when alignment_tokens ==
+        # block_size. Then trim blocks past the new tail.
+        hit_length -= hit_length % alignment_tokens
+        num_blocks = cdiv(hit_length, block_size)
+        for computed in computed_blocks:
+            del computed[num_blocks:]
+        return computed_blocks, hit_length
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        retention_interval: int | None = None,
+    ) -> None:
+        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        hash_block_size = self.block_pool.hash_block_size
+        if self.block_size == hash_block_size:
+            return
+        self._cache_partial_tail_block(request, num_tokens)
+
+    def _cache_partial_tail_block(
+        self,
+        request: Request,
+        num_tokens: int,
+    ) -> None:
+        """Cache the prompt tail when it ends inside a cache block.
+
+        Only the final prompt hash boundary is registered as a partial
+        prefix-cache entry; intermediate hash boundaries inside the same cache
+        block are intentionally skipped.
+        """
+        hash_block_size = self.block_pool.hash_block_size
+        boundary_tokens = request.num_prompt_tokens // hash_block_size * hash_block_size
+        if boundary_tokens == 0 or boundary_tokens > num_tokens:
+            return
+        if boundary_tokens % self.block_size == 0:
+            return
+
+        blocks = self.req_to_blocks[request.request_id]
+        block_idx = boundary_tokens // self.block_size
+        if block_idx >= len(blocks):
+            return
+        self.block_pool.cache_partial_block(
+            request=request,
+            block=blocks[block_idx],
+            num_tokens=boundary_tokens,
+            kv_cache_group_id=self.kv_cache_group_id,
+            block_size=self.block_size,
+        )
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        blocks = self.req_to_blocks[running_request_id]
+        num_common_blocks = 0
+        for block in blocks:
+            if block.ref_cnt == len(self.req_to_blocks):
+                num_common_blocks += 1
+            else:
+                break
+        return num_common_blocks
+
+
+class RSWAManager(FullAttentionManager):
+    """KV cache manager for Reference Sliding Window Attention (R-SWA).
+
+    When ``num_prompt_tokens`` is supplied to ``remove_skipped_blocks``, frees
+    gap blocks between the prefill tail and the current decode window.  This
+    bounds per-request KV memory at O(prefix_len + rswa_window) instead of
+    growing linearly with decode length.
+    """
+
+    def __init__(self, kv_cache_spec: RSWASpec, **kwargs) -> None:
+        super().__init__(kv_cache_spec, **kwargs)
+        self.rswa_window: int = kv_cache_spec.rswa_window
+
+    def remove_skipped_blocks(
+        self,
+        request_id: str,
+        processed_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
+    ) -> None:
+        """Free gap blocks that are no longer needed for attention.
+
+        Gap = blocks entirely within
+            [ceil(prefix_len / block_size) * block_size,
+             max(prefix_len, processed_computed_tokens - rswa_window))
+
+        Freed blocks are replaced with null_block in req_to_blocks so the
+        block_table passed to FA4 is valid (null_block KV is all-zero;
+        rswa_mask_mod marks gap positions as non-visible so FA4 skips them).
+        """
+        if num_prompt_tokens is None:
+            super().remove_skipped_blocks(
+                request_id, processed_computed_tokens, num_prompt_tokens
+            )
+            return
+
+        bs = self.block_size
+        # First block fully after the prefill boundary.
+        first_gap_block = cdiv(num_prompt_tokens, bs)
+        # Decode window start position; blocks before this are evictable.
+        window_start = max(
+            num_prompt_tokens, processed_computed_tokens - self.rswa_window
+        )
+        last_gap_block = window_start // bs  # exclusive upper bound
+        self._remove_blocks_in_range(request_id, first_gap_block, last_gap_block)
+
+
+class SlidingWindowManager(SingleTypeKVCacheManager):
+    def __init__(self, kv_cache_spec: SlidingWindowSpec, **kwargs) -> None:
+        super().__init__(kv_cache_spec, **kwargs)
+        self.sliding_window = kv_cache_spec.sliding_window
+
+    @classmethod
+    def _contiguous_blocks_for_hit(
+        cls, window_size: int, block_size: int, use_eagle: bool
+    ) -> int:
+        blocks = cdiv(window_size - 1, block_size)
+        if use_eagle:
+            # Need to drop the last matched block if eagle is enabled. For
+            # sliding window layer, we achieve this by increasing the number of
+            # contiguous blocks needed for prefix cache hit by one and dropping
+            # the last matched block.
+            blocks += 1
+        return blocks
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        drop_eagle_block: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        assert isinstance(kv_cache_spec, SlidingWindowSpec), (
+            "SlidingWindowManager can only be used for sliding window groups"
+        )
+        assert dcp_world_size == 1, "DCP not support sliding window attn now."
+        assert pcp_world_size == 1, "PCP not support sliding window attn now."
+        # Fine-grained partial hits are not supported for sliding window now
+        assert alignment_tokens % kv_cache_spec.block_size == 0, (
+            "SlidingWindowManager does not support fine-grained (partial) cache hits"
+        )
+        block_hashes = resolve_block_hashes(
+            block_hashes,
+            block_pool.hash_block_size,
+            kv_cache_spec.block_size,
+            supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
+            alignment_tokens=alignment_tokens,
+        )
+
+        # The number of contiguous blocks needed for a prefix cache hit.
+        sliding_window_contiguous_blocks = cls._contiguous_blocks_for_hit(
+            kv_cache_spec.sliding_window, kv_cache_spec.block_size, drop_eagle_block
+        )
+
+        # TODO: reduce i by sliding_window_contiguous_blocks when cache miss, to
+        # optimize the time complexity from O(max_num_blocks) to
+        # O(max_num_blocks / sliding_window_contiguous_blocks +
+        # sliding_window_contiguous_blocks),
+        # which is good for low cache hit rate scenarios.
+        max_num_blocks = max_length // kv_cache_spec.block_size
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [block_pool.null_block] * max_num_blocks
+            for _ in range(len(kv_cache_group_ids))
+        )
+        block_size = kv_cache_spec.block_size
+        num_contiguous_blocks = 0
+        match_found = False
+        # Search from right to left and early stop when a match is found.
+        for i in range(max_num_blocks - 1, -1, -1):
+            if cached_block := block_pool.get_cached_block(
+                block_hashes[i], kv_cache_group_ids
+            ):
+                # Skip prefix matching check if the block is not aligned with
+                # `alignment_tokens`.
+                if num_contiguous_blocks == 0 and block_size != alignment_tokens:
+                    post_pop_blocks = i if drop_eagle_block else i + 1
+                    if (post_pop_blocks * block_size) % alignment_tokens != 0:
+                        continue
+                # Add the cached block to the computed blocks.
+                for computed, cached in zip(computed_blocks, cached_block):
+                    computed[i] = cached
+                num_contiguous_blocks += 1
+                if num_contiguous_blocks >= sliding_window_contiguous_blocks:
+                    # Trim the trailing blocks.
+                    # E.g., [NULL, NULL, 8, 3, NULL, 9] -> [NULL, NULL, 8, 3]
+                    # when sliding_window_contiguous_blocks=2.
+                    for computed in computed_blocks:
+                        del computed[i + num_contiguous_blocks :]
+                    match_found = True
+                    break
+            else:
+                num_contiguous_blocks = 0
+        if not match_found:
+            # The first `num_contiguous_blocks` is a cache hit even if
+            # `num_contiguous_blocks < sliding_window_contiguous_blocks`.
+            for computed in computed_blocks:
+                del computed[num_contiguous_blocks:]
+            while (
+                block_size != alignment_tokens  # Faster for common case.
+                and len(computed_blocks[0]) * block_size % alignment_tokens != 0
+            ):
+                for computed in computed_blocks:
+                    computed.pop()
+        if drop_eagle_block and computed_blocks[0]:
+            for computed in computed_blocks:
+                computed.pop()
+            # Re-align after eagle pop: the pop may break the alignment
+            # when block_size != alignment_tokens (hybrid models with
+            # different page sizes, e.g. Gemma4).
+            while (
+                block_size != alignment_tokens
+                and len(computed_blocks[0]) * block_size % alignment_tokens != 0
+            ):
+                for computed in computed_blocks:
+                    computed.pop()
+        hit_length = len(computed_blocks[0]) * block_size
+        return computed_blocks, hit_length
+
+    @classmethod
+    def reachable_block_mask(
+        cls,
+        start_block: int,
+        end_block: int,
+        alignment_tokens: int | None,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        retention_interval: int | None = None,
+        reachable_boundaries: Sequence[int] = (),
+    ) -> list[bool] | None:
+        assert isinstance(kv_cache_spec, SlidingWindowSpec)
+        if alignment_tokens is None:
+            # Fast path: when the coordinator imposes no alignment constraint.
+            return None
+        assert alignment_tokens % kv_cache_spec.block_size == 0
+
+        block_size = kv_cache_spec.block_size
+        # Contiguous blocks a hit needs at a boundary (incl. the EAGLE peek).
+        need = cls._contiguous_blocks_for_hit(
+            window_size=kv_cache_spec.sliding_window,
+            block_size=block_size,
+            use_eagle=use_eagle,
+        )
+        # The matched run's right edge sits on the aligned boundary block when
+        # EAGLE peeks one block past it (shift=1), otherwise on the last block
+        # before the boundary (shift=0).
+        shift = 1 if use_eagle else 0
+
+        mask = [False] * (end_block - start_block)
+
+        # (1) Segment-boundary tails. ``retention_interval``:
+        #   None -> dense (a tail at every ``alignment_tokens`` boundary);
+        #   0    -> no dense tails (only the replay boundary below);
+        #   >0   -> a tail once per ``retention_interval``-sized segment.
+        segment_tokens = (
+            alignment_tokens
+            if retention_interval is None
+            else (None if retention_interval == 0 else retention_interval)
+        )
+        if segment_tokens is not None:
+            per_segment = segment_tokens // block_size
+            if need >= per_segment:
+                # Every block is reachable; cache them all.
+                return None
+            for i in range(start_block, end_block):
+                if i >= shift and (i - shift) % per_segment >= per_segment - need:
+                    mask[i - start_block] = True
+
+        # (2) Reachable-boundary tails: the replay boundary (``num_prompt - 1``,
+        # capped by ``get_computed_blocks``) and any shared-prefix junction. Both
+        # land before segments would cover them under sparse retention, so keep
+        # the ``need``-block tail ending on each boundary explicitly.
+        if retention_interval is not None:
+            for boundary_tokens in reachable_boundaries:
+                aligned = boundary_tokens // alignment_tokens * alignment_tokens
+                end = aligned // block_size + shift
+                for j in range(max(start_block, end - need), min(end_block, end)):
+                    mask[j - start_block] = True
+
+        return mask
+
+    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+        """
+        Get the number of tokens that will be skipped for attention computation.
+
+        For sliding window, this corresponds to the tokens that are prior to
+        the current sliding window.
+
+        Example:
+        sliding_window=4, num_computed_tokens=7
+
+        Tokens:   [ 0  1  2  3  4  5  6  7 ]
+                  | ---- computed -----|
+                                         ^ next token to be computed
+                               |-----------| sliding window for next token
+                  |--skipped---|
+
+        The current window contains tokens 4~7. Tokens 0~3 will be skipped for
+        attention computation since they are outside the sliding window.
+        Thus, get_num_skipped_tokens(7) == 4.
+
+        Args:
+            num_computed_tokens: The number of tokens that have been computed.
+
+        Returns:
+            The number of tokens that will be skipped for attention computation.
+        """
+        return max(0, num_computed_tokens - self.sliding_window + 1)
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        """
+        NOTE(Chen): The prefix blocks are null blocks for sliding window layers.
+        So it's not correct to count ref_cnt like FullAttentionManager. Return
+        0 here for correctness. Need to support cascade attention + sliding
+        window in the future.
+        """
+        return 0
+
+
+class KpoolTailManager(FullAttentionManager):
+    """Fixed 1-block-per-request circular buffer for ``KpoolTailSpec``.
+
+    The GLM5Next kpool indexer tail cache holds the in-progress (incomplete)
+    pool's raw K + gate score: exactly one block of ``kpool`` slots per request,
+    overwritten in place by ``pos % kpool`` as decode/spec-decode advances.
+    Prefill seeds it; the connector transfers it across PD; decode reads it to
+    compress the boundary pool correctly.
+
+    This manager allocates that single block on first admission and reuses it
+    for the request's whole lifetime. It **never skips, never prunes, never
+    prefix-caches**. The no-prune guarantee is load-bearing:
+    ``SlidingWindowManager.remove_skipped_blocks`` would evict the in-progress
+    pool's earlier tokens mid-pool (before completion, before PD transfer),
+    which is fatal. Because the block is circularly reused, allocation is
+    independent of sequence length and of MTP size (MTP > kpool still fits in
+    one block: completed pools flush mid-step).
+    """
+
+    supports_fine_grained_hash_lookup: ClassVar[bool] = False
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        drop_eagle_block: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        # Tail state is per-request transient (circularly overwritten), so it is
+        # neither shareable nor a stable function of a shareable prefix.
+        return tuple([] for _ in range(len(kv_cache_group_ids))), 0
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        retention_interval: int | None = None,
+    ) -> None:
+        # Never hash tail blocks into the prefix cache.
+        return
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        return 0
+
+    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+        # The single block holds the in-progress pool for the whole request; no
+        # token is ever out of window.
+        return 0
+
+    def remove_skipped_blocks(
+        self,
+        request_id: str,
+        processed_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
+    ) -> None:
+        # Never prune mid-request; the block is freed on request completion.
+        return
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        total_computed_tokens: int,
+        num_local_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+    ) -> int:
+        # Exactly one block per request, reused circularly; never grow.
+        return max(1 - len(self.req_to_blocks.get(request_id, ())), 0)
+
+    def allocate_new_blocks(
+        self, request_id: str, num_tokens: int, num_tokens_main_model: int
+    ) -> list[KVCacheBlock]:
+        # Cap at one block regardless of num_tokens; the kernel reuses its slots
+        # via pos % kpool. No partial-hit CoW path (find_longest_cache_hit never
+        # hits, so _partial_hit_reqs is always empty).
+        req_blocks = self.req_to_blocks[request_id]
+        if len(req_blocks) >= 1:
+            return []
+        new_blocks = self.block_pool.get_new_blocks(1)
+        req_blocks.extend(new_blocks)
+        if self._record_new_block_ids:
+            self.new_block_ids.extend(b.block_id for b in new_blocks)
+        return new_blocks
+
+    def add_local_computed_blocks(
+        self,
+        request_id: str,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        # The tail never has local prefix-cache hits (find_longest_cache_hit
+        # returns none); external (PD-transferred) tokens are handled by
+        # allocate_external_computed_blocks below.
+        return
+
+    def allocate_external_computed_blocks(
+        self,
+        request_id: str,
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        # The tail is a fixed 1-block circular buffer; PD-transferred
+        # (external) tokens do not grow it -- the kernel reuses the single
+        # block's slots via pos % kpool. The base FullAttention path would
+        # allocate cdiv(num_external, block_size) blocks (one per kpool
+        # tokens), which (a) wastes blocks and (b) mismatches the producer's
+        # 1-block transfer and trips the NIXL reconcile block-count assert.
+        # Cap at one block, matching allocate_new_blocks / the producer.
+        req_blocks = self.req_to_blocks[request_id]
+        if len(req_blocks) >= 1:
+            return
+        new_blocks = self.block_pool.get_new_blocks(1)
+        req_blocks.extend(new_blocks)
+        if self._record_new_block_ids:
+            self.new_block_ids.extend(b.block_id for b in new_blocks)
+
+
+class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
+    def __init__(self, kv_cache_spec: ChunkedLocalAttentionSpec, **kwargs) -> None:
+        super().__init__(kv_cache_spec, **kwargs)
+        self.attention_chunk_size = kv_cache_spec.attention_chunk_size
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        drop_eagle_block: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        """
+        For chunked local attention, we need to find the longest cache hit
+        prefix of the blocks that is not longer than `max_length`. The prefix
+        should be a common prefix hit for all the kv cache groups in
+        `kv_cache_group_ids`. If no cache hit is found, return an empty list.
+        note we mark as computed if the whole block is outside of the local
+        window, and set the block as null. Examples:
+
+        1. Attention chunk size of 8, block size of 4, max length of 15
+        for next token at 15th (zero-indexed), 8th - 14th tokens are in
+        the window(needs lookup), 0th - 7th are not in the window,
+        so they are already marked as computed. We check the complete
+        block3 (8th - 11th tokens), Assume block 3 is hit, we will return
+        [null, null, block 3], otherwise, we return [null, null]
+
+        2. Attention chunk size of 8, block size of 4, max length of 16
+        for next token at 16th (zero-indexed), 0th - 15th tokens are not
+        in the window, so they are already marked as computed.
+        we return 4 blocks[null, null, null, null]
+
+        Args:
+            block_hashes: The block hashes of the request.
+            max_length: The maximum length of the cache hit prefix.
+            kv_cache_group_ids: The ids of the kv cache groups.
+            block_pool: The block pool.
+            kv_cache_spec: The kv cache spec.
+            drop_eagle_block: Whether to drop the last matched block for EAGLE/MTP.
+            dcp_world_size: The world size of decode context parallelism.
+            pcp_world_size: The world size of prefill context parallelism.
+            alignment_tokens: The returned cache hit length (in tokens) should
+                be a multiple of this value (in tokens).
+
+        Returns:
+            A list of cached blocks
+        """
+        assert isinstance(kv_cache_spec, ChunkedLocalAttentionSpec), (
+            "ChunkedLocalAttentionManager can only be used for "
+            "chunked local attention groups"
+        )
+        assert drop_eagle_block is False, (
+            "Hybrid KV cache is not supported for " + "eagle + chunked local attention."
+        )
+        assert dcp_world_size == 1, "DCP not support chunked local attn now."
+        assert pcp_world_size == 1, "PCP not support chunked local attn now."
+        assert kv_cache_spec.block_size == alignment_tokens, (
+            "KV cache groups with different block sizes are not compatible with "
+            "chunked local attention now"
+        )
+        block_hashes = resolve_block_hashes(
+            block_hashes,
+            block_pool.hash_block_size,
+            kv_cache_spec.block_size,
+            supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
+            alignment_tokens=alignment_tokens,
+        )
+        max_num_blocks = max_length // kv_cache_spec.block_size
+        if max_length > 0:
+            local_attention_start_idx = (
+                max_length
+                // kv_cache_spec.attention_chunk_size
+                * kv_cache_spec.attention_chunk_size
+            )
+        else:
+            local_attention_start_idx = 0
+        # we marked blocks out of window as computed
+        # with null blocks, and blocks inside window based on cache lookup
+        # result [null] [null] ... [null] [hit block 1 (1st block contain
+        # last window)] [hit block 2] ... [hit block x]
+        local_attention_start_block_idx = (
+            local_attention_start_idx // kv_cache_spec.block_size
+        )
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [block_pool.null_block] * local_attention_start_block_idx
+            for _ in range(len(kv_cache_group_ids))
+        )
+        for i in range(local_attention_start_block_idx, max_num_blocks):
+            block_hash = block_hashes[i]
+            if cached_block := block_pool.get_cached_block(
+                block_hash, kv_cache_group_ids
+            ):
+                for computed, cached in zip(computed_blocks, cached_block):
+                    computed.append(cached)
+            else:
+                break
+        hit_length = len(computed_blocks[0]) * kv_cache_spec.block_size
+        return computed_blocks, hit_length
+
+    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+        """
+        Get the number of tokens that will be skipped for attention computation.
+
+        For chunked local attention, this corresponds to the tokens that are on
+        the left side of the current chunk.
+
+        Example 1:
+        chunk size = 8, num_computed_tokens = 13
+        Tokens:  [ 0 1 2 3 4 5 6 7 | 8 9 10 11 12 13 14 15 ] ...
+                 | ----- computed ---------------|
+                                                  ^^ next token to be computed
+                                   |----------------| <-- attention window for
+                                                          next token
+                 |--- skipped -----|
+        Output: get_num_skipped_tokens(13) == 8
+
+        Example 2:
+        chunk size = 8, num_computed_tokens = 8
+        Tokens:  [ 0 1 2 3 4 5 6 7 | 8 9 10 11 12 13 14 15 ] ...
+                 | --- computed ---|
+                                     ^ next token to be computed
+                                   |--| <-- attention window for next token
+                 | --- skipped ----|
+        Output: get_num_skipped_tokens(8) == 8
+
+        Example 3:
+        chunk size = 8, num_computed_tokens = 7
+        Tokens:  [ 0 1 2 3 4 5 6 7 | 8 9 10 11 12 13 14 15 ] ...
+                 |---computed---|
+                                 ^ next token to be computed
+                 |-----------------| <-- attention window for next token
+                 no token should be skipped.
+        Output: get_num_skipped_tokens(7) == 0
+
+        Args:
+            num_computed_tokens: The number of tokens that have been computed.
+
+        Returns:
+            The number of tokens that will be skipped for attention computation.
+        """
+        num_skipped_tokens = (
+            num_computed_tokens // self.attention_chunk_size
+        ) * self.attention_chunk_size
+        return num_skipped_tokens
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        """
+        cascade attention is not supported by chunked local attention.
+        """
+        return 0
+
+
+class MambaManager(SingleTypeKVCacheManager):
+    supports_fine_grained_hash_lookup: ClassVar[bool] = True
+
+    def __init__(
+        self, kv_cache_spec: MambaSpec, block_pool: BlockPool, **kwargs
+    ) -> None:
+        super().__init__(kv_cache_spec, block_pool, **kwargs)
+        # Mamba layers use TP instead of DCP, so each rank holds the full
+        # recurrent state. Undo the DCP/PCP block_size scaling that the base
+        # class applies for attention groups whose KV cache is partitioned.
+        self.block_size = kv_cache_spec.block_size
+        self.mamba_cache_mode = kv_cache_spec.mamba_cache_mode
+        self.num_speculative_blocks: int = kv_cache_spec.num_speculative_blocks
+        self.cached_blocks_this_step: set[BlockHashWithGroupId] = set()
+        if self.mamba_cache_mode == "align":
+            # Mapping from request ID to the index of the block
+            # allocated in the previous step
+            self.last_state_block_idx: dict[str, int] = {}
+            # The set of the requests that have been allocated blocks
+            self._allocated_block_reqs: set[str] = set()
+            # Requests that registered their own last-prompt-boundary partial
+            # tail (producers). On the next step's CoW the boundary state moves
+            # into a private cow_block; we record that block for connector
+            # offload (see _pending_partial_tail_offloads).
+            self._producer_partial_tail_reqs: dict[str, int] = {}
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        drop_eagle_block: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        assert isinstance(kv_cache_spec, MambaSpec), (
+            "MambaManager can only be used for mamba groups"
+        )
+        assert dcp_world_size == 1, "DCP not support mamba now."
+        assert pcp_world_size == 1, "PCP not support mamba now."
+        block_hashes = resolve_block_hashes(
+            block_hashes,
+            block_pool.hash_block_size,
+            kv_cache_spec.block_size,
+            supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
+            alignment_tokens=alignment_tokens,
+        )
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [] for _ in range(len(kv_cache_group_ids))
+        )
+        hit_length = 0
+
+        block_size = kv_cache_spec.block_size
+        if alignment_tokens < block_size and block_size % alignment_tokens == 0:
+            # list or lazy BlobBlockHashes view
+            assert isinstance(block_hashes, Sequence)
+            hash_block_size = alignment_tokens
+            scale_factor = block_size // hash_block_size
+            max_num_partial_units = min(
+                max_length // hash_block_size, len(block_hashes)
+            )
+            for fine_idx in range(max_num_partial_units - 1, -1, -1):
+                num_tokens = (fine_idx + 1) * hash_block_size
+                block_hash = block_hashes[fine_idx]
+                if cached_block := block_pool.get_cached_block(
+                    block_hash, kv_cache_group_ids
+                ):
+                    block_idx = fine_idx // scale_factor
+                    for computed, cached in zip(computed_blocks, cached_block):
+                        computed.extend([block_pool.null_block] * block_idx)
+                        computed.append(cached)
+                    hit_length = num_tokens
+                    break
+            return computed_blocks, hit_length
+
+        max_num_blocks = max_length // block_size
+        # Search from right to left and early stop when a match is found.
+        for i in range(max_num_blocks - 1, -1, -1):
+            if cached_block := block_pool.get_cached_block(
+                block_hashes[i], kv_cache_group_ids
+            ):
+                # When enable Mamba prefix caching, `block_size` will be aligned
+                # across full attention layers and Mamba layers to ensure the
+                # prefix hit length aligned at block
+                if (
+                    block_size != alignment_tokens  # Faster for common case.
+                    and (i + 1) * block_size % alignment_tokens != 0
+                ):
+                    continue
+                for computed, cached in zip(computed_blocks, cached_block):
+                    # the hit length logic later assumes:
+                    #  hit_length = len(hit_blocks_other_attn[0])
+                    #               * self.other_block_size
+                    # so we insert dummy blocks at the beginning:
+                    computed.extend([block_pool.null_block] * i)
+                    computed.append(cached)
+                hit_length = (i + 1) * block_size
+                break  # we just need the last match - early stopping
+
+        return computed_blocks, hit_length
+
+    @classmethod
+    def reachable_block_mask(
+        cls,
+        start_block: int,
+        end_block: int,
+        alignment_tokens: int | None,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        retention_interval: int | None = None,
+        reachable_boundaries: Sequence[int] = (),
+    ) -> list[bool] | None:
+        """Sparse Mamba state-snapshot retention.
+
+        ``retention_interval``:
+
+          ``None`` -> dense (cache every block; default, unchanged behavior)
+          ``0``    -> keep only the ``reachable_boundaries`` states
+          ``> 0``  -> keep one state per ``retention_interval``-sized segment
+
+        ``reachable_boundaries`` are proven reuse points (the replay boundary and
+        any cross-request shared-prefix junction, Marconi-style APC); their
+        boundary state is always kept so sparse retention does not defeat reuse.
+        """
+        if retention_interval is None or alignment_tokens is None:
+            # Dense caching (default) or no alignment constraint imposed.
+            return None
+        assert isinstance(kv_cache_spec, MambaSpec)
+        block_size = kv_cache_spec.block_size
+        mask = [False] * (end_block - start_block)
+
+        # (1) Segment-boundary states. A Mamba hit needs exactly the single
+        # state block ending on the boundary (no window, and draft models have
+        # no mamba layers, so no eagle shift). Block ``i`` ends at token
+        # ``(i + 1) * block_size``.
+        segment_tokens = None if retention_interval == 0 else retention_interval
+        if segment_tokens is not None:
+            per_segment = segment_tokens // block_size
+            if per_segment <= 1:
+                # Interval at/below the block size: every block is a boundary.
+                return None
+            first_boundary = (
+                start_block + per_segment
+            ) // per_segment * per_segment - 1
+            for i in range(first_boundary - start_block, len(mask), per_segment):
+                mask[i] = True
+
+        # (2) Reachable-boundary states: the replay boundary (``num_prompt - 1``,
+        # capped by ``get_computed_blocks``) and any shared-prefix junction, both
+        # of which segments would otherwise skip under sparse retention. A Mamba
+        # hit needs exactly the single state block ending on the boundary.
+        for boundary_tokens in reachable_boundaries:
+            aligned = boundary_tokens // alignment_tokens * alignment_tokens
+            boundary_block = aligned // block_size - 1
+            if start_block <= boundary_block < end_block:
+                mask[boundary_block - start_block] = True
+
+        return mask
+
+    def remove_skipped_blocks(
+        self,
+        request_id: str,
+        processed_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
+    ) -> None:
+        assert isinstance(self.kv_cache_spec, MambaSpec)
+
+        super().remove_skipped_blocks(
+            request_id, processed_computed_tokens, num_prompt_tokens
+        )
+        if self.mamba_cache_mode == "align":
+            # `last_state_block_idx` refers to the block index allocated two steps ago.
+            # The block allocated in the previous step is used to copy Mamba states
+            # into the block allocated in the current step; the earlier block is
+            # no longer needed and should be freed here.
+            last_state_block_idx = self.last_state_block_idx.get(request_id)
+            # Blocks allocated during prefill may be non-contiguous. Use
+            # `last_state_block_idx` to free the appropriate block and replace it
+            # with a null block.
+            if (
+                last_state_block_idx is not None
+                and last_state_block_idx
+                < cdiv(processed_computed_tokens, self.block_size) - 1
+            ):
+                blocks = self.req_to_blocks[request_id]
+                if blocks[last_state_block_idx] != self._null_block:
+                    self.block_pool.free_blocks([blocks[last_state_block_idx]])
+                    blocks[last_state_block_idx] = self._null_block
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        """
+        cascade attention is not supported by mamba
+        """
+        return 0
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        total_computed_tokens: int,
+        num_local_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+    ) -> int:
+        assert isinstance(self.kv_cache_spec, MambaSpec)
+        if (
+            len(new_computed_blocks) > 0
+            and new_computed_blocks[-1].block_hash in self.cached_blocks_this_step
+        ):
+            # Mamba can't rely on blocks generated by other requests in the current step
+            # To put it in the next step, we return num_gpu_blocks + 1 so
+            # that kv_cache_manager will think there is no enough blocks to allocate now
+            # and don't schedule it in the current step.
+            return self.block_pool.num_gpu_blocks + 1
+        if self.mamba_cache_mode != "align":
+            # Allocate extra `num_speculative_blocks` blocks for
+            # speculative decoding (MTP/EAGLE) with linear attention.
+            if self.num_speculative_blocks > 0:
+                num_tokens += (
+                    self.kv_cache_spec.block_size * self.num_speculative_blocks
+                )
+            return super().get_num_blocks_to_allocate(
+                request_id,
+                num_tokens,
+                new_computed_blocks,
+                total_computed_tokens,
+                num_local_computed_tokens,
+                num_tokens_main_model,
+                apply_admission_cap=apply_admission_cap,
+            )
+        else:
+            # We don't allocate blocks for lookahead tokens in align mode, because if
+            # x * block_size tokens are scheduled, num_tokens is
+            # x * block_size + num_lookahead_tokens and breaks the alignment.
+            # We can ignore lookahead tokens because current draft models don't have
+            # mamba layers.
+            num_tokens = num_tokens_main_model
+
+            # NOTE(tdouble): this is an over-estimate of how many blocks we need because
+            # num_tokens can include draft tokens that will later be rejected.
+            num_required_blocks = (
+                cdiv(num_tokens, self.block_size) + self.num_speculative_blocks
+            )
+            num_new_blocks = (
+                num_required_blocks
+                - len(new_computed_blocks)
+                - len(self.req_to_blocks[request_id])
+            )
+            has_partial_hit = (
+                self._has_partial_local_hit(
+                    new_computed_blocks, num_local_computed_tokens
+                )
+                or request_id in self._partial_hit_reqs
+            )
+            if has_partial_hit:
+                num_new_blocks = max(num_new_blocks, 0) + 1
+            if num_new_blocks > 0:
+                if request_id in self._allocated_block_reqs:
+                    # Old request. Needs at most 1 more blocks as we can reuse the
+                    # speculative blocks in previous step.
+                    num_new_blocks = 1 + int(has_partial_hit)
+                else:
+                    # First prefill. Allocate 1 block for running state, the
+                    # speculative blocks, and one extra block if a partial cache
+                    # hit must be copy-on-written before the new tokens run.
+                    num_new_blocks = (
+                        1 + self.num_speculative_blocks + int(has_partial_hit)
+                    )
+
+            num_evictable_computed_blocks = self._get_num_evictable_blocks(
+                new_computed_blocks
+            )
+            return num_new_blocks + num_evictable_computed_blocks
+
+    def allocate_new_blocks(
+        self, request_id: str, num_tokens: int, num_tokens_main_model: int
+    ) -> list[KVCacheBlock]:
+        assert isinstance(self.kv_cache_spec, MambaSpec)
+        if self.mamba_cache_mode != "align":
+            # Allocate extra `num_speculative_blocks` blocks for
+            # speculative decoding (MTP/EAGLE) with linear attention.
+            if self.num_speculative_blocks > 0:
+                num_tokens += self.block_size * self.num_speculative_blocks
+            return super().allocate_new_blocks(
+                request_id, num_tokens, num_tokens_main_model
+            )
+        else:
+            # We don't allocate blocks for lookahead tokens in align mode, because if
+            # x * block_size tokens are scheduled, num_tokens is
+            # x * block_size + num_lookahead_tokens and breaks the alignment.
+            # We can ignore lookahead tokens because current draft models don't have
+            # mamba layers.
+            num_tokens = num_tokens_main_model
+            req_blocks: list[KVCacheBlock] = self.req_to_blocks[request_id]
+            # NOTE(tdouble): this is an over-estimate of how many blocks we need because
+            # num_tokens can include draft tokens that will later be rejected.
+            num_required_blocks = (
+                cdiv(num_tokens, self.block_size) + self.num_speculative_blocks
+            )
+            partial_hit = self._partial_hit_reqs.get(request_id)
+            has_partial_hit = partial_hit is not None
+            # `num_required_blocks` might be less than `len(req_blocks)` if blocks are
+            # over-allocated at last round.
+            if num_required_blocks <= len(req_blocks) and not has_partial_hit:
+                self._allocated_block_reqs.add(request_id)
+                return []
+            else:
+                prev_block_len = len(req_blocks)
+                blocks_allocated = request_id in self._allocated_block_reqs
+                # Record the last state block
+                if blocks_allocated:
+                    # We always save the running state at the last
+                    # (1 + num_speculative_blocks) block
+                    self.last_state_block_idx[request_id] = (
+                        prev_block_len - 1 - self.num_speculative_blocks
+                    )
+                elif prev_block_len > 0:
+                    # When a new request hits the prefix cache, the last block
+                    # saves the hit state.
+                    self.last_state_block_idx[request_id] = prev_block_len - 1
+
+                num_skipped_blocks = (
+                    num_required_blocks - self.num_speculative_blocks - 1
+                )
+                # null blocks
+                if prev_block_len < num_skipped_blocks:
+                    req_blocks.extend(
+                        [
+                            self._null_block
+                            for _ in range(prev_block_len, num_skipped_blocks)
+                        ]
+                    )
+
+                if blocks_allocated:
+                    # reuse previous speculative blocks in this step
+                    for block_idx in range(
+                        prev_block_len - self.num_speculative_blocks, prev_block_len
+                    ):
+                        if block_idx < num_skipped_blocks:
+                            req_blocks.append(req_blocks[block_idx])
+                            req_blocks[block_idx] = self._null_block
+                        else:
+                            break
+                num_new_blocks = num_required_blocks - len(req_blocks)
+                if has_partial_hit:
+                    num_new_blocks = max(num_new_blocks, 0) + 1
+                if blocks_allocated:
+                    assert num_new_blocks <= 1 + int(has_partial_hit)
+                else:
+                    assert num_new_blocks <= self.num_speculative_blocks + 1 + int(
+                        has_partial_hit
+                    )
+                new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
+                returned_blocks = req_blocks[prev_block_len:]
+                if partial_hit is not None:
+                    block_idx, source_block = partial_hit
+                    cow_block = new_blocks[0]
+                    new_blocks = new_blocks[1:]
+                    if blocks_allocated:
+                        # The worker block table of a running request is
+                        # append-only, so the request must stay on
+                        # source_block. Move the cache entry to cow_block
+                        # instead; the queued copy fills it before forward
+                        # overwrites source_block.
+                        assert req_blocks[block_idx] is source_block
+                        self.block_pool.move_block_hashes(source_block, cow_block)
+                        self._pending_cow_copies.append((source_block, cow_block))
+                        source_block.ref_cnt += 1
+                        boundary_tokens = self._producer_partial_tail_reqs.pop(
+                            request_id, None
+                        )
+                        if boundary_tokens is not None:
+                            # This CoW preserved a producer's own boundary
+                            # state in cow_block; hand it to the connector for
+                            # partial-tail offload once the copy has run.
+                            self._pending_partial_tail_offloads.append(
+                                (
+                                    request_id,
+                                    self.kv_cache_group_id,
+                                    cow_block,
+                                    boundary_tokens,
+                                )
+                            )
+                        if cow_block.block_hash is not None:
+                            # The moved entry is only filled by this step's
+                            # copy, so defer same-step hits on it.
+                            self.cached_blocks_this_step.add(cow_block.block_hash)
+                    else:
+                        self._apply_cow(request_id, block_idx, source_block, cow_block)
+                        returned_blocks = [cow_block] + returned_blocks
+                req_blocks.extend(new_blocks)
+                self._allocated_block_reqs.add(request_id)
+                self._partial_hit_reqs.pop(request_id, None)
+                returned_blocks.extend(new_blocks)
+                return returned_blocks
+
+    def pop_blocks_for_free(self, request_id: str) -> list[KVCacheBlock]:
+        if self.mamba_cache_mode == "align":
+            self._allocated_block_reqs.discard(request_id)
+            self.last_state_block_idx.pop(request_id, None)
+            self._producer_partial_tail_reqs.pop(request_id, None)
+            # A hand-off whose request died in this same scheduling pass must
+            # not reach the connector: its unpin hook (free) has already run.
+            self._pending_partial_tail_offloads = [
+                entry
+                for entry in self._pending_partial_tail_offloads
+                if entry[0] != request_id
+            ]
+        return super().pop_blocks_for_free(request_id)
+
+    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+        """
+        Get the number of tokens whose mamba state are not needed anymore. Mamba only
+        need to keep the state of the last computed token, so we return
+        num_computed_tokens - 1.
+        """
+        return num_computed_tokens - 1
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        retention_interval: int | None = None,
+    ) -> None:
+        num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
+        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
+        if self.mamba_cache_mode == "align":
+            partial_hash = self._cache_partial_tail_block(request, num_tokens)
+            if partial_hash is not None:
+                self.cached_blocks_this_step.add(partial_hash)
+        if num_cached_blocks_after > num_cached_blocks_before:
+            for block in self.req_to_blocks[request.request_id][
+                num_cached_blocks_before:num_cached_blocks_after
+            ]:
+                # Skip null blocks (align-mode skipped states) and blocks that
+                # were not cached this step — with sparse retention
+                # (reachable_block_mask) the intermediate state snapshots carry
+                # no hash and must not be recorded as cached-this-step.
+                if block.is_null or block.block_hash is None:
+                    continue
+                self.cached_blocks_this_step.add(block.block_hash)
+
+    def new_step_starts(self) -> None:
+        self.cached_blocks_this_step.clear()
+
+    def _cache_partial_tail_block(
+        self,
+        request: Request,
+        num_tokens: int,
+    ) -> BlockHashWithGroupId | None:
+        hash_block_size = self.block_pool.hash_block_size
+        if self.block_size == hash_block_size:
+            return None
+        if num_tokens % self.block_size == 0:
+            return None
+        if num_tokens % hash_block_size != 0:
+            return None
+        latest_prompt_hash_boundary = (
+            request.num_prompt_tokens // hash_block_size
+        ) * hash_block_size
+        if num_tokens != latest_prompt_hash_boundary:
+            return None
+
+        block_idx = num_tokens // self.block_size
+        blocks = self.req_to_blocks[request.request_id]
+        if block_idx >= len(blocks):
+            return None
+        source_block = blocks[block_idx]
+        if source_block.is_null:
+            return None
+
+        partial_hash = self.block_pool.cache_partial_block(
+            request=request,
+            block=source_block,
+            num_tokens=num_tokens,
+            kv_cache_group_id=self.kv_cache_group_id,
+            block_size=self.block_size,
+        )
+        if partial_hash is not None:
+            self._partial_hit_reqs[request.request_id] = (block_idx, source_block)
+            self.num_cached_block[request.request_id] = block_idx
+            # Producer of this partial tail: the boundary state currently lives
+            # in ``source_block`` but the next step's forward overwrites it. The
+            # upcoming CoW copies it into a durable cow_block; record the req so
+            # allocate_new_blocks hands that block to the connector for offload.
+            self._producer_partial_tail_reqs[request.request_id] = num_tokens
+        return partial_hash
+
+
+class CrossAttentionManager(SingleTypeKVCacheManager):
+    """Manager for cross-attention KV cache in encoder-decoder models."""
+
+    def add_local_computed_blocks(
+        self,
+        request_id: str,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        # We do not cache blocks for cross-attention to be shared between
+        # requests, so  `new_computed_blocks` should always be empty.
+        assert len(new_computed_blocks) == 0
+
+    def allocate_external_computed_blocks(
+        self,
+        request_id: str,
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        # Cross-attention does not use prefix caching / external KV loads.
+        return
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        retention_interval: int | None = None,
+    ) -> None:
+        # We do not cache blocks for cross-attention to be shared between
+        # requests, so this method is not relevant.
+        raise ValueError("Should not be called as prefix caching is disabled.")
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        # Cross-attention blocks contain request-specific encoder states
+        # and are not shared between different requests
+        return 0
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        drop_eagle_block: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        assert isinstance(kv_cache_spec, CrossAttentionSpec), (
+            "CrossAttentionManager can only be used for cross-attention groups"
+        )
+        # Cross-attention does not benefit from prefix caching since:
+        # 1. Encoder states are unique per request (different audio/image
+        #    inputs)
+        # 2. Encoder states are computed once per request, not incrementally
+        # 3. No reusable prefix exists between different multimodal inputs
+        # Return empty blocks to indicate no cache hits
+        raise NotImplementedError("CrossAttentionManager does not support caching")
+
+
+class SinkFullAttentionManager(FullAttentionManager):
+    def __init__(
+        self,
+        kv_cache_spec: SinkFullAttentionSpec,
+        block_pool: BlockPool,
+        enable_caching: bool,
+        kv_cache_group_id: int,
+        scheduler_block_size: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ):
+        super().__init__(
+            kv_cache_spec=kv_cache_spec,
+            block_pool=block_pool,
+            enable_caching=enable_caching,
+            kv_cache_group_id=kv_cache_group_id,
+            scheduler_block_size=scheduler_block_size,
+            dcp_world_size=dcp_world_size,
+            pcp_world_size=pcp_world_size,
+        )
+        sink_len = kv_cache_spec.sink_len
+        assert sink_len is not None and sink_len > 0 and sink_len % self.block_size == 0
+        num_sink_block = sink_len // self.block_size
+        self.sink_blocks = self.block_pool.free_block_queue.popleft_n(num_sink_block)
+
+
+def get_manager_for_kv_cache_spec(
+    kv_cache_spec: KVCacheSpec,
+    max_in_flight_tokens: int,
+    max_model_len: int,
+    **kwargs,
+) -> SingleTypeKVCacheManager:
+    """
+    Get the appropriate manager for a given KVCacheSpec.
+
+    Uses the KVCacheSpecRegistry to look up the manager class, supporting
+    both built-in and custom specs registered via @register_kv_cache_spec
+    and KVCacheSpecRegistry.register.
+
+    Args:
+        kv_cache_spec: The KVCacheSpec instance
+        max_in_flight_tokens: The max tokens scheduled but not yet settled
+            (one batch per concurrent step); see `VllmConfig.max_in_flight_tokens`
+        max_model_len: The maximum context length the model could serve
+    Returns:
+        An instance of the appropriate SingleTypeKVCacheManager subclass
+    """
+    manager_class = KVCacheSpecRegistry.get_manager_class(kv_cache_spec)
+    assert manager_class is not None, (
+        f"No manager registered for KVCacheSpec {type(kv_cache_spec)}"
+    )
+    # SlidingWindow / ChunkedLocalAttention managers recycle blocks;
+    # the runtime admission cap must match the recycling-aware bound the
+    # startup pool sizer uses (single source of truth: the spec method).
+    # R-SWA also recycles gap blocks but peak physical KV still fits the
+    # full-attention bound (prefix + window <= max_model_len), so it inherits
+    # FullAttentionSpec sizing without a separate admission cap.
+    if isinstance(
+        kv_cache_spec,
+        (SlidingWindowSpec, ChunkedLocalAttentionSpec),
+    ):
+        kwargs["max_admission_blocks_per_request"] = (
+            kv_cache_spec.max_admission_blocks_per_request(
+                max_in_flight_tokens=max_in_flight_tokens,
+                max_model_len=max_model_len,
+            )
+        )
+    manager = manager_class(kv_cache_spec, **kwargs)
+    return manager
+
+
+def register_all_kvcache_specs(vllm_config):
+    """Built-in spec registration"""
+    KVCacheSpecRegistry.register(
+        FullAttentionSpec,
+        FullAttentionManager,
+        uniform_type_base_spec=FullAttentionSpec,
+    )
+
+    KVCacheSpecRegistry.register(
+        SlidingWindowSpec,
+        SlidingWindowManager,
+        uniform_type_base_spec=SlidingWindowSpec,
+    )
+    KVCacheSpecRegistry.register(
+        SlidingWindowMLASpec,
+        SlidingWindowManager,
+        uniform_type_base_spec=SlidingWindowMLASpec,
+    )
+    KVCacheSpecRegistry.register(
+        KpoolTailSpec,
+        KpoolTailManager,
+        uniform_type_base_spec=KpoolTailSpec,
+    )
+
+    KVCacheSpecRegistry.register(
+        MambaSpec, MambaManager, uniform_type_base_spec=MambaSpec
+    )
+    KVCacheSpecRegistry.register(
+        ChunkedLocalAttentionSpec,
+        ChunkedLocalAttentionManager,
+        uniform_type_base_spec=ChunkedLocalAttentionSpec,
+    )
+    KVCacheSpecRegistry.register(
+        CrossAttentionSpec,
+        CrossAttentionManager,
+        uniform_type_base_spec=CrossAttentionSpec,
+    )
+
+    # FullAttentionSpec subclasses — grouped with FullAttentionSpec
+    KVCacheSpecRegistry.register(
+        TQFullAttentionSpec,
+        FullAttentionManager,
+        uniform_type_base_spec=FullAttentionSpec,
+    )
+    KVCacheSpecRegistry.register(
+        MLAAttentionSpec, FullAttentionManager, uniform_type_base_spec=FullAttentionSpec
+    )
+    KVCacheSpecRegistry.register(
+        RSWASpec, RSWAManager, uniform_type_base_spec=FullAttentionSpec
+    )
+    # NOTE(Mengqing): HiddenStateCacheSpec won't take part in
+    # grouping, thus the uniform_type_base_spec is just a
+    # placeholder.
+    KVCacheSpecRegistry.register(
+        HiddenStateCacheSpec,
+        FullAttentionManager,
+        uniform_type_base_spec=FullAttentionSpec,
+    )
+    KVCacheSpecRegistry.register(
+        SinkFullAttentionSpec,
+        SinkFullAttentionManager,
+        uniform_type_base_spec=FullAttentionSpec,
+    )
+
+    from vllm.platforms import current_platform
+
+    current_platform.register_custom_kv_cache_specs(vllm_config)

--- a/tests/stage3_mamba_differential_protocol.sh
+++ b/tests/stage3_mamba_differential_protocol.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Stage-3 mamba cross-boot differential test — the EXACT live protocol.
+#
+# STATUS: DESIGNED IN STAGE 2, NOT RUN. This script refuses to execute
+# without GLM53_STAGE3_LIVE=1 and prints the protocol instead. Stage 2 ships
+# it so the stage-3 acceptance gate is pinned in advance (PLAN-KV-OFFLOAD
+# §3.1/§11 stage 3; Codex OFFLOAD2 finding 14: the host-side harness in
+# tests/_mamba_differential.py is an ABI/codec comparator, NOT evidence —
+# THIS protocol, run live, is the evidence instrument).
+#
+# Prerequisites (all owner-gated): stage-2 live receipts green on the probe;
+# mamba group restore implemented (stage 3 code, NOT stage 2); an idle
+# server window on both Sparks; PR-PAUSE absent.
+set -euo pipefail
+
+HEAD_SSH="${HEAD_SSH:-blockbrain@100.68.104.95}"
+API="${GLM53_API:-http://127.0.0.1:8000/v1}"
+STORE_DIR="${GLM53_KV_OFFLOAD_DIR:-$HOME/glm53-kv-offload}"
+OUT_DIR="${GLM53_STAGE3_OUT:-$HOME/stage3-mamba-differential}"
+BOUNDARIES=(1 2 8)          # park boundaries k (tokens = (k+1) * 3584)
+CONTINUATIONS=(16 256 2048) # continuation lengths per boundary
+PROMPT_TOKENS=$(( (8 + 1) * 3584 + 1500 ))  # covers the deepest boundary + tail
+
+protocol() {
+    cat <<'EOF'
+================= STAGE-3 MAMBA CROSS-BOOT DIFFERENTIAL PROTOCOL =================
+Step 0 — STATE-INDEX CONVENTION RECEIPT (the open stage-0 R13 residual; gate
+  for everything below):
+  - In-container, instrument the mamba align-mode manager on ONE boundary
+    materialization: dump the (block_id, state_index, accepted-token offset)
+    triple and the raw conv/temporal bytes at snapshot time, per rank.
+  - Verify the snapshot bytes equal the block's bytes the connector's store
+    path gathers (byte-diff == 0) — the "the page is the state" assumption
+    made real, or refuted HERE before any cross-boot claim.
+
+Step 1 — BOOT A PARK:
+  - Boot the pair with GLM53_KV_OFFLOAD=1 GLM53_KV_OFFLOAD_RESTORE=0.
+  - Drive the park probe (deterministic token prompt, temp 0, fresh
+    cache_salt) to PROMPT_TOKENS; force store-cascade completion (request
+    finish); confirm boundary manifests for every k in BOUNDARIES on BOTH
+    ranks' NVMe stores.
+  - Capture per-rank state fixtures: copy each parked boundary's four mamba
+    chunk files + manifest to $OUT_DIR/bootA/r{0,1}/ (files are content-
+    addressed; the copy is the frozen boot-A state).
+  - Record the uninterrupted CONTROL: continue the same conversation to each
+    continuation length, logging per-token logprobs (temp 0, logprobs on).
+
+Step 2 — RESTART (the cross-boot cut):
+  - ./stop.sh && ./start.sh restart (same recipe SHA, same knobs, RESTORE=1).
+  - Confirm namespace hash unchanged (same-config boot) in the writer-up log.
+
+Step 3 — BOOT B RESTORE + DIFFERENTIAL:
+  For each k in BOUNDARIES:
+  - Issue the SAME prompt truncated to the boundary + 1 token (forces the
+    lookup at the deepest manifested boundary <= k).
+  - Verify the restore receipts: WAITING_FOR_REMOTE_KVS entered, disk load
+    job on both ranks, cache_blocks re-entry, zero load errors.
+  - BIT-DIFFERENTIAL: copy the restored blocks' bytes (in-container dump of
+    the mamba state blocks after restore) and run
+      python3 tests/_mamba_differential.py-style compare_state_bits
+    against $OUT_DIR/bootA fixtures → per-(group, layer, tensor) mismatch
+    counts. Gate: ZERO mismatches (the ABI holds bit-exact) BEFORE any
+    behavioral claim.
+  For each continuation length c in CONTINUATIONS:
+  - Generate c tokens at temp 0 with logprobs; compare against the boot-A
+    control per token: max |delta logprob| must sit inside the probe-v3
+    measured noise band.
+  - Needle-at-depth: query a fact planted before the boundary; must match.
+  - FRESH-SESSION CONTROL: a new cache_salt session of the same prompt must
+    produce control-equal output (proves no cross-contamination).
+
+Step 4 — FAULT MATRIX (plan T4, group x rank x {normal, preemption, reuse}):
+  - For each mamba group g in {2,3,4,5} x rank r in {0,1}: corrupt/remove
+    that (g, r) chunk file; re-run the restore; REQUIRED: global miss or
+    invalid-block recompute, fresh-session control green, NEVER a served
+    half-restore. Repeat one cell under forced preemption and one under
+    block-reuse pressure (small pool).
+
+Step 5 — RECEIPTS: p50/p95 restore timing table (replaces plan §9's
+  hypothesis rows), all logs + fixtures + comparator outputs archived under
+  $OUT_DIR; STAGE3-RECEIPTS.md written from this protocol's numbered steps.
+==================================================================================
+EOF
+}
+
+if [ "${GLM53_STAGE3_LIVE:-0}" != "1" ]; then
+    echo "stage3_mamba_differential_protocol.sh: GLM53_STAGE3_LIVE=1 not set."
+    echo "This protocol is DESIGNED (stage 2) but NOT runnable yet: mamba"
+    echo "restore is stage-3 code. Printing the protocol instead:"
+    echo
+    protocol
+    exit 0
+fi
+
+echo "GLM53_STAGE3_LIVE=1: refusing anyway — mamba group restore is not"
+echo "implemented in this branch (stage 2 is g0-only). Remove this guard"
+echo "only in the stage-3 branch that implements it."
+exit 2

--- a/tests/test_kpool_tail_slotmap.py
+++ b/tests/test_kpool_tail_slotmap.py
@@ -182,7 +182,12 @@ def test_recipe_wiring_if_present() -> None:
     launcher = start.read_text()
     image = dockerfile.read_text()
     assert 'KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-' in launcher
-    assert launcher.count("python3 /opt/glm53/patch_kpool_tail_slotmap.py") == 2
+    # Both ranks apply the one pinned list (GLM53_OVERLAY_ORDER) that
+    # write_inner_scripts emits into the head and worker inner scripts.
+    order = launcher[launcher.index("GLM53_OVERLAY_ORDER=(") : launcher.index(")", launcher.index("GLM53_OVERLAY_ORDER=("))]
+    assert "\n    patch_kpool_tail_slotmap.py\n" in order
+    assert 'emit_overlay_block >> "$HEAD_SCRIPT"' in launcher
+    assert 'emit_overlay_block >> "$WORKER_SCRIPT"' in launcher
     assert (
         "-v '/tmp/patch_kpool_tail_slotmap.py:"
         "/opt/glm53/patch_kpool_tail_slotmap.py:ro'" in launcher

--- a/tests/test_kv_offload_restore_g0.py
+++ b/tests/test_kv_offload_restore_g0.py
@@ -99,7 +99,23 @@ def test_patcher_hygiene() -> None:
         restore.prepare(tampered, restore.SITES_SCHED, "t")
         check(False, "A4 half-patched file refused")
     except ValueError as exc:
-        check("half-patched" in str(exc), "A4 half-patched file refused")
+        check("tampered" in str(exc), "A4 half-patched file refused")
+
+    # F10 (review): tampering INSIDE a patched block while keeping every
+    # marker line must be refused on the already-present path.
+    tampered2 = texts["scheduler"].replace(
+        "self._glm53_restore.job_started(load_job_id)",
+        "pass  # neutered gate",
+        1,
+    )
+    assert all(
+        tampered2.count(m) == 1 for _n, m, _a, _p in restore.SITES_SCHED
+    )
+    try:
+        restore.prepare(tampered2, restore.SITES_SCHED, "t")
+        check(False, "A4b marked-but-tampered file refused (review f10)")
+    except ValueError:
+        check(True, "A4b marked-but-tampered file refused (review f10)")
 
     # A store-less scheduler must fail anchors (R10 anchors store output).
     store_less = patched_texts(with_store=False)["scheduler"]
@@ -393,6 +409,92 @@ def test_scheduler_restore() -> None:
             cands[0], key=lambda m: m["boundary_token_index"]
         )] == [1, 2],
         f"B10 zero-cow manifest candidates cumulative per boundary (got {cands})",
+    )
+
+    # B12 (review f11): distinct num_tokens vs num_prompt_tokens — the
+    # lookup caps at num_tokens (a re-admitted request's decoded tokens are
+    # legitimately restorable; offload_prompt_only=false stores them).
+    req_d = stub.FakeRequest(
+        num_tokens=3 * 3584,
+        req_id="rq-decode",
+        num_prompt_tokens=2 * 3584,
+    )
+    req_d.block_hashes = req.block_hashes[: len(req_d.block_hashes)]
+    sched.on_new_request(req_d)
+    hit_d, _ = sched.get_num_new_matched_tokens(req_d, 0)
+    check(
+        hit_d == 10752,
+        f"B12 boundary past num_prompt but within num_tokens hits (got {hit_d})",
+    )
+
+    # B13: local prefix already AT the deepest boundary => no restore hit.
+    st_d = sched._req_status[req_d.request_id]
+    st_d.num_locally_computed_tokens = 10752
+    check(
+        rst.lookup(sched, st_d) == 0,
+        "B13 local == deepest boundary => 0 (nothing beyond to restore)",
+    )
+
+    # B14 (review f7/f8): garbage ranks never satisfy the quorum; a changed
+    # writer boot id retracts that rank's availability.
+    req_e = stub.FakeRequest(num_tokens=2 * 3584, req_id="rq-e", salt=b"e14")
+    sched.on_new_request(req_e)
+    b1e = _boundary_hash(req_e, 1)
+    rst.consume_events([("+", 0, "ns1", b1e, 7168, "boot0")])
+    rst.consume_events([("+", 7, "ns1", b1e, 7168, "boot0")])  # bogus rank
+    hit_e, _ = sched.get_num_new_matched_tokens(req_e, 0)
+    check(hit_e == 0, "B14 out-of-range rank never completes the quorum")
+    rst.consume_events([("+", 1, "ns1", b1e, 7168, "boot0")])
+    hit_e, _ = sched.get_num_new_matched_tokens(req_e, 0)
+    check(hit_e == 7168, "B14b real second rank completes it")
+    rst.consume_events([("+", 1, "ns1", "ff" * 32, 3584, "boot1")])  # restart
+    hit_e, _ = sched.get_num_new_matched_tokens(req_e, 0)
+    check(
+        hit_e == 0,
+        "B14c changed writer boot id retracts that rank's availability",
+    )
+    # Repair rank 1's availability under its new generation for B16 (the
+    # boot-id retraction dropped rank 1 from EVERY boundary, including the
+    # main chain's b1 that B16 relies on).
+    rst.consume_events([("+", 1, "ns1", b1, 7168, "boot1")])
+
+    # B15 (review f2): a short hash list ships an all-fail spec, never an
+    # IndexError out of update_state_after_alloc.
+    spec_bad = rst.build_load_spec(
+        SimpleNamespace(request_id="rq-short", block_hashes=[b"x" * 32]),
+        SimpleNamespace(num_locally_computed_tokens=0),
+        10752,
+        10752,
+    )
+    check(
+        spec_bad["entries"] == [] and spec_bad["glm53_disk_load"] == 1,
+        "B15 short hash list => empty-entry (all-fail) spec, no IndexError",
+    )
+
+    # B16 (review f1, BLOCKER): a request whose disk LOAD job is still
+    # registered must not reach _build_store_jobs' is_store assert — store
+    # creation is deferred instead.
+    req_f = stub.FakeRequest(num_tokens=2 * 3584 + 5, req_id="rq-f")
+    req_f.block_hashes = req.block_hashes[: len(req_f.block_hashes)]
+    sched.on_new_request(req_f)
+    hit_f, _ = sched.get_num_new_matched_tokens(req_f, 0)
+    check(hit_f == 7168, "B16 setup hit")
+    blocks_f = mods["kv_cache_manager"].KVCacheBlocks(
+        blocks=([FakeBlock(400), FakeBlock(401)],)
+    )
+    sched.update_state_after_alloc(req_f, blocks_f, hit_f)
+    sched._current_batch_load_jobs.clear()  # job registered in _jobs
+    so_f = SimpleNamespace(
+        num_scheduled_tokens={req_f.request_id: 5},
+        finished_req_ids=set(),
+        req_data={req_f.request_id: (None, False)},
+        partial_tail_offloads=None,
+    )
+    sched._update_req_states(so_f)
+    jobs_f = sched._build_store_jobs(so_f)  # would assert without R11
+    check(
+        jobs_f == {},
+        "B16b store-job creation deferred while the load job is in flight",
     )
 
     # B11: RESTORE=0 keeps the stage-1 short-circuit (no disk lookup).
@@ -726,6 +828,7 @@ def test_disk_loader() -> None:
 
         # C8 wrong-rank chunk header rejected.
         h0path = Path(writer._file_path(_hash(0), 0))
+        h0_orig_blob = h0path.read_bytes()
         h0 = store.read_chunk_header(str(h0path), verify_payload=True)
         payload = h0path.read_bytes()[16 + len(json.dumps(h0, sort_keys=True,
                                                           separators=(",", ":")).encode()):]
@@ -746,6 +849,7 @@ def test_disk_loader() -> None:
             and cw._glm53_load_error_ids == {60, 61, 62},
             "C8 wrong-rank header: failed from chunk 0 (never cross-rank bytes)",
         )
+        h0path.write_bytes(h0_orig_blob)
         cw._glm53_disk_done.clear()
         cw._glm53_load_error_ids.clear()
 
@@ -759,6 +863,115 @@ def test_disk_loader() -> None:
         )
         cw._glm53_disk_done.clear()
         cw._glm53_load_error_ids.clear()
+
+        # C10 (review f11): truncated chunk file.
+        v0 = Path(writer._file_path(_hash(0), 0))
+        v0_blob = v0.read_bytes()
+        v0.write_bytes(v0_blob[:-5])
+        ns["_glm53_run_disk_load"](
+            cw, 84, _load_spec(writer, 3), SimpleNamespace(block_ids=[70, 71, 72])
+        )
+        check(
+            cw._glm53_disk_done == [84]
+            and cw._glm53_load_error_ids == {70, 71, 72},
+            "C10 truncated chunk: failed from chunk 0, job done",
+        )
+        v0.write_bytes(v0_blob)
+        cw._glm53_disk_done.clear()
+        cw._glm53_load_error_ids.clear()
+
+        # C11: wrong spec_kind header rejected.
+        h0 = store.read_chunk_header(str(v0))
+        raw = v0.read_bytes()
+        hlen = int.from_bytes(raw[8:12], "little")
+        payload0 = raw[16 + hlen :]
+        h_bad = {
+            k: v
+            for k, v in h0.items()
+            if k not in ("payload_len", "payload_crc32", "crc_algo", "format_version")
+        }
+        h_bad["spec_kind"] = "MambaSpec"
+        v0.write_bytes(store.encode_chunk(h_bad, payload0))
+        ns["_glm53_run_disk_load"](
+            cw, 85, _load_spec(writer, 1), SimpleNamespace(block_ids=[75])
+        )
+        check(
+            cw._glm53_disk_done == [85] and cw._glm53_load_error_ids == {75},
+            "C11 wrong spec_kind rejected",
+        )
+        v0.write_bytes(v0_blob)
+        cw._glm53_disk_done.clear()
+        cw._glm53_load_error_ids.clear()
+
+        # C12: segment-table mismatch (tampered dtype) rejected.
+        h_bad2 = {
+            k: v
+            for k, v in h0.items()
+            if k not in ("payload_len", "payload_crc32", "crc_algo", "format_version")
+        }
+        import copy
+
+        h_bad2["segment_table"] = copy.deepcopy(h0["segment_table"])
+        h_bad2["segment_table"][0]["dtype"] = "torch.float16"
+        v0.write_bytes(store.encode_chunk(h_bad2, payload0))
+        ns["_glm53_run_disk_load"](
+            cw, 86, _load_spec(writer, 1), SimpleNamespace(block_ids=[76])
+        )
+        check(
+            cw._glm53_disk_done == [86] and cw._glm53_load_error_ids == {76},
+            "C12 segment-table mismatch rejected (byte count alone not enough)",
+        )
+        v0.write_bytes(v0_blob)
+        cw._glm53_disk_done.clear()
+        cw._glm53_load_error_ids.clear()
+
+        # C13: manifest chain tampered => all chunks failed.
+        m2p = Path(writer._manifest_path(_hash(2)))
+        m2_raw = json.loads(m2p.read_text())
+        m2_bad = dict(m2_raw)
+        m2_bad["chunk_hashes"] = [_hash(9), _hash(1), _hash(2)]
+        m2p.write_text(json.dumps(m2_bad, sort_keys=True))
+        ns["_glm53_run_disk_load"](
+            cw, 87, _load_spec(writer, 3), SimpleNamespace(block_ids=[80, 81, 82])
+        )
+        check(
+            cw._glm53_disk_done == [87]
+            and cw._glm53_load_error_ids == {80, 81, 82},
+            "C13 manifest chain divergence: all chunks failed",
+        )
+        m2p.write_text(json.dumps(m2_raw, sort_keys=True))
+        cw._glm53_disk_done.clear()
+        cw._glm53_load_error_ids.clear()
+
+        # C14: manifest per-chunk CRC ledger mismatch => that chunk fails.
+        m2_bad2 = json.loads(json.dumps(m2_raw))
+        m2_bad2["full_groups"]["0"][1][2] ^= 0xFF
+        m2p.write_text(json.dumps(m2_bad2, sort_keys=True))
+        ns["_glm53_run_disk_load"](
+            cw, 88, _load_spec(writer, 3), SimpleNamespace(block_ids=[90, 91, 92])
+        )
+        check(
+            cw._glm53_disk_done == [88]
+            and cw._glm53_load_error_ids == {91, 92},
+            "C14 ledger CRC mismatch: chunk 1 suffix failed",
+        )
+        m2p.write_text(json.dumps(m2_raw, sort_keys=True))
+        cw._glm53_disk_done.clear()
+        cw._glm53_load_error_ids.clear()
+
+        # C15 (review f3): unidentifiable destinations PROPAGATE (fail-stop,
+        # never an ack that could serve stale bytes).
+        try:
+            ns["_glm53_run_disk_load"](
+                cw, 89, _load_spec(writer, 1),
+                SimpleNamespace(block_ids=["not-an-int"]),
+            )
+            check(False, "C15 malformed dst_spec propagates (fail-stop)")
+        except (TypeError, ValueError):
+            check(
+                89 not in cw._glm53_disk_done,
+                "C15 malformed dst_spec propagates (fail-stop)",
+            )
     _cleanup_env()
 
 

--- a/tests/test_kv_offload_restore_g0.py
+++ b/tests/test_kv_offload_restore_g0.py
@@ -253,7 +253,7 @@ def test_scheduler_restore() -> None:
     check(hit == 0, "B3d store-write failure event denies the boundary")
 
     # B4: deepest boundary wins; foreign namespace dropped; alignment guard.
-    rst._failed_keys.clear()
+    rst._failed_by_rank.clear()
     b2 = _boundary_hash(req, 2)
     rst.consume_events(_events([0, 1], b2, 10752))
     hit, _ = sched.get_num_new_matched_tokens(req, 0)
@@ -484,18 +484,80 @@ def test_scheduler_restore() -> None:
     )
     sched.update_state_after_alloc(req_f, blocks_f, hit_f)
     sched._current_batch_load_jobs.clear()  # job registered in _jobs
+    # The request is ABORTED while its disk load is still registered — the
+    # exact route the review's BLOCKER named (finished_req_ids processing in
+    # _build_store_jobs while a non-store job is in transfer_jobs).
+    req_f.status = sys.modules["vllm.v1.request"].RequestStatus.FINISHED_ABORTED
+    req_f.num_computed_tokens = 0
+    req_f.is_finished = lambda: True
     so_f = SimpleNamespace(
-        num_scheduled_tokens={req_f.request_id: 5},
-        finished_req_ids=set(),
-        req_data={req_f.request_id: (None, False)},
+        num_scheduled_tokens={},
+        finished_req_ids={req_f.request_id},
+        req_data={},
         partial_tail_offloads=None,
     )
     sched._update_req_states(so_f)
     jobs_f = sched._build_store_jobs(so_f)  # would assert without R11
     check(
         jobs_f == {},
-        "B16b store-job creation deferred while the load job is in flight",
+        "B16b aborted-during-load: store creation deferred, no assert",
     )
+    # Complete B16's load job (both ranks ack) so the single-flight gate is
+    # free for the following subtests.
+    jid_f = rst._inflight_job
+    sched.update_connector_output(
+        SimpleNamespace(
+            kv_connector_worker_meta=mods["common"].OffloadingWorkerMetadata(
+                completed_jobs={jid_f: 2}
+            )
+        )
+    )
+    check(rst._inflight_job is None, "B16c load-job completion frees the gate")
+
+    # B17 (confirm f9): a writer restart retracts that rank's FAILURES too —
+    # a recovered writer is not permanently suppressed.
+    req_g = stub.FakeRequest(num_tokens=2 * 3584, req_id="rq-g", salt=b"g17")
+    sched.on_new_request(req_g)
+    b1g = _boundary_hash(req_g, 1)
+    rst.consume_events(
+        [("+", 0, "ns1", b1g, 7168, "boot0"), ("+", 1, "ns1", b1g, 7168, "boot1")]
+    )
+    rst.consume_events([("F", 0, "ns1", b1g, 0, "boot0")])
+    hit_g, _ = sched.get_num_new_matched_tokens(req_g, 0)
+    check(hit_g == 0, "B17 rank-0 write failure denies the boundary")
+    # rank 0's writer restarts (new generation) and republishes cleanly:
+    rst.consume_events([("+", 0, "ns1", b1g, 7168, "boot0b")])
+    hit_g, _ = sched.get_num_new_matched_tokens(req_g, 0)
+    check(
+        hit_g == 7168,
+        "B17b generation change clears the old generation's failures",
+    )
+
+    # B18 (confirm new f1): a NON-disk load job keeps the stock crash
+    # semantics — never misclassified as ours.
+    req_h = stub.FakeRequest(num_tokens=3584, req_id="rq-h", salt=b"h18")
+    sched.on_new_request(req_h)
+    st_h = sched._req_status[req_h.request_id]
+    foreign_jid = sched._generate_job_id()
+    sched._jobs[foreign_jid] = sched_mod.TransferJobStatus(
+        req_id=req_h.request_id, pending_count=2, keys=set(), is_store=False
+    )
+    st_h.transfer_jobs.add(foreign_jid)
+    so_h = SimpleNamespace(
+        num_scheduled_tokens={},
+        finished_req_ids=set(),
+        req_data={},
+        partial_tail_offloads=None,
+        preempted_req_ids={req_h.request_id},
+        scheduled_new_reqs=[],
+    )
+    try:
+        sched.build_connector_meta(so_h)
+        check(False, "B18 foreign (non-disk) load keeps stock assert semantics")
+    except AssertionError:
+        check(True, "B18 foreign (non-disk) load keeps stock assert semantics")
+    st_h.transfer_jobs.discard(foreign_jid)
+    sched._jobs.pop(foreign_jid, None)
 
     # B11: RESTORE=0 keeps the stage-1 short-circuit (no disk lookup).
     os.environ["GLM53_KV_OFFLOAD_RESTORE"] = "0"

--- a/tests/test_kv_offload_restore_g0.py
+++ b/tests/test_kv_offload_restore_g0.py
@@ -1,0 +1,1107 @@
+#!/usr/bin/env python3
+"""Regression tests for overlay/patch_kv_offload_restore_g0.py.
+
+A  Patcher hygiene on the pinned image fixtures (incl. the two NEW stage-2
+   captures): preflight/apply/idempotence/tamper on all five targets;
+   refusal against a tree missing the scope/store marks; --check-injected.
+B  Patched-runtime scheduler drive (stubbed vllm, PATCHED modules):
+   eligibility matrix (7-group hybrid INERT with the named reason;
+   single-TOTAL-group probe ACTIVE; one-eligible-plus-excluded-group INERT —
+   Codex OFFLOAD2 finding 2), AND-across-ranks manifest registry (one rank
+   => miss, both => hit, "-" retraction => miss, "F" store failure => miss),
+   deepest-boundary lookup + alignment guard, single-flight gate (defer +
+   self-heal + completion/reset clear), disk load-job shape (dict src_spec,
+   1:1 entries, ZERO manager lookup/prepare_load calls, stage-1 bookkeeping
+   preserved — finding 12), request.glm53_restored_boundary lifecycle,
+   preemption load-job guard (finding 3), zero-cow manifest candidates (S1),
+   RESTORE=0 short-circuit parity.
+C  Worker-side synchronous disk loader against REAL writer output: byte-
+   exact happy-path restore into stubbed GPU tensors, full segment-table
+   verification (finding 13), T4 failure matrix (missing file / truncated /
+   CRC flip / wrong rank / null dst / manifest missing / precondition) =>
+   zero-fill + invalid ids + the job STILL completes (finding 5), earlier
+   chunks keep their restored bytes, later chunks abandoned.
+D  Manifest-event channel: writer "+"/"-"/"F" emission, validated dedup
+   (finding 9), worker-meta attach + event-only meta flows (finding 7),
+   aggregate() concatenation incl. a legacy meta without the field, pickle
+   round-trip; facade get_block_ids_with_load_errors drain (patched facade
+   text driven directly).
+E  T2 (patched single_type_kv_cache_manager text): cache_blocks appends
+   glm53_restored_boundary to reachable_boundaries (absent/0 => unchanged);
+   MambaManager.reachable_block_mask keeps exactly the restored boundary's
+   state block under retention_interval=0 (end-exclusive convention,
+   finding 10: 3584/7168 select blocks 0/1; 3583 selects none).
+
+Run:  python3 tests/test_kv_offload_restore_g0.py   (or pytest)
+"""
+from __future__ import annotations
+
+import json
+import os
+import pickle
+import sys
+import tempfile
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(ROOT / "overlay"))
+
+import patch_kv_offload_restore_g0 as restore  # noqa: E402
+import patch_kv_offload_store_local as store  # noqa: E402
+
+FIXTURES = HERE / "fixtures"
+
+FAILURES: list[str] = []
+
+
+def check(cond: bool, label: str) -> None:
+    print(("  ok   " if cond else "  FAIL ") + label)
+    if not cond:
+        FAILURES.append(label)
+
+
+# ------------------------------------------------------------------ part A --
+def test_patcher_hygiene() -> None:
+    print("Part A: patcher hygiene")
+    from _kv_offload_stub_env import patched_texts
+
+    texts = patched_texts(with_store=True, with_restore=True)
+    for name in ("common", "scheduler", "worker"):
+        compile(texts[name], name, "exec")
+    check(True, "A1 restore overlay applies onto scope+store output and compiles")
+
+    fac = (FIXTURES / "image_487ecf187_offloading_connector.py").read_text()
+    st = (FIXTURES / "image_487ecf187_single_type_kv_cache_manager.py").read_text()
+    fac2, _ = restore.prepare(fac, restore.SITES_FACADE, "facade")
+    st2, _ = restore.prepare(st, restore.SITES_SINGLE_TYPE, "single_type")
+    compile(fac2, "facade", "exec")
+    compile(st2, "single_type", "exec")
+    check(True, "A2 facade + single_type fixtures patch and compile")
+
+    check(
+        restore.prepare(fac2, restore.SITES_FACADE, "f")[1] == "already present"
+        and restore.prepare(st2, restore.SITES_SINGLE_TYPE, "s")[1]
+        == "already present"
+        and restore.prepare(
+            texts["scheduler"], restore.SITES_SCHED, "sched"
+        )[1]
+        == "already present",
+        "A3 idempotence: patched output detected as already present",
+    )
+
+    tampered = texts["scheduler"].replace(restore.MARK_R2, "", 1)
+    try:
+        restore.prepare(tampered, restore.SITES_SCHED, "t")
+        check(False, "A4 half-patched file refused")
+    except ValueError as exc:
+        check("half-patched" in str(exc), "A4 half-patched file refused")
+
+    # A store-less scheduler must fail anchors (R10 anchors store output).
+    store_less = patched_texts(with_store=False)["scheduler"]
+    try:
+        restore.prepare(store_less, restore.SITES_SCHED, "t")
+        check(False, "A5 store-less scheduler refused (anchor drift)")
+    except ValueError:
+        check(True, "A5 store-less scheduler refused (anchor drift)")
+
+    import subprocess
+
+    r = subprocess.run(
+        [sys.executable, str(ROOT / "overlay" / "patch_kv_offload_restore_g0.py"),
+         "--check-injected"],
+        capture_output=True,
+        text=True,
+    )
+    check(r.returncode == 0, "A6 --check-injected compiles all injected sources")
+
+
+# ------------------------------------------------------------------ part B --
+class FakeBlock:
+    def __init__(self, block_id, is_null=False, block_hash=None):
+        self.block_id = block_id
+        self.is_null = is_null
+        self.block_hash = block_hash
+
+
+def _single_group_layout(stub):
+    """One TOTAL KV-cache group: full attention, block 3584 (the g0 probe)."""
+    layers = ("mla.0", "mla.1")
+    g0 = stub.FakeKVCacheGroup(
+        stub.UniformTypeKVCacheSpecs(
+            3584, {n: stub.MLAAttentionSpec(3584) for n in layers}
+        ),
+        layers,
+    )
+    return stub.FakeKVCacheConfig([g0])
+
+
+def _one_eligible_plus_excluded_layout(stub):
+    """One eligible full-attn group + one EXCLUDED scratch group (finding 2)."""
+    cfg = _single_group_layout(stub)
+    g1 = stub.FakeKVCacheGroup(
+        stub.KpoolTailSpec(4, prefix_cacheable=False), ("kpool.0",)
+    )
+    cfg.kv_cache_groups.append(g1)
+    return cfg
+
+
+def _mk_scheduler(stub, mods, kv_cache_config, spec_off=False):
+    vllm_config = stub.FakeVllmConfig(
+        kv_transfer_config=stub.FakeKVTransferConfig()
+    )
+    if spec_off:
+        vllm_config.speculative_config = None
+    cfg = stub.build_offloading_config(mods, vllm_config, kv_cache_config)
+    spec = stub.FakeSchedSpec(mods, cfg)
+    sched = mods["scheduler"].OffloadingConnectorScheduler(
+        spec, vllm_config, kv_cache_config
+    )
+    return sched, spec
+
+
+def _events(ranks, bhash, tokens, ns="ns1", code="+"):
+    return [(code, r, ns, bhash, tokens, "boot0") for r in ranks]
+
+
+def _boundary_hash(req, k, hashes_per_chunk=56):
+    return bytes(req.block_hashes[(k + 1) * hashes_per_chunk - 1]).hex()
+
+
+def test_scheduler_restore() -> None:
+    print("Part B: patched-runtime scheduler drive")
+    os.environ["GLM53_KV_OFFLOAD"] = "1"
+    os.environ["GLM53_KV_OFFLOAD_RESTORE"] = "1"
+    os.environ.pop("GLM53_KV_OFFLOAD_DRAFTER", None)
+    import _kv_offload_stub_env as stub
+
+    mods = stub.install_fake_vllm(with_restore=True)
+    sched_mod = mods["scheduler"]
+
+    # B1: the live 7-group hybrid is INERT with a named reason.
+    sched7, _ = _mk_scheduler(stub, mods, stub.boot_layout())
+    reason7 = sched7._glm53_restore.disabled_reason
+    check(
+        reason7 is not None and "7 KV-cache groups" in reason7,
+        f"B1 hybrid layout INERT with named reason (got {reason7!r})",
+    )
+    check(
+        any("restore INERT" in ln for ln in mods["logger"].lines),
+        "B1b inert reason logged at boot",
+    )
+
+    # B2: single-TOTAL-group probe is ACTIVE (speculative off: the image
+    # flags every group eagle under an eagle spec config with no marks).
+    sched, spec = _mk_scheduler(
+        stub, mods, _single_group_layout(stub), spec_off=True
+    )
+    rst = sched._glm53_restore
+    check(
+        rst.disabled_reason is None,
+        f"B2 single-group probe ACTIVE (got {rst.disabled_reason!r})",
+    )
+
+    # B2b: one eligible + one excluded group must stay INERT (finding 2).
+    sched_x, _ = _mk_scheduler(
+        stub, mods, _one_eligible_plus_excluded_layout(stub), spec_off=True
+    )
+    rx = sched_x._glm53_restore.disabled_reason
+    check(
+        rx is not None and "2 KV-cache groups" in rx and "1 eligible" in rx,
+        f"B2b eligible+excluded layout INERT (got {rx!r})",
+    )
+
+    # B3: AND-across-ranks registry (num_workers=2 in the stub config).
+    req = stub.FakeRequest(num_tokens=3 * 3584 + 5, req_id="rq1")
+    sched.on_new_request(req)
+    b1 = _boundary_hash(req, 1)
+    rst.consume_events(_events([0], b1, 7168))
+    hit, _async = sched.get_num_new_matched_tokens(req, 0)
+    check(hit == 0, "B3 one-rank manifest => miss (AND across ranks)")
+    rst.consume_events(_events([1], b1, 7168))
+    hit, is_async = sched.get_num_new_matched_tokens(req, 0)
+    check(
+        hit == 7168 and is_async,
+        f"B3b both-rank manifest => hit at the boundary (got {hit})",
+    )
+    rst.consume_events(_events([1], b1, 7168, code="-"))
+    hit, _ = sched.get_num_new_matched_tokens(req, 0)
+    check(hit == 0, "B3c retraction on one rank => miss again")
+    rst.consume_events(_events([1], b1, 7168))
+    rst.consume_events([("F", 1, "ns1", b1, 0, "boot0")])
+    hit, _ = sched.get_num_new_matched_tokens(req, 0)
+    check(hit == 0, "B3d store-write failure event denies the boundary")
+
+    # B4: deepest boundary wins; foreign namespace dropped; alignment guard.
+    rst._failed_keys.clear()
+    b2 = _boundary_hash(req, 2)
+    rst.consume_events(_events([0, 1], b2, 10752))
+    hit, _ = sched.get_num_new_matched_tokens(req, 0)
+    check(hit == 10752, f"B4 deepest manifested boundary wins (got {hit})")
+    rst.consume_events(_events([0, 1], b2, 10752, ns="other"))
+    check(
+        rst._namespace == "ns1", "B4b foreign-namespace events are dropped"
+    )
+    req_off = stub.FakeRequest(num_tokens=3 * 3584, req_id="rq-unaligned")
+    sched.on_new_request(req_off)
+    req_off.block_hashes = req.block_hashes[: len(req_off.block_hashes)]
+    sched._req_status[req_off.request_id].num_locally_computed_tokens = 0
+    check(
+        rst.lookup(sched, sched._req_status[req_off.request_id]) in (10752,),
+        "B4c same-chain request hits via content addressing",
+    )
+    st_un = sched._req_status[req_off.request_id]
+    st_un.num_locally_computed_tokens = 100  # not chunk-aligned
+    check(
+        rst.lookup(sched, st_un) == 0,
+        "B4d non-chunk-aligned local hit => no disk extension (plan F6)",
+    )
+
+    # B5/B6: allocation builds a DISK load job; manager untouched.
+    manager = spec._manager
+    manager.prepare_load_calls.clear()
+    lookup_calls_before = len(manager.lookup_calls)
+    touched_before = len(manager.touched)
+    hit, _ = sched.get_num_new_matched_tokens(req, 0)
+    check(hit == 10752, "B5 lookup ready for allocation")
+    n_blocks = 3
+    blocks = mods["kv_cache_manager"].KVCacheBlocks(
+        blocks=([FakeBlock(100 + i) for i in range(n_blocks)],)
+    )
+    sched.update_state_after_alloc(req, blocks, hit)
+    check(
+        len(manager.prepare_load_calls) == 0
+        and len(manager.lookup_calls) == lookup_calls_before,
+        "B6 ZERO manager lookup/prepare_load calls on the disk path",
+    )
+    check(
+        len(manager.touched) > touched_before
+        and sched._req_status[req.request_id].group_states[0].offload_keys,
+        "B6b stage-1 bookkeeping preserved (touch ran, offload keys built)",
+    )
+    check(
+        len(sched._current_batch_load_jobs) == 1,
+        "B6c one disk load job created",
+    )
+    job_id, job = next(iter(sched._current_batch_load_jobs.items()))
+    ss = job.src_spec
+    check(
+        isinstance(ss, dict)
+        and ss["glm53_disk_load"] == 1
+        and ss["v"] == 1
+        and ss["namespace_hash"] == "ns1"
+        and ss["boundary_token_index"] == 10752
+        and len(ss["entries"]) == n_blocks
+        and [e[2] for e in ss["entries"]] == [0, 1, 2]
+        and ss["entries"][-1][0] == b2
+        and list(job.dst_spec.block_ids) == [100, 101, 102],
+        f"B6d disk src_spec shape + 1:1 entry alignment (got {ss})",
+    )
+    check(
+        sched._jobs[job_id].keys == set()
+        and not sched._jobs[job_id].is_store,
+        "B6e TransferJobStatus: empty keys, is_store=False",
+    )
+    check(
+        getattr(req, "glm53_restored_boundary", None) == 10752,
+        "B6f request.glm53_restored_boundary set END-EXCLUSIVE (T2)",
+    )
+
+    # B7: single-flight gate defers, self-heals, and clears on completion.
+    req_b = stub.FakeRequest(num_tokens=2 * 3584, req_id="rq2", salt=b"s")
+    req_b.block_hashes = req.block_hashes[: len(req_b.block_hashes)]
+    sched.on_new_request(req_b)
+    hit_b, _ = sched.get_num_new_matched_tokens(req_b, 0)
+    check(hit_b is None, "B7 second restore while in flight => defer (None)")
+    rst._inflight_job = 424242  # vanished job
+    hit_b, _ = sched.get_num_new_matched_tokens(req_b, 0)
+    check(
+        hit_b == 7168 and rst._inflight_job is None,
+        "B7b gate self-heals when its job vanished (finding 11)",
+    )
+    rst.job_started(job_id)
+    out_meta = mods["common"].OffloadingWorkerMetadata(
+        completed_jobs={job_id: 2}
+    )
+    sched.update_connector_output(
+        SimpleNamespace(kv_connector_worker_meta=out_meta)
+    )
+    check(
+        rst._inflight_job is None and job_id not in sched._jobs,
+        "B7c all-rank completion clears the gate (complete_load(set()) no-op)",
+    )
+
+    # B8: preemption with a disk LOAD job must not assert (finding 3).
+    req_c = stub.FakeRequest(num_tokens=2 * 3584, req_id="rq3", salt=b"s")
+    req_c.block_hashes = req.block_hashes[: len(req_c.block_hashes)]
+    sched.on_new_request(req_c)
+    hit_c, _ = sched.get_num_new_matched_tokens(req_c, 0)
+    check(hit_c == 7168, "B8 setup hit")
+    blocks_c = mods["kv_cache_manager"].KVCacheBlocks(
+        blocks=([FakeBlock(200), FakeBlock(201)],)
+    )
+    sched.update_state_after_alloc(req_c, blocks_c, hit_c)
+    load_c = next(iter(sched._current_batch_load_jobs))
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={},
+        finished_req_ids=set(),
+        req_data={},
+        partial_tail_offloads=None,
+        preempted_req_ids={req_c.request_id},
+        scheduled_new_reqs=[],
+    )
+    meta_out = sched.build_connector_meta(scheduler_output)
+    check(
+        load_c not in (meta_out.jobs_to_flush or set())
+        and rst._inflight_job is None,
+        "B8b preempted load job: no assert, not flushed, gate cleared",
+    )
+
+    # B9: reset clears gate + pending hits; lookup self-heals after.
+    rst.job_started(9999)
+    rst._pending_hits["zombie"] = 3584
+    sched.reset_cache()
+    check(
+        rst._inflight_job is None and not rst._pending_hits,
+        "B9 reset_cache clears the gate and pending hits",
+    )
+
+    # B10 (S1): a zero-cow layout publishes manifest candidates.
+    req_s = stub.FakeRequest(num_tokens=2 * 3584 + 5, req_id="rq-s1", salt=b"x")
+    sched.on_new_request(req_s)
+    sched.get_num_new_matched_tokens(req_s, 0)
+    so = SimpleNamespace(
+        num_scheduled_tokens={req_s.request_id: req_s.num_tokens},
+        finished_req_ids=set(),
+        req_data={req_s.request_id: (([300 + j for j in range(2)],), False)},
+        partial_tail_offloads=None,
+    )
+    sched._update_req_states(so)
+    jobs_s = sched._build_store_jobs(so)
+    metas = [j.glm53_store_meta for j in jobs_s.values() if j.glm53_store_meta]
+    cands = [m["manifests"] for m in metas]
+    check(
+        len(jobs_s) == 1
+        and metas
+        and metas[0]["cow_groups"] == []
+        and {m["boundary_token_index"] for m in cands[0]} == {3584, 7168}
+        and [len(m["chunk_hashes"]) for m in sorted(
+            cands[0], key=lambda m: m["boundary_token_index"]
+        )] == [1, 2],
+        f"B10 zero-cow manifest candidates cumulative per boundary (got {cands})",
+    )
+
+    # B11: RESTORE=0 keeps the stage-1 short-circuit (no disk lookup).
+    os.environ["GLM53_KV_OFFLOAD_RESTORE"] = "0"
+    mods0 = stub.install_fake_vllm(with_restore=True)
+    sched0, _ = _mk_scheduler(
+        stub, mods0, _single_group_layout(stub), spec_off=True
+    )
+    check(
+        sched0._glm53_restore.disabled_reason == "GLM53_KV_OFFLOAD_RESTORE=0",
+        "B11 RESTORE=0: restore state disabled with the knob reason",
+    )
+    req0 = stub.FakeRequest(num_tokens=7168, req_id="rq0")
+    sched0.on_new_request(req0)
+    hit0, async0 = sched0.get_num_new_matched_tokens(req0, 0)
+    check(hit0 == 0 and not async0, "B11b RESTORE=0: zero external hits")
+    _cleanup_env()
+
+
+# ------------------------------------------------------------------ part C --
+class FakeTorchBuf:
+    def __init__(self, data: bytearray):
+        self.data = data
+
+
+class FakeGpuRow:
+    def __init__(self, backing: bytearray, start: int, length: int):
+        self.backing = backing
+        self.start = start
+        self.length = length
+
+    def copy_(self, buf: FakeTorchBuf):
+        assert len(buf.data) == self.length
+        self.backing[self.start : self.start + self.length] = buf.data
+
+    def zero_(self):
+        self.backing[self.start : self.start + self.length] = bytes(self.length)
+
+
+class FakeGpuTensor:
+    """(num_rows, page) int8 GPU tensor over a flat bytearray."""
+
+    def __init__(self, num_rows: int, page: int):
+        self.page = page
+        self.backing = bytearray(os.urandom(num_rows * page))
+
+    def __getitem__(self, key):
+        row, sl = key
+        start, stop, _ = sl.indices(self.page)
+        return FakeGpuRow(self.backing, row * self.page + start, stop - start)
+
+    def row_bytes(self, row: int, n: int) -> bytes:
+        return bytes(self.backing[row * self.page : row * self.page + n])
+
+
+def _install_fake_torch():
+    t = types.ModuleType("torch")
+    t.int8 = "int8"
+
+    def frombuffer(data, dtype):
+        assert dtype == t.int8
+        return FakeTorchBuf(data)
+
+    t.frombuffer = frombuffer
+    t.Tensor = object
+    t.Event = object
+    sys.modules["torch"] = t
+
+
+def _g0_env(store_mod, tmpdir, logger):
+    """Single-full-attn-group writer env (2 layers: pages 64 + 8)."""
+    from test_kv_offload_store_local import FakeCpuTensor, FakeRef
+
+    import _kv_offload_stub_env as stub
+
+    layers = ("mla.0", "idx.0")
+    g0 = stub.FakeKVCacheGroup(
+        stub.UniformTypeKVCacheSpecs(
+            3584, {n: stub.MLAAttentionSpec(3584) for n in layers}
+        ),
+        layers,
+    )
+    kv_cache_config = SimpleNamespace(kv_cache_groups=[g0])
+    tensors = [FakeCpuTensor(0, 64, 64), FakeCpuTensor(1, 64, 8)]
+    refs = [[FakeRef(0, 64), FakeRef(1, 8)]]
+    handler = SimpleNamespace(
+        dst_tensors=tensors,
+        layer_refs_per_group=refs,
+        _canonical_copy_plans=None,
+    )
+    worker = SimpleNamespace(_store_handler=handler)
+    parallel = SimpleNamespace(rank=0, world_size=2, tp_size=2)
+    spec = SimpleNamespace(
+        blocks_per_chunk=1,
+        tokens_per_hash=64,
+        config=SimpleNamespace(
+            parallel=parallel,
+            model=SimpleNamespace(name="test/model", dtype="fp8"),
+            groups=[
+                SimpleNamespace(
+                    group_idx=0, tokens_per_block=3584, layer_names=layers
+                )
+            ],
+        ),
+    )
+    vllm_config = stub.FakeVllmConfig()
+    cw = SimpleNamespace(
+        spec=spec,
+        worker=worker,
+        kv_cache_config=kv_cache_config,
+        vllm_config=vllm_config,
+        _glm53_store_writer=None,
+        _glm53_job_meta={},
+        _glm53_gpu_caches=None,
+        _glm53_disk_done=[],
+        _glm53_load_error_ids=set(),
+        _connector_worker_meta=SimpleNamespace(
+            completed_jobs={},
+            glm53_manifest_events=[],
+            transfer_stats=SimpleNamespace(
+                load=SimpleNamespace(record=lambda n, t: None)
+            ),
+            mark_completed=lambda job_id: None,
+        ),
+    )
+    os.environ["GLM53_KV_OFFLOAD_DIR"] = str(tmpdir)
+    ns = _load_restore_helpers(store_mod, logger)
+    writer = ns["Glm53LocalStoreWriter"](cw, logger)
+    cw._glm53_store_writer = writer
+    # GPU-side canonical caches mirroring the staging layout (mapping=None).
+    gpu_tensors = [
+        SimpleNamespace(tensor=FakeGpuTensor(64, 64), page_size_bytes=64),
+        SimpleNamespace(tensor=FakeGpuTensor(64, 8), page_size_bytes=8),
+    ]
+    gpu_refs = [[FakeRef(0, 64), FakeRef(1, 8)]]
+    cw._glm53_gpu_caches = SimpleNamespace(
+        tensors=gpu_tensors, group_data_refs=gpu_refs
+    )
+    return cw, writer, ns, tensors, gpu_tensors
+
+
+def _load_restore_helpers(store_mod, logger) -> dict:
+    """Exec the store writer + restore worker sources with one logger, the
+    same composition the patched worker.py carries."""
+    ns: dict = {"logger": logger}
+    src = (
+        store_mod.MODE_HELPERS_SRC
+        + store_mod.CODEC_SRC
+        + _restore_patched_writer_src()
+        + restore.RESTORE_WORKER_SRC
+    )
+    exec(compile(src, "<restore-test helpers>", "exec"), ns)
+    return ns
+
+
+def _restore_patched_writer_src() -> str:
+    """The store WRITER_SRC with the restore overlay's writer sites applied
+    (W7-W12 anchor inside the writer text), so tests drive the same composed
+    class the container runs."""
+    src = store.WRITER_SRC
+    for _n, _m, anchor, patched in restore.SITES_WORKER:
+        if anchor in src:
+            src = src.replace(anchor, patched, 1)
+    return src
+
+
+def _hash(i: int) -> str:
+    import hashlib
+
+    return hashlib.sha256(b"g0chunk%d" % i).hexdigest()
+
+
+def _g0_job_meta(n_boundaries: int):
+    keys = [(_hash(k), 0, k, 3584) for k in range(n_boundaries)]
+    manifests = [
+        {
+            "boundary_token_index": (k + 1) * 3584,
+            "chunk_hashes": [_hash(j) for j in range(k + 1)],
+        }
+        for k in range(n_boundaries)
+    ]
+    return {
+        "v": 1,
+        "keys": keys,
+        "cow_groups": [],
+        "full_groups": [0],
+        "manifests": manifests,
+    }
+
+
+def _load_spec(writer, n: int, start: int = 0):
+    return {
+        "glm53_disk_load": 1,
+        "v": 1,
+        "namespace_hash": writer._namespace_hash,
+        "boundary_token_index": n * 3584,
+        "entries": [(_hash(k), 0, k, 3584) for k in range(start, n)],
+    }
+
+
+class _TestLogger:
+    def __init__(self):
+        self.lines = []
+
+    def _fmt(self, msg, *args):
+        try:
+            self.lines.append(msg % args if args else str(msg))
+        except TypeError:
+            self.lines.append(str(msg))
+
+    info = debug = warning = error = exception = _fmt
+
+
+def test_disk_loader() -> None:
+    print("Part C: worker-side synchronous disk loader")
+    import _kv_offload_stub_env as stub
+
+    if "vllm" not in sys.modules:
+        stub.install_fake_vllm(with_restore=True)
+    _install_fake_torch()
+
+    logger = _TestLogger()
+    with tempfile.TemporaryDirectory() as td:
+        os.environ["GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"] = "0"
+        cw, writer, ns, staging, gpu_tensors = _g0_env(store, Path(td), logger)
+        check(writer._disabled_reason is None, "C1 writer up on the g0 layout")
+
+        # Store three boundaries (real writer path => real files+manifests).
+        meta = _g0_job_meta(3)
+        rows = list(range(3))
+        expected = [
+            staging[0].rows[r][:64] + staging[1].rows[r][:8] for r in rows
+        ]
+        writer.capture_job(1, meta, rows)
+        writer.shutdown(timeout=20)
+        base = Path(writer._base)
+        check(
+            len(list(base.rglob("*.bin"))) == 3
+            and len(list(base.rglob("manifests/**/*.json"))) == 3,
+            "C2 zero-cow store: 3 chunk files + 3 boundary manifests",
+        )
+
+        # C3 happy path: byte-exact restore into the GPU tensors.
+        dst = SimpleNamespace(block_ids=[10, 11, 12])
+        ns["_glm53_run_disk_load"](cw, 77, _load_spec(writer, 3), dst)
+        check(cw._glm53_disk_done == [77], "C3 job completes (done queue)")
+        check(not cw._glm53_load_error_ids, "C3b no load errors on happy path")
+        got = [
+            gpu_tensors[0].tensor.row_bytes(10 + i, 64)
+            + gpu_tensors[1].tensor.row_bytes(10 + i, 8)
+            for i in range(3)
+        ]
+        check(
+            got == expected and any(any(b) for b in expected),
+            "C3c GPU bytes == original staging bytes (byte-exact restore)",
+        )
+        cw._glm53_disk_done.clear()
+
+        # C4 failure matrix: corrupt chunk 1 => chunk 0 restored, 1+2 failed
+        # and zero-filled, job still completes.
+        victim = Path(writer._file_path(_hash(1), 0))
+        blob = victim.read_bytes()
+        victim.write_bytes(blob[:-3] + b"\x00\x00\x00")
+        for t in gpu_tensors:
+            t.tensor.backing[:] = os.urandom(len(t.tensor.backing))
+        pre_fail_row2 = gpu_tensors[0].tensor.row_bytes(22, 64)
+        ns["_glm53_run_disk_load"](
+            cw, 78, _load_spec(writer, 3), SimpleNamespace(block_ids=[20, 21, 22])
+        )
+        check(
+            cw._glm53_disk_done == [78]
+            and cw._glm53_load_error_ids == {21, 22},
+            f"C4 CRC failure at chunk 1: ids 21+22 invalid, job done "
+            f"(got {cw._glm53_load_error_ids})",
+        )
+        check(
+            gpu_tensors[0].tensor.row_bytes(20, 64) == expected[0][:64]
+            and gpu_tensors[0].tensor.row_bytes(21, 64) == bytes(64)
+            and gpu_tensors[1].tensor.row_bytes(22, 8) == bytes(8)
+            and gpu_tensors[0].tensor.row_bytes(22, 64) != pre_fail_row2,
+            "C4b earlier chunk restored; failed suffix zero-filled",
+        )
+        victim.write_bytes(blob)  # repair
+        cw._glm53_disk_done.clear()
+        cw._glm53_load_error_ids.clear()
+
+        # C5 missing chunk file.
+        gone = Path(writer._file_path(_hash(2), 0))
+        gone_blob = gone.read_bytes()
+        gone.unlink()
+        ns["_glm53_run_disk_load"](
+            cw, 79, _load_spec(writer, 3), SimpleNamespace(block_ids=[30, 31, 32])
+        )
+        check(
+            cw._glm53_disk_done == [79] and cw._glm53_load_error_ids == {32},
+            "C5 missing chunk file: only its suffix invalid, job done",
+        )
+        gone.write_bytes(gone_blob)
+        cw._glm53_disk_done.clear()
+        cw._glm53_load_error_ids.clear()
+
+        # C6 wrong namespace => whole job failed (all ids), still done.
+        bad = _load_spec(writer, 3)
+        bad["namespace_hash"] = "deadbeef"
+        ns["_glm53_run_disk_load"](
+            cw, 80, bad, SimpleNamespace(block_ids=[40, 41, 42])
+        )
+        check(
+            cw._glm53_disk_done == [80]
+            and cw._glm53_load_error_ids == {40, 41, 42},
+            "C6 namespace mismatch: every chunk failed, job done",
+        )
+        cw._glm53_disk_done.clear()
+        cw._glm53_load_error_ids.clear()
+
+        # C7 manifest missing at load time (retention race) => all failed.
+        mpath = Path(writer._manifest_path(_hash(2)))
+        mblob = mpath.read_bytes()
+        mpath.unlink()
+        ns["_glm53_run_disk_load"](
+            cw, 81, _load_spec(writer, 3), SimpleNamespace(block_ids=[50, 51, 52])
+        )
+        check(
+            cw._glm53_disk_done == [81]
+            and cw._glm53_load_error_ids == {50, 51, 52},
+            "C7 manifest gone at load: all chunks failed (T4 degradation)",
+        )
+        mpath.write_bytes(mblob)
+        cw._glm53_disk_done.clear()
+        cw._glm53_load_error_ids.clear()
+
+        # C8 wrong-rank chunk header rejected.
+        h0path = Path(writer._file_path(_hash(0), 0))
+        h0 = store.read_chunk_header(str(h0path), verify_payload=True)
+        payload = h0path.read_bytes()[16 + len(json.dumps(h0, sort_keys=True,
+                                                          separators=(",", ":")).encode()):]
+        # (re-encode with tp_rank flipped; payload re-derived via the codec)
+        raw = h0path.read_bytes()
+        hlen = int.from_bytes(raw[8:12], "little")
+        payload = raw[16 + hlen:]
+        h_bad = {k: v for k, v in h0.items()
+                 if k not in ("payload_len", "payload_crc32", "crc_algo",
+                              "format_version")}
+        h_bad["tp_rank"] = 1
+        h0path.write_bytes(store.encode_chunk(h_bad, payload))
+        ns["_glm53_run_disk_load"](
+            cw, 82, _load_spec(writer, 3), SimpleNamespace(block_ids=[60, 61, 62])
+        )
+        check(
+            cw._glm53_disk_done == [82]
+            and cw._glm53_load_error_ids == {60, 61, 62},
+            "C8 wrong-rank header: failed from chunk 0 (never cross-rank bytes)",
+        )
+        cw._glm53_disk_done.clear()
+        cw._glm53_load_error_ids.clear()
+
+        # C9 null dst block refused.
+        ns["_glm53_run_disk_load"](
+            cw, 83, _load_spec(writer, 1), SimpleNamespace(block_ids=[0])
+        )
+        check(
+            cw._glm53_disk_done == [83] and 0 not in cw._glm53_load_error_ids,
+            "C9 null block 0 never enters the invalid set (DS4F rule)",
+        )
+        cw._glm53_disk_done.clear()
+        cw._glm53_load_error_ids.clear()
+    _cleanup_env()
+
+
+# ------------------------------------------------------------------ part D --
+def test_event_channel() -> None:
+    print("Part D: manifest-event channel + facade drain")
+    import _kv_offload_stub_env as stub
+
+    if "vllm" not in sys.modules:
+        stub.install_fake_vllm(with_restore=True)
+    _install_fake_torch()
+    logger = _TestLogger()
+
+    with tempfile.TemporaryDirectory() as td:
+        os.environ["GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"] = "1"
+        cw, writer, ns, _staging, _gpu = _g0_env(store, Path(td), logger)
+        writer._keep_boundaries = 1
+        writer.capture_job(1, _g0_job_meta(2), [0, 1])
+        writer.shutdown(timeout=20)
+        events = writer.drain_manifest_events()
+        codes = [e[0] for e in events]
+        check(
+            codes.count("+") == 2
+            and codes.count("-") == 1
+            and events[0][1] == 0
+            and events[0][2] == writer._namespace_hash,
+            f"D1 publish x2 + supersede x1 events with rank+namespace (got {codes})",
+        )
+        check(
+            writer.drain_manifest_events() == [],
+            "D1b drain empties the queue",
+        )
+
+        # D2 write-failure event ("F") from an ineligible-group key.
+        bad_meta = {
+            "v": 1,
+            "keys": [(_hash(9), 5, 0, 3584)],
+            "cow_groups": [],
+            "full_groups": [0],
+            "manifests": [],
+        }
+        writer.capture_job(2, bad_meta, [7])
+        writer.shutdown(timeout=20)
+        evs = writer.drain_manifest_events()
+        check(
+            any(e[0] == "F" and e[3] == _hash(9) and e[4] == 5 for e in evs),
+            f"D2 write failure emits an F event (got {evs})",
+        )
+
+        # D3 validated dedup: republish over an existing valid manifest
+        # re-emits '+'; a corrupted manifest is rewritten instead.
+        writer2 = ns["Glm53LocalStoreWriter"](cw, logger)
+        writer2._keep_boundaries = 0
+        writer2.capture_job(3, _g0_job_meta(2), [0, 1])
+        writer2.shutdown(timeout=20)
+        evs2 = writer2.drain_manifest_events()
+        check(
+            [e[0] for e in evs2].count("+") == 2,
+            "D3 dedup path validates then re-announces existing manifests",
+        )
+        mpath = Path(writer2._manifest_path(_hash(0)))
+        mpath.write_text("{ corrupt")
+        writer3 = ns["Glm53LocalStoreWriter"](cw, logger)
+        writer3._keep_boundaries = 0
+        writer3.capture_job(4, _g0_job_meta(1), [0])
+        writer3.shutdown(timeout=20)
+        man = json.loads(mpath.read_text())
+        check(
+            man.get("chunk_hashes") == [_hash(0)]
+            and [e[0] for e in writer3.drain_manifest_events()] == ["+"],
+            "D3b corrupt existing manifest is rewritten, then announced",
+        )
+
+    # D4 worker-meta plumbing: event-only meta flows; aggregate concatenates;
+    # legacy meta without the field tolerated; pickle round-trip.
+    common = sys.modules[
+        "vllm.distributed.kv_transfer.kv_connector.v1.offloading.common"
+    ]
+    m1 = common.OffloadingWorkerMetadata()
+    m1.glm53_manifest_events.append(("+", 0, "ns", "h", 3584, "b"))
+    check(
+        bool(m1.glm53_manifest_events) and not m1.completed_jobs,
+        "D4 event-only meta constructible",
+    )
+    m2 = common.OffloadingWorkerMetadata(completed_jobs={5: 1})
+    m2.glm53_manifest_events.append(("+", 1, "ns", "h", 3584, "b"))
+    agg = m1.aggregate(m2)
+    check(
+        len(agg.glm53_manifest_events) == 2 and agg.completed_jobs == {5: 1},
+        "D4b aggregate() concatenates events and keeps completions",
+    )
+    legacy = common.OffloadingWorkerMetadata(completed_jobs={6: 1})
+    del legacy.__dict__["glm53_manifest_events"]
+    agg2 = m1.aggregate(legacy)
+    check(
+        len(agg2.glm53_manifest_events) == 1,
+        "D4c legacy meta without the field aggregates via getattr",
+    )
+    rt = pickle.loads(pickle.dumps(agg))
+    check(
+        rt.glm53_manifest_events == agg.glm53_manifest_events,
+        "D4d events pickle round-trip on the wire",
+    )
+
+    # D5 patched connector-worker: build_connector_worker_meta returns an
+    # event-only meta; get_finished drains disk loads into finished_recving.
+    worker_mod = sys.modules[
+        "vllm.distributed.kv_transfer.kv_connector.v1.offloading.worker"
+    ]
+    cw2 = object.__new__(worker_mod.OffloadingConnectorWorker)
+    cw2._connector_worker_meta = common.OffloadingWorkerMetadata()
+    cw2._glm53_store_writer = None
+    cw2._glm53_disk_done = []
+    cw2._glm53_load_error_ids = set()
+    cw2._load_jobs = {}
+    cw2._unsubmitted_store_jobs = []
+    check(
+        cw2.build_connector_worker_meta() is None,
+        "D5 no completions + no events => meta None (stock behavior kept)",
+    )
+    cw2._connector_worker_meta.glm53_manifest_events.append(
+        ("+", 0, "ns", "h", 3584, "b")
+    )
+    meta = cw2.build_connector_worker_meta()
+    check(
+        meta is not None and len(meta.glm53_manifest_events) == 1,
+        "D5b event-only meta FLOWS (finding 7)",
+    )
+    cw2.worker = SimpleNamespace(get_finished=lambda: [])
+    cw2._glm53_disk_done = [11]
+    cw2._load_jobs = {11: "req-z"}
+    sent, recv = cw2.get_finished(set())
+    check(
+        recv == {"req-z"}
+        and cw2._connector_worker_meta.completed_jobs.get(11) == 1,
+        "D5c get_finished drains disk loads: ack + finished_recving",
+    )
+
+    # D6 facade drain (patched facade text, constructor bypassed).
+    fac_text, _ = restore.prepare(
+        (FIXTURES / "image_487ecf187_offloading_connector.py").read_text(),
+        restore.SITES_FACADE,
+        "facade",
+    )
+    import re as _re
+
+    m = _re.search(
+        r"    def get_block_ids_with_load_errors.*?\n(?=    def )",
+        fac_text,
+        _re.S,
+    )
+    fac_ns: dict = {}
+    exec(  # drive the patched method text verbatim
+        compile(
+            "class _F:\n" + m.group(0) + "    pass\n", "facade-method", "exec"
+        ),
+        fac_ns,
+    )
+    f = fac_ns["_F"]()
+    f.connector_worker = None
+    check(f.get_block_ids_with_load_errors() == set(), "D6 no worker => empty")
+    f.connector_worker = SimpleNamespace(_glm53_load_error_ids={3, 4})
+    got = f.get_block_ids_with_load_errors()
+    check(
+        got == {3, 4}
+        and f.connector_worker._glm53_load_error_ids == set()
+        and f.get_block_ids_with_load_errors() == set(),
+        "D6b facade drains-and-clears the error set",
+    )
+    _cleanup_env()
+
+
+# ------------------------------------------------------------------ part E --
+def _install_single_type_stub():
+    """Extra stub modules the patched single_type manager imports."""
+    import _kv_offload_stub_env as stub
+
+    def _mod(name):
+        m = types.ModuleType(name)
+        sys.modules[name] = m
+        return m
+
+    m = _mod("vllm.v1.core.block_pool")
+    m.BlockPool = object
+    m = _mod("vllm.v1.core.kv_cache_utils")
+    for n in (
+        "BlockHashList",
+        "BlockHashListWithBlockSize",
+        "BlockHashWithGroupId",
+        "KVCacheBlock",
+        "resolve_block_hashes",
+    ):
+        setattr(m, n, object)
+    kci = sys.modules["vllm.v1.kv_cache_interface"]
+    for n in (
+        "CrossAttentionSpec",
+        "HiddenStateCacheSpec",
+        "KpoolTailSpec",
+        "RSWASpec",
+        "SinkFullAttentionSpec",
+        "SlidingWindowMLASpec",
+        "TQFullAttentionSpec",
+    ):
+        if not hasattr(kci, n):
+            setattr(m if False else kci, n, type(n, (stub.KVCacheSpec,), {}))
+    m = _mod("vllm.v1.kv_cache_spec_registry")
+
+    class KVCacheSpecRegistry:
+        @staticmethod
+        def register(*a, **k):
+            pass
+
+    m.KVCacheSpecRegistry = KVCacheSpecRegistry
+
+
+def test_single_type_t2() -> None:
+    print("Part E: T2 reachable_boundaries (patched single_type text)")
+    import _kv_offload_stub_env as stub
+
+    if "vllm" not in sys.modules:
+        stub.install_fake_vllm(with_restore=True)
+    _install_single_type_stub()
+    st_text, _ = restore.prepare(
+        (FIXTURES / "image_487ecf187_single_type_kv_cache_manager.py").read_text(),
+        restore.SITES_SINGLE_TYPE,
+        "st",
+    )
+    st_mod = types.ModuleType("patched_single_type")
+    exec(compile(st_text, "single_type_kv_cache_manager.py", "exec"),
+         st_mod.__dict__)
+
+    recorded = {}
+
+    class Recorder:
+        def cache_full_blocks(self, **kw):
+            recorded["block_mask"] = kw.get("block_mask")
+
+    def _mask_recorder(**kw):
+        recorded["reachable_boundaries"] = list(kw["reachable_boundaries"])
+        return None
+
+    def _drive(request, retention_interval=0):
+        recorded.clear()
+        self_stub = SimpleNamespace(
+            num_cached_block={},
+            block_size=3584,
+            scheduler_block_size=3584,
+            kv_cache_spec=None,
+            use_eagle=False,
+            kv_cache_group_id=0,
+            block_pool=Recorder(),
+            req_to_blocks={request.request_id: [None, None]},
+            reachable_block_mask=_mask_recorder,
+        )
+        st_mod.SingleTypeKVCacheManager.cache_blocks(
+            self_stub, request, 7168, retention_interval=retention_interval
+        )
+        return recorded.get("reachable_boundaries", [])
+
+    req = SimpleNamespace(
+        request_id="r1", num_prompt_tokens=9000, shared_prefix_boundary=0
+    )
+    rb = _drive(req)
+    check(
+        rb == [8999],
+        f"E1 absent attribute: reachable_boundaries unchanged (got {rb})",
+    )
+    req.glm53_restored_boundary = 7168
+    rb = _drive(req)
+    check(
+        rb == [8999, 7168],
+        f"E2 restored boundary appended END-EXCLUSIVE (got {rb})",
+    )
+    req.glm53_restored_boundary = 0
+    rb = _drive(req)
+    check(rb == [8999], "E3 zero value is ignored (falsy guard)")
+    req.shared_prefix_boundary = 3584
+    req.glm53_restored_boundary = 7168
+    rb = _drive(req)
+    check(
+        rb == [8999, 3584, 7168],
+        "E4 composes with shared_prefix_boundary (both appended)",
+    )
+
+    # E5 MambaManager.reachable_block_mask keeps exactly the restored
+    # boundary's state block under retention 0 (end-exclusive convention).
+    spec = stub.MambaSpec(3584)
+    mask = st_mod.MambaManager.reachable_block_mask(
+        start_block=0,
+        end_block=3,
+        alignment_tokens=3584,
+        kv_cache_spec=spec,
+        use_eagle=False,
+        retention_interval=0,
+        reachable_boundaries=[7168],
+    )
+    check(mask == [False, True, False], f"E5 7168 keeps mamba block 1 (got {mask})")
+    mask = st_mod.MambaManager.reachable_block_mask(
+        start_block=0,
+        end_block=3,
+        alignment_tokens=3584,
+        kv_cache_spec=spec,
+        use_eagle=False,
+        retention_interval=0,
+        reachable_boundaries=[3584],
+    )
+    check(mask == [True, False, False], f"E5b 3584 keeps block 0 (got {mask})")
+    mask = st_mod.MambaManager.reachable_block_mask(
+        start_block=0,
+        end_block=3,
+        alignment_tokens=3584,
+        kv_cache_spec=spec,
+        use_eagle=False,
+        retention_interval=0,
+        reachable_boundaries=[3583],
+    )
+    check(
+        mask == [False, False, False],
+        f"E5c 3583 (not end-exclusive-aligned) keeps nothing (got {mask})",
+    )
+
+
+def _cleanup_env() -> None:
+    for name in (
+        "GLM53_KV_OFFLOAD",
+        "GLM53_KV_OFFLOAD_DIR",
+        "GLM53_KV_OFFLOAD_CPU_GB",
+        "GLM53_KV_OFFLOAD_RESTORE",
+        "GLM53_KV_OFFLOAD_DRAFTER",
+        "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES",
+    ):
+        os.environ.pop(name, None)
+
+
+def main() -> int:
+    test_patcher_hygiene()
+    test_scheduler_restore()
+    test_disk_loader()
+    test_event_channel()
+    test_single_type_t2()
+    print(f"\n{len(FAILURES)} failure(s)")
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_kv_offload_restore_venv.py
+++ b/tests/test_kv_offload_restore_venv.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Coordinator-level checks against the CPU vLLM venv, where APIs match.
+
+The venv (upstream-vllm/.venv + the upstream source tree @ 22df3a34-era) is a
+DIFFERENT generation from the image [I]: the fork's retention/reachable
+machinery ([I] single_type_kv_cache_manager cache_blocks retention_interval +
+reachable_block_mask) is fork-only. Everything here FEATURE-DETECTS and skips
+cleanly when the API differs — an honest skip, never a fake pass (the task
+contract: "where APIs match — feature-detect").
+
+V1  venv availability + vllm importability from the source tree.
+V2  single_type cache_blocks signature: retention_interval present => drive
+    the T2 attribute against the REAL class; absent => SKIP (upstream tree).
+V3  offloading connector base API surface stage 2 relies on:
+    get_block_ids_with_load_errors on KVConnectorBase_V1 (the mixin's
+    consumer contract) — present in both generations.
+
+Run:  python3 tests/test_kv_offload_restore_venv.py   (or pytest)
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+VENV_PY = ROOT.parent / "upstream-vllm" / ".venv" / "bin" / "python"
+TREE = ROOT.parent / "upstream-vllm" / "vllm"
+
+FAILURES: list[str] = []
+
+
+def check(cond: bool, label: str) -> None:
+    print(("  ok   " if cond else "  FAIL ") + label)
+    if not cond:
+        FAILURES.append(label)
+
+
+def skip(label: str) -> None:
+    print("  SKIP " + label)
+
+
+PROBE = r"""
+import inspect, json, sys
+out = {}
+try:
+    import vllm
+    out["vllm"] = str(getattr(vllm, "__version__", "?"))
+except Exception as exc:
+    print(json.dumps({"error": f"{type(exc).__name__}: {exc}"}))
+    sys.exit(0)
+try:
+    from vllm.v1.core.single_type_kv_cache_manager import SingleTypeKVCacheManager
+    sig = inspect.signature(SingleTypeKVCacheManager.cache_blocks)
+    out["cache_blocks_params"] = list(sig.parameters)
+except Exception as exc:
+    out["cache_blocks_params"] = f"unavailable: {type(exc).__name__}"
+try:
+    from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorBase_V1
+    out["has_load_errors_api"] = hasattr(
+        KVConnectorBase_V1, "get_block_ids_with_load_errors"
+    )
+except Exception as exc:
+    out["has_load_errors_api"] = f"unavailable: {type(exc).__name__}"
+print(json.dumps(out))
+"""
+
+
+def main() -> int:
+    print("Venv coordinator-level checks (feature-detected)")
+    if not VENV_PY.is_file() or not TREE.is_dir():
+        skip("V1 CPU vLLM venv not present on this host")
+        print(f"\n{len(FAILURES)} failure(s)")
+        return 0
+    r = subprocess.run(
+        [str(VENV_PY), "-c", PROBE],
+        capture_output=True,
+        text=True,
+        cwd=str(TREE),
+        timeout=180,
+    )
+    if r.returncode != 0 or not r.stdout.strip():
+        skip(f"V1 venv probe failed to run ({r.stderr.strip()[:80]!r})")
+        print(f"\n{len(FAILURES)} failure(s)")
+        return 0
+    out = json.loads(r.stdout.strip().splitlines()[-1])
+    if "error" in out:
+        skip(f"V1 vllm unimportable in venv: {out['error'][:80]}")
+        print(f"\n{len(FAILURES)} failure(s)")
+        return 0
+    check(True, f"V1 venv vllm importable ({out['vllm']})")
+
+    params = out.get("cache_blocks_params")
+    if isinstance(params, list) and "retention_interval" in params:
+        # Fork-generation tree: the T2 seam exists — prove the restore
+        # patcher's single_type anchor applies to the REAL tree file.
+        sys.path.insert(0, str(ROOT / "overlay"))
+        import patch_kv_offload_restore_g0 as restore
+
+        st = TREE / "vllm" / "v1" / "core" / "single_type_kv_cache_manager.py"
+        try:
+            patched, action = restore.prepare(
+                st.read_text(), restore.SITES_SINGLE_TYPE, "venv-tree"
+            )
+            compile(patched, str(st), "exec")
+            check(True, f"V2 T2 anchor applies to the real tree ({action})")
+        except ValueError as exc:
+            check(False, f"V2 T2 anchor drifted on a fork-generation tree: {exc}")
+    else:
+        skip(
+            f"V2 upstream-generation tree: cache_blocks has no "
+            f"retention_interval (params={params}) — the T2 seam is fork-only"
+        )
+
+    api = out.get("has_load_errors_api")
+    if api is True:
+        check(True, "V3 KVConnectorBase_V1.get_block_ids_with_load_errors exists")
+    elif api is False:
+        check(False, "V3 load-errors API missing from connector base")
+    else:
+        skip(f"V3 connector base unimportable ({api})")
+
+    print(f"\n{len(FAILURES)} failure(s)")
+    return 1 if FAILURES else 0
+
+
+def test_venv():  # pytest entry
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_kv_offload_scope.py
+++ b/tests/test_kv_offload_scope.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Regression tests for overlay/patch_kv_offload_scope.py (port of vllm#54743).
+
+A  Patcher mechanics on the PINNED image fixtures (byte-exact captures of the
+   deployed tree, tests/fixtures/README.md): preflight, apply, idempotence,
+   tamper/drift refusal, half-patched refusal, compile of the patched text.
+B  Eligibility predicate (the exec'd shipped helper, not a replica): kpool
+   scratch never eligible; drafter excluded only under EAGLE context and only
+   while GLM53_KV_OFFLOAD_DRAFTER=0; strict 0/1 env parsing.
+C  Patched-runtime drive (Codex OFFLOAD1 finding 6): the PATCHED
+   build_offloading_config / scheduler module executed under a stubbed vllm
+   namespace on the 7-group boot layout — eligible set {0,2,3,4,5}, original
+   indices in keys, full-length group_sizes with zeros for ineligible groups,
+   num_kv_cache_groups=7, mamba alignment 3584, supports_partial_tail False,
+   no-scratch uniform model unchanged (upstream-equivalence guard).
+D  In-image preflight when GLM53_REQUIRE_TARGET=1 (Docker build): the real
+   tree must accept the anchors before the patcher bakes them in.
+
+Run:  python3 tests/test_kv_offload_scope.py   (or pytest)
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str((ROOT / "overlay")))
+# In-image the test rides next to the overlay under /opt/glm53.
+sys.path.insert(0, str(HERE.parent))
+
+import patch_kv_offload_scope as scope  # noqa: E402
+
+FIXTURES = HERE / "fixtures"
+IN_IMAGE = not FIXTURES.is_dir()
+
+FAILURES: list[str] = []
+
+
+def check(cond: bool, label: str) -> None:
+    print(("  ok   " if cond else "  FAIL ") + label)
+    if not cond:
+        FAILURES.append(label)
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURES / name).read_text()
+
+
+# ------------------------------------------------------------------ part A --
+def test_patcher_mechanics() -> None:
+    if IN_IMAGE:
+        print("Part A: skipped (fixtures not shipped in-image; D covers the real tree)")
+        return
+    print("Part A: patcher mechanics on pinned image fixtures")
+    cases = [
+        ("image_487ecf187_kv_offload_config.py", scope.SITES_KVO_CONFIG),
+        ("image_487ecf187_offloading_config.py", scope.SITES_CONN_CONFIG),
+        ("image_487ecf187_offloading_scheduler.py", scope.SITES_SCHED),
+    ]
+    for name, sites in cases:
+        src = _fixture(name)
+        patched, action = scope.prepare(src, sites, name)
+        check(action == "patched" and patched != src, f"A1 {name}: applies")
+        try:
+            compile(patched, name, "exec")
+            check(True, f"A2 {name}: patched text compiles")
+        except SyntaxError as exc:
+            check(False, f"A2 {name}: patched text compiles ({exc})")
+        again, action2 = scope.prepare(patched, sites, name)
+        check(
+            action2 == "already present" and again == patched,
+            f"A3 {name}: idempotent second run",
+        )
+        # Drift: tamper the first anchor (drop its first character — always a
+        # real mutation regardless of the anchor's shape).
+        _n, _m, anchor, _p = sites[0]
+        broken = src.replace(anchor, anchor[1:], 1)
+        assert broken != src
+        try:
+            scope.prepare(broken, sites, name)
+            check(False, f"A4 {name}: tampered anchor refused")
+        except ValueError:
+            check(True, f"A4 {name}: tampered anchor refused")
+        # Half-patched: one mark present, others missing.
+        if len(sites) > 1:
+            half = src
+            n0, m0, a0, p0 = sites[0]
+            half = half.replace(a0, p0, 1)
+            try:
+                scope.prepare(half, sites, name)
+                check(False, f"A5 {name}: half-patched file refused")
+            except ValueError:
+                check(True, f"A5 {name}: half-patched file refused")
+
+
+# ------------------------------------------------------------------ part B --
+def test_eligibility_predicate() -> None:
+    print("Part B: eligibility predicate (exec'd shipped helper)")
+    from _kv_offload_stub_env import boot_layout
+
+    layout = boot_layout().kv_cache_groups
+    layout[6].is_eagle_group = False  # GLM sets no flag; EAGLE context decides
+
+    def eligible(drafter: bool, use_eagle: bool = True) -> list[int]:
+        return [
+            i
+            for i, g in enumerate(layout)
+            if scope.kvo_group_eligible(g, drafter, use_eagle)
+        ]
+
+    check(eligible(False) == [0, 2, 3, 4, 5], "B1 default eligible set {0,2,3,4,5}")
+    check(
+        eligible(True) == [0, 2, 3, 4, 5, 6],
+        "B2 GLM53_KV_OFFLOAD_DRAFTER=1 adds only the drafter group",
+    )
+    check(
+        eligible(False, use_eagle=False) == [0, 2, 3, 4, 5, 6],
+        "B3 without EAGLE context a SlidingWindowSpec group is genuine SWA and stays",
+    )
+    layout[6].is_eagle_group = True
+    check(
+        eligible(False, use_eagle=False) == [0, 2, 3, 4, 5],
+        "B4 is_eagle_group excludes even without speculative context",
+    )
+    layout[6].is_eagle_group = False
+    check(1 not in eligible(True), "B5 kpool scratch is NEVER eligible")
+
+    for raw, expect in ((None, False), ("0", False), ("1", True)):
+        if raw is None:
+            os.environ.pop("GLM53_KV_OFFLOAD_DRAFTER", None)
+        else:
+            os.environ["GLM53_KV_OFFLOAD_DRAFTER"] = raw
+        check(
+            scope.kvo_drafter_included() is expect,
+            f"B6 GLM53_KV_OFFLOAD_DRAFTER={raw!r} -> {expect}",
+        )
+    for junk in ("", "2", "yes", " 1", "01"):
+        os.environ["GLM53_KV_OFFLOAD_DRAFTER"] = junk
+        try:
+            scope.kvo_drafter_included()
+            check(False, f"B7 junk {junk!r} raises")
+        except ValueError:
+            check(True, f"B7 junk {junk!r} raises")
+    os.environ.pop("GLM53_KV_OFFLOAD_DRAFTER", None)
+
+
+# ------------------------------------------------------------------ part C --
+def test_patched_runtime() -> None:
+    if IN_IMAGE:
+        print("Part C: skipped in-image (fixtures not shipped)")
+        return
+    print("Part C: patched-runtime drive (stubbed vllm, PATCHED module text)")
+    os.environ.pop("GLM53_KV_OFFLOAD_DRAFTER", None)
+    os.environ["GLM53_KV_OFFLOAD"] = "0"
+    os.environ["GLM53_KV_OFFLOAD_RESTORE"] = "0"
+    from _kv_offload_stub_env import (
+        FakeRequest,
+        FakeSchedSpec,
+        FakeVllmConfig,
+        FakeKVTransferConfig,
+        boot_layout,
+        build_offloading_config,
+        install_fake_vllm,
+    )
+
+    mods = install_fake_vllm()
+    kv_cache_config = boot_layout()
+    vllm_config = FakeVllmConfig(kv_transfer_config=FakeKVTransferConfig())
+
+    cfg = build_offloading_config(mods, vllm_config, kv_cache_config)
+    check(
+        [g.group_idx for g in cfg.groups] == [0, 2, 3, 4, 5],
+        "C1 build_offloading_config scopes to {0,2,3,4,5} and boots (no g1 assert crash)",
+    )
+    check(
+        all(g.tokens_per_block == 3584 for g in cfg.groups),
+        "C2 every eligible group is on the 3584 grid",
+    )
+    log_lines = "\n".join(mods["logger"].lines)
+    check(
+        "eligible groups" in log_lines and "[0, 2, 3, 4, 5]" in log_lines,
+        "C3 boot log names the eligible set",
+    )
+
+    sched_mod = mods["scheduler"]
+    spec = FakeSchedSpec(mods, cfg)
+    sched_cfg = sched_mod.SchedulerOffloadConfig.from_spec(
+        spec, vllm_config, kv_cache_config
+    )
+    check(sched_cfg.num_kv_cache_groups == 7, "C4 num_kv_cache_groups is the FULL count")
+    check(
+        tuple(g.group_idx for g in sched_cfg.kv_group_configs) == (0, 2, 3, 4, 5),
+        "C5 kv_group_configs keep original indices",
+    )
+    check(
+        sched_mod.resolve_mamba_align_size(spec, kv_cache_config) == 3584,
+        "C6 mamba alignment resolves to 3584 over eligible groups",
+    )
+    check(not sched_cfg.supports_partial_tail, "C7 partial tails off (scratch groups)")
+
+    scheduler = sched_mod.OffloadingConnectorScheduler(
+        spec, vllm_config, kv_cache_config
+    )
+    check(
+        sorted(scheduler._group_config_by_idx) == [0, 2, 3, 4, 5],
+        "C8 _group_config_by_idx keyed by original indices",
+    )
+    check(
+        scheduler._sliding_window_groups == (2, 3, 4, 5)
+        and scheduler._lookup_groups[0] == 0,
+        "C9 mamba groups looked up as window groups after the full-attn group",
+    )
+
+    req = FakeRequest(num_tokens=7 * 3584 + 100)
+    scheduler.on_new_request(req)
+    st = scheduler._req_status[req.request_id]
+    check(len(st.group_states) == 7, "C10 group_states sized by the FULL group count")
+
+    num_hit, is_async = scheduler.get_num_new_matched_tokens(req, 0)
+    check(
+        (num_hit, is_async) == (0, False),
+        "C11 store-only mode: external hits are always (0, False)",
+    )
+    check(
+        spec._manager.lookup_calls == [],
+        "C12 store-only mode: the manager lookup is NEVER consulted",
+    )
+
+    base = mods["base"]
+    gidxs = set()
+    for g_idx, gs in enumerate(st.group_states):
+        for key in gs.offload_keys:
+            gidxs.add(base.get_offload_group_idx(key))
+            check_hash = base.get_offload_block_hash(key)
+            assert check_hash in req.block_hashes
+    check(
+        gidxs == {0, 2, 3, 4, 5},
+        f"C13 offload keys carry ONLY eligible original indices (got {sorted(gidxs)})",
+    )
+    n_expected = (req.num_tokens // 3584)
+    check(
+        all(
+            len(st.group_states[g].offload_keys) == n_expected
+            for g in (0, 2, 3, 4, 5)
+        )
+        and all(len(st.group_states[g].offload_keys) == 0 for g in (1, 6)),
+        "C14 per-group key counts: full chunks for eligible, zero for scratch/drafter",
+    )
+
+    # update_state_after_alloc: full-length layout, zeros at 1 and 6.
+    class FakeBlock:
+        def __init__(self, block_id):
+            self.block_id = block_id
+            self.is_null = False
+            self.block_hash = None
+
+    kvm = mods["kv_cache_manager"]
+    n_cached = 3584
+    per_group_needed = [1, 896, 1, 1, 1, 1, 56]
+    blocks = kvm.KVCacheBlocks(
+        tuple(
+            [FakeBlock(100 * g + j + 1) for j in range(per_group_needed[g])]
+            for g in range(7)
+        )
+    )
+    st.num_locally_computed_tokens = 0
+    scheduler.update_state_after_alloc(req, blocks, n_cached)
+    job = next(iter(scheduler._current_batch_load_jobs.values()))
+    gs = job.dst_spec.group_sizes
+    check(
+        len(gs) == 7 and gs[1] == 0 and gs[6] == 0 and gs[0] == 1,
+        f"C15 load-job group_sizes full-length with zeros at 1/6 (got {gs})",
+    )
+    check(
+        len(job.dst_spec.block_indices) == 7,
+        "C16 block_indices full-length",
+    )
+
+    # Upstream-equivalence guard: a uniform no-scratch model is unchanged.
+    from _kv_offload_stub_env import (
+        FakeKVCacheConfig,
+        FakeKVCacheGroup,
+        MLAAttentionSpec,
+    )
+
+    uniform = FakeKVCacheConfig(
+        [
+            FakeKVCacheGroup(MLAAttentionSpec(64), ("l0", "l1")),
+        ]
+    )
+    vllm_plain = FakeVllmConfig(
+        kv_transfer_config=FakeKVTransferConfig(), speculative_config=None
+    )
+    cfg_u = build_offloading_config(mods, vllm_plain, uniform)
+    check(
+        [g.group_idx for g in cfg_u.groups] == [0],
+        "C17 no-scratch uniform model keeps every group (behaviour unchanged)",
+    )
+
+    # Divisibility regression: a prefix-cacheable misaligned group still asserts.
+    bad = boot_layout()
+    bad.kv_cache_groups[2].kv_cache_spec.block_size = 96  # 96 % 64 != 0
+    try:
+        build_offloading_config(mods, vllm_config, bad)
+        check(False, "C18 misaligned CACHEABLE group still asserts at boot")
+    except AssertionError:
+        check(True, "C18 misaligned CACHEABLE group still asserts at boot")
+    _cleanup_env()
+
+
+# ------------------------------------------------------------------ part D --
+def test_in_image_preflight() -> None:
+    if os.environ.get("GLM53_REQUIRE_TARGET") != "1":
+        print("Part D: skipped (GLM53_REQUIRE_TARGET!=1)")
+        return
+    print("Part D: real-tree preflight (in-image)")
+    rc = 0
+    try:
+        scope.main(["patch_kv_offload_scope.py", "--preflight"])
+    except SystemExit as exc:
+        rc = int(exc.code or 0)
+    check(rc == 0, "D1 patcher preflight accepts the real in-image tree")
+    _cleanup_env()
+
+
+
+
+def _cleanup_env() -> None:
+    """These tests mutate GLM53_KV_OFFLOAD* in os.environ; scrub them so the
+    rest of the suite (and any subprocess-driving test that inherits the
+    process env) sees a clean slate."""
+    for name in ("GLM53_KV_OFFLOAD","GLM53_KV_OFFLOAD_DIR","GLM53_KV_OFFLOAD_CPU_GB","GLM53_KV_OFFLOAD_RESTORE","GLM53_KV_OFFLOAD_DRAFTER","GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"):
+        os.environ.pop(name, None)
+
+
+def main() -> int:
+    test_patcher_mechanics()
+    test_eligibility_predicate()
+    test_patched_runtime()
+    test_in_image_preflight()
+    print(f"\n{len(FAILURES)} failure(s)")
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_kv_offload_store_local.py
+++ b/tests/test_kv_offload_store_local.py
@@ -608,6 +608,32 @@ def test_writer() -> None:
             w7._namespace_hash != w8._namespace_hash,
             "C22 num_speculative_tokens forks the namespace hash",
         )
+        # Policy/diagnostic fields must NOT disable a later boot (fenced-only
+        # comparison): same config, different keep_boundaries reuses the store.
+        os.environ["GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"] = "5"
+        cw7b, _, _ = _mini_env(num_spec=7)
+        w7b = ns["Glm53LocalStoreWriter"](cw7b, logger5)
+        check(
+            w7b._disabled_reason is None
+            and w7b._namespace_hash == w7._namespace_hash,
+            "C22b retention-K change neither forks nor disables the namespace",
+        )
+        os.environ["GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"] = "2"
+        # A corrupted namespace record fails closed.
+        ns_files = [
+            f
+            for f in Path(os.environ["GLM53_KV_OFFLOAD_DIR"]).glob("glm53kv_*.json")
+            if w7._namespace_hash in f.name
+        ]
+        check(len(ns_files) == 1, "C22c one namespace record per namespace")
+        ns_files[0].write_text("{ truncated")
+        cw7c, _, _ = _mini_env(num_spec=7)
+        w7c = ns["Glm53LocalStoreWriter"](cw7c, logger5)
+        check(
+            w7c._disabled_reason is not None
+            and "unreadable" in w7c._disabled_reason,
+            "C22d corrupted namespace record disables the writer (fail closed)",
+        )
 
     # Capture helpers through the connector-worker seam (both call sites).
     logger6 = _TestLogger()
@@ -731,12 +757,18 @@ def test_gc_tool() -> None:
             out == 1,
             "D8 orphan reported with ZERO manifests present (header-based)",
         )
-        # Stale temp: any *.tmp.* is reported and swept.
+        # Stale temps: payload temps under the base AND namespace-record
+        # temps beside it (the store root) are reported and swept.
         t = base / _hash(3)[:3] / f"{_hash(3)[3:5]}_g4" / "x.bin.tmp.r0.1.2"
         t.write_bytes(b"partial")
-        check(gc_tool.main([str(base)]) == 1, "D9 stale temp flagged by dry-run")
+        ns_t = base.parent / "glm53kv_test_model_deadbeef.json.tmp.r0.1"
+        ns_t.write_text("{}")
+        check(gc_tool.main([str(base)]) == 1, "D9 stale temps flagged by dry-run")
         gc_tool.main([str(base), "--sweep"])
-        check(not t.exists(), "D10 --sweep removes stale temps")
+        check(
+            not t.exists() and not ns_t.exists(),
+            "D10 --sweep removes payload AND namespace temps",
+        )
 
     # Forked chains: a shared divergence-point boundary survives while ANY
     # branch still keeps it (writer rule mirrored in the GC tool).

--- a/tests/test_kv_offload_store_local.py
+++ b/tests/test_kv_offload_store_local.py
@@ -1,0 +1,702 @@
+#!/usr/bin/env python3
+"""Regression tests for overlay/patch_kv_offload_store_local.py.
+
+A  Chunk-header codec (format v1): round-trip, truncation at every region,
+   CRC corruption, wrong magic, oversized header — all rejected.
+B  Patched-runtime store-job drive (stubbed vllm, PATCHED modules): a request
+   walking three 3584 boundaries produces store jobs whose GPULoadStoreSpec
+   is full-length with zeros for scratch/drafter groups, whose
+   glm53_store_meta keys align 1:1 with the src/dst block order, whose
+   manifest candidates carry CUMULATIVE chunk-hash chains, and whose
+   TransferJob pickles round-trip. Knob off => meta is None.
+C  Worker-local writer on a miniature 7-group layout: per-(hash,group) files
+   with REAL (unpadded) bytes gathered ref-by-ref from the staging tensors,
+   headers with KDA conv/temporal segment split (shape/dtype/stride),
+   manifest publish ordering (missing any mamba payload or any cumulative
+   full-attn chunk => no manifest), inline K-boundary retention, dedup,
+   failed-key ledger, ENOSPC pause, rank-disagreement disable, delayed-ack
+   drain semantics, namespace forking on num_spec change.
+D  GC tool (overlay/kv_offload_store_gc.py): dry-run reports orphans and
+   corrupt files without deleting; --sweep removes them; --keep-boundaries
+   preserves cumulative full-attn references (plan §4 C1).
+
+Run:  python3 tests/test_kv_offload_store_local.py   (or pytest)
+"""
+from __future__ import annotations
+
+import errno
+import json
+import os
+import pickle
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(ROOT / "overlay"))
+sys.path.insert(0, str(HERE.parent))
+
+import patch_kv_offload_store_local as store  # noqa: E402
+
+FIXTURES = HERE / "fixtures"
+IN_IMAGE = not FIXTURES.is_dir()
+
+FAILURES: list[str] = []
+
+
+def check(cond: bool, label: str) -> None:
+    print(("  ok   " if cond else "  FAIL ") + label)
+    if not cond:
+        FAILURES.append(label)
+
+
+# ------------------------------------------------------------------ part A --
+def test_codec() -> None:
+    print("Part A: chunk-header codec")
+    payload = bytes(range(256)) * 4
+    header = {"namespace_hash": "abc", "group_idx": 2, "hash": "ff" * 16}
+    blob = store.encode_chunk(header, payload)
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "x.bin"
+        p.write_bytes(blob)
+        h = store.read_chunk_header(str(p), verify_payload=True)
+        check(
+            h["group_idx"] == 2 and h["payload_len"] == len(payload),
+            "A1 round-trip keeps fields and payload length",
+        )
+        check(h["crc_algo"] == "crc32-zlib", "A2 header names its CRC algorithm")
+
+        cuts = {
+            "magic": 4,
+            "header-length": 10,
+            "header": 14,
+            "header-crc": len(blob) - len(payload) - 2,
+            "payload": len(blob) - 100,
+        }
+        for label, cut in cuts.items():
+            p.write_bytes(blob[:cut])
+            try:
+                store.read_chunk_header(str(p), verify_payload=True)
+                check(False, f"A3 truncated at {label} rejected")
+            except ValueError:
+                check(True, f"A3 truncated at {label} rejected")
+
+        flipped = bytearray(blob)
+        flipped[-1] ^= 0xFF
+        p.write_bytes(bytes(flipped))
+        try:
+            store.read_chunk_header(str(p), verify_payload=True)
+            check(False, "A4 payload bit-flip rejected (CRC)")
+        except ValueError:
+            check(True, "A4 payload bit-flip rejected (CRC)")
+
+        p.write_bytes(b"NOTMAGIC" + blob[8:])
+        try:
+            store.read_chunk_header(str(p))
+            check(False, "A5 wrong magic rejected")
+        except ValueError:
+            check(True, "A5 wrong magic rejected")
+
+        # Extra trailing bytes (torn rename of a longer file) rejected too.
+        p.write_bytes(blob + b"x")
+        try:
+            store.read_chunk_header(str(p))
+            check(False, "A6 trailing garbage rejected")
+        except ValueError:
+            check(True, "A6 trailing garbage rejected")
+
+
+# ------------------------------------------------------------------ part B --
+def test_store_job_meta() -> None:
+    if IN_IMAGE:
+        print("Part B: skipped in-image (fixtures not shipped)")
+        return
+    print("Part B: patched-runtime store-job drive")
+    os.environ["GLM53_KV_OFFLOAD"] = "1"
+    os.environ["GLM53_KV_OFFLOAD_RESTORE"] = "0"
+    os.environ.pop("GLM53_KV_OFFLOAD_DRAFTER", None)
+    from _kv_offload_stub_env import (
+        FakeRequest,
+        FakeSchedSpec,
+        FakeVllmConfig,
+        FakeKVTransferConfig,
+        boot_layout,
+        build_offloading_config,
+        install_fake_vllm,
+    )
+
+    mods = install_fake_vllm()
+    kv_cache_config = boot_layout()
+    vllm_config = FakeVllmConfig(kv_transfer_config=FakeKVTransferConfig())
+    cfg = build_offloading_config(mods, vllm_config, kv_cache_config)
+    sched_mod = mods["scheduler"]
+    spec = FakeSchedSpec(mods, cfg)
+    scheduler = sched_mod.OffloadingConnectorScheduler(
+        spec, vllm_config, kv_cache_config
+    )
+
+    n_chunks = 3
+    req = FakeRequest(num_tokens=n_chunks * 3584 + 5)
+    scheduler.on_new_request(req)
+    scheduler.get_num_new_matched_tokens(req, 0)
+
+    per_group_blocks = {0: 1, 1: 896, 2: 1, 3: 1, 4: 1, 5: 1, 6: 56}
+    block_id_groups = tuple(
+        [1000 * g + j + 1 for j in range(per_group_blocks[g] * n_chunks)]
+        for g in range(7)
+    )
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={req.request_id: req.num_tokens},
+        finished_req_ids=set(),
+        req_data={req.request_id: (block_id_groups, False)},
+        partial_tail_offloads=None,
+    )
+    scheduler._update_req_states(scheduler_output)
+    store_jobs = scheduler._build_store_jobs(scheduler_output)
+    check(len(store_jobs) == 1, "B1 one store job for the request")
+    job = next(iter(store_jobs.values()))
+    gs = job.src_spec.group_sizes
+    check(
+        len(gs) == 7 and gs[1] == 0 and gs[6] == 0 and gs[0] == n_chunks,
+        f"B2 store group_sizes full-length, zeros at 1/6 (got {gs})",
+    )
+    meta = job.glm53_store_meta
+    check(meta is not None and meta["v"] == 1, "B3 store meta attached, versioned")
+    check(
+        len(meta["keys"]) == len(job.src_spec.block_ids) == 5 * n_chunks,
+        "B4 meta keys align 1:1 with src blocks (5 eligible groups x 3 chunks)",
+    )
+    check(
+        meta["cow_groups"] == [2, 3, 4, 5] and meta["full_groups"] == [0],
+        "B5 cow/full group sets carry original indices",
+    )
+    bounds = {m["boundary_token_index"]: len(m["chunk_hashes"]) for m in meta["manifests"]}
+    check(
+        bounds == {3584: 1, 7168: 2, 10752: 3},
+        f"B6 manifest candidates cumulative per boundary (got {bounds})",
+    )
+    # Pickle round-trip: the stub spec classes are function-local (unpicklable
+    # by construction), so exercise the WIRE payload — the patched TransferJob
+    # dataclass with its meta field — with picklable stand-in specs.
+    wire = mods["common"].TransferJob(
+        req_id=job.req_id, src_spec=None, dst_spec=None, glm53_store_meta=meta
+    )
+    job2 = pickle.loads(pickle.dumps(wire))
+    check(
+        job2.glm53_store_meta == meta,
+        "B7 TransferJob.glm53_store_meta pickles round-trip unchanged",
+    )
+    default_job = mods["common"].TransferJob(req_id="r", src_spec=None, dst_spec=None)
+    check(
+        default_job.glm53_store_meta is None,
+        "B7b meta defaults to None (stock constructors unchanged)",
+    )
+
+    # Knob off => no meta (and a fresh request to avoid job-state carryover).
+    os.environ["GLM53_KV_OFFLOAD"] = "0"
+    req_off = FakeRequest(num_tokens=3584 + 5, req_id="req-off", salt=b"t")
+    scheduler.on_new_request(req_off)
+    scheduler.get_num_new_matched_tokens(req_off, 0)
+    bid_off = tuple(
+        [5000 * (g + 1) + j + 1 for j in range(per_group_blocks[g])] for g in range(7)
+    )
+    so_off = SimpleNamespace(
+        num_scheduled_tokens={req_off.request_id: req_off.num_tokens},
+        finished_req_ids=set(),
+        req_data={req_off.request_id: (bid_off, False)},
+        partial_tail_offloads=None,
+    )
+    scheduler._update_req_states(so_off)
+    jobs_off = scheduler._build_store_jobs(so_off)
+    check(
+        all(j.glm53_store_meta is None for j in jobs_off.values()),
+        "B8 GLM53_KV_OFFLOAD=0: no store meta is attached",
+    )
+    _cleanup_env()
+
+
+# ------------------------------------------------------------------ part C --
+class FakeSlice:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def numpy(self):
+        return self
+
+    def tobytes(self) -> bytes:
+        return self._data
+
+
+class FakeCpuTensor:
+    """(num_rows, page) staging tensor; row content is deterministic."""
+
+    def __init__(self, tensor_idx: int, num_rows: int, page: int):
+        self.page = page
+        self.rows = [
+            bytes(((tensor_idx * 31 + r * 7 + i) % 256) for i in range(page))
+            for r in range(num_rows)
+        ]
+
+    def __getitem__(self, key):
+        row, sl = key
+        return FakeSlice(self.rows[row][sl])
+
+
+@dataclass
+class FakeRef:
+    tensor_idx: int
+    page_size_bytes: int
+
+
+def _mini_env(rank=0, cfg_rank=None, num_spec=7):
+    """Miniature 7-group layout for the writer (tiny pages, real semantics)."""
+    from _kv_offload_stub_env import (
+        FakeKVCacheGroup,
+        FakeParallelConfig,
+        FakeVllmConfig,
+        MLAAttentionSpec,
+        KpoolTailSpec,
+        MambaSpec,
+        SlidingWindowSpec,
+        UniformTypeKVCacheSpecs,
+        FakeSpeculativeConfig,
+    )
+
+    # conv (2,3) bf16 = 12 B + temporal (2,2) f32 = 16 B => real page 28.
+    mamba_spec = lambda: MambaSpec(  # noqa: E731
+        3584, shapes=((2, 3), (2, 2)), dtypes=("torch.bfloat16", "torch.float32")
+    )
+    groups = [
+        FakeKVCacheGroup(
+            UniformTypeKVCacheSpecs(
+                3584,
+                {"mla.0": MLAAttentionSpec(3584), "mla.1": MLAAttentionSpec(3584), "idx.0": MLAAttentionSpec(3584)},
+            ),
+            ("mla.0", "mla.1", "idx.0"),
+        ),
+        FakeKVCacheGroup(KpoolTailSpec(4, prefix_cacheable=False), ("kpool.0",)),
+        FakeKVCacheGroup(UniformTypeKVCacheSpecs(3584, {"kda2.0": mamba_spec(), "kda2.1": mamba_spec()}), ("kda2.0", "kda2.1")),
+        FakeKVCacheGroup(UniformTypeKVCacheSpecs(3584, {"kda3.0": mamba_spec()}), ("kda3.0",)),
+        FakeKVCacheGroup(UniformTypeKVCacheSpecs(3584, {"kda4.0": mamba_spec()}), ("kda4.0",)),
+        FakeKVCacheGroup(UniformTypeKVCacheSpecs(3584, {"kda5.0": mamba_spec()}), ("kda5.0",)),
+        FakeKVCacheGroup(SlidingWindowSpec(64, 2048), ("draft.0",)),
+    ]
+    kv_cache_config = SimpleNamespace(kv_cache_groups=groups)
+
+    # tensors: t0/t1 page 64 (MLA slots, mamba parasitizes), t2 page 8 (idx)
+    tensors = [FakeCpuTensor(0, 64, 64), FakeCpuTensor(1, 64, 64), FakeCpuTensor(2, 64, 8)]
+    refs_per_group = [
+        [FakeRef(0, 64), FakeRef(1, 64), FakeRef(2, 8)],  # g0 (3 layers)
+        [FakeRef(2, 2)],                                   # g1 (never written)
+        [FakeRef(0, 28), FakeRef(1, 28)],                  # g2 (2 KDA layers)
+        [FakeRef(0, 28)],                                  # g3
+        [FakeRef(1, 28)],                                  # g4
+        [FakeRef(0, 28)],                                  # g5
+        [FakeRef(1, 16)],                                  # g6 (never written)
+    ]
+    handler = SimpleNamespace(
+        dst_tensors=tensors,
+        layer_refs_per_group=refs_per_group,
+        _canonical_copy_plans=None,
+    )
+    worker = SimpleNamespace(_store_handler=handler)
+    # Shaped like OffloadingParallelConfig (rank/world_size/tp_size), NOT the
+    # vllm ParallelConfig: that is what the writer reads via spec.config.
+    parallel = SimpleNamespace(
+        rank=cfg_rank if cfg_rank is not None else rank,
+        world_size=2,
+        tp_size=2,
+    )
+    del FakeParallelConfig  # imported for parity; unused on purpose
+    eligible = []
+    for gidx in (0, 2, 3, 4, 5):
+        eligible.append(
+            SimpleNamespace(
+                group_idx=gidx,
+                tokens_per_block=3584,
+                layer_names=groups[gidx].layer_names,
+            )
+        )
+    spec = SimpleNamespace(
+        blocks_per_chunk=1,
+        tokens_per_hash=64,
+        config=SimpleNamespace(
+            parallel=parallel,
+            model=SimpleNamespace(name="test/model", dtype="fp8"),
+            groups=eligible,
+        ),
+    )
+    vllm_config = FakeVllmConfig()
+    vllm_config.speculative_config = FakeSpeculativeConfig(
+        num_speculative_tokens=num_spec
+    )
+    cw = SimpleNamespace(
+        spec=spec,
+        worker=worker,
+        kv_cache_config=kv_cache_config,
+        vllm_config=vllm_config,
+        _glm53_store_writer=None,
+        _glm53_job_meta={},
+        _connector_worker_meta=SimpleNamespace(
+            completed=[], mark_completed=lambda job_id: None
+        ),
+    )
+    cw._connector_worker_meta.mark_completed = cw._connector_worker_meta.completed.append
+    return cw, tensors, refs_per_group
+
+
+class _TestLogger:
+    def __init__(self):
+        self.lines = []
+
+    def _fmt(self, msg, *args):
+        try:
+            self.lines.append(msg % args if args else str(msg))
+        except TypeError:
+            self.lines.append(str(msg))
+
+    info = debug = warning = error = exception = _fmt
+
+
+def _hash(i: int) -> str:
+    import hashlib
+
+    return hashlib.sha256(b"chunk%d" % i).hexdigest()[:64]
+
+
+def _job_meta(n_boundaries: int):
+    """Meta for one job storing all 5 eligible groups at n boundaries."""
+    keys = []
+    for k in range(n_boundaries):
+        for g in (0, 2, 3, 4, 5):
+            keys.append((_hash(k), g, k, 3584))
+    manifests = [
+        {
+            "boundary_token_index": (k + 1) * 3584,
+            "chunk_hashes": [_hash(j) for j in range(k + 1)],
+        }
+        for k in range(n_boundaries)
+    ]
+    return {
+        "v": 1,
+        "keys": keys,
+        "cow_groups": [2, 3, 4, 5],
+        "full_groups": [0],
+        "manifests": manifests,
+    }
+
+
+def test_writer() -> None:
+    print("Part C: worker-local writer")
+    import _kv_offload_stub_env as stub
+
+    if "vllm" not in sys.modules:
+        stub.install_fake_vllm()
+
+    logger = _TestLogger()
+    with tempfile.TemporaryDirectory() as td:
+        os.environ["GLM53_KV_OFFLOAD_DIR"] = td
+        os.environ["GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"] = "0"
+        ns = store.load_writer_helpers(logger)
+        cw, tensors, refs = _mini_env()
+        writer = ns["Glm53LocalStoreWriter"](cw, logger)
+        check(writer._disabled_reason is None, "C1 writer initialises on the layout")
+        check(writer._rank == 0 and writer._base.endswith("_r0"), "C2 per-rank base dir")
+
+        meta = _job_meta(2)
+        rows = list(range(len(meta["keys"])))
+        deferred = writer.submit_job(7, meta, rows)
+        check(deferred, "C3 job ack deferred to the disk writer")
+        writer.shutdown(timeout=20)
+        done = writer.drain_done()
+        check(done == [7], "C4 job completion surfaces via the done queue")
+
+        base = Path(writer._base)
+        g2_path = base / _hash(0)[:3] / f"{_hash(0)[3:5]}_g2" / f"{_hash(0)}.bin"
+        check(g2_path.is_file(), "C5 mamba chunk file lands under its group dir")
+        h = store.read_chunk_header(str(g2_path), verify_payload=True)
+        check(
+            h["payload_len"] == 56 and h["spec_kind"] == "MambaSpec",
+            "C6 mamba payload = REAL bytes (2 layers x 28 B, padding never written)",
+        )
+        segs = h["segment_table"]
+        check(
+            len(segs) == 4
+            and segs[0]["kind"] == "conv_state"
+            and segs[0]["shape"] == [2, 3]
+            and segs[0]["dtype"] == "torch.bfloat16"
+            and segs[0]["stride"] == [3, 1]
+            and segs[1]["kind"] == "temporal_state"
+            and segs[1]["length"] == 16
+            and segs[2]["offset"] == 28,
+            "C7 KDA segment table: conv/temporal split with shape/dtype/stride",
+        )
+        # Payload bytes must equal the staging rows' unpadded prefixes, in
+        # group layer order (row = dst cpu block of that key).
+        g2_row = rows[meta["keys"].index((_hash(0), 2, 0, 3584))]
+        expected = tensors[0].rows[g2_row][:28] + tensors[1].rows[g2_row][:28]
+        blob = g2_path.read_bytes()
+        check(blob.endswith(expected), "C8 payload bytes == staging real bytes per ref")
+
+        g0_path = base / _hash(0)[:3] / f"{_hash(0)[3:5]}_g0" / f"{_hash(0)}.bin"
+        h0 = store.read_chunk_header(str(g0_path))
+        check(h0["payload_len"] == 64 + 64 + 8, "C9 g0 payload spans all 3 layer pages")
+
+        m0 = base / "manifests" / _hash(0)[:3] / f"{_hash(0)}.json"
+        m1 = base / "manifests" / _hash(1)[:3] / f"{_hash(1)}.json"
+        check(m0.is_file() and m1.is_file(), "C10 manifests published for both boundaries")
+        man = json.loads(m1.read_text())
+        check(
+            man["chunk_hashes"] == [_hash(0), _hash(1)]
+            and set(man["cow_groups"]) == {"2", "3", "4", "5"}
+            and man["full_groups"] == {"0": 2},
+            "C11 manifest carries cumulative chunk chain + per-group entries",
+        )
+        n_files = len(list(base.rglob("*.bin")))
+        check(n_files == 10, f"C12 5 groups x 2 boundaries = 10 chunk files (got {n_files})")
+
+        # Incomplete boundary: mamba g3 write missing => no manifest.
+        meta3 = _job_meta(3)
+        del_idx = meta3["keys"].index((_hash(2), 3, 2, 3584))
+        meta3["keys"] = meta3["keys"][:del_idx] + meta3["keys"][del_idx + 1 :]
+        meta3["manifests"] = meta3["manifests"][2:]  # only the new boundary
+        writer.submit_job(8, meta3, list(range(len(meta3["keys"]))))
+        writer.shutdown(timeout=20)
+        m2 = base / "manifests" / _hash(2)[:3] / f"{_hash(2)}.json"
+        check(
+            not m2.is_file(),
+            "C13 a boundary missing one mamba payload publishes NO manifest",
+        )
+
+        # Failed-key ledger: even with the file later present, a key that
+        # failed this boot cannot enter a manifest.
+        writer._failed_keys.add((_hash(2), 3))
+        meta_fk = {
+            "v": 1,
+            "keys": [(_hash(2), 3, 2, 3584)],
+            "cow_groups": [2, 3, 4, 5],
+            "full_groups": [0],
+            "manifests": [
+                {
+                    "boundary_token_index": 3 * 3584,
+                    "chunk_hashes": [_hash(0), _hash(1), _hash(2)],
+                }
+            ],
+        }
+        writer.submit_job(9, meta_fk, [40])
+        writer.shutdown(timeout=20)
+        check(
+            not m2.is_file(),
+            "C14 failed-key ledger blocks the manifest even after a later write",
+        )
+
+    # ENOSPC pause.
+    logger2 = _TestLogger()
+    with tempfile.TemporaryDirectory() as td:
+        os.environ["GLM53_KV_OFFLOAD_DIR"] = td
+        ns = store.load_writer_helpers(logger2)
+        cw, _, _ = _mini_env()
+        writer = ns["Glm53LocalStoreWriter"](cw, logger2)
+        real_open = open
+
+        def enospc_open(path, mode="r", *a, **k):
+            if "b" in mode and "w" in mode:
+                raise OSError(errno.ENOSPC, "No space left on device")
+            return real_open(path, mode, *a, **k)
+
+        ns["open"] = enospc_open
+        writer.submit_job(1, _job_meta(1), list(range(5)))
+        writer.shutdown(timeout=20)
+        check(
+            writer._paused_reason == "ENOSPC" and writer.drain_done() == [1],
+            "C15 ENOSPC pauses the writer; the job still completes (lost store)",
+        )
+        check(
+            not list(Path(writer._base).rglob("*.bin"))
+            and not list(Path(writer._base).rglob("*.tmp.*")),
+            "C16 no partial files or stale temps left behind",
+        )
+        check(
+            not list(Path(writer._base).rglob("manifests/**/*.json")),
+            "C17 paused writer publishes no manifests",
+        )
+
+    # Retention K=1: publishing boundary 2 supersedes boundary 1.
+    logger3 = _TestLogger()
+    with tempfile.TemporaryDirectory() as td:
+        os.environ["GLM53_KV_OFFLOAD_DIR"] = td
+        os.environ["GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"] = "1"
+        ns = store.load_writer_helpers(logger3)
+        cw, _, _ = _mini_env()
+        writer = ns["Glm53LocalStoreWriter"](cw, logger3)
+        writer.submit_job(1, _job_meta(2), list(range(10)))
+        writer.shutdown(timeout=20)
+        base = Path(writer._base)
+        m0 = base / "manifests" / _hash(0)[:3] / f"{_hash(0)}.json"
+        m1 = base / "manifests" / _hash(1)[:3] / f"{_hash(1)}.json"
+        g2_b0 = base / _hash(0)[:3] / f"{_hash(0)[3:5]}_g2" / f"{_hash(0)}.bin"
+        g0_b0 = base / _hash(0)[:3] / f"{_hash(0)[3:5]}_g0" / f"{_hash(0)}.bin"
+        check(
+            m1.is_file() and not m0.is_file(),
+            "C18 keep_boundaries=1: older boundary manifest superseded",
+        )
+        check(
+            not g2_b0.is_file() and g0_b0.is_file(),
+            "C19 superseded boundary: mamba payload unlinked, full-attn chunk kept (C1)",
+        )
+
+    # Rank disagreement: TP rank 0 vs config rank 1 => disabled, no writes.
+    ps = sys.modules["vllm.distributed.parallel_state"]
+
+    old = ps.get_tensor_model_parallel_rank
+    ps.get_tensor_model_parallel_rank = lambda: 0
+    try:
+        logger4 = _TestLogger()
+        with tempfile.TemporaryDirectory() as td:
+            os.environ["GLM53_KV_OFFLOAD_DIR"] = td
+            ns = store.load_writer_helpers(logger4)
+            cw, _, _ = _mini_env(cfg_rank=1)
+            writer = ns["Glm53LocalStoreWriter"](cw, logger4)
+            check(
+                writer._disabled_reason is not None
+                and "disagrees" in writer._disabled_reason,
+                "C20 TP-rank/config-rank disagreement DISABLES the writer",
+            )
+            check(
+                writer.submit_job(1, _job_meta(1), list(range(5))) is False,
+                "C21 disabled writer never defers acks (jobs flow normally)",
+            )
+    finally:
+        ps.get_tensor_model_parallel_rank = old
+
+    # Namespace forks on num_spec (stage-0 A2: num_spec is state-ABI).
+    logger5 = _TestLogger()
+    with tempfile.TemporaryDirectory() as td:
+        os.environ["GLM53_KV_OFFLOAD_DIR"] = td
+        os.environ["GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"] = "2"
+        ns = store.load_writer_helpers(logger5)
+        cw7, _, _ = _mini_env(num_spec=7)
+        cw8, _, _ = _mini_env(num_spec=8)
+        w7 = ns["Glm53LocalStoreWriter"](cw7, logger5)
+        w8 = ns["Glm53LocalStoreWriter"](cw8, logger5)
+        check(
+            w7._namespace_hash != w8._namespace_hash,
+            "C22 num_speculative_tokens forks the namespace hash",
+        )
+
+    # Delayed-ack drain semantics through the connector-worker helpers.
+    logger6 = _TestLogger()
+    with tempfile.TemporaryDirectory() as td:
+        os.environ["GLM53_KV_OFFLOAD_DIR"] = td
+        ns = store.load_writer_helpers(logger6)
+        cw, _, _ = _mini_env()
+        dst = SimpleNamespace(block_ids=list(range(5)))
+        cw._glm53_job_meta[42] = (_job_meta(1), dst)
+        intercepted = ns["_glm53_intercept_store_completion"](cw, 42)
+        check(
+            intercepted and cw._connector_worker_meta.completed == [],
+            "C23 store completion intercepted: no immediate ack",
+        )
+        cw._glm53_store_writer.shutdown(timeout=20)
+        ns["_glm53_drain_finished_disk_writes"](cw)
+        check(
+            cw._connector_worker_meta.completed == [42],
+            "C24 ack lands via drain after the disk write finishes",
+        )
+        check(
+            ns["_glm53_intercept_store_completion"](cw, 43) is False,
+            "C25 jobs without meta (loads) are never intercepted",
+        )
+    _cleanup_env()
+
+
+# ------------------------------------------------------------------ part D --
+def test_gc_tool() -> None:
+    print("Part D: GC/verify tool")
+    import _kv_offload_stub_env as stub
+
+    if "vllm" not in sys.modules:
+        stub.install_fake_vllm()
+    import kv_offload_store_gc as gc_tool
+
+    logger = _TestLogger()
+    with tempfile.TemporaryDirectory() as td:
+        os.environ["GLM53_KV_OFFLOAD_DIR"] = td
+        os.environ["GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"] = "0"
+        ns = store.load_writer_helpers(logger)
+        cw, _, _ = _mini_env()
+        writer = ns["Glm53LocalStoreWriter"](cw, logger)
+        writer.submit_job(1, _job_meta(2), list(range(10)))
+        writer.shutdown(timeout=20)
+        base = Path(writer._base)
+
+        rc = gc_tool.main([str(base)])
+        check(rc == 0, "D1 clean store passes the dry-run")
+
+        # Orphan: a mamba payload whose manifest never published.
+        meta3 = {
+            "v": 1,
+            "keys": [(_hash(9), 2, 9, 3584)],
+            "cow_groups": [2, 3, 4, 5],
+            "full_groups": [0],
+            "manifests": [],
+        }
+        writer2 = ns["Glm53LocalStoreWriter"](cw, logger)
+        writer2.submit_job(2, meta3, [50])
+        writer2.shutdown(timeout=20)
+        orphan = base / _hash(9)[:3] / f"{_hash(9)[3:5]}_g2" / f"{_hash(9)}.bin"
+        check(orphan.is_file(), "D2 orphan payload staged")
+        rc = gc_tool.main([str(base)])
+        check(rc == 1 and orphan.is_file(), "D3 dry-run reports the orphan, deletes nothing")
+
+        # Corrupt file: truncate one chunk.
+        victim = base / _hash(1)[:3] / f"{_hash(1)[3:5]}_g3" / f"{_hash(1)}.bin"
+        victim.write_bytes(victim.read_bytes()[:20])
+        rc = gc_tool.main([str(base)])
+        check(rc == 1, "D4 dry-run flags the truncated chunk")
+
+        rc = gc_tool.main([str(base), "--sweep"])
+        check(
+            not orphan.is_file() and not victim.is_file(),
+            "D5 --sweep removes orphan and corrupt files",
+        )
+
+        # keep-boundaries: keep 1 => boundary-0 manifest superseded, its mamba
+        # chunk swept, but the cumulative g0 chunk of boundary 0 survives (C1).
+        rc = gc_tool.main([str(base), "--sweep", "--keep-boundaries", "1"])
+        m0 = base / "manifests" / _hash(0)[:3] / f"{_hash(0)}.json"
+        g0_b0 = base / _hash(0)[:3] / f"{_hash(0)[3:5]}_g0" / f"{_hash(0)}.bin"
+        g2_b0 = base / _hash(0)[:3] / f"{_hash(0)[3:5]}_g2" / f"{_hash(0)}.bin"
+        check(not m0.is_file(), "D6 --keep-boundaries supersedes the older manifest")
+        check(
+            g0_b0.is_file() and not g2_b0.is_file(),
+            "D7 cumulative full-attn refs protected; superseded mamba swept",
+        )
+    _cleanup_env()
+
+
+
+
+def _cleanup_env() -> None:
+    """These tests mutate GLM53_KV_OFFLOAD* in os.environ; scrub them so the
+    rest of the suite (and any subprocess-driving test that inherits the
+    process env) sees a clean slate."""
+    for name in ("GLM53_KV_OFFLOAD","GLM53_KV_OFFLOAD_DIR","GLM53_KV_OFFLOAD_CPU_GB","GLM53_KV_OFFLOAD_RESTORE","GLM53_KV_OFFLOAD_DRAFTER","GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"):
+        os.environ.pop(name, None)
+
+
+def main() -> int:
+    test_codec()
+    test_store_job_meta()
+    test_writer()
+    test_gc_tool()
+    print(f"\n{len(FAILURES)} failure(s)")
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_kv_offload_store_local.py
+++ b/tests/test_kv_offload_store_local.py
@@ -13,12 +13,17 @@ C  Worker-local writer on a miniature 7-group layout: per-(hash,group) files
    with REAL (unpadded) bytes gathered ref-by-ref from the staging tensors,
    headers with KDA conv/temporal segment split (shape/dtype/stride),
    manifest publish ordering (missing any mamba payload or any cumulative
-   full-attn chunk => no manifest), inline K-boundary retention, dedup,
-   failed-key ledger, ENOSPC pause, rank-disagreement disable, delayed-ack
-   drain semantics, namespace forking on num_spec change.
-D  GC tool (overlay/kv_offload_store_gc.py): dry-run reports orphans and
-   corrupt files without deleting; --sweep removes them; --keep-boundaries
-   preserves cumulative full-attn references (plan §4 C1).
+   full-attn chunk => no manifest), inline K-boundary retention,
+   header-verified dedup, failed-key ledger, ENOSPC pause,
+   rank-disagreement disable, capture-then-write snapshot isolation (the
+   reset_cache()/row-reuse regression: staging mutated after capture must
+   not change disk bytes), flush-path capture, namespace forking on
+   num_spec change.
+D  GC tool (overlay/kv_offload_store_gc.py): dry-run reports orphans (found
+   from headers even with zero manifests), corrupt files and stale temps
+   without deleting; --sweep removes them; --keep-boundaries applies the
+   writer's leaf-walk keep-set (forked chains: shared divergence ancestors
+   survive) and preserves cumulative full-attn references (plan §4 C1).
 
 Run:  python3 tests/test_kv_offload_store_local.py   (or pytest)
 """
@@ -409,11 +414,22 @@ def test_writer() -> None:
 
         meta = _job_meta(2)
         rows = list(range(len(meta["keys"])))
-        deferred = writer.submit_job(7, meta, rows)
-        check(deferred, "C3 job ack deferred to the disk writer")
+        # Capture-then-write (review finding 1): the capture snapshots bytes
+        # synchronously; mutating the staging rows AFTERWARDS must not change
+        # what lands on disk (this is the reset_cache()/row-reuse regression).
+        g2_row = rows[meta["keys"].index((_hash(0), 2, 0, 3584))]
+        pre0 = tensors[0].rows[g2_row][:28]
+        pre1 = tensors[1].rows[g2_row][:28]
+        writer.capture_job(7, meta, rows)
+        for t in tensors:
+            t.rows = [bytes(len(r)) for r in t.rows]  # zero every staging row
         writer.shutdown(timeout=20)
         done = writer.drain_done()
-        check(done == [7], "C4 job completion surfaces via the done queue")
+        check(done == [7], "C3 job completion surfaces via the done queue")
+        check(
+            writer.capture_job(7, meta, rows) is None,
+            "C4 capture is idempotent per job id and never defers acks",
+        )
 
         base = Path(writer._base)
         g2_path = base / _hash(0)[:3] / f"{_hash(0)[3:5]}_g2" / f"{_hash(0)}.bin"
@@ -435,12 +451,14 @@ def test_writer() -> None:
             and segs[2]["offset"] == 28,
             "C7 KDA segment table: conv/temporal split with shape/dtype/stride",
         )
-        # Payload bytes must equal the staging rows' unpadded prefixes, in
-        # group layer order (row = dst cpu block of that key).
-        g2_row = rows[meta["keys"].index((_hash(0), 2, 0, 3584))]
-        expected = tensors[0].rows[g2_row][:28] + tensors[1].rows[g2_row][:28]
+        # Payload bytes must equal the PRE-MUTATION staging snapshot, in
+        # group layer order — proof the writer worked from private buffers.
+        expected = pre0 + pre1
         blob = g2_path.read_bytes()
-        check(blob.endswith(expected), "C8 payload bytes == staging real bytes per ref")
+        check(
+            blob.endswith(expected) and any(expected),
+            "C8 payload == pre-mutation staging snapshot (private buffers)",
+        )
 
         g0_path = base / _hash(0)[:3] / f"{_hash(0)[3:5]}_g0" / f"{_hash(0)}.bin"
         h0 = store.read_chunk_header(str(g0_path))
@@ -450,11 +468,13 @@ def test_writer() -> None:
         m1 = base / "manifests" / _hash(1)[:3] / f"{_hash(1)}.json"
         check(m0.is_file() and m1.is_file(), "C10 manifests published for both boundaries")
         man = json.loads(m1.read_text())
+        g0_chunks = man["full_groups"]["0"]
         check(
             man["chunk_hashes"] == [_hash(0), _hash(1)]
             and set(man["cow_groups"]) == {"2", "3", "4", "5"}
-            and man["full_groups"] == {"0": 2},
-            "C11 manifest carries cumulative chunk chain + per-group entries",
+            and [c[0] for c in g0_chunks] == [_hash(0), _hash(1)]
+            and all(c[1] == 136 and isinstance(c[2], int) for c in g0_chunks),
+            "C11 manifest: cumulative chain + per-chunk [hash, len, crc] per group",
         )
         n_files = len(list(base.rglob("*.bin")))
         check(n_files == 10, f"C12 5 groups x 2 boundaries = 10 chunk files (got {n_files})")
@@ -464,7 +484,7 @@ def test_writer() -> None:
         del_idx = meta3["keys"].index((_hash(2), 3, 2, 3584))
         meta3["keys"] = meta3["keys"][:del_idx] + meta3["keys"][del_idx + 1 :]
         meta3["manifests"] = meta3["manifests"][2:]  # only the new boundary
-        writer.submit_job(8, meta3, list(range(len(meta3["keys"]))))
+        writer.capture_job(8, meta3, list(range(len(meta3["keys"]))))
         writer.shutdown(timeout=20)
         m2 = base / "manifests" / _hash(2)[:3] / f"{_hash(2)}.json"
         check(
@@ -487,7 +507,7 @@ def test_writer() -> None:
                 }
             ],
         }
-        writer.submit_job(9, meta_fk, [40])
+        writer.capture_job(9, meta_fk, [40])
         writer.shutdown(timeout=20)
         check(
             not m2.is_file(),
@@ -509,7 +529,7 @@ def test_writer() -> None:
             return real_open(path, mode, *a, **k)
 
         ns["open"] = enospc_open
-        writer.submit_job(1, _job_meta(1), list(range(5)))
+        writer.capture_job(1, _job_meta(1), list(range(5)))
         writer.shutdown(timeout=20)
         check(
             writer._paused_reason == "ENOSPC" and writer.drain_done() == [1],
@@ -533,7 +553,7 @@ def test_writer() -> None:
         ns = store.load_writer_helpers(logger3)
         cw, _, _ = _mini_env()
         writer = ns["Glm53LocalStoreWriter"](cw, logger3)
-        writer.submit_job(1, _job_meta(2), list(range(10)))
+        writer.capture_job(1, _job_meta(2), list(range(10)))
         writer.shutdown(timeout=20)
         base = Path(writer._base)
         m0 = base / "manifests" / _hash(0)[:3] / f"{_hash(0)}.json"
@@ -566,9 +586,10 @@ def test_writer() -> None:
                 and "disagrees" in writer._disabled_reason,
                 "C20 TP-rank/config-rank disagreement DISABLES the writer",
             )
+            writer.capture_job(1, _job_meta(1), list(range(5)))
             check(
-                writer.submit_job(1, _job_meta(1), list(range(5))) is False,
-                "C21 disabled writer never defers acks (jobs flow normally)",
+                not list(Path(td).rglob("*.bin")),
+                "C21 disabled writer captures nothing (jobs flow normally)",
             )
     finally:
         ps.get_tensor_model_parallel_rank = old
@@ -588,7 +609,7 @@ def test_writer() -> None:
             "C22 num_speculative_tokens forks the namespace hash",
         )
 
-    # Delayed-ack drain semantics through the connector-worker helpers.
+    # Capture helpers through the connector-worker seam (both call sites).
     logger6 = _TestLogger()
     with tempfile.TemporaryDirectory() as td:
         os.environ["GLM53_KV_OFFLOAD_DIR"] = td
@@ -596,20 +617,30 @@ def test_writer() -> None:
         cw, _, _ = _mini_env()
         dst = SimpleNamespace(block_ids=list(range(5)))
         cw._glm53_job_meta[42] = (_job_meta(1), dst)
-        intercepted = ns["_glm53_intercept_store_completion"](cw, 42)
+        ns["_glm53_capture_store_job"](cw, 42)
         check(
-            intercepted and cw._connector_worker_meta.completed == [],
-            "C23 store completion intercepted: no immediate ack",
+            42 not in cw._glm53_job_meta
+            and cw._glm53_store_writer is not None,
+            "C23 get_finished capture consumes the job meta",
         )
         cw._glm53_store_writer.shutdown(timeout=20)
-        ns["_glm53_drain_finished_disk_writes"](cw)
+        base = Path(cw._glm53_store_writer._base)
         check(
-            cw._connector_worker_meta.completed == [42],
-            "C24 ack lands via drain after the disk write finishes",
+            len(list(base.rglob("*.bin"))) == 5,
+            "C24 captured job's files land on disk",
         )
+        ns["_glm53_capture_store_job"](cw, 43)
         check(
-            ns["_glm53_intercept_store_completion"](cw, 43) is False,
-            "C25 jobs without meta (loads) are never intercepted",
+            43 not in cw._glm53_job_meta,
+            "C25 jobs without meta (loads) are a no-op capture",
+        )
+        # Flush/reset path: capture fires for exactly the flushed store jobs.
+        cw._glm53_job_meta[44] = (_job_meta(1), dst)
+        ns["_glm53_capture_flushed_store_jobs"](cw, {44, 45})
+        cw._glm53_store_writer.shutdown(timeout=20)
+        check(
+            44 not in cw._glm53_job_meta,
+            "C26 flush-path capture consumes flushed store jobs (reset-safe)",
         )
     _cleanup_env()
 
@@ -630,7 +661,7 @@ def test_gc_tool() -> None:
         ns = store.load_writer_helpers(logger)
         cw, _, _ = _mini_env()
         writer = ns["Glm53LocalStoreWriter"](cw, logger)
-        writer.submit_job(1, _job_meta(2), list(range(10)))
+        writer.capture_job(1, _job_meta(2), list(range(10)))
         writer.shutdown(timeout=20)
         base = Path(writer._base)
 
@@ -646,7 +677,7 @@ def test_gc_tool() -> None:
             "manifests": [],
         }
         writer2 = ns["Glm53LocalStoreWriter"](cw, logger)
-        writer2.submit_job(2, meta3, [50])
+        writer2.capture_job(2, meta3, [50])
         writer2.shutdown(timeout=20)
         orphan = base / _hash(9)[:3] / f"{_hash(9)[3:5]}_g2" / f"{_hash(9)}.bin"
         check(orphan.is_file(), "D2 orphan payload staged")
@@ -675,6 +706,78 @@ def test_gc_tool() -> None:
         check(
             g0_b0.is_file() and not g2_b0.is_file(),
             "D7 cumulative full-attn refs protected; superseded mamba swept",
+        )
+
+    # Crash-before-first-manifest: orphans must be found from HEADERS alone.
+    logger7 = _TestLogger()
+    with tempfile.TemporaryDirectory() as td:
+        os.environ["GLM53_KV_OFFLOAD_DIR"] = td
+        os.environ["GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"] = "0"
+        ns = store.load_writer_helpers(logger7)
+        cw, _, _ = _mini_env()
+        w = ns["Glm53LocalStoreWriter"](cw, logger7)
+        meta = {
+            "v": 1,
+            "keys": [(_hash(3), 4, 3, 3584)],
+            "cow_groups": [2, 3, 4, 5],
+            "full_groups": [0],
+            "manifests": [],
+        }
+        w.capture_job(1, meta, [7])
+        w.shutdown(timeout=20)
+        base = Path(w._base)
+        out = gc_tool.main([str(base)])
+        check(
+            out == 1,
+            "D8 orphan reported with ZERO manifests present (header-based)",
+        )
+        # Stale temp: any *.tmp.* is reported and swept.
+        t = base / _hash(3)[:3] / f"{_hash(3)[3:5]}_g4" / "x.bin.tmp.r0.1.2"
+        t.write_bytes(b"partial")
+        check(gc_tool.main([str(base)]) == 1, "D9 stale temp flagged by dry-run")
+        gc_tool.main([str(base), "--sweep"])
+        check(not t.exists(), "D10 --sweep removes stale temps")
+
+    # Forked chains: a shared divergence-point boundary survives while ANY
+    # branch still keeps it (writer rule mirrored in the GC tool).
+    logger8 = _TestLogger()
+    with tempfile.TemporaryDirectory() as td:
+        os.environ["GLM53_KV_OFFLOAD_DIR"] = td
+        os.environ["GLM53_KV_OFFLOAD_KEEP_BOUNDARIES"] = "0"
+        ns = store.load_writer_helpers(logger8)
+        cw, _, _ = _mini_env()
+        w = ns["Glm53LocalStoreWriter"](cw, logger8)
+        keys = []
+        for k, h in ((0, _hash(0)), (1, _hash(10)), (1, _hash(11))):
+            for g in (0, 2, 3, 4, 5):
+                keys.append((h, g, k, 3584))
+        meta = {
+            "v": 1,
+            "keys": keys,
+            "cow_groups": [2, 3, 4, 5],
+            "full_groups": [0],
+            "manifests": [
+                {"boundary_token_index": 3584, "chunk_hashes": [_hash(0)]},
+                {"boundary_token_index": 7168, "chunk_hashes": [_hash(0), _hash(10)]},
+                {"boundary_token_index": 7168, "chunk_hashes": [_hash(0), _hash(11)]},
+            ],
+        }
+        w.capture_job(1, meta, list(range(len(keys))))
+        w.shutdown(timeout=20)
+        base = Path(w._base)
+        m_shared = base / "manifests" / _hash(0)[:3] / f"{_hash(0)}.json"
+        check(m_shared.is_file(), "D11 forked store staged (shared ancestor manifested)")
+        gc_tool.main([str(base), "--sweep", "--keep-boundaries", "2"])
+        check(
+            m_shared.is_file(),
+            "D12 K=2: shared divergence-point ancestor kept (both branches need it)",
+        )
+        gc_tool.main([str(base), "--sweep", "--keep-boundaries", "1"])
+        m_a = base / "manifests" / _hash(10)[:3] / f"{_hash(10)}.json"
+        m_b = base / "manifests" / _hash(11)[:3] / f"{_hash(11)}.json"
+        check(
+            m_a.is_file() and m_b.is_file() and not m_shared.is_file(),
+            "D13 K=1: both leaves kept, only the shared ancestor superseded",
         )
     _cleanup_env()
 

--- a/tests/test_launcher_kv_offload.py
+++ b/tests/test_launcher_kv_offload.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Static + dry-run launcher regression for the kv-offload store tier knobs.
+
+A  Knob guard matrix (numeric-config block lifted by its sentinels): the
+   three bool knobs are exactly 0/1; GLM53_KV_OFFLOAD_RESTORE=1 is REFUSED
+   (stage 1 is store-only); CPU_GB is a canonical positive int <= 64; the
+   store dir must be absolute with no quotes/whitespace; KEEP_BOUNDARIES is
+   an integer 0..1024. All validated only when the tier is on, except the
+   bool shape and the restore refusal (always).
+B  Pre-stop gate: `./start.sh restart` with a bad knob, or with the scope or
+   store overlay missing/truncated/mis-pointed, exits 2 with ZERO docker or
+   ssh calls (the healthy pair is never stopped); a valid configuration
+   reaches the stop path.
+C  knob=0 byte-parity: the generated inner scripts gate --kv-transfer-config
+   on the env, both docker runs replay GLM53_KV_OFFLOAD=0, and NO store
+   mount or store mkdir appears anywhere.
+D  knob=1 both-rank parity: every GLM53_KV_OFFLOAD* env is present and
+   identical on both ranks (container dir path, CPU GiB, restore, drafter,
+   keep-boundaries), the store dir is mounted rw on both ranks from the same
+   host path, both overlays ride the scp -> /tmp -> mount chain, and
+   GLM53_OVERLAY_ORDER pins scope BEFORE store_local in BOTH inner scripts.
+   The parity comparator itself is exercised with a synthetic one-rank
+   mismatch. The inner scripts' JSON builder is executed and its shape
+   checked (OffloadingConnector / TieringOffloadingSpec / cpu_bytes /
+   blocks_per_chunk=1 / NO secondary tiers — Codex OFFLOAD1 finding 3).
+
+Everything drives the shipped start.sh under bash from an allow-listed
+environment with docker/ssh/scp/rsync/curl/ip/nvidia-smi stubbed first on
+PATH. Nothing talks to a real host.
+
+Run:  python3 tests/test_launcher_kv_offload.py   (or pytest)
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+START = ROOT / "start.sh"
+
+FAILURES: list[str] = []
+SEP = "\x1f"
+
+KNOBS = (
+    "GLM53_KV_OFFLOAD",
+    "GLM53_KV_OFFLOAD_DIR",
+    "GLM53_KV_OFFLOAD_CPU_GB",
+    "GLM53_KV_OFFLOAD_RESTORE",
+    "GLM53_KV_OFFLOAD_DRAFTER",
+    "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES",
+)
+
+STUB = """#!/usr/bin/env bash
+{ printf '%s\\x1f' "$(basename "$0")" "$@"; printf '\\n'; } >> "$GLM53_STUB_LOG"
+case "$(basename "$0")" in
+    ip) printf 'inet %s/24\\n' "${GLM53_STUB_HEAD_IP:-10.0.0.1}" ;;
+esac
+exit 0
+"""
+
+
+def check(cond: bool, label: str) -> None:
+    print(("  ok   " if cond else "  FAIL ") + label)
+    if not cond:
+        FAILURES.append(label)
+
+
+def source() -> str:
+    return START.read_text()
+
+
+def guard_source() -> str:
+    text = source()
+    begin = text.index("# GLM53 numeric config guard (begin)")
+    end_marker = "# GLM53 numeric config guard (end)"
+    return text[begin : text.index(end_marker, begin) + len(end_marker)]
+
+
+def base_env(**extra: str) -> dict[str, str]:
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", "/"),
+        "USER": "glm53-kvo",
+        "LC_ALL": "C",
+        "TERM": "dumb",
+    }
+    env.update(extra)
+    return env
+
+
+def run_guard(extra_env: dict[str, str]) -> tuple[int, str]:
+    script = (
+        guard_source()
+        + "\nGPU_MEM_UTIL=0.87; MAX_MODEL_LEN=1000000; MAX_NUM_SEQS=4\n"
+        + "MAX_NUM_BATCHED_TOKENS=1024\n"
+        + 'GLM53_KV_OFFLOAD_DIR="${GLM53_KV_OFFLOAD_DIR:-/tmp/kvo}"\n'
+        + 'GLM53_KV_OFFLOAD_CPU_GB="${GLM53_KV_OFFLOAD_CPU_GB:-4}"\n'
+        + 'GLM53_KV_OFFLOAD_KEEP_BOUNDARIES="${GLM53_KV_OFFLOAD_KEEP_BOUNDARIES:-2}"\n'
+        + "validate_numeric_config || exit $?\n"
+        + 'echo OK\n'
+    )
+    r = subprocess.run(
+        ["bash", "-c", script], text=True, capture_output=True, env=base_env(**extra_env)
+    )
+    return r.returncode, (r.stderr or r.stdout).strip()
+
+
+def part_a() -> None:
+    print("Part A: knob guard matrix")
+    ok_cases = [
+        {},
+        {"GLM53_KV_OFFLOAD": "0"},
+        {"GLM53_KV_OFFLOAD": "1"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_CPU_GB": "64"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES": "0"},
+        {"GLM53_KV_OFFLOAD": "0", "GLM53_KV_OFFLOAD_CPU_GB": "junk"},  # gated off
+    ]
+    for env in ok_cases:
+        rc, out = run_guard(env)
+        check(rc == 0, f"A1 accepted: {env} (rc={rc} {out[:60]!r})")
+    bad_cases = [
+        {"GLM53_KV_OFFLOAD": ""},
+        {"GLM53_KV_OFFLOAD": "2"},
+        {"GLM53_KV_OFFLOAD": "yes"},
+        {"GLM53_KV_OFFLOAD_RESTORE": "1"},  # refused even with the tier off
+        {"GLM53_KV_OFFLOAD_RESTORE": "x"},
+        {"GLM53_KV_OFFLOAD_DRAFTER": "01"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_CPU_GB": "0"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_CPU_GB": "65"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_CPU_GB": "4.5"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES": "-1"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES": "1025"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_DIR": "relative/path"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_DIR": "/tmp/has space"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_DIR": "/tmp/it's"},
+    ]
+    for env in bad_cases:
+        rc, out = run_guard(env)
+        named = any(k.split("_")[0] == "GLM53" and k in out for k in env) or "GLM53" in out
+        check(rc == 2 and named, f"A2 rejected rc=2 with named error: {env} (rc={rc} {out[:70]!r})")
+
+
+class Harness:
+    def __init__(self, tmp: Path) -> None:
+        self.tmp = tmp
+        self.repo = tmp / "repo"
+        self.repo.mkdir()
+        shutil.copy2(START, self.repo / "start.sh")
+        shutil.copy2(ROOT / ".env.example", self.repo / ".env.example")
+        (self.repo / ".env").write_text((ROOT / ".env.example").read_text())
+        for sub in ("overlay", "files", "ablit"):
+            if (ROOT / sub).is_dir():
+                shutil.copytree(ROOT / sub, self.repo / sub)
+        self.home = tmp / "home"
+        self.home.mkdir()
+        self.bin = tmp / "bin"
+        self.bin.mkdir()
+        for tool in ("docker", "ssh", "scp", "rsync", "curl", "ip", "nvidia-smi"):
+            p = self.bin / tool
+            p.write_text(STUB)
+            p.chmod(p.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        self.log = tmp / "calls.log"
+        text = (self.repo / "start.sh").read_text()
+        assert text.rstrip().endswith('\nmain "$@"')
+        (self.repo / "start.fn.sh").write_text(
+            text.rstrip()[: -len('main "$@"')] + '"$@"\n'
+        )
+
+    def env(self, **extra: str) -> dict[str, str]:
+        return base_env(
+            PATH=f"{self.bin}{os.pathsep}{os.environ.get('PATH', '/usr/bin:/bin')}",
+            HOME=str(self.home),
+            GLM53_STUB_LOG=str(self.log),
+            **extra,
+        )
+
+    def calls(self) -> list[list[str]]:
+        if not self.log.exists():
+            return []
+        out = []
+        for line in self.log.read_text().splitlines():
+            argv = line.split(SEP)
+            if argv and argv[-1] == "":
+                argv.pop()
+            out.append(argv)
+        return out
+
+    def run(self, args: list[str], entry: str = "start.sh", **extra: str):
+        if self.log.exists():
+            self.log.unlink()
+        return subprocess.run(
+            ["bash", f"./{entry}", *args],
+            cwd=self.repo,
+            text=True,
+            capture_output=True,
+            check=False,
+            env=self.env(**extra),
+        )
+
+    def host_calls(self) -> list[list[str]]:
+        return [c for c in self.calls() if c and c[0] in ("docker", "ssh", "scp", "rsync")]
+
+
+def part_b(h: Harness) -> None:
+    print("Part B: pre-stop gate fails closed")
+    r = h.run(["restart"], GLM53_KV_OFFLOAD="maybe")
+    check(
+        r.returncode == 2 and not h.host_calls(),
+        f"B1 bad knob: rc=2, zero docker/ssh calls (rc={r.returncode}, calls={len(h.host_calls())})",
+    )
+    r = h.run(["restart"], GLM53_KV_OFFLOAD_RESTORE="1")
+    check(
+        r.returncode == 2 and "store-only" in r.stderr and not h.host_calls(),
+        "B2 RESTORE=1 refused pre-stop with the stage-1 reason",
+    )
+    scope = h.repo / "overlay" / "patch_kv_offload_scope.py"
+    backup = scope.read_text()
+    scope.unlink()
+    r = h.run(["restart"])
+    check(
+        r.returncode == 2 and not h.host_calls(),
+        "B3 missing scope overlay: rc=2 before any host call",
+    )
+    scope.write_text(backup[: len(backup) // 2])
+    r = h.run(["restart"])
+    check(
+        r.returncode == 2 and not h.host_calls(),
+        "B4 truncated scope overlay: rc=2 before any host call",
+    )
+    scope.write_text(backup)
+    store_p = h.repo / "overlay" / "patch_kv_offload_store_local.py"
+    store_backup = store_p.read_text()
+    store_p.write_text(backup)  # mis-pointed: scope contents under store name
+    r = h.run(["restart"])
+    check(
+        r.returncode == 2 and not h.host_calls(),
+        "B5 mis-pointed store overlay (identity string): rc=2 pre-stop",
+    )
+    store_p.write_text(store_backup)
+    r = h.run(["restart"])
+    stopped = any(c[:3] == ["docker", "rm", "-f"] or (c[0] == "docker" and "stop" in c) for c in h.host_calls()) or any(
+        c[0] == "ssh" for c in h.host_calls()
+    )
+    check(
+        r.returncode != 2 and stopped,
+        f"B6 valid config passes the gate and reaches the stop path (rc={r.returncode})",
+    )
+
+
+def _inner_scripts(h: Harness, **env: str) -> tuple[str, str]:
+    r = h.run(["eval", "write_inner_scripts"], entry="start.fn.sh", **env)
+    assert r.returncode == 0, r.stderr[-800:]
+    head = (h.repo / ".glm53-exl3-head.inner.sh").read_text()
+    worker = (h.repo / ".glm53-exl3-worker.inner.sh").read_text()
+    return head, worker
+
+
+def _launch(h: Harness, **env: str):
+    r = h.run(
+        ["eval", "MODEL_DIR=/models/glm DFLASH_MODEL_DIR=/models/dflash; write_inner_scripts; launch_cluster"],
+        entry="start.fn.sh",
+        **env,
+    )
+    assert r.returncode == 0, (r.stderr[-1200:], r.stdout[-400:])
+    calls = h.calls()
+    head_run = next(
+        c for c in calls if c[0] == "docker" and c[1] == "run" and "glm53-exl3-head" in c
+    )
+    worker_cmds = [c[-1] for c in calls if c[0] == "ssh" and "docker run" in c[-1]]
+    assert worker_cmds, "no worker docker run captured"
+    return calls, head_run, worker_cmds[0]
+
+
+def _env_of_head(head_run: list[str]) -> dict[str, str]:
+    envs: dict[str, str] = {}
+    for i, tok in enumerate(head_run):
+        if tok == "-e" and i + 1 < len(head_run) and "=" in head_run[i + 1]:
+            k, v = head_run[i + 1].split("=", 1)
+            envs[k] = v
+    return envs
+
+
+def _env_of_worker(worker_cmd: str) -> dict[str, str]:
+    envs: dict[str, str] = {}
+    for tok in shlex.split(worker_cmd):
+        if "=" in tok and tok.split("=", 1)[0].replace("_", "").isalnum():
+            k, v = tok.split("=", 1)
+            if k.isupper():
+                envs[k] = v
+    return envs
+
+
+def part_c(h: Harness) -> None:
+    print("Part C: knob=0 parity (byte-identical serving)")
+    head, worker = _inner_scripts(h)
+    gate = 'if [ "${GLM53_KV_OFFLOAD:-0}" = "1" ]; then'
+    check(
+        gate in head and gate in worker,
+        "C1 both inner scripts gate --kv-transfer-config on the env knob",
+    )
+    calls, head_run, worker_cmd = _launch(h)
+    henv, wenv = _env_of_head(head_run), _env_of_worker(worker_cmd)
+    check(
+        henv.get("GLM53_KV_OFFLOAD") == "0" and wenv.get("GLM53_KV_OFFLOAD") == "0",
+        "C2 knob replayed as 0 to BOTH ranks",
+    )
+    # A mount token is "host:/data/glm53-kv-offload" (no '='); the env replay
+    # token "GLM53_KV_OFFLOAD_DIR=/data/..." must NOT count as a mount.
+    mounts = [
+        t for t in head_run if ":/data/glm53-kv-offload" in t and "=" not in t
+    ]
+    worker_mounts = [
+        t
+        for t in shlex.split(worker_cmd)
+        if ":/data/glm53-kv-offload" in t and "=" not in t
+    ]
+    check(
+        not mounts and not worker_mounts,
+        "C3 knob=0: no store mount on either rank",
+    )
+    mkdirs = [c for c in calls if c[0] == "ssh" and "glm53-kv-offload" in c[-1] and "mkdir" in c[-1]]
+    check(not mkdirs, "C4 knob=0: no store mkdir on the worker")
+
+
+def part_d(h: Harness) -> None:
+    print("Part D: knob=1 both-rank parity")
+    store_dir = str(h.tmp / "kv-store")
+    env = {
+        "GLM53_KV_OFFLOAD": "1",
+        "GLM53_KV_OFFLOAD_DIR": store_dir,
+        "GLM53_KV_OFFLOAD_CPU_GB": "6",
+        "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES": "3",
+    }
+    calls, head_run, worker_cmd = _launch(h, **env)
+    henv, wenv = _env_of_head(head_run), _env_of_worker(worker_cmd)
+    expected = {
+        "GLM53_KV_OFFLOAD": "1",
+        "GLM53_KV_OFFLOAD_DIR": "/data/glm53-kv-offload",
+        "GLM53_KV_OFFLOAD_CPU_GB": "6",
+        "GLM53_KV_OFFLOAD_RESTORE": "0",
+        "GLM53_KV_OFFLOAD_DRAFTER": "0",
+        "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES": "3",
+    }
+    for k, v in expected.items():
+        check(
+            henv.get(k) == v and wenv.get(k) == v,
+            f"D1 {k}={v!r} present and identical on BOTH ranks "
+            f"(head={henv.get(k)!r} worker={wenv.get(k)!r})",
+        )
+    head_mount = f"{store_dir}:/data/glm53-kv-offload"
+    check(
+        any(head_mount == t for t in head_run),
+        "D2 head mounts the store dir rw at the container path",
+    )
+    check(
+        f"-v '{head_mount}'" in worker_cmd,
+        "D3 worker mounts the SAME host dir at the same container path",
+    )
+    mkdirs = [c for c in calls if c[0] == "ssh" and store_dir in c[-1] and "mkdir" in c[-1]]
+    check(bool(mkdirs), "D4 worker store dir mkdir'ed over ssh")
+
+    # scp -> /tmp -> mount chain for both overlays.
+    for name in ("patch_kv_offload_scope.py", "patch_kv_offload_store_local.py"):
+        scps = [
+            c
+            for c in calls
+            if c[0] == "scp" and any(name in a for a in c) and any(f"/tmp/{name}" in a for a in c)
+        ]
+        head_m = any(f"/opt/glm53/{name}:ro" in t for t in head_run)
+        worker_m = f"-v '/tmp/{name}:/opt/glm53/{name}:ro'" in worker_cmd
+        check(
+            bool(scps) and head_m and worker_m,
+            f"D5 {name}: scp chain + both-rank mounts",
+        )
+
+    # Overlay order: scope before store_local, identically in both scripts.
+    head, worker = _inner_scripts(h, **env)
+    m = re.findall(r"python3 /opt/glm53/(patch_[a-z0-9_]+\.py)", head)
+    check(
+        m.index("patch_kv_offload_scope.py") < m.index("patch_kv_offload_store_local.py"),
+        "D6 overlay order pins scope before store_local",
+    )
+    m2 = re.findall(r"python3 /opt/glm53/(patch_[a-z0-9_]+\.py)", worker)
+    check(m == m2, "D7 both ranks apply the identical overlay list")
+
+    # The comparator itself must catch a planted one-rank difference.
+    planted = dict(wenv)
+    planted["GLM53_KV_OFFLOAD_CPU_GB"] = "5"
+    mismatch = [k for k in expected if henv.get(k) != planted.get(k)]
+    check(
+        mismatch == ["GLM53_KV_OFFLOAD_CPU_GB"],
+        "D8 synthetic one-rank mismatch is detected by the parity comparison",
+    )
+
+    # JSON shape: execute the inner script's builder verbatim.
+    snippet = re.search(
+        r"python3 -S -c '([^']*GLM53_KV_OFFLOAD_CPU_GB[^']*)'", head, re.S
+    )
+    check(snippet is not None, "D9 inner script builds the connector JSON via python3")
+    if snippet:
+        out = subprocess.run(
+            [sys.executable, "-S", "-c", snippet.group(1)],
+            text=True,
+            capture_output=True,
+            env={**os.environ, "GLM53_KV_OFFLOAD_CPU_GB": "6"},
+        )
+        cfg = json.loads(out.stdout.strip())
+        extra = cfg["kv_connector_extra_config"]
+        check(
+            cfg["kv_connector"] == "OffloadingConnector"
+            and cfg["kv_role"] == "kv_both"
+            and extra["spec_name"] == "TieringOffloadingSpec"
+            and extra["cpu_bytes_to_use"] == 6 * (1 << 30)
+            and extra["blocks_per_chunk"] == 1
+            and "secondary_tiers" not in extra,
+            f"D10 connector JSON shape (got {cfg})",
+        )
+
+
+def main() -> int:
+    part_a()
+    with tempfile.TemporaryDirectory() as td:
+        h = Harness(Path(td))
+        part_b(h)
+        part_c(h)
+        part_d(h)
+    print(f"\n{len(FAILURES)} failure(s)")
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_launcher_kv_offload.py
+++ b/tests/test_launcher_kv_offload.py
@@ -123,6 +123,9 @@ def part_a() -> None:
         {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_CPU_GB": "64"},
         {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_KEEP_BOUNDARIES": "0"},
         {"GLM53_KV_OFFLOAD": "0", "GLM53_KV_OFFLOAD_CPU_GB": "junk"},  # gated off
+        # Stage 2: restore is accepted iff the store tier is on.
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_RESTORE": "1"},
+        {"GLM53_KV_OFFLOAD": "1", "GLM53_KV_OFFLOAD_RESTORE": "0"},
     ]
     for env in ok_cases:
         rc, out = run_guard(env)
@@ -219,9 +222,27 @@ def part_b(h: Harness) -> None:
     )
     r = h.run(["restart"], GLM53_KV_OFFLOAD_RESTORE="1")
     check(
-        r.returncode == 2 and "store-only" in r.stderr and not h.host_calls(),
-        "B2 RESTORE=1 refused pre-stop with the stage-1 reason",
+        r.returncode == 2
+        and "requires GLM53_KV_OFFLOAD=1" in r.stderr
+        and not h.host_calls(),
+        "B2 RESTORE=1 without the store tier refused pre-stop (stage-2 rule)",
     )
+    r = h.run(["restart"], GLM53_KV_OFFLOAD="0", GLM53_KV_OFFLOAD_RESTORE="1")
+    check(
+        r.returncode == 2
+        and "requires GLM53_KV_OFFLOAD=1" in r.stderr
+        and not h.host_calls(),
+        "B2b explicit OFFLOAD=0 + RESTORE=1 refused pre-stop",
+    )
+    restore_p = h.repo / "overlay" / "patch_kv_offload_restore_g0.py"
+    restore_backup = restore_p.read_text()
+    restore_p.write_text(restore_backup[: len(restore_backup) // 2])
+    r = h.run(["restart"])
+    check(
+        r.returncode == 2 and not h.host_calls(),
+        "B2c truncated restore overlay: rc=2 before any host call",
+    )
+    restore_p.write_text(restore_backup)
     scope = h.repo / "overlay" / "patch_kv_offload_scope.py"
     backup = scope.read_text()
     scope.unlink()
@@ -369,7 +390,11 @@ def part_d(h: Harness) -> None:
     check(bool(mkdirs), "D4 worker store dir mkdir'ed over ssh")
 
     # scp -> /tmp -> mount chain for both overlays.
-    for name in ("patch_kv_offload_scope.py", "patch_kv_offload_store_local.py"):
+    for name in (
+        "patch_kv_offload_scope.py",
+        "patch_kv_offload_store_local.py",
+        "patch_kv_offload_restore_g0.py",
+    ):
         scps = [
             c
             for c in calls
@@ -386,11 +411,25 @@ def part_d(h: Harness) -> None:
     head, worker = _inner_scripts(h, **env)
     m = re.findall(r"python3 /opt/glm53/(patch_[a-z0-9_]+\.py)", head)
     check(
-        m.index("patch_kv_offload_scope.py") < m.index("patch_kv_offload_store_local.py"),
-        "D6 overlay order pins scope before store_local",
+        m.index("patch_kv_offload_scope.py")
+        < m.index("patch_kv_offload_store_local.py")
+        < m.index("patch_kv_offload_restore_g0.py"),
+        "D6 overlay order pins scope -> store_local -> restore_g0",
     )
     m2 = re.findall(r"python3 /opt/glm53/(patch_[a-z0-9_]+\.py)", worker)
     check(m == m2, "D7 both ranks apply the identical overlay list")
+
+    # Stage 2: RESTORE=1 launch replays the knob identically to both ranks
+    # and changes nothing else about the connector JSON.
+    env_r = dict(env)
+    env_r["GLM53_KV_OFFLOAD_RESTORE"] = "1"
+    _, head_run_r, worker_cmd_r = _launch(h, **env_r)
+    henv_r, wenv_r = _env_of_head(head_run_r), _env_of_worker(worker_cmd_r)
+    check(
+        henv_r.get("GLM53_KV_OFFLOAD_RESTORE") == "1"
+        and wenv_r.get("GLM53_KV_OFFLOAD_RESTORE") == "1",
+        "D11 RESTORE=1 replayed identically to BOTH ranks",
+    )
 
     # The comparator itself must catch a planted one-rank difference.
     planted = dict(wenv)

--- a/tests/test_launcher_kv_offload.py
+++ b/tests/test_launcher_kv_offload.py
@@ -421,6 +421,7 @@ def part_d(h: Harness) -> None:
             and extra["spec_name"] == "TieringOffloadingSpec"
             and extra["cpu_bytes_to_use"] == 6 * (1 << 30)
             and extra["blocks_per_chunk"] == 1
+            and extra["offload_prompt_only"] is False
             and "secondary_tiers" not in extra,
             f"D10 connector JSON shape (got {cfg})",
         )

--- a/tests/test_launcher_kv_offload.py
+++ b/tests/test_launcher_kv_offload.py
@@ -290,12 +290,17 @@ def _env_of_head(head_run: list[str]) -> dict[str, str]:
 
 
 def _env_of_worker(worker_cmd: str) -> dict[str, str]:
+    # Only count KEY=value tokens that immediately follow a -e flag: a malformed
+    # worker command whose env assignment drifted away from its -e must FAIL the
+    # env checks, not pass on a stray token (Codex 087b5ea review, finding 1).
     envs: dict[str, str] = {}
-    for tok in shlex.split(worker_cmd):
-        if "=" in tok and tok.split("=", 1)[0].replace("_", "").isalnum():
-            k, v = tok.split("=", 1)
-            if k.isupper():
-                envs[k] = v
+    toks = shlex.split(worker_cmd)
+    for i in range(len(toks) - 1):
+        if toks[i] != "-e" or "=" not in toks[i + 1]:
+            continue
+        k, v = toks[i + 1].split("=", 1)
+        if k.replace("_", "").isalnum() and k.isupper():
+            envs[k] = v
     return envs
 
 
@@ -362,7 +367,8 @@ def part_d(h: Harness) -> None:
             f"D1 {k}={v!r} present and identical on BOTH ranks "
             f"(head={henv.get(k)!r} worker={wenv.get(k)!r})",
         )
-    # vLLM refuses OffloadingConnector + expandable_segments:True (VMM remap
+    # vLLM refuses OffloadingConnector + expandable_segments:True unless the
+    # CuMem allocator is enabled — it is not on this deployment (VMM remap
     # under pinned KV memory; live receipt-window finding): knob=1 must DROP
     # the env on both ranks; knob=0 keeps the stock value (see part_c).
     check(

--- a/tests/test_launcher_kv_offload.py
+++ b/tests/test_launcher_kv_offload.py
@@ -327,6 +327,12 @@ def part_c(h: Harness) -> None:
         not mounts and not worker_mounts,
         "C3 knob=0: no store mount on either rank",
     )
+    check(
+        henv.get("PYTORCH_CUDA_ALLOC_CONF") == "expandable_segments:True"
+        and wenv.get("PYTORCH_CUDA_ALLOC_CONF") == "expandable_segments:True",
+        "C3b knob=0 keeps the stock PYTORCH_CUDA_ALLOC_CONF on BOTH ranks "
+        "(byte-identical container env)",
+    )
     mkdirs = [c for c in calls if c[0] == "ssh" and "glm53-kv-offload" in c[-1] and "mkdir" in c[-1]]
     check(not mkdirs, "C4 knob=0: no store mkdir on the worker")
 
@@ -356,6 +362,16 @@ def part_d(h: Harness) -> None:
             f"D1 {k}={v!r} present and identical on BOTH ranks "
             f"(head={henv.get(k)!r} worker={wenv.get(k)!r})",
         )
+    # vLLM refuses OffloadingConnector + expandable_segments:True (VMM remap
+    # under pinned KV memory; live receipt-window finding): knob=1 must DROP
+    # the env on both ranks; knob=0 keeps the stock value (see part_c).
+    check(
+        "PYTORCH_CUDA_ALLOC_CONF" not in henv
+        and "PYTORCH_CUDA_ALLOC_CONF" not in wenv,
+        f"D1b knob=1 drops PYTORCH_CUDA_ALLOC_CONF on BOTH ranks "
+        f"(head={henv.get('PYTORCH_CUDA_ALLOC_CONF')!r} "
+        f"worker={wenv.get('PYTORCH_CUDA_ALLOC_CONF')!r})",
+    )
     head_mount = f"{store_dir}:/data/glm53-kv-offload"
     check(
         any(head_mount == t for t in head_run),

--- a/tests/test_mamba_differential_harness.py
+++ b/tests/test_mamba_differential_harness.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Tests for the stage-3 mamba cross-boot differential harness
+(tests/_mamba_differential.py).
+
+WHAT THIS IS (Codex OFFLOAD2 finding 14, adopted): state-ABI/codec fixture
+tests + the bit-comparator stage 3 will run against real captures. It is NOT
+stage-3 evidence: no live state is captured, the mamba state-index convention
+is still an open stage-0 residual, and the live protocol
+(tests/stage3_mamba_differential_protocol.sh) is guarded and not run here.
+
+A  Park fixtures: boot-A park-at-boundary-k writes 4 mamba chunk files +
+   a boundary manifest in the stage-1 on-disk format, real (unpadded) bytes
+   only, num_spec + state-ABI tag in every header.
+B  ABI field checks: conv (10,12288) bf16 245,760 B + temporal (32,128,128)
+   fp32 2,097,152 B per layer, real page 2,342,912 B, 9/9/8/8 layers,
+   padded bytes never on disk; a violated fixture is FLAGGED.
+C  Bit comparator: identical boots compare clean; a restored-boot copy of
+   boot A compares clean; a single flipped bit is localized to the exact
+   (group, layer, tensor); a divergent boot reports every tensor.
+
+Run:  python3 tests/test_mamba_differential_harness.py   (or pytest)
+"""
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(HERE.parent / "overlay"))
+
+import _mamba_differential as md  # noqa: E402
+import patch_kv_offload_store_local as store  # noqa: E402
+
+FAILURES: list[str] = []
+
+
+def check(cond: bool, label: str) -> None:
+    print(("  ok   " if cond else "  FAIL ") + label)
+    if not cond:
+        FAILURES.append(label)
+
+
+def test_harness() -> None:
+    print("Mamba differential harness (ABI/codec fixtures — NOT stage-3 evidence)")
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        k = 1
+        base_a = md.write_park_fixture(root / "bootA", "bootA", boundary_k=k)
+        bhash = md.boundary_hash("chainA", k)
+
+        files = sorted(p.name for p in base_a.rglob("*.bin"))
+        check(
+            len(files) == 4 and all(n == f"{bhash}.bin" for n in files),
+            "A1 boot-A park: one chunk file per mamba group (g2-g5)",
+        )
+        mpath = base_a / "manifests" / bhash[:3] / f"{bhash}.json"
+        check(mpath.is_file(), "A2 boundary manifest published")
+        import json
+
+        man = json.loads(mpath.read_text())
+        check(
+            len(man["chunk_hashes"]) == k + 1
+            and set(man["cow_groups"]) == {"2", "3", "4", "5"},
+            "A3 manifest: cumulative chain + all four mamba groups",
+        )
+        g2 = base_a / bhash[:3] / f"{bhash[3:5]}_g2" / f"{bhash}.bin"
+        h2 = store.read_chunk_header(str(g2), verify_payload=True)
+        check(
+            h2["payload_len"] == 9 * md.KDA_REAL_PAGE
+            and h2["payload_len"] == 21_086_208,
+            f"A4 g2 payload = 9 x 2,342,912 real bytes (got {h2['payload_len']})",
+        )
+        check(
+            h2["payload_len"] != 9 * md.KDA_PADDED_PAGE,
+            "A5 slot-share padding never reaches disk",
+        )
+
+        # B: ABI checks pass on a good fixture; violations are flagged.
+        check(md.check_state_abi(base_a, k) == [], "B1 ABI field checks pass")
+        bad_root = root / "bootBad"
+        base_bad = md.write_park_fixture(bad_root, "bootBad", boundary_k=k)
+        g3 = base_bad / bhash[:3] / f"{bhash[3:5]}_g3" / f"{bhash}.bin"
+        payload, segs = md.group_payload_and_segments("bootBad", 3)
+        hdr = store.read_chunk_header(str(g3))
+        hdr_bad = {
+            key: hdr[key]
+            for key in hdr
+            if key not in ("payload_len", "payload_crc32", "crc_algo", "format_version")
+        }
+        hdr_bad["num_speculative_tokens"] = 8  # ABI break: conv width changes
+        g3.write_bytes(store.encode_chunk(hdr_bad, payload))
+        problems = md.check_state_abi(base_bad, k)
+        check(
+            any("num_spec" in p for p in problems),
+            f"B2 num_spec drift is FLAGGED (got {problems})",
+        )
+
+        # C: comparator.
+        base_a2 = md.write_park_fixture(root / "bootA2", "bootA", boundary_k=k)
+        check(
+            md.compare_state_bits(base_a, base_a2, k) == {},
+            "C1 identical park states compare bit-clean",
+        )
+        # A 'restored' boot B: byte-copy of boot A's store (what a correct
+        # cross-boot restore must reproduce) compares clean.
+        restored = root / "bootB-restored" / base_a.name
+        shutil.copytree(base_a, restored)
+        check(
+            md.compare_state_bits(base_a, restored, k) == {},
+            "C2 restored-copy boot compares bit-clean",
+        )
+        # A single flipped bit localizes to the exact (group, layer, tensor).
+        g4 = restored / bhash[:3] / f"{bhash[3:5]}_g4" / f"{bhash}.bin"
+        raw = bytearray(g4.read_bytes())
+        hlen = int.from_bytes(raw[8:12], "little")
+        # Flip one bit inside layer kda4.2's temporal state.
+        seg = next(
+            s
+            for s in store.read_chunk_header(str(g4))["segment_table"]
+            if s["layer"] == "kda4.2" and s["kind"] == "temporal_state"
+        )
+        raw[16 + hlen + seg["offset"] + 5] ^= 0x01
+        # Re-encode so the CRC stays valid (the comparator verifies payloads;
+        # a CRC-invalid file is a CODEC failure, not a state difference).
+        hdr4 = store.read_chunk_header(str(g4))
+        hdr4_clean = {
+            key: hdr4[key]
+            for key in hdr4
+            if key not in ("payload_len", "payload_crc32", "crc_algo", "format_version")
+        }
+        g4.write_bytes(store.encode_chunk(hdr4_clean, bytes(raw[16 + hlen :])))
+        diff = md.compare_state_bits(base_a, restored, k)
+        check(
+            diff == {(4, "kda4.2", "temporal_state"): 1},
+            f"C3 single bit flip localized to (g4, kda4.2, temporal) (got {diff})",
+        )
+        # A genuinely different boot reports every tensor.
+        base_c = md.write_park_fixture(root / "bootC", "bootC", boundary_k=k)
+        diff_c = md.compare_state_bits(base_a, base_c, k)
+        check(
+            len(diff_c) == 2 * sum(md.MAMBA_GROUP_LAYERS.values()),
+            f"C4 divergent boot: every (layer, tensor) differs "
+            f"(got {len(diff_c)} of {2 * sum(md.MAMBA_GROUP_LAYERS.values())})",
+        )
+
+
+def main() -> int:
+    test_harness()
+    print(f"\n{len(FAILURES)} failure(s)")
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_warm_restart_stdout.py
+++ b/tests/test_warm_restart_stdout.py
@@ -13,7 +13,9 @@ ROOT = Path(__file__).resolve().parents[1]
 def test_json_command_substitutions_skip_sitecustomize() -> None:
     source = (ROOT / "start.sh").read_text()
     marker = '$(python3 -S -c \'import json,os'
-    assert source.count(marker) == 2
+    # 2 speculative-config builders + 2 kv-offload connector-JSON builders
+    # (one per rank inner script each).
+    assert source.count(marker) == 4
 
 
 def test_import_time_overlay_never_writes_stdout() -> None:

--- a/tests/test_xgrammar_termination.py
+++ b/tests/test_xgrammar_termination.py
@@ -385,7 +385,12 @@ def test_recipe_wiring_if_present() -> None:
     launcher = start.read_text()
     image = dockerfile.read_text()
     assert 'XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-' in launcher
-    assert launcher.count("python3 /opt/glm53/patch_xgrammar_termination.py") == 2
+    # Both ranks apply the one pinned list (GLM53_OVERLAY_ORDER) that
+    # write_inner_scripts emits into the head and worker inner scripts.
+    order = launcher[launcher.index("GLM53_OVERLAY_ORDER=(") : launcher.index(")", launcher.index("GLM53_OVERLAY_ORDER=("))]
+    assert "\n    patch_xgrammar_termination.py\n" in order
+    assert 'emit_overlay_block >> "$HEAD_SCRIPT"' in launcher
+    assert 'emit_overlay_block >> "$WORKER_SCRIPT"' in launcher
     assert (
         "-v '/tmp/patch_xgrammar_termination.py:"
         "/opt/glm53/patch_xgrammar_termination.py:ro'" in launcher


### PR DESCRIPTION
# Stage-2 g0 (MLA + indexer) disk restore at 3584 boundaries (`GLM53_KV_OFFLOAD_RESTORE`, default off) + the stage-3 mamba differential harness

**Stacks on #99** (`pr/kv-offload-store-only`): this branch is
`pr/kv-offload-mla-restore` = #99 + additive commits; review the diff against
that branch. Codex gates: advisory on the design BEFORE coding
(CODEX-OFFLOAD2-PLAN.md: DO-NOT-PROCEED, 5 BLOCKER + 10 MAJOR — every finding
adopted or rebutted in writing before the build), adversarial review of the
final diff (CODEX-OFFLOAD2-REVIEW.md: DO-NOT-SHIP, 1 BLOCKER + 8 MAJOR +
2 MINOR — every finding adopted or rebutted; fixes in the review-fixes
commit; confirm pass appended there). Host suites green (pytest 40 + six
standalone runners, 0 failures). Live
receipts are posted in the thread; rows 1 and 4 are captured, row 5 is
partial, and rows 2/3 remain open for the reasons in the Receipts section
below.

## The honest headline

**A group-0-only restore yields ZERO hit uplift on GLM-5.3-Flash itself, by
design — and this PR says so up front.** The connector's reconciled external
hit is the min across all KV-cache groups; the four mamba (KDA) groups have
no restore source in this stage. Independently, the core scheduler's
invalid-block path is single-group (pinned fixture
`tests/fixtures/image_487ecf187_core_sched_scheduler.py:2954-2955`, the
`(req_block_ids,) = …get_block_ids(req_id)` under the hybrid-allocator TODO)
— a load-failure report on the 7-group layout would crash the core. The
restore path therefore requires **exactly one TOTAL KV-cache group** and is
**INERT on this deployment** with one boot log line naming the reason;
serving with `GLM53_KV_OFFLOAD_RESTORE=0` (default) matches #99 at the
serve-argv level (live capture); byte-for-byte runtime parity is a host-test
property, not a live receipt.

What stage 2 delivers instead: the restore machinery and host-side tests.
The 2026-09-02 dense single-full-attention-group probe live-receipted the
path through scheduler lookup and disk-job creation, but not successful
worker restore. It is not the exact MLA+indexer shape of g0, and the T4
recompute contract remains unproven live. These are the prerequisites
stage 3 (mamba restore, the actual TTFT win) needs underneath it.

## What this ships

### `overlay/patch_kv_offload_restore_g0.py` (five patch targets)

- **Lookup from the on-disk manifests, keys/hashes only**: each rank's store
  writer announces manifest availability over the worker→scheduler metadata
  channel (`+` validated publish / `-` retention supersede / `F` write
  failure); the scheduler ANDs `+` across ranks (plan §4 C2 — "workers
  report it; the scheduler takes the min across ranks") and never touches
  the filesystem. Contiguity is content-addressing: block hashes are
  prefix-chained, so boundary-hash equality implies the whole chain.
  **The per-job store failure bit is on the wire and load-bearing**: a
  boundary whose g0 chunk failed to write on any rank is never offered
  (closes the recorded stage-1 limit).
- **Delay-cache allocation + disk load jobs**: a disk hit skips
  `manager.prepare_load` entirely (CPU staging is a bounce, not a tier);
  the load job's `src_spec` is a versioned plain dict with entries aligned
  1:1 to the dst blocks; `WAITING_FOR_REMOTE_KVS` and the `cache_blocks`
  re-entry are the stock core chain.
- **Worker pread with full verification**: synchronous per-chunk
  pread → header identity (namespace/hash/group/spec/rank/world) → payload
  CRC → **exact segment-table equality** against this rank's own spec
  derivation → scatter into the GPU canonical tensors. Restore
  concurrency = 1. Manifest re-validated on each rank at load time.
- **T4 (stage-2 contract)**: any per-(chunk, rank) failure zero-fills the
  failed chunk and every later chunk's dst blocks, reports their ids via
  `get_block_ids_with_load_errors` (facade override; the model-runner mixin
  consumes it into `invalid_block_ids`), and the job still completes — the
  core's `kv_load_failure_policy=recompute` truncates at the failed chunk
  and recomputes. All roads lead to reprefill, never a served half-restore.
- **T2**: `request.glm53_restored_boundary` (end-exclusive) rides into
  `reachable_boundaries` in the single_type manager's `cache_blocks`, so
  sparse retention masks can never silently drop a restored boundary's
  re-entry (dense masks unaffected; the anchor also applies verbatim to
  upstream's tree — retention exists at HEAD).
- **Preemption/reset hygiene**: neither the preemption flush nor
  `_build_store_jobs` can hit the stock `is_store` asserts on a disk load
  job (flush skips it; store creation is deferred while a load is
  registered); the single-flight gate self-heals; stale completions are
  discarded by the existing `_stale_job_threshold`; per-rank writer
  generations are fenced; every registry/queue is bounded fail-closed.
- **S1**: boundary manifests now also publish on layouts with no recurrent
  groups (hybrid layouts byte-identical to #99) — without this the probe
  layout had nothing to look up.

### Launcher

`GLM53_KV_OFFLOAD_RESTORE=1` is accepted IFF `GLM53_KV_OFFLOAD=1` (refused
fail-closed pre-stop otherwise, zero docker/ssh calls); the restore overlay
rides the same artifact-guard / `--check-injected` / scp / mount / order
machinery as the stage-1 pair (order pinned scope → store_local →
restore_g0); `offload_prompt_only:false` and every stage-1 knob unchanged.

### Stage-3 mamba cross-boot differential harness (design + fixtures ONLY)

`tests/_mamba_differential.py` + `tests/test_mamba_differential_harness.py`:
park-at-boundary fixtures with stubbed KDA state tensors at the receipted ABI
(conv (10,12288) bf16 + temporal (32,128,128) fp32, real page 2,342,912 B,
9/9/8/8 layers, num_spec=7 in every header, padding never on disk) and the
exact bit-comparator stage 3 will run (a flipped bit localizes to its
(group, layer, tensor)). `tests/stage3_mamba_differential_protocol.sh` pins
the live protocol (step 0 = receipt the still-open mamba state-index
convention) and refuses to run on this branch. **This is an ABI/codec fixture
comparator, not stage-3 evidence** — no live state was captured.

### New pinned fixtures (read-only captures, sha256 in `tests/fixtures/README.md`)

`offloading_connector.py` and `single_type_kv_cache_manager.py` (patch
targets) plus the core `sched/scheduler.py` (receipt only, not patched) —
captured from the live container running the identical vllm tree
(0.1.dev20051+g487ecf187; the four actual offloading patch-target fixture
sha256s were re-verified against it byte-exact; the core scheduler capture
is a non-target receipt — see the 2026-09-02 receipts comment's P3
exception).

## Tests (host-side, all green: pytest 40 + 6 standalone runners)

| file | covers |
|---|---|
| `tests/test_kv_offload_restore_g0.py` | patcher hygiene on all five targets (idempotence/tamper/store-less refusal/--check-injected); patched-runtime scheduler: eligibility matrix (7-group INERT + named reason, single-group ACTIVE, one-eligible-plus-excluded INERT), AND-across-ranks registry (+/−/F), deepest-boundary lookup, alignment guard, single-flight gate (defer/self-heal/completion/reset), disk-job shape with ZERO manager calls and preserved stage-1 bookkeeping, preemption load-job guard, zero-cow manifest candidates, RESTORE=0 parity; loader: byte-exact restore round-trip against real writer output, failure matrix (CRC/missing file/namespace/manifest-gone/wrong-rank/null-block) with zero-fill + invalid ids + job-always-completes, earlier-chunks-kept/suffix-abandoned; event channel: emission, validated dedup, event-only meta flow, aggregate + legacy meta, pickle; facade drain; T2 on the patched single_type text incl. the mamba mask end-exclusive convention (3583/3584/7168) |
| `tests/test_mamba_differential_harness.py` | ABI field checks (shapes/dtypes/sizes/num_spec/padding-never-on-disk, drift flagged), comparator (clean/restored-copy/single-bit localization/full divergence) |
| `tests/test_kv_offload_restore_venv.py` | feature-detected coordinator checks against the CPU vLLM venv: T2 anchor applies to the real tree; connector load-errors API present |
| `tests/test_launcher_kv_offload.py` (extended) | RESTORE=1 without OFFLOAD=1 refused pre-stop (zero host calls); OFFLOAD=1+RESTORE=1 accepted; truncated restore overlay blocks pre-stop; overlay order scope→store→restore; RESTORE replayed identically to both ranks |

## Receipts (status 2026-09-02; history in the thread's receipts comments)

Rows 1 and 4 are captured. Rows 2/3 were run live on a purpose-built
single-group probe (2026-09-02 receipts comment) and remain open on three
branch gaps that run found: (A) the v1 loader's fail-closed mapped-layout
guard means no dense model can exercise the restore chain (`ACTIVE` proves
scheduler eligibility, not worker restorability); (B) the launcher leaves
`kv_load_failure_policy` at the image default `fail`, so load failures 500
the request instead of the designed degrade-to-recompute; (C) no
per-boundary failure suppression exists after a failed load. Each needs a
reviewed branch commit before rows 2/3 can close:

1. **Inert-on-live receipt**: boot the 7-group deployment with
   `GLM53_KV_OFFLOAD=1 GLM53_KV_OFFLOAD_RESTORE=1`; the boot log shows
   `[glm53-kv-offload-restore] restore INERT on this layout: layout has 7
   KV-cache groups (5 eligible)…` on the head; serving probes green;
   decode/prefill ranges overlap #99's knob=1 sample, but this capture does
   not establish the body's "within noise" criterion (no decode-rate
   comparison was captured).
2. **Probe fork-trace receipt** (single-full-attention-group probe config,
   plan §5/F5) — **OPEN, blocked on gap A (then B)**: park a session past
   the store cascade; new request hits the disk lookup → async-load path
   evidenced by `WAITING_FOR_REMOTE_KVS` state occupancy (the core logs the
   in-state line at DEBUG only and never logs the transition pair), the
   `disk load job N restored …` line on BOTH ranks, zero load errors, and a
   follow-up request served as an ordinary GPU prefix hit with zero disk
   traffic. 2026-09-02: everything upstream of the worker pread is
   live-receipted on the dense probe (cascade, lookup/offer, state entry,
   job creation on both ranks); the pread stage requires an MLA-layout
   model or v1.1 inverse-scatter support.
3. **T4 fault receipts** — **OPEN, blocked on gaps B/C** (the scheduler
   recompute path applies only when `kv_load_failure_policy="recompute"` is
   explicitly configured; the current launcher does not set it and has not
   proven live reprefill): corrupt one
   chunk file (bit flip) and delete one manifest on one rank → restore
   degrades to recompute (invalid-block log + recompute), output equals the
   cold-path control, fresh-session control green. The null-block exclusion
   is host-suite evidence (`test_kv_offload_restore_g0.py`); live logs carry
   only counts. 2026-09-02: the worker half (fail-closed, invalid-block
   report, zero-fill) is live-receipted; the scheduler recompute half needs
   `kv_load_failure_policy="recompute"` pinned by the launcher plus
   per-boundary failure suppression.
4. **Kill-switch receipts**: `RESTORE=1` without `OFFLOAD=1` refused
   pre-stop with rc=2 and the serving container's `StartedAt` unchanged
   (live); the zero docker/ssh-call property is established by launcher stub
   tests, not the live transcript. `RESTORE=0` adds no restore arguments;
   the live capture establishes serve-argv parity only, not byte-for-byte
   runtime parity with #99.
5. **Event-channel receipt** — **PARTIAL (strengthened 2026-09-02)**: the
   overlay logs neither publish counts nor the scheduler AND, so the
   literal wording is not observable. Live-receipted instead: writers up on
   both ranks and a real boundary offered from disk with the load job
   created on BOTH ranks — per the overlay source a boundary is offered
   only after the scheduler ANDs `+` events from both ranks, so this is
   source-backed indirect evidence the cross-rank registry ANDed live.

---

Submitted by nood-co1 on behalf of Blockbrain Labs (https://x.com/blockbrain_labs, GitHub org blockbrain-ai). Measured on our 2× NVIDIA DGX Spark deployment.

