### PR TITLE
Fix fine-grained prefix-cache hits for hybrid GLM KV

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ same path as the compact-64 fp8 serve (not NVFP4 KV).
 | Worker | `WORKER_USER@WORKER_IP` (this kit: `zurih@10.0.0.2`), `--headless`, `glm53-exl3-worker` |
 | Fabric | CX7 QSFP: `enp1s0f1np1`/`rocep1s0f1` ↔ `enp1s0f0np0`/`rocep1s0f0`. Image NCCL (`USE_HOST_NCCL=0`) |
 | Attention | `FLASHINFER_MLA_SPARSE_SM120` (NoPE MLA padded into GLM_NSA 576-wide) |
-| KV | `--kv-cache-dtype fp8` → packed **`fp8_ds_mla`** (target). Draft DFlash2 KV is `auto`/bf16. Latest validated 7168/rightsize pool: **1,243,902** tokens / **1.24×** at 1M. `--enable-prefix-caching` (block-aligned hits; see Prefix caching) |
+| KV | `--kv-cache-dtype fp8` → packed **`fp8_ds_mla`** (target). Draft DFlash2 KV is `auto`/bf16. Latest validated 7168/rightsize pool: **1,243,902** tokens / **1.24×** at 1M. `--enable-prefix-caching` (64-token hash lookup; 3584-token physical attention pages; see Prefix caching) |
 | Experts | packed trellis + suh + svh + mcg, codebook MCG, **one fused `exllamav3_ext.exl3_moe` launch per layer** |
 | Dense / shared / attn / embed / lm_head | native (unquantized) |
 | Spec | **DFlash2 k=7** (`incoai/GLM-5.3-Flash-DFlash2`); draft KV `auto`/bf16, draft TP=2, FLASH_ATTN. Rollback `SPEC_METHOD=mtp` |
@@ -305,14 +305,15 @@ Keep **`SKIP_MM_PROFILING=1`** — a max-size image+video dummy profile OOMs thi
 **NVFP4 KV is not available here.** FlashInfer’s SM12x NVFP4 kernels are dense MHA,
 not sparse MLA. Do not confuse that with NVFP4 **weights** (`--moe-backend marlin`).
 
-## Prefix caching (this kit, 2026-08-30)
+## Prefix caching (this kit, 2026-09-04)
 
 `--enable-prefix-caching` is on. The OpenAI API is **stateless**: the client
 resends the full history each turn; vLLM hashes that prefix. Concurrent chats
 do **not** mix activations. `--max-num-seqs 4` is four **in-flight** generations,
-not four parked sessions. MLA `KpoolTailManager` disables **fine-grained**
-hits — only **block-aligned** tokens count (3584-token hybrid align).
-`KpoolTail` already opts out of the hybrid min (1-block circular scratch).
+not four parked sessions. Physical sparse-MLA attention pages remain 3584
+tokens, but reusable prefix hashes now match at the underlying **64-token**
+cache-block granularity. `KpoolTail` is 1-block circular scratch and already
+opts out of prefix caching.
 
 `dflash` is `use_eagle()`. GLM never sets `is_eagle_group` (that annotator is
 DeepseekV4-only), so stock HybridKVCacheCoordinator flagged **every** group.
@@ -323,7 +324,14 @@ does **not** let that group shrink the MLA+mamba hit. Mamba stays in the min
 (skipping a mamba miss is a correctness hole). Do not raise
 `--max-num-batched-tokens` to “fix” APC.
 
