### PR TITLE
tp4: tune .env.tp4.example for promaxgb10 switch (192.168.100.x, GID3…

### DIFF
--- a/.env.tp4.example
+++ b/.env.tp4.example
@@ -6,35 +6,38 @@
 # reads this file.
 
 # --- ranks (edit these) ------------------------------------------------
-HEAD_IP=10.0.0.1
-WORKER_IP=10.0.0.2
-WORKER2_IP=10.0.0.3
-WORKER3_IP=10.0.0.4
-# Mixed OS accounts (unset = same user as the head / WORKER_USER):
-# WORKER_USER=
-# WORKER2_USER=
-# WORKER3_USER=
-# WORKER2_HOME=/home/you
-# WORKER3_HOME=/home/you
-# WORKER2_SSH=you@10.0.0.3
-# WORKER3_SSH=you@10.0.0.4
+# promaxgb10 rack (MikroTik CRS804-4DDQ, 200G forced, RoCE switch):
+#   bc60  192.168.178.41 / 192.168.100.1 (head, rank 0)
+#   6016  192.168.178.40 / 192.168.100.2 (rank 1)
+#   600c  192.168.178.72 / 192.168.100.3 (rank 2)
+#   bc55  192.168.178.70 / 192.168.100.4 (rank 3)
+HEAD_IP=192.168.100.1
+WORKER_IP=192.168.100.2
+WORKER2_IP=192.168.100.3
+WORKER3_IP=192.168.100.4
+# All nodes SSH as dejan (same user). Override only if mixed accounts:
+# WORKER_USER=dejan
+# WORKER2_USER=dejan
+# WORKER3_USER=dejan
+# WORKER2_HOME=/home/dejan
+# WORKER3_HOME=/home/dejan
+# WORKER2_SSH=dejan@192.168.100.3
+# WORKER3_SSH=dejan@192.168.100.4
 
 # --- fabric --------------------------------------------------------------
-# Four Sparks need a RoCE path among all ranks (QSFP ring on both CX7
-# ports, or a switch). NCCL cannot use the 10.0.0.x loopback aliases.
-# Per-rank pins are what the containers get.
-# Dual-port ring example (comma-separated HCAs / IFs):
-#   HEAD_CX7_IB=rocep1s0f0,rocep1s0f1
-#   HEAD_CX7_IF=enp1s0f0np0,enp1s0f1np1
+# Switched RoCE: all ranks on same L2 (enp1s0f1np1 / rocep1s0f1, 200G,
+# GID 3 = RoCE v2 ::ffff:192.168.100.x). NCCL_CROSS_NIC=1 keeps both
+# rails usable if dual-rail is later enabled.
+# Ring example would use per-rank pins; switch keeps them uniform.
 NCCL_CROSS_NIC=1
 HEAD_CX7_IF=enp1s0f1np1
 HEAD_CX7_IB=rocep1s0f1
-WORKER_CX7_IF=enp1s0f0np0
-WORKER_CX7_IB=rocep1s0f0
-WORKER2_CX7_IF=enp1s0f0np0
-WORKER2_CX7_IB=rocep1s0f0
-WORKER3_CX7_IF=enp1s0f0np0
-WORKER3_CX7_IB=rocep1s0f0
+WORKER_CX7_IF=enp1s0f1np1
+WORKER_CX7_IB=rocep1s0f1
+WORKER2_CX7_IF=enp1s0f1np1
+WORKER2_CX7_IB=rocep1s0f1
+WORKER3_CX7_IF=enp1s0f1np1
+WORKER3_CX7_IB=rocep1s0f1
 # Per-rank RoCEv2 GID (empty = NCCL_IB_GID_INDEX). Inspect:
 #   cat /sys/class/infiniband/<dev>/ports/1/gids/{0..7}
 # HEAD_GID=3


### PR DESCRIPTION
- head 192.168.100.1 bc60, workers .2/.3/.4 6016/600c/bc55
- all CX7 pins enp1s0f1np1/rocep1s0f1 (switched RoCE, 200G, GID3=RoCEv2 ::ffff)
- NCCL_CROSS_NIC=1 kept for dual-rail headroom
- keeps TP=4/NNODES=4/DFLASH_DRAFT_TP=4 from upstream
- no raw ~/models changes, assumes HF hub + image already fanned