### PR TITLE
github: issue forms + PR template (ported from Qwen3.8 kit, adapted)

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug.md
+++ b/.github/ISSUE_TEMPLATE/1_bug.md
@@ -1,0 +1,102 @@
+---
+name: Bug report
+about: The kit is not behaving as expected, produces an error, or numbers do not match the README.
+title: ""
+labels: "bug"
+assignees: ""
+---
+
+<!-- Thank you for using this model kit!
+
+     If you are looking for support, please check the README first,
+     or reach out on X:
+      * https://x.com/MiaAI_lab
+
+     If you have found a bug, then fill out the template below.
+-->
+
+---
+
+## Environment
+
+<!-- Fill in what applies to your setup. The README's tables list every knob and its default. -->
+
+- Hardware / nodes: <!-- e.g. 2x DGX Spark (GB10, 128 GB unified memory), 4x via start-tp4.sh, ... -->
+- Interconnect: <!-- e.g. ConnectX RoCE/IB, 10GbE, ... -->
+- Image: <!-- `docker images | grep glm` — the kit image is ghcr.io/miaai-lab/glm-5.3-flash-2x-dgx-sparks:exl3 -->
+- Model (`MODEL` + `MODEL_REVISION`): <!-- e.g. Mia-AiLab/GLM-5.3-Flash-EXL3-TR3-4bpw @ 25a44fd -->
+- Served name (`SERVED_MODEL_NAME`): <!-- e.g. GLM-5.3-Flash-EXL3 -->
+- How you started the serve: <!-- e.g. ./start.sh, ./start.sh restart, ABLIT=1 ./start.sh, custom compose -->
+- Relevant settings: <!-- e.g. MAX_MODEL_LEN, MAX_NUM_SEQS, MAX_NUM_BATCHED_TOKENS, EXL3_FAT_KERNEL, SPEC_METHOD, DFLASH_DRAFT_TP, LANGUAGE_MODEL_ONLY, ABLIT -->
+
+---
+
+## Steps to Reproduce
+
+<!-- Full steps so that we can reproduce the problem. -->
+
+1. <!-- e.g. `./start.sh` — what it printed up to the failure -->
+2. ... <!-- the request or action that shows the bug -->
+3. ... <!-- e.g. "curl /v1/models returns a different served name than configured" -->
+
+**Expected results:** <!-- what did you expect to happen? -->
+
+**Actual results:** <!-- what did you actually see happen? -->
+
+---
+
+### Additional context
+
+Add anything else: a minimal failing request, JSON responses, `docker inspect` output, and so on.
+
+<details>
+<summary>Minimal reproduction sample</summary>
+
+<!--
+      If the bug is about model output or API behavior, attach a minimal reproducible
+      request below between the lines with the backticks.
+-->
+
+```bash
+curl -s http://localhost:8888/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "GLM-5.3-Flash-EXL3",
+    "messages": [{"role": "user", "content": "..."}],
+    "max_tokens": 256
+  }'
+```
+
+</details>
+
+<details>
+  <summary>Logs</summary>
+
+<!--
+      Paste the log output below between the lines with the backticks, and mention
+      whether it came from start.sh, the container logs on either node, or a client.
+
+      Common culprits worth checking before filing:
+        * Weights missing or incomplete at boot -> run ./download.sh first and check
+          the MODEL / MODEL_REVISION pins.
+        * Decode much slower than the README tables -> check MAX_NUM_BATCHED_TOKENS
+          (7168 is the validated default), DFLASH_DRAFT_TP, and whether
+          EXL3_FAT_KERNEL applied (boot log).
+        * Lower context than 1M -> do not reduce MAX_MODEL_LEN; pool size depends on
+          MNBT and graph reservations (README "Context").
+        * Vision requests rejected -> LANGUAGE_MODEL_ONLY=1 disables image/video;
+          check --limit-mm-per-prompt shape {image:4,video:1}.
+-->
+
+```
+
+```
+
+</details>
+
+<!--
+      Consider also attaching screenshots and/or videos to better illustrate the issue.
+
+      You can upload them directly on GitHub.
+      Beware that video file size is limited to 10MB.
+-->

--- a/.github/ISSUE_TEMPLATE/2_improvement.md
+++ b/.github/ISSUE_TEMPLATE/2_improvement.md
@@ -1,0 +1,86 @@
+---
+name: Improvement proposal
+about: General improvements to the kit. Anything that exists and works, but could be enhanced or optimized.
+title: ""
+labels: "enhancement"
+assignees: ""
+---
+
+<!-- Thank you for using this model kit!
+
+     If you are looking for support, please check the README first,
+     or reach out on X:
+      * https://x.com/MiaAI_lab
+
+     If you think something can be improved, then fill out the template below.
+-->
+
+---
+
+## Improvement description
+
+<!--
+      What is it that you think can be improved? Give a clear explanation of what
+      element can be done better and how the kit can benefit from it.
+
+      Examples that fit this repo: better KV pool / concurrency defaults, faster
+      startup, safer start.sh validation, clearer docs, a script to re-measure
+      performance after changing knobs, a benchmark harness, changes to the
+      download -> boot -> warmup pipeline, the EXL3 kernel/overlay approach,
+      draft (DFlash2) configuration and acceptance measurement, the two-node
+      TP=2 / four-node TP=4 orchestration, and so on.
+-->
+
+---
+
+### Additional context
+
+Add any other context here: code snippets, measured numbers (e.g. TTFT / decode throughput before and after), log excerpts, screenshots, and so on.
+
+<details>
+<summary>Code sample</summary>
+
+<!--
+      Attach a minimal code sample that demonstrates the improvement you have in mind,
+      below between the lines with the backticks.
+-->
+
+```bash
+
+```
+
+</details>
+
+<details>
+  <summary>Logs / measurements</summary>
+
+<!--
+      Paste any measured numbers or log output below between the lines with the
+      backticks, so the benefit of the change can be evaluated.
+-->
+
+```
+
+```
+
+</details>
+
+<details>
+  <summary>Screenshots</summary>
+
+<!--
+      Consider also attaching screenshots and/or videos to better illustrate the issue.
+
+      You can upload them directly on GitHub.
+      Beware that video file size is limited to 10MB.
+-->
+
+```
+
+```
+
+</details>
+
+<!--
+      Include any additional resource that doesn't fit the categories previously listed.
+-->

