### PR TITLE
feat: LONG_PREFILL_TOKEN_THRESHOLD — stop a long prefill starving every other session (440 s freeze -> 20 s)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,17 @@ MAX_NUM_SEQS=4
 # Prefill chunk. E2 one-shot keep on this 2× GB10 kit (2026-09-01): 7168.
 # 2048/3548 were similar or slower on 100k–300k. Never 8192 (indexer smem).
 MAX_NUM_BATCHED_TOKENS=7168
+# Per-step prefill cap (vLLM --long-prefill-token-threshold). 0 = stock.
+# Unset/0, ONE chunked prefill claims the whole token budget for its entire
+# duration, so a long cold prefill freezes every other session until it is done.
+# Measured on 2x GB10 TP=2, a warm 325k peer polled every 25 s while a second
+# session cold-prefilled 325k:
+#     stock (0)                     peer froze 440 s, lost its cached blocks
+#     GLM53_MIXED_PREFILL_CHUNK=0   peer froze 449 s  (the gate is NOT the cause)
+#     1024                          peer stayed 17.9-24.9 s, zero evictions
+# Cost is only paid under contention: the long prefill goes 447 -> 494 s (+10.6%);
+# a SOLO prefill is unchanged (424.9 -> 435.9 s). Must be <= MAX_NUM_BATCHED_TOKENS.
+LONG_PREFILL_TOKEN_THRESHOLD=1024
 GPU_MEM_UTIL=0.87
 KV_CACHE_DTYPE=fp8
 # 0 = load vision tower (image + video). 1 = language-only.

--- a/start.sh
+++ b/start.sh
@@ -182,6 +182,13 @@ MAX_NUM_SEQS="${MAX_NUM_SEQS:-4}"
 # 8192 chunk × long history oversubscribes GB10 persistent_topk smem (300k crash).
 # E2 one-shot 2026-09-01: 7168 keep (100k ~1148 / 300k ~1107); 2048/3548 similar or slower.
 MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-7168}"
+# Per-step prefill cap. Unset/0 = stock: one chunked prefill claims the whole
+# token budget for its entire duration, so a long cold prefill freezes every
+# other session until it finishes (measured 440 s on a warm 325k peer). 1024
+# leaves budget for other requests: the same peer stayed at 17.9-24.9 s with
+# zero evictions, costing the long prefill ~10% (447 -> 494 s) and a SOLO
+# prefill nothing (424.9 -> 435.9 s, within noise). Set 0 to restore stock.
+LONG_PREFILL_TOKEN_THRESHOLD="${LONG_PREFILL_TOKEN_THRESHOLD:-1024}"
 CHAT_TEMPLATE_HOST="${CHAT_TEMPLATE_HOST:-$SCRIPT_DIR/files/chat_template.jinja}"
 CHAT_TEMPLATE="${CHAT_TEMPLATE:-/opt/glm53/chat_template.jinja}"
 VIDEO_PATCH_HOST="${VIDEO_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm_video_placeholders.py}"
@@ -361,6 +368,15 @@ validate_numeric_config() {
     _glm53_canonical_positive_int MAX_MODEL_LEN "$MAX_MODEL_LEN" 1000000 || return
     _glm53_canonical_positive_int MAX_NUM_SEQS "$MAX_NUM_SEQS" 4096 || return
     _glm53_canonical_positive_int MAX_NUM_BATCHED_TOKENS "$MAX_NUM_BATCHED_TOKENS" 8388608 || return
+    case "${LONG_PREFILL_TOKEN_THRESHOLD-0}" in
+        ''|*[!0-9]*)
+            echo "LONG_PREFILL_TOKEN_THRESHOLD must be a base-10 integer >= 0 (0 = stock) (got: ${LONG_PREFILL_TOKEN_THRESHOLD-})" >&2
+            return 2 ;;
+    esac
+    if [ "${LONG_PREFILL_TOKEN_THRESHOLD:-0}" -gt "${MAX_NUM_BATCHED_TOKENS}" ] 2>/dev/null; then
+        echo "LONG_PREFILL_TOKEN_THRESHOLD (${LONG_PREFILL_TOKEN_THRESHOLD}) exceeds MAX_NUM_BATCHED_TOKENS (${MAX_NUM_BATCHED_TOKENS}); it would never bind" >&2
+        return 2
+    fi
     _glm53_validate_enum GLM53_INDEXER_WORKSPACE "${GLM53_INDEXER_WORKSPACE-stock}" \
         stock rightsize || return
     _glm53_validate_spinwait_ms || return