-**Historical pre-E2 receipts** (thinking off, temp 0, unique pads), 1M serve, **`MAX_NUM_BATCHED_TOKENS=2048`** (P1 keep; 3584/4096 reverted), **`DFLASH_DRAFT_TP=2`**. Idle 8k/16k/100k are the 2026-08-30 C4 keep A/B. 12k/256k/300k and the concurrent follow-ups are the prior TP=1 production ladder (chunk size does not change those hit counts). The MNBT=1024 baseline is `docs/cold-prefill.md`. Details: `docs/improve-prefill.md`.
+The same overlay also fixes the fine-grained eligibility check. Upstream
+included every manager in that check, so non-shareable `KpoolTailManager`
+vetoed 64-token lookup even though it never participates in prefix caching.
+The overlay ignores only managers whose KV spec explicitly opts out; MLA and
+Mamba still constrain the match. This changes lookup granularity, not the
+3584-token physical allocation geometry.
+
+**Historical pre-E2, pre-fine-grained receipts** (thinking off, temp 0, unique pads), 1M serve, **`MAX_NUM_BATCHED_TOKENS=2048`** (P1 keep; 3584/4096 reverted), **`DFLASH_DRAFT_TP=2`**. Idle 8k/16k/100k are the 2026-08-30 C4 keep A/B. 12k/256k/300k and the concurrent follow-ups are the prior TP=1 production ladder. The 3584-quantized hit counts below document the old behavior. The MNBT=1024 baseline is `docs/cold-prefill.md`. Details: `docs/improve-prefill.md`.
 
 | Turn | Hits | Compute | Prompt tok | TTFT | Prefill tok/s |
 |---|---:|---:|---:|---:|---:|
@@ -355,15 +363,19 @@ Re-measure (see also `tests/bench_prefix_cache.py`):
 
 ```bash
 # unique-content cold/warm pairs; hit ratio from the vllm:prefix_cache_*
-# counter deltas; hit_efficiency scores against the 3584-token page model
+# counter deltas; hit_efficiency scores against 64-token hash blocks
 python3 tests/bench_prefix_cache.py --runs 3
 ```
 
-Note the page math: hits are **block-aligned to the 3584-token hybrid MLA
-page**, so a warm prompt only ever reuses `floor(tokens / 3584) × 3584`
-tokens — the 7168 / 10752 / 14336 hit rows above are exactly 2 / 3 / 4 full
-pages. And since this build exposes **no cache-reset endpoint**, the bench
-salts its filler content per invocation so every cold is genuinely cold.
+The physical page is still 3584 tokens, while prefix hits are now rounded to
+64-token hash blocks. A 2026-09-04 direct append-only canary (44 unchanged
+tools, thinking off, private cache salt) measured a 24,208-token rendered LCP
+with **24,192 cached tokens** and 0.531 s TTFT; the old path reused 17,920 and
+needed 5.95 s on the equivalent short append. A separate 8.7k semantic pair
+returned the correct unique checksum cold and warm, with 99.44% cache hits and
+8.31 s → 1.15 s wall time. Since this build exposes **no cache-reset
+endpoint**, the bench salts its filler content per invocation so every cold is
+genuinely cold.
 
 ## Quick start (2× Spark)
 

--- a/overlay/patch_hybrid_prefix_hit.py
+++ b/overlay/patch_hybrid_prefix_hit.py
@@ -11,17 +11,23 @@ Two coordinator bugs then throw the extra block away:
 2. The DFlash2 SlidingWindow group still participates in the hybrid min.
    After an EAGLE one-block pop it re-aligns down by a full 3584-token
    scheduler page (block=64, align=3584), which can wipe a longer MLA hit.
