### PR TITLE
docs(tp4): dated 4-Spark measurements and corrected stall attribution

### DIFF
--- a/.env.tp4.example
+++ b/.env.tp4.example
@@ -55,3 +55,29 @@ CONTAINER_HEAD=glm53-exl3-tp4-head
 CONTAINER_WORKER=glm53-exl3-tp4-w1
 CONTAINER_WORKER2=glm53-exl3-tp4-w2
 CONTAINER_WORKER3=glm53-exl3-tp4-w3
+
+# --- serve knobs measured on a 4-Spark kit (2026-09-02) ----------------------
+# Validated on four DGX Sparks (2x 200G + 2x 100G to a CRS812 switch) with this
+# image/overlay (493cb88, then c190db1) and weights, DFlash2 draft TP=4, 1M context: 24
+# one-knob experiments, ten-minute production-mix bench after every relaunch,
+# then a 50-minute soak on the winner (188 requests, 0 errors). Receipts:
+# https://github.com/punkjazz-labs/glm-5.3-flash-exl3-4x-dgx-spark
+#   GPU_MEM_UTIL   0.85 left <1-2 GiB host memory per rank on TP=4 and preceded
+#                  two engine deaths (NVRM NV_ERR_NO_MEMORY); 0.75 keeps ~9 GiB
+#                  free, KV pool still >3M tokens, no throughput cost.
+#   MAX_NUM_SEQS   4 queues everything above four streams (84 tok/s aggregate at
+#                  8 streams, 27 s worst first token); 8 gives 135 tok/s and
+#                  1.0 s. 16 adds nothing on TP=4 (131 tok/s).
+#   DFLASH_TOKENS  3 accepts 53 % vs 30 % at 7: prose decode 31-33 vs 26-28 tok/s
+#                  single stream. 2 and 5 are worse than 3; no speculation 22.6.
+#   MAX_NUM_BATCHED_TOKENS  1024/2048/4096/8192: cold prefill on TP=4 is the same
+#                  (fabric-bound, ~1.15k tok/s at 282k), 8192 makes the first
+#                  token of a coding request 20 s under a 24k prefill. Keep 2048.
+#   GLM53_MIXED_PREFILL_CHUNK  skip makes a short question wait for the whole
+#                  running generation (330 s behind a 12k answer); off answers it
+#                  in 0.5 s and the running decode keeps ~90 % of its speed.
+GPU_MEM_UTIL=0.75
+MAX_NUM_SEQS=8
+DFLASH_TOKENS=3
+MAX_NUM_BATCHED_TOKENS=2048
+GLM53_MIXED_PREFILL_CHUNK=off

--- a/.env.tp4.example
+++ b/.env.tp4.example
@@ -76,6 +76,15 @@ CONTAINER_WORKER3=glm53-exl3-tp4-w3
 #   GLM53_MIXED_PREFILL_CHUNK  skip makes a short question wait for the whole
 #                  running generation (330 s behind a 12k answer); off answers it
 #                  in 0.5 s and the running decode keeps ~90 % of its speed.
+#   SPEC_METHOD / DFlash2 on TP=4 (2026-09-03): a 150-min soak at the 8-seq cap with
+#                  96k prompts in the mix hung the engine 3/3 times (31-78 min) with the
+#                  draft on: the 96k chunked prefill shares steps with 6-7 draft-verified
+#                  decode streams, all four ranks stop at the same forward, GPUs spin at
+#                  96 % / 21 W, vLLM dies 5 min later on "RPC call to sample_tokens timed
+#                  out". Fat-expert kernel on/off made no difference; the same soak with
+#                  the draft off passed 150 min (472 req, 0 err). Until fixed: run the
+#                  draft off on TP=4 (decode 22.6 tok/s), or keep prompts under ~64k, or
+#                  supervise the engine (a watchdog relaunch takes ~10 min).
 GPU_MEM_UTIL=0.75
 MAX_NUM_SEQS=8
 DFLASH_TOKENS=3