@@ -953,6 +969,7 @@ ARGS=(
 [ -n "${GPU_MEM_UTIL:-}" ]  && ARGS+=(--gpu-memory-utilization "${GPU_MEM_UTIL}")
 [ -n "${MAX_NUM_SEQS:-}" ] && ARGS+=(--max-num-seqs "${MAX_NUM_SEQS}")
 [ -n "${MAX_NUM_BATCHED_TOKENS:-}" ] && ARGS+=(--max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}")
+[ "${LONG_PREFILL_TOKEN_THRESHOLD:-0}" != "0" ] && ARGS+=(--long-prefill-token-threshold "${LONG_PREFILL_TOKEN_THRESHOLD}")
 [ -n "${KV_CACHE_DTYPE:-}" ] && ARGS+=(--kv-cache-dtype "${KV_CACHE_DTYPE}")
 if [ "${SPEC_METHOD:-mtp}" = "dflash" ]; then
     ARGS+=(--speculative-config "$(python3 -S -c 'import json,os
@@ -1051,6 +1068,7 @@ ARGS=(
 [ -n "${GPU_MEM_UTIL:-}" ]  && ARGS+=(--gpu-memory-utilization "${GPU_MEM_UTIL}")
 [ -n "${MAX_NUM_SEQS:-}" ] && ARGS+=(--max-num-seqs "${MAX_NUM_SEQS}")
 [ -n "${MAX_NUM_BATCHED_TOKENS:-}" ] && ARGS+=(--max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}")
+[ "${LONG_PREFILL_TOKEN_THRESHOLD:-0}" != "0" ] && ARGS+=(--long-prefill-token-threshold "${LONG_PREFILL_TOKEN_THRESHOLD}")
 [ -n "${KV_CACHE_DTYPE:-}" ] && ARGS+=(--kv-cache-dtype "${KV_CACHE_DTYPE}")
 if [ "${SPEC_METHOD:-mtp}" = "dflash" ]; then
     ARGS+=(--speculative-config "$(python3 -S -c 'import json,os
@@ -1212,6 +1230,7 @@ launch_cluster() {
     local v
     for v in SERVED_MODEL_NAME PORT TP NNODES HEAD_IP MASTER_PORT QUANTIZATION \
              MAX_MODEL_LEN GPU_MEM_UTIL MAX_NUM_SEQS MAX_NUM_BATCHED_TOKENS \
+             LONG_PREFILL_TOKEN_THRESHOLD \
              KV_CACHE_DTYPE MTP_TOKENS SPEC_METHOD DFLASH_TOKENS DFLASH_MODEL_DIR \
              DFLASH_DRAFT_TP \
              LANGUAGE_MODEL_ONLY SKIP_MM_PROFILING \
@@ -1294,6 +1313,7 @@ launch_cluster() {
         -e MAX_MODEL_LEN="$MAX_MODEL_LEN" -e GPU_MEM_UTIL="$GPU_MEM_UTIL" \
         -e MAX_NUM_SEQS="$MAX_NUM_SEQS" \
         -e MAX_NUM_BATCHED_TOKENS="$MAX_NUM_BATCHED_TOKENS" \
+        -e LONG_PREFILL_TOKEN_THRESHOLD="${LONG_PREFILL_TOKEN_THRESHOLD:-0}" \
         -e KV_CACHE_DTYPE="$KV_CACHE_DTYPE" -e MTP_TOKENS="$MTP_TOKENS" \
         -e SPEC_METHOD="$SPEC_METHOD" \
         -e DFLASH_TOKENS="${DFLASH_TOKENS:-7}" \


### PR DESCRIPTION
Fixes #110.

## Problem

Unset, one chunked prefill claims the **whole per-step token budget for its entire duration**, so every other session on the engine is frozen until it finishes. This is, I believe, the mechanism behind #85 ("concurrency seems totally dead… it seems to only work for 1 stream") and part of what #43, #6 and #7 each see from a different angle.

## Measurement

2× GB10, TP=2, MNBT=2048. Session A warmed to ~325k then polled with a short follow-up every 25 s; 60 s in, session B starts a cold ~325k prefill with unrelated text. Only the one knob changes between arms.

| arm | A's follow-ups during B's prefill | evictions | B's cold prefill |
|---|---|---:|---:|
| `GLM53_MIXED_PREFILL_CHUNK=skip` (default) | **froze 440.2 s** | 1 | 447.0 s |
| `GLM53_MIXED_PREFILL_CHUNK=0` (policy off) | **froze 448.9 s** | 1 | 451.9 s |
| **`--long-prefill-token-threshold 1024`** | **17.9–24.9 s** (median 19.8) | **0** | 494.2 s |

Arm 2 is the control worth noting: **the mixed-prefill gate is not the cause.** Disabling it entirely changes nothing, which is why this went unfound for a while — the gate is the obvious suspect.

Second-order effect: a request that waits also **loses its cached blocks**. Our traces show the waiting session logging a 322,560-token prefix hit repeatedly, then dropping to `computed=0`. So the symptom presents as "prefix caching is broken" when it is really "this request was never scheduled".

## Cost

| | without | with 1024 |
|---|---:|---:|
| long prefill, **contended** | 447.0 s | 494.2 s (+10.6%) |
| long prefill, **solo** | 424.9 / 432.4 s | 435.9 s (within noise) |

Paid only under contention. It is a fairness change: sessions split the budget instead of one starving another.

## Change

- `LONG_PREFILL_TOKEN_THRESHOLD`, default **1024**; `0` restores stock behaviour exactly (the flag is simply not passed).
- Validated as a non-negative base-10 integer in `validate_numeric_config`, and rejected when it exceeds `MAX_NUM_BATCHED_TOKENS`, where it could never bind.
- Threaded to **both ranks** (serve args, worker env passthrough, `docker -e`), following the `MAX_NUM_BATCHED_TOKENS` pattern.
- Documented in `.env.example` with the measurements above.

`bash -n start.sh` clean.

## On the default

I set it to 1024 because the solo-prefill cost is within noise and the contended benefit is a 440 s freeze becoming ~20 s. **Happy to flip it to `0` (opt-in) if you would rather not change default behaviour** — say the word and I will push that.

Credit: the MiaAI-Lab DeepSeek-V4-Flash DSpark recipe has shipped `--long-prefill-token-threshold 1024` for months. That is where the idea came from, after our GLM port went to production without it and stalled a real 552k agent session.

## Not tested here

TP=4 (`start-tp4.sh`) — the plumbing follows the same pattern but I have no 4-Spark kit to verify on.