--- a/.github/ISSUE_TEMPLATE/3_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/3_feature_request.md
@@ -1,0 +1,47 @@
+---
+name: Feature request
+about: Suggest a new idea for this kit. Something that doesn't exist currently, and you want to see.
+title: ""
+labels: "enhancement"
+assignees: ""
+---
+
+<!-- Thank you for using this model kit!
+
+     If you are looking for support, please check the README first,
+     or reach out on X:
+      * https://x.com/MiaAI_lab
+
+     If you want the kit to do something it currently doesn't, then fill out the
+     template below.
+-->
+
+## Use case
+
+<!--
+     Please tell us the challenge you are running into that led to you wanting
+     a new feature, or the workload you are trying to serve.
+
+     Examples that could fit this repo: single-node mode, an OpenAI-compatible
+     client example, a benchmark script, a systemd unit or compose file, support
+     for a different cluster topology, a new measured-knob experiment (with the
+     before/after numbers), a lint/validate step in CI, and so on.
+
+     Describe the alternative solutions you've considered.
+-->
+
+## Proposal
+
+<!--
+     Briefly but precisely describe what you would like this kit to be able to do.
+
+     Consider attaching something showing what you are imagining:
+      * images
+      * videos
+      * code samples
+      * a benchmark result or log you are trying to reproduce
+
+     Does this have to be provided by this kit directly, or can it be a small
+     user-land script? If the latter, maybe consider implementing and sharing it
+     with us in a pull request rather than filing an issue.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: I want help using this model kit on my own hardware.
+    url: https://x.com/MiaAI_lab
+    about: Ask questions about setting this up on a different cluster, or about how a particular piece of this kit works.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,62 @@
+## Description and Motivation
+
+<!--
+
+    Please write a description of what this PR is changing, removing or adding, and why.
+    Consider including before/after comparisons.
+
+    For this kit, a good description usually covers:
+      * which knob, default, script behavior, overlay or kernel path changes
+      * whether the change affects measured numbers (KV pool, TTFT / cold prefill,
+        decode throughput, draft acceptance, concurrency) and, if so, the expected
+        direction
+      * why the change is safe on both nodes of the two-node TP=2 lane
+      * for measurement claims: the exact protocol (prompts, concurrency, medians)
+
+-->
+
+## Related Issues
+
+<!--
+
+    Add the list of issues related to this PR from the issue tracker.
+    Indicate which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.
+
+-->
+
+---
+
+## Testing
+
+<!--
+
+    Tell us how you verified this change. For this kit that usually means:
+
+      * `bash -n start.sh stop.sh download.sh` (syntax check) for script changes
+      * an actual boot on the cluster with the change, and the resulting boot-log
+        facts (pool size, kernel applied, capture sizes)
+      * if behavior changed, the measured numbers with the new settings in the
+        README's format (e.g. tests/bench_decode.py median-of-5, or the
+        cold-prefill table from docs/cold-prefill.md)
+      * draft-behavior changes: an acceptance measurement, not just tok/s
+
+-->
+
+---
+
+## Checklist:
+
+<!--
+
+    Thanks for contributing to Mia's AI Lab!
+
+    Before you file this pull request, please follow the items on this checklist and
+    put an x in each of the boxes, like this: [x].
+
+-->
+
+- [ ] I have read the README and kept my changes consistent with it.
+- [ ] My pull request has a sound title and description (not something vague like `Update README.md`).
+- [ ] My change is reproducible and verified (a boot and, for behavior changes, measurements).
+- [ ] Defaults still work out of the box; a new knob has a sane fallback consistent with the existing ones.
+- [ ] I updated the README (and docs/ where relevant) for any knob, default, or measured number I changed.


### PR DESCRIPTION
## What

Same template set as MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark#219, adapted to this kit:

- `.github/ISSUE_TEMPLATE/1_bug.md` — environment block (nodes/interconnect, kit image, `MODEL` + `MODEL_REVISION` pin, served name, start path, relevant settings: `MAX_MODEL_LEN` / `MAX_NUM_SEQS` / `MAX_NUM_BATCHED_TOKENS` / `EXL3_FAT_KERNEL` / `SPEC_METHOD` / `DFLASH_DRAFT_TP` / `LANGUAGE_MODEL_ONLY` / `ABLIT`), repro steps, expected/actual, minimal-repro curl, and kit-specific common culprits (weights download/pins, MNBT 7168 vs decode speed, `MAX_MODEL_LEN` vs pool, vision gating).
- `2_improvement.md` / `3_feature_request.md` — light adaptations.
- `config.yml` — blank issues disabled so new issues must pick a form; same X contact link.
- `.github/PULL_REQUEST_TEMPLATE.md` — testing section mapped to this kit (`bash -n`, boot-log facts, README-format measurements, acceptance measurement for draft changes).

No code, no runtime behavior. Merging makes the forms live for new issues/PRs.