+3. Fine-grained 64-token Mamba/MLA hits are disabled when *any* manager with
+   a wider block lacks fine-grained lookup support. That check includes
+   KpoolTailManager even though KpoolTailSpec explicitly opts out of prefix
+   caching, so one transient scratch group forces every reusable group back
+   to 3584-token hit alignment.
 
 KpoolTail already opts out of prefix caching (1-block circular scratch).
 Mamba align-mode state *does* materialize at 896-token chunk ends, and
 3584 is a multiple of 896, so mamba must stay in the min — skipping a
 mamba miss is a correctness hole (vLLM #47491 / #43090).
 
-This patch: flag only exact SlidingWindowSpec groups as EAGLE, and do not
-let that drafter group shrink ``curr_hit_length``. If the drafter window
-does not cover the MLA/mamba hit, leave its blocks empty so a fresh
-window is allocated (zeros / new pages). Wrong indexer tail state is
-fatal — we do not touch KpoolTailManager.
+This patch: flag only exact SlidingWindowSpec groups as EAGLE, do not let that
+drafter group shrink ``curr_hit_length``, and ignore non-participating cache
+groups when checking whether fine-grained lookup is safe. If the drafter
+window does not cover the MLA/mamba hit, leave its blocks empty so a fresh
+window is allocated (zeros / new pages). Wrong indexer tail state is fatal —
+we do not change KpoolTailManager or make its transient state shareable.
 
 Fail closed if the vLLM coordinator anchors drift.
 """
@@ -38,6 +44,7 @@ P = Path(
     )
 )
 MARK = "# [glm53-hybrid-apc]"
+FINE_MARK = "# [glm53-hybrid-apc-fine]"
 
 HELPER = '''
 def _glm53_inner_kv_spec(spec):
@@ -139,6 +146,27 @@ LOG_NEW = """        # Propagate the eagle bit to each manager (default to ``use
         )
 """
 
+FINE_OLD = """            unsupported_partial_hit_managers = {
+                type(manager).__name__
+                for manager in self.single_type_managers
+                if not manager.supports_fine_grained_hash_lookup
+                and manager.block_size != hash_block_size
+            }
+"""
+
+FINE_NEW = """            unsupported_partial_hit_managers = {  # [glm53-hybrid-apc-fine]
+                type(manager).__name__
+                for manager, group in zip(
+                    self.single_type_managers, kv_cache_config.kv_cache_groups
+                )
+                # A transient/non-shareable manager cannot constrain prefix-hit
+                # granularity because it never participates in the lookup.
+                if group.kv_cache_spec.participates_in_prefix_caching
+                and not manager.supports_fine_grained_hash_lookup
+                and manager.block_size != hash_block_size
+            }
+"""
+
 
 def replace_once(text: str, old: str, new: str, label: str) -> str:
     n = text.count(old)
@@ -151,19 +179,36 @@ def main() -> int:
     if not P.is_file():
         raise SystemExit(f"missing {P}")
     text = P.read_text()
-    if MARK in text:
-        print(f"{P.name}: {MARK} already present — skipping")
+    changes: list[str] = []
+
+    # The GHCR image can already contain an older revision of this overlay.
+    # Preserve the original idempotence while still allowing additive upgrades.
+    if MARK not in text:
+        needle = "def _validate_prefix_cache_retention_interval(\n"
+        if text.count(needle) != 1:
+            raise SystemExit(f"{P}: helper insert point not unique")
+        if "def _glm53_inner_kv_spec(" not in text:
+            text = text.replace(needle, HELPER + needle, 1)
+        text = replace_once(text, EAGLE_OLD, EAGLE_NEW, "eagle-fallback")
+        text = replace_once(text, MIN_OLD, MIN_NEW, "hybrid-min")
+        text = replace_once(text, LOG_OLD, LOG_NEW, "group-log")
+        changes.append("hybrid APC")
+
+    if FINE_MARK not in text:
+        text = replace_once(
+            text,
+            FINE_OLD,
+            FINE_NEW,
+            "fine-grained manager eligibility",
+        )
+        changes.append("64-token fine-grained hits")
+
+    if not changes:
+        print(f"{P.name}: {MARK} and {FINE_MARK} already present — skipping")
         return 0
-    needle = "def _validate_prefix_cache_retention_interval(\n"
-    if text.count(needle) != 1:
-        raise SystemExit(f"{P}: helper insert point not unique")
-    if "def _glm53_inner_kv_spec(" not in text:
-        text = text.replace(needle, HELPER + needle, 1)
-    text = replace_once(text, EAGLE_OLD, EAGLE_NEW, "eagle-fallback")
-    text = replace_once(text, MIN_OLD, MIN_NEW, "hybrid-min")
-    text = replace_once(text, LOG_OLD, LOG_NEW, "group-log")
+
     P.write_text(text)
-    print(f"patched {P.name} (hybrid APC: drafter SWA skipped in min, eagle on SWA only)")
+    print(f"patched {P.name} ({', '.join(changes)})")
     return 0
 
 

--- a/tests/bench_prefix_cache.py
+++ b/tests/bench_prefix_cache.py
@@ -17,14 +17,13 @@ Protocol (mirrors the kit README's prefix-caching table):
   repeated runs measure true colds instead of silently hitting the previous
   session's pages.
 
-Page granularity (IMPORTANT on this stack): the sparse-MLA KpoolTailManager
-only counts BLOCK-ALIGNED hits at the 3584-token hybrid MLA page. Hits are
-therefore `floor(tokens / 3584) * 3584` at best — a 6.8k-token conversation
-reuses ONE page (3584 tokens, ~53%), a 7.7k conversation TWO pages (~93%,
-the upstream headline). The summary reports `hit_efficiency` = measured hit
-tokens / full-page expectation so 1.0 means "the page model is respected".
-Size --prompt-tokens so the warm prompt crosses the next 3584 boundary
-(default 8400 -> ~8.1k measured tokens -> 2 pages).
+Lookup granularity (IMPORTANT on this stack): physical sparse-MLA attention
+pages remain 3584 tokens, but patch_hybrid_prefix_hit.py permits the reusable
+MLA/Mamba managers to match hashes at the underlying 64-token cache-block
+granularity. KpoolTailManager is transient and opts out of prefix caching, so
+it must not force reusable groups back to 3584-token matches. The summary
+reports `hit_efficiency` = measured hit tokens / the full-block expectation;
+1.0 means the fine-grained lookup is working.
 
 Usage:
   python3 tests/bench_prefix_cache.py --runs 3
@@ -57,8 +56,9 @@ RESULTS_DIR = Path(__file__).resolve().parents[1] / "results"
 # ~4.5 chars per token for the English filler (measured on this checkpoint's
 # tokenizer); the reported prompt_tokens comes from the server usage block.
 _CHARS_PER_TOKEN = 4.5
-# Hybrid MLA page: sparse-MLA prefix hits are block-aligned to this size.
-DEFAULT_PAGE_TOKENS = 3584
+# Hash/cache block used for fine-grained prefix lookup. The physical hybrid
+# attention page remains 3584 tokens; this is lookup, not allocation geometry.
+DEFAULT_PAGE_TOKENS = 64
 # Unique per invocation: this vLLM build offers no cache-reset endpoint, so
 # colds must not reuse pages cached by a previous bench session (observed
 # 2026-08-29: reruns reused chat content and "cold" TTFT dropped 10.3s -> 1.9s).
@@ -255,8 +255,8 @@ def run_pair(base_url: str, model: str, api_key: str, chat_index: int,
         if d_queries > 0:
             hit_ratio = round(d_hits / d_queries, 4)
 
-    # Page-model expectation: hits can only cover full 3584-token pages of the
-    # warm prompt. efficiency ~1.0 => the reuse mechanism works as designed.
+    # Lookup-block expectation: the final incomplete 64-token hash block is
+    # recomputed. efficiency ~1.0 => fine-grained reuse works as designed.
     warm_tokens = warm.get("prompt_tokens")
     hit_efficiency = None
     if hit_ratio is not None and warm_tokens:
@@ -291,10 +291,9 @@ def main() -> int:
     ap.add_argument("--runs", type=int, default=3, help="cold+warm pairs per chat")
     ap.add_argument("--concurrent", type=int, default=1, help="independent chats in flight")
     ap.add_argument("--prompt-tokens", type=int, default=8400,
-                    help="approx cold prompt size; keep the warm prompt above the "
-                         "next 3584-token page boundary (e.g. >7168) to see ~90%% hits")
+                    help="approximate cold prompt size")
     ap.add_argument("--page-tokens", type=int, default=DEFAULT_PAGE_TOKENS,
-                    help="hybrid MLA page size for the hit-efficiency model")
+                    help="prefix lookup block size for the hit-efficiency model")
     ap.add_argument("--reset-prefix-cache", action=argparse.BooleanOptionalAction, default=True,
                     help="POST /reset_prefix_cache before each cold turn (true colds)")
     ap.add_argument("--timeout", type=float, default=600.0)

--- a/tests/test_hybrid_prefix_hit.py
+++ b/tests/test_hybrid_prefix_hit.py
@@ -36,14 +36,19 @@ def main() -> int:
         env["GLM53_KV_COORDINATOR_PY"] = str(dst)
         subprocess.check_call([sys.executable, str(PATCH)], env=env)
         text = dst.read_text()
+        compile(text, str(dst), "exec")
         assert "[glm53-hybrid-apc]" in text
         assert text.count("[glm53-hybrid-apc]") >= 3
+        assert text.count("[glm53-hybrid-apc-fine]") == 1
         assert "def _glm53_is_draft_swa_spec(" in text
         assert "swa_ids or set(" in text
+        assert "for manager, group in zip(" in text
+        assert "group.kv_cache_spec.participates_in_prefix_caching" in text
         subprocess.check_call([sys.executable, str(PATCH)], env=env)
         assert dst.read_text().count("[glm53-hybrid-apc]") == text.count(
             "[glm53-hybrid-apc]"
         )
+        assert dst.read_text().count("[glm53-hybrid-apc-fine]") == 1
     print("hybrid prefix-hit patch OK")
     return 0
 


### PR DESCRIPTION
Restore 64-token prefix-cache lookup for the GLM hybrid KV layout.

`KpoolTailSpec` explicitly opts out of prefix caching, but its `KpoolTailManager` was still included when vLLM decided whether fine-grained hash lookup was safe. Because that transient manager does not support fine-grained lookup and has a wider block, it forced every reusable cache group back to the 3,584-token hybrid-page boundary.

This change excludes only KV groups whose specs explicitly set `participates_in_prefix_caching=False`.

MLA and Mamba still participate in and constrain cache matching. KpoolTail remains transient and is rebuilt normally. Physical KV allocation remains 3,584-token pages; only prefix lookup granularity changes to 64 tokens.

The patcher is also additive: it can install this fix when the published image already contains the earlier `glm53-hybrid-apc` overlay.

## Measured impact

Tested directly against a 2× DGX Spark TP=2 deployment:

- GLM-5.3 Flash EXL3
- DFlash2 `k=7`, draft TP=2
- FP8 KV
- `max_model_len=1,000,000`
- `max_num_batched_tokens=7,168`
- 44 unchanged tool definitions
- Thinking disabled
- Stable per-run cache salt
- Exact rendered-token LCP measured before every request

| Append workload | Cached before | Cached after | TTFT before | TTFT after |
|---|---:|---:|---:|---:|
| Extend a 12K prefix to 24.2K | 7,168 | 11,968 | 14.38s | 10.18s |
| Short append to a 24,208-token prefix | 17,920 | 24,192 | 5.95s | 0.53s |
| Next short append at ~24.3K | 21,504 | 24,256 | 2.88s | 0.71s |

For the closest matched short-append case:

- Cache-hit ratio: 73.7% → 99.5%
- Reusable-prefix tokens unnecessarily recomputed: 6,288 → 16
- Redundant repeat-prefill reduced by 99.75%
- TTFT reduced by 91.1%
- Time to first token improved by 11.2×

The next append showed a 75.4% TTFT reduction, or 4.1× faster.

A separate semantic long-document test retained the correct unique checksum
across the cached follow-up:

- Cold: 8.31s
- Warm: 1.15s
- Prefix-cache hit ratio: 99.44%
- Speedup: 7.24×

This PR does not claim a steady-state decode tok/s improvement. It does not touch model execution, DFlash2 sampling, decode scheduling, or KV allocation.  The improvement comes from eliminating redundant prefill before the first token.

## Correctness and safety

- Only managers whose KV specs explicitly opt out of prefix caching are ignored
  by the fine-grained eligibility check.
- MLA and Mamba remain part of the hybrid cache minimum.
- KpoolTail is not made persistent or shareable.
- Physical 3,584-token attention-page geometry is unchanged.
- Cold requests follow the same compute path.
- If upstream source anchors change, the overlay fails closed.

## Validation

- Focused patch test passed against the published Mia image.
- Patched source compiles successfully.
- Reapplying the overlay is idempotent.
- TP=2 startup and CUDA graph capture completed on both ranks.
- Built-in shape/sampler warmup: 20/20 requests passed.
- Four-request exact-LCP append-only canary passed.
- Long-document semantic cold/warm test passed.
- Both ranks remained healthy with zero restarts and no engine errors.