--- a/README.md
+++ b/README.md
@@ -439,7 +439,12 @@ at 100G, CRS812 switch), this image and overlay at 493cb88, DFlash2 draft TP=4,
 TP=4 vs the 2-node baseline on the same production-mix bench (temperature 0,
 30-min soak): decode 1.45x, mixed phases 20-35 % shorter, **cold prefill only
 +29 %** at 282k tokens (1162 vs 901 tok/s: a 4-node TP job is fabric-bound on
-prefill). The defaults above are tuned for 2 nodes; on 4 nodes an autoresearch
+prefill). One caveat found by a 150-minute soak on 2026-09-03: with the DFlash2
+draft on, a 96k chunked prefill sharing steps with 6-7 speculative decode
+streams hangs all four ranks (3/3 runs, 31-78 min; independent of the E2
+fat-expert kernel), while the same soak with the draft off passed clean, so the
+4-node production config runs without speculation until that is fixed (details
+and receipts in the linked repo). The defaults above are tuned for 2 nodes; on 4 nodes an autoresearch
 loop (one knob per relaunch, hard reliability gates) settled on the values now
 in `.env.tp4.example`: `GPU_MEM_UTIL=0.75` (0.85 left <2 GiB host memory per
 rank and preceded two engine deaths), `MAX_NUM_SEQS=8` (135 vs 84 tok/s

--- a/README.md
+++ b/README.md
@@ -433,6 +433,23 @@ and weights, does not change the supported 2× path. First run copies
 
 Do not pull `glm53-flash-sm121:v8` — that is the older NVFP4/Ray kernel.
 
+**Measured on a 4-Spark kit (2026-09-02).** Four DGX Sparks (two at 200G, two
+at 100G, CRS812 switch), this image and overlay at 493cb88, DFlash2 draft TP=4,
+1M context, launched per rank with the same `docker run` shape as `start.sh`.
+TP=4 vs the 2-node baseline on the same production-mix bench (temperature 0,
+30-min soak): decode 1.45x, mixed phases 20-35 % shorter, **cold prefill only
++29 %** at 282k tokens (1162 vs 901 tok/s: a 4-node TP job is fabric-bound on
+prefill). The defaults above are tuned for 2 nodes; on 4 nodes an autoresearch
+loop (one knob per relaunch, hard reliability gates) settled on the values now
+in `.env.tp4.example`: `GPU_MEM_UTIL=0.75` (0.85 left <2 GiB host memory per
+rank and preceded two engine deaths), `MAX_NUM_SEQS=8` (135 vs 84 tok/s
+aggregate at 8 streams, worst first token 1.0 s vs 27 s), `DFLASH_TOKENS=3`
+(53 % accepted vs 30 % at 7; prose decode 31-33 vs 26-28 tok/s),
+`MAX_NUM_BATCHED_TOKENS=2048` (larger chunks do not prefill faster on TP=4 and
+hurt first-token latency), `GLM53_MIXED_PREFILL_CHUNK=off`. Full recipe,
+launcher, watchdog, benchmark and every receipt:
+<https://github.com/punkjazz-labs/glm-5.3-flash-exl3-4x-dgx-spark>.
+
 API: `http://127.0.0.1:8888/v1` (LAN: `http://10.0.0.1:8888/v1`).
 `/v1` is unauthenticated unless you set `VLLM_API_KEY` in `.env` (opt-in;
 empty = no auth). vLLM reads the env var natively so the key never lands in


### PR DESCRIPTION
`start-tp4.sh` is marked "untested here (no 4-Spark kit)". We ran this recipe's image, overlay and weights on four DGX Sparks (two at 200G, two at 100G, CRS812 switch), DFlash2 draft TP=4, 1M context, and tuned the serve knobs with an autoresearch loop: one knob per relaunch, a ten-minute production-mix benchmark (coding + 24k tool-call mix, long generation, cold 64k prompt, 4/8-stream ladder, cancellation), a geometric-mean score against the baseline, and hard gates (contract checks, cancel drain, needle, zero errors, memory floor, no foreign traffic, GPU clocks). 24 experiments, replicates on the winner, then a 30-minute soak (195 requests, 0 errors).

This PR only adds documentation: the measured knobs and the reason for each to `.env.tp4.example` (sourced after `.env`, so nothing changes for the 2-node path), and one paragraph under "Experimental: 4× Spark". It does not touch `start-tp4.sh`.

What moved on TP=4 and why:

| knob | 2-node default | measured on 4 Sparks |
|---|---|---|
| `GPU_MEM_UTIL` | 0.87 | **0.75**: 0.85 left <1-2 GiB host memory per rank and preceded two engine deaths (NVRM `NV_ERR_NO_MEMORY`); 0.75 keeps ~9 GiB free, KV pool >3M tokens, no throughput cost |
| `MAX_NUM_SEQS` | 4 | **8**: 135 vs 84 tok/s aggregate at 8 streams, worst first token 1.0 s vs 27 s; 16 adds nothing (131) |
| `DFLASH_TOKENS` | 7 | **3**: 53 % accepted vs 30 %; prose decode 31-33 vs 26-28 tok/s; 2 and 5 worse; no speculation 22.6 |
| `MAX_NUM_BATCHED_TOKENS` | 7168 | **2048**: cold prefill on TP=4 is fabric-bound (1024-8192 all ~1.15k tok/s at 282k on 493cb88; +2-7 % at 4096/7168 with the E2 kernel), while 4096/7168/8192 push the first token of concurrent requests to 6-20 s |
| `GLM53_MIXED_PREFILL_CHUNK` | skip | **off**: with skip a short question waited 330 s behind a 12k answer; off answers it in 0.5 s and the running decode keeps ~90 % of its speed |

Also measured, in case useful for the 2-node docs: PR77's E2 kernel gives +16-18 % uncached prefill on TP=4 too (1156 → 1361 tok/s at 64k, 1162 → 1324 at 282k), replicated; `vm.swappiness=0` produced one engine death in two runs here and no gain, so we kept 60; TP=4 vs TP=2 on the same bench is 1.45x decode but only +29 % on 282k prefill.

Full recipe (node-local launcher, controller, watchdog, benchmark, autoresearch loop) and every receipt: https://github.com/punkjazz-labs/glm-5.3-flash-exl3-4x-dgx-spark

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Um6EfS81CU5BXMxYw94pkL


## Maintainer update 2026-09-15 — dated observations, corrected causality

Reviewed head `1ebad7129c77a08481d025fe7612d8ade2a3339a` updates the README and TP4-example caveat to the author’s [September 9 correction](https://github.com/MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks/pull/115#issuecomment-5599489540): disabling DFlash did not eliminate the stalls, and the subsequent packet-loss-only explanation was withdrawn after stalls reproduced with flat monitored RoCE counters. On the reported kit, an H16 sparse-attention progress failure was localized; the internal race remains unidentified. The bounded final sparse-attention call (at most 64 query rows) is the workaround reported there, not a universal root-cause claim or a fix supplied by these env knobs.

The dated knob measurements and soak observations remain author-reported historical receipts. The five measured assignment lines and their dated explanatory block are byte-identical to the original PR head, including `GLM53_MIXED_PREFILL_CHUNK=off`; the correction adds no runtime/default change relative to that head. No new soak, benchmark, GPU run or runtime change was performed. These measurements are not fresh qualification of current main or another topology.
