### PR TITLE
docs: clarify deployment-specific MNBT guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,8 +100,10 @@ DFLASH_DRAFT_TP=2
 MTP_TOKENS=2
 MAX_MODEL_LEN=1000000
 MAX_NUM_SEQS=4
-# Prefill chunk. E2 one-shot keep on this 2× GB10 kit (2026-09-01): 7168.
-# 2048/3548 were similar or slower on 100k–300k. Never 8192 (indexer smem).
+# Prefill chunk. Current maintainer default at MAX_NUM_SEQS=4: 7168.
+# On an independent MAX_NUM_SEQS=16 geometry, 2048 gave the best measured
+# throughput/KV balance. Re-run 2048 vs 7168 before changing; never 8192
+# (indexer smem).
 MAX_NUM_BATCHED_TOKENS=7168
 GPU_MEM_UTIL=0.87
 KV_CACHE_DTYPE=fp8


### PR DESCRIPTION
## Summary

- align `.env.example` with the deployment-dependent MNBT guidance merged in #107
- distinguish the current `MAX_NUM_SEQS=4` maintainer default from the independent `MAX_NUM_SEQS=16` result
- replace the stale `3548` reference and retain the 8192 indexer-smem warning

This is the minimal non-overlapping part of #104; its larger README expansion is now superseded by #107.

## Validation

- `git diff --check -- .env.example`
- `python3 tests/test_numeric_config.py`
- `python3 tests/test_start_overrides.py`