### PR TITLE
APC: opt-in per-group retention, draft eviction priority, and safe DFlash replay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -229,3 +229,9 @@ NCCL_IB_GID_INDEX=3
 # still enabled. 1 = upstream default.
 CG_ESTIMATE=1
 NCCL_DEBUG=WARN
+
+# Per-group APC retention for the DFlash2 drafter SWA group. Empty inherits the
+# global policy; 0 keeps reachable boundaries only; N must be a multiple of
+# 3584. The global interval (VLLM_PREFIX_CACHE_RETENTION_INTERVAL) stays unset.
+# TP=2 only; start-tp4.sh rejects a non-empty value.
+GLM53_APC_RETENTION_INTERVAL_SWA=

--- a/.env.example
+++ b/.env.example
@@ -232,6 +232,6 @@ NCCL_DEBUG=WARN
 
 # Per-group APC retention for the DFlash2 drafter SWA group. Empty inherits the
 # global policy; 0 keeps reachable boundaries only; N must be a multiple of
-# 3584. The global interval (VLLM_PREFIX_CACHE_RETENTION_INTERVAL) stays unset.
+# 3584. Leave the global launcher knob GLM53_APC_RETENTION_INTERVAL unset.
 # TP=2 only; start-tp4.sh rejects a non-empty value.
 GLM53_APC_RETENTION_INTERVAL_SWA=

--- a/Dockerfile
+++ b/Dockerfile
@@ -451,6 +451,8 @@ COPY tests/test_suppress_stops.py /opt/glm53/test_suppress_stops.py
 COPY overlay/patch_scheduler_decode_floor.py /opt/glm53/patch_scheduler_decode_floor.py
 COPY tests/test_scheduler_decode_floor.py /opt/glm53/test_scheduler_decode_floor.py
 COPY overlay/patch_hybrid_prefix_hit.py /opt/glm53/patch_hybrid_prefix_hit.py
+COPY overlay/patch_apc_per_group_retention.py /opt/glm53/patch_apc_per_group_retention.py
+COPY tests/test_apc_per_group_retention.py /opt/glm53/test_apc_per_group_retention.py
 COPY tests/test_hybrid_prefix_hit.py /opt/glm53/test_hybrid_prefix_hit.py
 COPY overlay/patch_xgrammar_termination.py /opt/glm53/patch_xgrammar_termination.py
 COPY tests/test_xgrammar_termination.py /opt/glm53/test_xgrammar_termination.py
@@ -470,7 +472,10 @@ RUN python3 /opt/glm53/patch_glm_eagle3.py
 RUN python3 /opt/glm53/patch_glm5_drafter_group.py
 RUN python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
 RUN python3 /opt/glm53/patch_scheduler_decode_floor.py
+RUN GLM53_KV_COORDINATOR_PY_SRC=/usr/local/lib/python3.12/dist-packages/vllm/v1/core/kv_cache_coordinator.py \
+    python3 /opt/glm53/test_apc_per_group_retention.py
 RUN python3 /opt/glm53/patch_hybrid_prefix_hit.py
+RUN python3 /opt/glm53/patch_apc_per_group_retention.py
 RUN python3 /opt/glm53/patch_xgrammar_termination.py
 RUN python3 /opt/glm53/patch_kpool_tail_slotmap.py
 # Applied unconditionally; the injected sizing reads GLM53_INDEXER_WORKSPACE

--- a/README.md
+++ b/README.md
@@ -463,6 +463,9 @@ took 112.49 s instead of 14.70 s, and a branch at 90% took 99.89 s instead of
 111,104. All tested answers were correct. These are sequential histories,
 not four simultaneously active 210K streams.
 
+The global launcher spelling is `GLM53_APC_RETENTION_INTERVAL` (TP=2 only).
+Leave it unset for normal use; TP=4 rejects either retention override.
+
 Both retention knobs remain unset by default. Keep that default unless the
 tradeoff fits the workload. SWA-only sparse retention with a dense target is
 a separate configuration; the all-zero results do not qualify it. See the

--- a/README.md
+++ b/README.md
@@ -445,6 +445,30 @@ tokens — the 7168 / 10752 / 14336 hit rows above are exactly 2 / 3 / 4 full
 pages. And since this build exposes **no cache-reset endpoint**, the bench
 salts its filler content per invocation so every cold is genuinely cold.
 
+### Optional sparse retention and DFlash replay
+
+`GLM53_APC_RETENTION_INTERVAL_SWA` controls the DFlash2 drafter separately
+from target retention. Empty inherits the global retention policy and keeps
+ordinary eviction priority. Explicit `0` retains reachable drafter boundaries
+and makes cached draft-only blocks lower priority than target cache blocks.
+Sparse target Mamba state also retains the prior replay boundary; a cached
+DFlash window is reused only after successful EAGLE verification, otherwise
+the request backs up to rebuild its window.
+
+**Sparse retention is not a general performance upgrade.** On one 2× Spark
+deployment, explicit global/SWA `0/0` retained four independent 210K histories
+for ~2.5 s revisits. In a matched 128K comparison, however, an edit at 90%
+took 112.49 s instead of 14.70 s, and a branch at 90% took 99.89 s instead of
+3.35 s: the sparse policy reused zero tokens where the old runtime reused
+111,104. All tested answers were correct. These are sequential histories,
+not four simultaneously active 210K streams.
+
+Both retention knobs remain unset by default. Keep that default unless the
+tradeoff fits the workload. SWA-only sparse retention with a dense target is
+a separate configuration; the all-zero results do not qualify it. See the
+[protocol, raw measurements, and limitations](docs/apc-retention-qualification.md)
+before selecting a policy or a cache budget for another kit.
+
 ## Quick start (2× Spark)
 
 ```bash
@@ -577,7 +601,7 @@ word lands at char 39 of the prompt, so changing it is a full prefix-cache miss
 on an otherwise-warm conversation, not a partial one.
 `tests/test_chat_template.py` pins that shape.
 
-Needs: Docker (no sudo) on both nodes, passwordless SSH head → worker,
+Needs: Docker (no sudo) on both nodes, python3 with Jinja2 on the head (verifies mounted inputs before `restart` stops anything), passwordless SSH head → worker,
 `hf` / `huggingface-cli` + `curl` + `rsync` on the head, ~180 GiB free per
 node for the first download. The GHCR image is public; login is only needed
 if you hit anonymous pull rate limits (`GHCR_TOKEN` + `GHCR_USER`).
@@ -652,6 +676,7 @@ that are now documented/enforced:
 | `MAX_MODEL_LEN` | `850000` | default context since 2026-09-07 (E3 default; 1M fits again with `EXL3_FAT_GROUPED=0`). 1M allocates on the 1.75M padded-slot-share pool. Do not drop to 256k to “free” KV — logged tokens ≈ concurrency × this cap; hybrid block-id overhead then shrinks the pool. At MNBT 7168 one 1M request needs **14.52 GiB** KV (10.98 GiB at 500k; ~7.4 GiB fixed + 7.1 GiB per 1M); the E3 recipe runs 500k |
 | `GPU_MEM_UTIL` | `0.85` | GB10 UMA budget (default lowered from 0.87 on 2026-09-07: each 0.01 is 1.2 GiB of host headroom, and long prefills need it — see *Cold prefill (E3)*). E3 at 900k / 0.85: pool ~1.05M tokens / 1.17× (0.87: 16.2 GiB / 1,051,648 tokens). Pre-E3 receipts at 1M / 0.87: 1,754,237 tokens / 18.67 GiB (MNBT 2048); 1,243,902 tokens / 1.24× (7168, rightsize, E2) |
 | `KV_CACHE_DTYPE` | `fp8` | packed `fp8_ds_mla`; not `nvfp4`, not bf16 |
+| `GLM53_APC_RETENTION_INTERVAL_SWA` | *(unset)* | TP=2 DFlash2 drafter retention. Empty inherits global retention with ordinary priority; explicit `0` keeps reachable boundaries and enables draft-only eviction priority; positive values must be multiples of 3584, at most 1,000,000. Requires `SPEC_METHOD=dflash` and the hybrid prefix overlay. TP=4 rejects a non-empty value. Qualify retention, branching, and draft acceptance for the chosen global/SWA pair; see [measurements](docs/apc-retention-qualification.md) |
 | `GLM53_MIXED_PREFILL_CHUNK` | `skip` | do not mix a peer prefill into a decode step (issue #6). `N>0` = cap tokens; `0` = off. Solo prefill stays MNBT (7168) |
 | `GLM53_SUPPRESS_STOPS_IN_REASONING` | `1` | ignore client `stop` strings until `</think>` (thinking-on default) |
 | `GLM53_DEFAULT_REASONING_EFFORT` | *(empty)* | `low` / `high` / `max` via `--default-chat-template-kwargs` on both ranks. Empty sends no flag, so omitted effort renders Max. Per-request `chat_template_kwargs.reasoning_effort` overrides the default; `medium` is rejected because the template maps it to Max |
@@ -689,6 +714,8 @@ After CUDA compile, Python overlay edits (`overlay/exl3.py`, tests) are a cheap 
 | `overlay/patch_exl3_ext_aarch64.py` | stub AVX CPU allreduce so the ext builds on GB10 |
 | `overlay/patch_model_overrides.py` | `"exl3"` in ModelConfig overrides |
 | `tests/test_exl3_overlay.py` | registry, TP shard, `sm_121a` cubin, fused vs loop GEMM, `EXL3_FUSED_MOE=0`, E2 diag schema, E3 grouped tables/parity/graph-replay/fallback checks |
+| `tests/test_apc_per_group_retention.py` | host: overlay apply/idempotence, min-exemption derivation, routing, env validation, composition with `patch_hybrid_prefix_hit.py` in both orders, id-cost/capacity arithmetic (needs `GLM53_KV_COORDINATOR_PY_SRC` + `_PRISTINE` copies of the fork's coordinator) |
+| `tests/test_launcher_rank_parity.py` | launcher (CPU-only, docker/ssh stubbed): retention validation, pre-stop artifact checks, ordered hybrid/per-group overlays, and matching rank environments and mounts |
 | `tests/bench_decode.py` | streaming decode + coherence; `--structured` is the count-1→200 median |
 | `tests/test_start_overrides.py` | CPU-only caller precedence: `.env` keys, empty exports, shell assignments, and child inheritance |
 | `start.sh` / `stop.sh` / `download.sh` | 2-node launch; Hub fetch on the head only |

--- a/docs/DESIGN-apc-per-group-retention.md
+++ b/docs/DESIGN-apc-per-group-retention.md
@@ -431,7 +431,7 @@ MARK/anchor, matching `overlay/patch_hybrid_prefix_hit.py`.
 * Depends on `_glm53_is_draft_swa_spec` / `_glm53_inner_kv_spec` (`C:33-43`); inserts them if the hybrid
   patch has not run, so ordering between the two overlays does not matter. Asserted, not assumed: the
   host test applies both overlays to a **pristine** copy in both orders and checks that they succeed, are
-  idempotent under re-application in any order, and produce **byte-identical** files (§8.1).
+  byte-idempotent under re-application, and produce **AST-equivalent** files across orders (§8.1).
 * Launcher wiring (`start.sh:1080-1085`, already on this branch):
   `GLM53_APC_RETENTION_INTERVAL_SWA` → `VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA`, accepted
   values `""` (inherit the global policy), `0`, or a positive multiple of 3584 ≤ 1,000,000 (largest legal value
@@ -483,7 +483,7 @@ Runs anywhere with a copy of `kv_cache_coordinator.py`; no GPU, no vLLM import.
    `_glm53_is_draft_swa_spec` exactly once, add `import os` exactly once, survive re-application of
    either patch in either order byte-identically, retain Mia's hybrid-`min()` skip and
    `eagle_group_ids` narrowing, resolve the live layout to `[None,…,None,0]` — and the two orders must
-   produce **byte-identical** output.
+   produce **AST-equivalent** output.
 8. **Id-cost + capacity arithmetic** (§2, §4.1) against a pure-Python replica of the two
    `reachable_block_mask` formulas (dense 33/56; `R=14336` 33/224; boundary tail 33), and the §4.1
    formula evaluated for all five rows — `14 / 23 / 42 / 72 / 54` — so the doc's table and the test

--- a/docs/DESIGN-apc-per-group-retention.md
+++ b/docs/DESIGN-apc-per-group-retention.md
@@ -1,0 +1,615 @@
+# DESIGN — per-group prefix-cache retention: stop the DFlash2 drafter from evicting the KV cache
+
+Train: root-cause code fix for prefix-cache eviction by the DFlash2 drafter's cache blocks, and per-group retention.
+Status: **design + unapplied overlay patch + host test + live test plan.** Nothing was written into the container;
+all source facts below are read-only reads of the live fork.
+Revision 2 (2026-08-31): incorporates the adversarial review in `research-2026-08-31/CODEX-drafter-retention.md`
+— one explicit capacity formula (§4.1), unconditional SWA env validation and a min-exemption-derived,
+fail-closed override (§5.2), the resolved-vector boot log as the deployment acceptance criterion (§7, L1),
+overlay-composition coverage (§8.1.7), and the divergence-suffix / acceptance-rate gate L5a (§8.2).
+
+Source paths (in the container, `glm53-exl3-head`, `/usr/local/lib/python3.12/dist-packages/vllm/`):
+
+| tag | file |
+|---|---|
+| `C` | `v1/core/kv_cache_coordinator.py` |
+| `S` | `v1/core/single_type_kv_cache_manager.py` |
+| `B` | `v1/core/block_pool.py` |
+| `M` | `v1/core/kv_cache_manager.py` |
+| `U` | `v1/core/kv_cache_utils.py` |
+| `I` | `v1/kv_cache_interface.py` |
+
+Every claim below is either a `file:line` citation or explicitly marked **[inference]**.
+
+---
+
+## 1. The live group layout
+
+Boot log (`deb8:/home/blockbrain/glm-restart-sweep-28672.log`, 08-31 13:16:09, emitted by `C:709`):
+
+```
+hybrid APC groups: [('MLAAttentionSpec', [0], 'FullAttentionManager', False),
+                    ('MambaSpec', [2, 3, 4, 5], 'MambaManager', False),
+                    ('SlidingWindowSpec', [6], 'SlidingWindowManager', True)];
+eagle_group_ids=[6]
+```
+
+Seven KV-cache groups, one `BlockPool` with **globally unique block ids** (`U:941-946`, `B:174-181`):
+
+| gid | spec | manager | block_size | in `attention_groups`? | eagle |
+|---|---|---|---|---|---|
+| 0 | `UniformTypeKVCacheSpecs` of 11 `MLAAttentionSpec` (`compress_ratio==1`) + 11 indexer (`compress_ratio>1`) | `FullAttentionManager` | 3584 | yes | no |
+| 1 | `KpoolTailSpec` | `KpoolTailManager` | kpool | **no** — `participates_in_prefix_caching=False` (`I:775-786`), skipped at `C:664-665` | – |
+| 2–5 | `MambaSpec`, `mamba_cache_mode="align"`, padded to `mla_page` | `MambaManager` | 3584 | yes | no |
+| 6 | `SlidingWindowSpec` **exact type**, window 2048, `block_size=64`, `page_size_padded=mla_page` (`U:1533-1552`) | `SlidingWindowManager` | 64 | yes | **yes** |
+
+The drafter group is created by `_get_kv_cache_groups_glm5_next` on the **PADDED SLOT-SHARE** branch
+(`U:1519-1552`, boot line `U:1549`: `padded slot-share block=64 mla_page=2351104 … draft_bytes/token=2048`).
+Because `page_size_bytes` returns the *padded* page, `draft_shared = draft_page == mla_page` is true
+(`U:1777-1780`), so the drafter adds **zero bytes** per pool block but **one full-MLA-page-priced block id**
+per 64 drafter tokens. That asymmetry is the whole bug.
+
+`eagle_group_ids=[6]` and the drafter's exemption from the hybrid `min()` both come from Mia's overlay
+(`C:121-133`, `C:856-868` — `overlay/patch_hybrid_prefix_hit.py`).
+
+---
+
+## 2. Exact per-group id cost of one cached 3584-token segment
+
+`scheduler_block_size = 3584`; fine-grained hash hits are **off** (`C:635` boot warning: "Disabling
+fine-grained prefix-cache hits because these KV cache managers require block-aligned lookups:
+KpoolTailManager"), so `_cache_hit_alignment_tokens == scheduler_block_size == 3584` (`C:643-651`).
+
+Which blocks get hashed is decided by `reachable_block_mask` → `block_mask` → `BlockPool.cache_full_blocks`,
+which skips masked-out and null blocks (`S:429-476`, `B:275-277`).
+
+### 2.1 MLA group (gid 0)
+
+`FullAttentionManager` does not override `reachable_block_mask`; the base returns `None` = "cache every
+non-null block" (`S:482-500`). Block size 3584 ⇒ **1 id per 3584-token segment, always, retention has no
+effect** (this is deliberate: full attention must keep the fine hit granularity, `C:52-56`).
+
+### 2.2 Mamba groups (gid 2–5)
+
+`MambaManager.reachable_block_mask` (`S:1487-1542`):
+* `retention_interval is None` → early `return None` (`S:1509-1511`) ⇒ dense ⇒ **1 id per group per segment = 4 ids**.
+* `retention_interval == R > 0` → `per_segment = R // 3584`, one state kept per segment (`S:1520-1533`)
+  ⇒ **4 · 3584/R ids per 3584 tokens**.
+* Plus one state per group at each `reachable_boundary` (`S:1534-1541`).
+
+### 2.3 Drafter SWA group (gid 6) — the flood
+
+`SlidingWindowManager.reachable_block_mask` (`S:998-1057`):
+
+```
+need  = _contiguous_blocks_for_hit(2048, 64, use_eagle=True)      # S:886-895
+      = cdiv(2048-1, 64) + 1 = 32 + 1 = 33
+shift = 1                                                          # S:1024 (use_eagle)
+segment_tokens = alignment_tokens = 3584   when retention_interval is None   # S:1032-1037
+per_segment    = 3584 // 64 = 56                                   # S:1039
+mask[i] = (i >= 1) and ((i - 1) % 56) >= 56 - 33 == 23             # S:1044-1046
+```
+
+⇒ **33 of every 56 drafter blocks per 3584-token segment are hashed.** With `retention_interval = R`:
+`per_segment = R // 64`, still `need = 33` ⇒ **33 ids per R tokens = 33 · 3584/R per segment**, plus a
+33-block tail at every `reachable_boundary` (`S:1048-1056`).
+
+All 33 masked blocks really are live (not yet nulled) when `cache_blocks` runs. Order inside
+`KVCacheManager.allocate_slots` is `remove_skipped_blocks` → allocate → `cache_blocks` (`M:495-508`, `M:564`);
+`remove_skipped_blocks` frees below `processed - window + 1` (`S:663-675`, `S:624-661`) while the mask covers
+tokens `[B-2048, B+64)` for boundary `B` — i.e. exactly the surviving window. **[inference, from the two
+formulas; not separately instrumented.]**
+
+### 2.4 Kpool tail (gid 1)
+
+`KpoolTailManager.cache_blocks` is a hard `return` (`S:1135-1142`) and `remove_skipped_blocks`/`find_longest_cache_hit`
+are no-ops (`S:1147-1160`, `S:1119-1133`) ⇒ **0 ids cached, 1 live block per request** (`I:770-777`).
+
+### 2.5 Summary table
+
+| group | ids per cached 3584-token segment (dense) | at retention `R` |
+|---|---:|---|
+| 0 MLA (+indexer) | **1** | 1 (unchanged — `reachable_block_mask` returns `None`) |
+| 1 kpool tail | 0 | 0 |
+| 2–5 mamba ×4 | **4** | 4·3584/R |
+| 6 drafter SWA | **33** | 33·3584/R |
+| **total** | **38** | 1 + 37·3584/R |
+
+**Dense: one block id burned per 94 tokens of conversation, 87 % of them by a drafter group that is
+exempted from the hybrid hit and therefore contributes nothing to hit length.**
+
+At the current default `R = 14336`: 1 + 1 + 8.25 = **10.25 ids / 3584 tokens**.
+At `R = 7168`: 1 + 2 + 16.5 = **19.5**. At `R = 28672`: 1 + 0.5 + 4.125 = **5.625**.
+
+Per *turn* (per `reachable_boundary`, `S:1048-1056` / `S:1534-1541`) a group with a
+**non-`None`** retention interval also pins a tail: 33 drafter + 4 mamba = **37 ids**.
+A dense group (`retention is None`) has no separate boundary tail — its mask is `None`,
+so those blocks are already counted in the per-segment number. In the proposed mode
+mamba/MLA are dense and only the drafter has a boundary tail, so the per-turn cost is
+**33**, not 37.
+
+**Do boundary tails overlap the periodically retained blocks?** They can: when a
+`reachable_boundary` happens to land on a multiple of `R`, the pinned tail *is* the
+periodic tail and the two counts are the same blocks. The model below adds them, so it
+over-counts `C` in that case (a *conservative* error) and under-counts nowhere. It is
+not modelled per-boundary because the boundary positions depend on
+`request.num_prompt_tokens`, which varies per turn. **[inference — not instrumented.]**
+
+---
+
+## 3. Pool size
+
+`num_blocks = available_memory // per_block` where `per_block = 11·mla_page + 11·idx_page`
+(`U:1789-1794`, mirrored by `U:982-1004`); the drafter is slot-shared so it adds no bytes
+(`U:1777-1780`, `U:996-1002`). `mla_page = 2,351,104 = 3584 × 656` — the `fp8_ds_mla` V3.2 layout
+(`I:443-445`). Boot: `Available KV cache memory: 16.75 GiB` (this evening's boots range 16.4–17.09 GiB).
+
+The pool size is not logged. Derive it from the logged capacity line
+(`GPU KV cache size: 1,553,140 tokens, Maximum concurrency for 1,000,000 tokens per request: 1.55x`,
+emitted at `U:2297`, value = `int(max_concurrency × max_model_len)`, `U:2260-2266`), with
+`max_concurrency = num_blocks / num_blocks_per_request` and both terms integers (`U:937-956`):
+
+```
+max_concurrency ∈ [1.553140, 1.553141)
+physical bound:  num_blocks ≤ 17.99e9 / (11 × 2,351,104) = 695   (idx_page > 0)
+unique integer solution in range:  num_blocks = 643,  num_blocks_per_request = 414
+```
+
+**Pool = 643 block ids; 642 usable** (id 0 is the null block, `B:190-191`; `get_usage` divides by
+`num_gpu_blocks - 1`, `B:808-819`). Implied `idx_page ≈ 191 kB ≈ 53 B/token/layer. **[inference —
+the derivation is exact given 11 MLA layers, but `idx_page` was not read from the model config.]**
+
+`num_blocks_per_request = 414` decomposes as 280 (`cdiv(1e6, 3584)` MLA) + 1 (kpool tail, `I:770-777`)
++ 4 mamba groups (`I:812-821`, align ⇒ `2 + num_speculative_blocks` pages each) + drafter
+(`I:617-647`, `cdiv(min(2047 + max_in_flight_tokens, max_model_len), 64) + 1`). **[inference — the exact
+split depends on `max_in_flight_tokens`, which is not logged; the total 414 is the derived quantity.]**
+
+---
+
+## 4. Reconciling the measured thresholds (14 segments OK / 17 fail, dense)
+
+The failure is not "too many ids" alone — it is **LRU position**. `BlockPool.free_blocks` (`B:719-743`):
+
+```python
+if block.block_hash is None or not self.enable_caching:
+    blocks_to_evict_first.append(block)   # -> prepend_n : LIFO front, reused immediately
+else:
+    blocks_to_evict_last.append(block)    # -> append_n  : LRU tail, evicted last
+```
+
+and `get_new_blocks` pops from the **front** (`B:647-677`), evicting whatever hash the popped block holds
+(`B:679-700`).
+
+Timeline for a conversation A of `S` segments:
+
+* Its drafter blocks are freed **progressively during prefill** by
+  `SlidingWindowManager.remove_skipped_blocks` → `_remove_blocks_in_range` → `free_blocks`
+  (`S:624-661`, `S:597-622`). The 33 masked ones are **hashed** ⇒ appended to the LRU tail; the other 23
+  per segment are unhashed ⇒ prepended to the front and immediately recycled.
+* Its MLA and mamba blocks are freed only when the request completes, `KVCacheManager.free` →
+  `coordinator.free` → per-manager `free` in group order (`S:521-530`), i.e. **behind** all of A's
+  mid-prefill drafter frees in the queue.
+
+So the queue after A finishes is, front → back:
+`[A drafter, hashed, oldest first] … [A MLA] [A mamba] [A drafter window]`.
+
+Conversation B then prefills. Per segment B makes 38 "deep" pops (its own 23 unhashed drafter blocks
+recycle from the front for free). A's MLA/mamba survive iff
+
+```
+free_at_B_start  +  A's_drafter_cache   ≥   B's_deep_pops
+(642 − 38·S)     +      33·S            ≥       38·S
+                       642 ≥ 43·S   ⇒   S ≤ 14.9 segments per conversation
+```
+
+**Measured (runbook A6, clean server, dense): 14 segments OK, 17 fail; 45K (12 seg) 99 %, 56K (15 seg) 0 %,
+66K (18 seg) 0 %.** The predicted knee sits between 14 and 15.
+
+The measured knee is **consistent with** `num_blocks = 643`, not a proof of it. The two were computed
+from disjoint evidence, which is worth something — but `642 ≥ 43·S` only pins the pool to the range
+that puts the knee in `[14, 15)`, i.e. `602 ≤ pool_usable < 645`. Any pool in that band reproduces the
+observation. The `num_blocks = 643` value comes from §3's `max_concurrency` derivation alone.
+
+### 4.1 The capacity formula (one formula, all rows)
+
+Let a conversation of `S` cached 3584-token segments and `t` turn boundaries cache
+
+```
+C = c·S + b·t          ids in total
+D = d·S + b_d·t        of which the drafter's share
+```
+
+`c`/`d` are the per-segment costs of §2.5, `b`/`b_d` the per-turn boundary tails (0 for a dense group).
+The drafter's ids are freed **cached, mid-prefill**, so by the time the next conversation B prefills they
+are already parked on the protected LRU tail; A's MLA/mamba blocks are freed later and sit ahead of them
+(the timeline above). A survives B iff the free pool plus A's drafter cache covers B's deep pops:
+
+```
+(P − C) + D  ≥  C            ⇔        P ≥ 2C − D
+
+                    P − (2b − b_d)·t
+        ⇒   S  ≤   ───────────────────           P = 642 usable ids
+                        2c − d
+```
+
+With `t = 3` turns (`floor` of the bound; the table's `2b − b_d` is 0 dense, 41 for any `R > 0`
+(`2·37 − 33`), 33 for the proposed mode (`2·33 − 33`)):
+
+| config | `c` | `d` | `b` | `b_d` | bound (t=3) | tokens | measured |
+|---|---:|---:|---:|---:|---|---:|---|
+| dense | 38 | 33 | 0 | 0 | `642 / 43` ⇒ **S ≤ 14** | 50K | 14 OK / 17 fail ✓ |
+| R=7168 | 19.5 | 16.5 | 37 | 33 | `(642−123) / 22.5` ⇒ **S ≤ 23** | 82K | 56K 98 %, **80K (23 seg) 0 %** ✗ |
+| R=14336 | 10.25 | 8.25 | 37 | 33 | `(642−123) / 12.25` ⇒ **S ≤ 42** | 150K | 45/56/66/80K = 99/98/97/96 % ✓ |
+| R=28672 | 5.625 | 4.125 | 37 | 33 | `(642−123) / 7.125` ⇒ **S ≤ 72** | 258K | 56K 98 %, 80K 96 % ✓ (no gain over 14336, as predicted) |
+| **proposed**: MLA+mamba dense, drafter boundary-only | **5** | 0 | 33 | 33 | `(642−99) / 10` ⇒ **S ≤ 54** | **193.5K** | to be measured |
+
+(These five numbers are asserted by `tests/test_apc_per_group_retention.py::test_id_cost`, so the table
+and the test cannot drift apart.)
+
+**The `R=7168` row is a miss, and a material one.** An 80K pair needs `cdiv(80000, 3584) = 23` segments
+per conversation — exactly the bound, i.e. zero headroom — and it measured **0 %**, not "marginal". The
+model is therefore optimistic by at least one segment at that operating point. The terms it omits all
+push the same way and are not quantified here:
+
+* the admission watermark and `scheduler_reserve_full_isl` headroom (blocks B must reserve up front, not
+  merely pop as it goes);
+* the **in-flight** request's live, unfreeable blocks — at 80K both conversations are large enough that
+  A's own live window overlaps B's prefill;
+* partial-block tails at the end of each segment;
+* `t` is a floor: an 80K conversation over three turns has boundary tails at each turn *plus* the replay
+  boundary.
+
+Against that, the boundary/periodic overlap noted in §2.5 pushes the other way. The net is measured, not
+predicted. Treat the formula as an ordering device — it predicts the sign and the rank of every measured
+row, and it is the reason the proposed mode is expected to beat `R=14336` — **not** as a capacity
+guarantee. The live ladder (§8.2 L2) is what decides.
+
+### The one-line root cause
+
+> A sliding-window KV group whose window (2048) is smaller than the prefix-cache hit granularity (3584)
+> hashes `cdiv(window−1, block)+1 = 33` block ids at **every** hit boundary, and those ids are freed
+> **cached** — onto the *most protected* end of a global LRU that is shared with the groups that actually
+> carry the hit. 87 % of the prefix cache is spent on a group whose hit is discarded by `min()` anyway.
+
+---
+
+## 5. Design A (recommended): per-group retention interval
+
+### 5.1 What changes
+
+`retention_interval` is currently a **single scalar** on the coordinator, read once from the env
+(`C:151-157`) and handed identically to every manager (`C:302-317` base, `C:723-755` hybrid). Make it a
+per-group tuple.
+
+```
+C:__init__          self.retention_interval          (kept: global default, validation, logging)
+              +     self.retention_interval_by_group : tuple[int|None, ...]
+C:cache_blocks (base)     manager.cache_blocks(..., retention_interval=self.retention_interval_by_group[i])
+C:cache_blocks (hybrid)   same, inside the existing per-manager loop
+```
+
+Nothing below the coordinator changes: `SingleTypeKVCacheManager.cache_blocks` already takes
+`retention_interval` per call (`S:429-434`) and every `reachable_block_mask` already honours
+`None` / `0` / `>0` (`S:482-500`, `S:998-1057`, `S:1487-1542`).
+
+### 5.2 The rule
+
+New env `VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA` (launcher knob
+`GLM53_APC_RETENTION_INTERVAL_SWA`) is an explicit opt-in. Unset means every group inherits the global
+retention policy. Explicit **`0` = "keep only the reachable boundaries"**, which under `S:1048-1056`
+means the 33-block tail ending at the request's replay boundary (`request.num_prompt_tokens - 1`) and at
+any `shared_prefix_boundary` — and nothing else. A positive value must be a multiple of the scheduler
+block size. Every other group keeps the global value.
+
+Two guards, both fail-closed at boot:
+
+1. **The raw value is validated unconditionally**, before any group is inspected:
+   integer, non-negative, a multiple of `scheduler_block_size` (so a retained tail lands on a real hit
+   boundary), and `≤ 1,000,000`. A typo is a boot failure even on a model with no sliding-window group —
+   it is never silently ignored.
+2. **It is applied only to a group a hybrid coordinator has singled out as the EAGLE-exempt drafter**,
+   never to "anything whose class is called `SlidingWindowSpec`". `_glm53_min_exempt_group_ids` derives
+   that set from coordinator type and state: the active coordinator must be a
+   `HybridKVCacheCoordinator`, group `i`'s inner spec must be an *exact* `SlidingWindowSpec` (never
+   `KpoolTailSpec`, which subclasses it), and `eagle_group_ids` must be *exactly* the set of such groups.
+   The last clause is the state `patch_hybrid_prefix_hit.py` establishes (`C:121-133`): it narrows
+   `eagle_group_ids` from the upstream all-groups fallback to the drafter SWA groups and, from the same
+   discriminator, makes those groups skip the hybrid hit `min()` (`C:856-868`). A base coordinator has
+   no hybrid `min()`, so even a unitary SWA/EAGLE layout is never exempt. Under either that layout or the
+   undiscriminating all-groups fallback, the exempt set is empty and setting the variable **raises at
+   boot** rather than sparsifying a hit-determining group. Leaving it unset remains inert.
+
+   *Limit of the inference:* the equality is a proxy for "this group is out of the hit `min()`", not a
+   reading of `find_longest_cache_hit`. If some future upstream annotates `is_eagle_group` on a genuine
+   SWA group **and** keeps it inside the `min()`, the proxy would let the override through. That is the
+   one configuration where the knob must not be set. The unset default preserves the global policy;
+   explicit sparse values require the live gates in §8.2.
+
+For this kit, explicit `0` assigns boundary-only retention (`need = 33`) to gid 6. Without that explicit
+value, behaviour is unchanged.
+
+### 5.3 Why the drafter can lose its window at a boundary
+
+The hit is already reconciled without the drafter today; this design only makes it the common case.
+
+1. `find_longest_cache_hit` (`C:856-868`, Mia's patch): if the drafter's own hit is shorter than the
+   candidate, the branch `continue`s **before** `curr_hit_length = _new_hit_length` and before
+   `longest_hit_length = max(...)`, so the drafter neither shortens the hybrid hit nor inflates
+   `num_uncached_common_prefix_tokens` (`C:886-893`). Its `hit_blocks_by_group[6]` stays `None` and is
+   emitted as `[]` (`C:894-896`).
+2. Admission: `get_num_blocks_to_allocate` with `new_computed_blocks=[]` computes
+   `num_skipped_blocks` from `get_num_skipped_tokens` (`S:196-224`, `S:1059-1085`) so the drafter reserves
+   only a fresh ~33-block window, not the whole prefix.
+3. Allocation: `add_local_computed_blocks` pads `req_to_blocks` with `num_skipped_blocks` null blocks and
+   sets `num_cached_block = len(req_blocks)` (`S:270-286`); `allocate_new_blocks` then pulls exactly the
+   window (`S:332-364`). Newly allocated drafter blocks are recorded for worker-side zeroing because the
+   spec is an `AttentionSpec` (`S:90-93`), so the fresh window is zeroed, not stale.
+4. Cost: target verification protects final output, but it does not validate drafter KV. The uncached
+   remainder refills the 2048-token window only when that remainder is long enough. A short warm suffix
+   can therefore leave part of the drafter window zeroed and uncomputed, collapsing draft acceptance
+   even though the target still produces the right answer. This is why sparse retention is explicit-only
+   and must pass the L5a/L5b gates in §8.2.
+
+### 5.4 Predicted effect
+
+| | dense | R=14336 everywhere (today's default) | **per-group (MLA+mamba dense, drafter boundary-only)** |
+|---|---|---|---|
+| ids per 3584 tokens | 38 | 10.25 | **5** (+33 per turn) |
+| pair capacity (S ≤, §4.1, t=3) | 14 seg (50K) | 42 seg (150K) | **54 seg (193.5K)** |
+| hit grid for a *diverging* prefix | 3584 | **14336** | **3584** |
+| own-conversation re-turn | 99 % | 99 % | 99 % (replay boundary pinned) |
+| subagent divergence hit | n/a (evicts) | 45 % | **≈ 65–70 %** (the 7168 run already showed 67.6 % on a 21504 boundary) |
+
+The point: today's fix buys capacity by coarsening *everybody's* grid. Per-group retention buys the same
+capacity by coarsening only the group whose hit is thrown away — so capacity **and** the fine grid.
+
+### 5.5 Risks
+
+| risk | assessment |
+|---|---|
+| Draft acceptance dip on a warm hit | A short uncached suffix can leave part of the drafter window uncomputed (§5.3.4). Sparse retention stays opt-in and is rejected unless it passes the acceptance and decode-rate controls in §8. |
+| `SlidingWindowManager.find_longest_cache_hit` scan cost rises | It scans right→left over `max_length // 64` blocks and early-stops on a run of 33 (`S:944-970`; the `TODO` at `S:938-943` acknowledges the O(n) scan). With few cached drafter blocks a miss walks the full range: ~1250 dict lookups at an 80K candidate, ~3100 at 200K, once per admission. Sub-millisecond; note it, do not block on it. |
+| Mamba dense again ⇒ 4 ids/segment instead of 1 | Included in the §5.4 arithmetic (the 5). Still 7.6× cheaper than dense-with-drafter. |
+| A group getting `0` when it *is* in the `min()` | An explicit override requires a hybrid coordinator plus min-exemption derived from `eagle_group_ids` (§5.2). Mamba and MLA must never receive `0` — a missing mamba state is a correctness hole (vLLM #47491/#43090, quoted in `overlay/patch_hybrid_prefix_hit.py`). |
+| Env/validation drift | `_validate_prefix_cache_retention_interval` (`C:46-73`) must run per group; the patch adds a per-group validator over the *resolved* vector **and** validates the raw SWA value unconditionally (non-negative, scheduler-block multiple, ≤ 1,000,000). Both fail closed at boot. |
+| Stale global knob  | The launcher may still be exporting `GLM53_APC_RETENTION_INTERVAL=14336`, in which case the fine hit grid is *not* restored and the win is only capacity. This is why the acceptance criterion is the **resolved vector**, logged at init (§7), not the env var: the head must show `retention_by_group=[None,None,None,None,None,None,0]`. |
+| Drafter reads zeroed KV after a sparse miss  | Freshly allocated drafter blocks are zeroed worker-side (`S:90-93`), so they never carry another request's data — but "zeroed" is not *valid* KV for the preceding prompt tokens either. Target verification hides this in the output; it does not make it safe. Gated by the divergence-suffix + acceptance-rate probes in §8.2 (L5a/L5b), not by the equivalence gate. |
+| Worker rank | The knob must reach both ranks like the existing one (`start.sh:1136-1140`). |
+
+---
+
+## 6. Design B (alternative, **not recommended**): free out-of-window drafter blocks *uncached*
+
+Mechanically: in `SlidingWindowManager._remove_blocks_in_range` (`S:597-622`), call
+`block_pool._maybe_evict_cached_block(blk)` (`B:679-700`) before `free_blocks`, so `block_hash is None`
+and `B:734-736` prepends them to the LIFO front instead of the LRU tail — except blocks in a
+boundary tail.
+
+It would work on capacity (a recycled block costs zero deep pops), but:
+
+1. **It is destructive on shared hashes.** `_maybe_evict_cached_block` removes the hash from
+   `cached_block_hash_to_block` *globally* (`B:571-590`). Blocks are shared objects: conversation A caches
+   a block, conversation B hits it and `touch`es it (`S:296`, `B:702-717`). When B's window later slides
+   past that block, B would delete **A's** cache entry. Design A cannot do this — a block that was never
+   hashed is freed unhashed by the existing code path, with no global side effect.
+2. **No simplicity win.** It still has to exempt the boundary tails, which means recomputing
+   `reachable_boundaries` inside `remove_skipped_blocks` — the same information `reachable_block_mask`
+   already has at cache time, one call site earlier.
+3. It still pays the hash insert + remove churn on 33 blocks per segment.
+4. **Not upstreamable as a default.** For a real SWA model, an out-of-window block *is* legitimately
+   reusable by another request whose prefix ends there.
+
+Keep it documented as a fallback only if the per-group threading turns out to be infeasible.
+
+Reason (1) is argued from `B:571-590` / `B:702-717`, it is **not tested** — no shared-hash
+regression exists, because Design B is not implemented. If Design B is ever revived, that test is a
+prerequisite, not a follow-up: construct two requests sharing a hashed block, let one slide its window
+past it, and assert the other's `cached_block_hash_to_block` entry survives. Until then, uncached frees
+stay off the table without ownership/reference tracking.
+
+---
+
+## 7. The overlay patch
+
+`overlay/patch_apc_per_group_retention.py`, recipe-overlay style: fail-closed, idempotent,
+MARK/anchor, matching `overlay/patch_hybrid_prefix_hit.py`.
+
+* Target: `C` (`GLM53_KV_COORDINATOR_PY`, same env var as the hybrid patch).
+* MARK: `# [glm53-apc-per-group]`; re-run is a no-op.
+* Inserts `_glm53_swa_retention_env()`, `_glm53_min_exempt_group_ids()`, `_glm53_retention_for_group()`,
+  `_glm53_resolve_retention_by_group()`, `_glm53_validate_retention_intervals()` and
+  `_glm53_format_retention_vector()` (self-contained, no new imports beyond `os`, which the module does
+  not yet import — the patch adds it under the MARK).
+* Logs the **resolved** vector at coordinator init, one greppable line:
+  `[glm53-apc-per-group] retention_by_group=[None,None,None,None,None,None,0] (global=None swa_env=0
+  eagle_min_exempt=[6])`. This is the deployment acceptance criterion (§8.2 L1) and is checkable from
+  `docker logs <container> 2>&1 | grep retention_by_group` on **both** ranks.
+* Anchors (each must appear **exactly once**, else `SystemExit`):
+  1. `self.retention_interval = envs.VLLM_PREFIX_CACHE_RETENTION_INTERVAL` + its validator call (`C:154-157`)
+  2. the base `cache_blocks` loop (`C:313-317`)
+  3. the hybrid `cache_blocks` loop header (`C:737-738`) and its `manager.cache_blocks(...)` call (`C:750-754`)
+* Depends on `_glm53_is_draft_swa_spec` / `_glm53_inner_kv_spec` (`C:33-43`); inserts them if the hybrid
+  patch has not run, so ordering between the two overlays does not matter. Asserted, not assumed: the
+  host test applies both overlays to a **pristine** copy in both orders and checks that they succeed, are
+  idempotent under re-application in any order, and produce **byte-identical** files (§8.1).
+* Launcher wiring (`start.sh:1080-1085`, already on this branch):
+  `GLM53_APC_RETENTION_INTERVAL_SWA` → `VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA`, accepted
+  values `""` (inherit the global policy), `0`, or a positive multiple of 3584 ≤ 1,000,000 (largest legal value
+  `999936 = 279 × 3584`); exported to **both** ranks. Before a restart stops anything, the launcher
+  validates the numeric shape and rejects a non-empty value outside `SPEC_METHOD=dflash`. At boot the
+  coordinator validates the value against the live scheduler geometry and group layout, then logs the
+  resolved per-group vector.
+
+Recommended production setting after validation:
+```
+GLM53_APC_RETENTION_INTERVAL=            # unset -> dense MLA + mamba, 3584 hit grid
+GLM53_APC_RETENTION_INTERVAL_SWA=0       # drafter: replay/junction boundaries only
+```
+
+## 8. Test plan
+
+### 8.1 Host test — `tests/test_apc_per_group_retention.py`
+
+Runs anywhere with a copy of `kv_cache_coordinator.py`; no GPU, no vLLM import.
+
+1. Apply the patch to a copy of the fork's file; assert MARK present, anchors consumed, `py_compile`
+   clean. Re-apply; assert byte-identical (idempotence).
+2. **Call sites and boot log.** Zero remaining `retention_interval=self.retention_interval,`, exactly two
+   `retention_interval_by_group[i]`, only the two `cache_blocks` loops enumerated, and an init
+   `logger.info` carrying `retention_by_group=%s` fed from `_glm53_format_retention_vector`.
+3. **Min-exemption derivation** . `_glm53_min_exempt_group_ids` over the live seven-group
+   hybrid layout: `{6}` under `eagle_group_ids={6}`; **empty** for a base coordinator, under the upstream
+   all-groups fallback, under `{0}`, under the superset `{0,6}`, under `∅`, and when the only SWA-derived
+   spec is `KpoolTailSpec`. A unitary SWA/EAGLE base coordinator is explicitly not exempt.
+4. **Routing matrix.** `exec` the injected helpers in an isolated namespace with stub spec objects:
+   exact-`SlidingWindowSpec` **and min-exempt** → SWA value; the same spec **not** min-exempt → global
+   (the explicit path honours min-exemption, not just the class name); `KpoolTailSpec` (subclass) →
+   global; `MambaSpec`/`MLAAttentionSpec`/`UniformTypeKVCacheSpecs`-wrapped → global even when
+   eagle-flagged; unset (`swa=None`) → global for every group, including a min-exempt drafter.
+5. **Resolved vector + fail-closed override.** `_glm53_resolve_retention_by_group` over the live layout
+   returns `(None,)*6 + (0,)` and renders as `[None,None,None,None,None,None,0]` — the exact string the
+   deployment acceptance criterion greps for. A leftover global `14336` shows up in the vector rather
+   than being hidden . Setting the SWA value raises `ValueError` for every non-exempt
+   `eagle_group_ids`, for a model with no SWA group, and for a unitary SWA/EAGLE base coordinator, while
+   an unset value inherits the global policy there.
+6. **Unconditional env validation** . `_glm53_swa_retention_env` accepts unset/empty/blank →
+   inherit-global, `0`, `14336`, and `999936` (= 279·3584, the largest legal value); rejects junk (`"nope"`,
+   `"3584.0"`), negatives (`-1`, `-3584`), non-multiples (`1`, `3000`) and over-cap (`1003520`), and its
+   documented cap is asserted to be exactly `1,000,000`. The per-group validator over the resolved
+   vector is asserted separately (no cap there — inherited *global* values are upstream's to bound).
+7. **Overlay composition** . Against a **pristine** copy of the fork's file, apply
+   `patch_hybrid_prefix_hit.py` then this one, and this one then `patch_hybrid_prefix_hit.py`. Both
+   orders must apply, `py_compile`, carry both MARKs, define the shared `_glm53_inner_kv_spec` /
+   `_glm53_is_draft_swa_spec` exactly once, add `import os` exactly once, survive re-application of
+   either patch in either order byte-identically, retain Mia's hybrid-`min()` skip and
+   `eagle_group_ids` narrowing, resolve the live layout to `[None,…,None,0]` — and the two orders must
+   produce **byte-identical** output.
+8. **Id-cost + capacity arithmetic** (§2, §4.1) against a pure-Python replica of the two
+   `reachable_block_mask` formulas (dense 33/56; `R=14336` 33/224; boundary tail 33), and the §4.1
+   formula evaluated for all five rows — `14 / 23 / 42 / 72 / 54` — so the doc's table and the test
+   cannot drift apart.
+
+Exit non-zero on any failure (validators must fail closed).
+
+**Status: green.** Run:
+
+```
+GLM53_KV_COORDINATOR_PY_SRC=<copy of the fork's kv_cache_coordinator.py> \
+GLM53_KV_COORDINATOR_PY_PRISTINE=<pristine copy of the same file> \
+    python3 tests/test_apc_per_group_retention.py
+```
+
+`..._PRISTINE` may be omitted when `..._SRC` is itself unpatched, or when a pristine copy sits at
+`/tmp/kv_cache_coordinator_pristine.py`; the composition case **fails closed** rather than skipping if
+neither is available. Verified 2026-08-31 against a copy of the live container file (which already
+carries `patch_hybrid_prefix_hit`) plus a pinned pristine copy of the same fork source.
+
+### 8.2 Live plan (after the current sweep finishes; the server must be idle and past the boot warm-up burst)
+
+Config under test: `GLM53_APC_RETENTION_INTERVAL=` (dense) + `GLM53_APC_RETENTION_INTERVAL_SWA=0`.
+Control: today's default `GLM53_APC_RETENTION_INTERVAL=14336`.
+
+| # | probe | pass criterion |
+|---|---|---|
+| L1 | boot receipt | `docker logs … \| grep retention_by_group` shows **`retention_by_group=[None,None,None,None,None,None,0]`** on **both** ranks (this, not the env var, is the acceptance criterion); `docker exec … env` on both ranks shows the SWA var |
+| L2 | pair ladder 45K / 56K / 66K / 80K (`tests/validate_apc_retention.py`) | **all ≥ 96 %**; predicted headroom to ~193.5K/conv (§4.1 — an *ordering* prediction, already one segment optimistic at `R=7168`) |
+| L3 | 3-turn multiturn | ≥ 99 % per turn; re-turn TTFT 0.9–4.0 s |
+| L4 | subagent divergence (the ~20K shared-prefix probe) | hit lands on the **3584** grid ⇒ **65–70 %** (vs 45 % at 14336, 67.6 % at 7168) |
+| **L5a** | **divergence-suffix sweep** (see below) | at every suffix length the run completes, and the drafter **acceptance rate** is within the stated band |
+| **L5b** | **drafter cold-window cost, repeated** | decode tok/s over the first 256 output tokens of an L4 warm hit ≥ 0.90 × the same prompt's cold-run rate, on the **median of 3 repetitions**, and the **worst of the 3** ≥ 0.85 × cold. If it fails, reject the sparse policy and leave `GLM53_APC_RETENTION_INTERVAL_SWA` unset |
+| L6 | equivalence gate v3 (logprob, A13 thresholds: cold-vs-warm max\|Δlogprob\| ≤ 3× the cold-vs-cold floor, position-0 token identical) | pass — **necessary, not sufficient**, see below |
+| L7 | pool pressure | `vllm:kv_cache_usage_perc` after L2 ≤ the 14336 control's value |
+
+#### L5a — divergence-suffix sweep 
+
+A sparse drafter miss allocates a **fresh, zeroed** window (`S:90-93`). Zeroed is not another request's
+data — but it is not valid KV for the preceding 2048 prompt tokens either, and the target's verification
+will hide that in the output. So probe it directly.
+
+Fix one warm 3584-aligned prefix, then issue a follow-up whose **divergence suffix** (tokens after the
+last cached boundary) is **0, 1, 64, 2047, 2048** tokens. 0 and 2048 are the interesting ends: at 0 the
+drafter must read the pinned replay-boundary tail and at 2048 the whole window is rewritten by the
+prefill of the uncached remainder, so it is free (§5.3.4). 1 / 64 / 2047 are the cases the design claims
+are bounded and self-limiting.
+
+For each suffix, measure the **draft acceptance rate** from the Prometheus deltas across the request:
+
+```
+acceptance = Δ vllm:spec_decode_num_accepted_tokens_total
+             / Δ vllm:spec_decode_num_draft_tokens_total
+```
+
+Record it against a **cold** run of the identical prompt (fresh `cache_salt`, same seed) and against the
+`R=14336` control. Pass: the warm acceptance rate at every suffix ≥ **0.90 ×** the cold rate for the same
+prompt, and the 0-token suffix (the pinned replay boundary — the case retention `0` exists to keep warm)
+≥ **0.97 ×**. Require both counters to be present; a missing metric fails, it does not default to pass.
+Failing at any suffix rejects the sparse policy. A positive interval such as `14336` is a separate
+candidate and must pass the same gates before deployment.
+
+#### Why L6 is not enough
+
+**Target-output equivalence does not prove the drafter's KV is valid.** The target model verifies and
+corrects every draft token, so a drafter reading zeroed KV still yields byte-identical output — it just
+yields it more slowly, with a collapsed acceptance rate. L6 therefore gates *correctness of the answer*;
+L5a gates *validity of the drafter state*. Neither substitutes for the other, and only L5a can fail in a
+way that says "the speculative path is now doing no work".
+
+#### Reproducibility
+
+Every validator asserts and exits non-zero; refuse a busy server; require each metric to be present
+rather than defaulting to pass. Beyond that:
+
+* **Identical seeds and cache namespaces** across the cold/warm pair and across the proposed/control
+  arms: fixed `seed`, `temperature=0`, and a unique `cache_salt` per *cold* run (the warm run reuses the
+  preceding run's salt — that is what makes it warm).
+* **3 repetitions** of the L5b cold/warm pair; report **median and the lower tail** (min of 3), not a
+  single noisy comparison. One run is not evidence at this effect size.
+* **"first 256 decode tokens" is defined as**: output tokens 1…256 of the warm request, timed from the
+  first token's arrival (so **TTFT and prefill are excluded**), excluding the final chunk if the request
+  stops before 256, and excluding any request that hit a preemption (`vllm:num_preempted_requests`
+  delta > 0) — such a run is discarded and repeated, not averaged in.
+
+Extension probe (cheap, worth doing once the above is green): push the ladder to 120K and 160K pairs — the
+model predicts coexistence to ~193.5K per conversation, which no configuration has reached yet — with
+the §4.1 caveat that the model was already one segment optimistic at `R=7168`.
+
+## 9. Upstreamability
+
+Two separable vLLM PRs, in increasing order of ambition:
+
+**PR-U1 — "prefix-cache retention interval per KV-cache group".**
+Purely mechanical: `KVCacheCoordinator.retention_interval` becomes `retention_interval_by_group`, the
+manager API is untouched (it is already per-call, `S:429-434`), and the default resolution keeps the
+current global value for every group ⇒ **byte-identical behaviour** unless a group opts out. This is a
+clean, reviewable change that unblocks any hybrid model whose groups have wildly different id costs per
+token (this kit: 33 vs 1). It is also the enabling refactor for anything else in this space.
+
+**PR-U2 — "do not LRU-cache sliding-window blocks outside the reachable set".**
+The general statement of the bug, model-independent:
+
+> When a sliding-window group's window is smaller than the coordinator's cache-hit alignment, a
+> `need`-block tail is hashed at every alignment boundary. Those blocks are later freed *cached*
+> (`BlockPool.free_blocks`, `B:719-743`), landing at the most-protected end of a global LRU shared with
+> full-attention and Mamba groups whose per-token id cost is `need` times lower. The result is a priority
+> inversion: the group with the least reusable state gets the most eviction protection.
+
+An upstream automatic policy would also need to recompute any skipped drafter window before decode;
+retention geometry alone is insufficient. This overlay therefore exposes only an explicit value and
+inherits the global policy when unset.
+
+A third, smaller upstream note worth filing separately: `SlidingWindowManager.find_longest_cache_hit`'s
+`TODO` at `S:938-943` (skip `sliding_window_contiguous_blocks` on a miss) becomes materially more
+valuable once SWA groups cache sparsely — it turns the miss scan from O(n) into O(n/need + need).
+
+
+## 9.1 Initialized-KV evidence
+What can be proven from code today: a drafter (SWA) miss at a boundary is served by `add_local_computed_blocks` padding
+nulls and `allocate_new_blocks` pulling a fresh window whose block ids are recorded via `_record_new_block_ids`
+(single_type_kv_cache_manager.py:270-286, :332-364), i.e. the drafter never reads another request's data — the blocks are
+either this request's own newly allocated blocks (written by the current prefill/decode) or null blocks. What is NOT proven by
+target-output equivalence is the *quality* of the drafter's proposals right after such a miss (the window is refilled by the
+uncached remainder before decode; a very short remainder leaves part of the window empty) — that is exactly what L5a's
+divergence-suffix sweep (0/1/64/2047/2048) with draft-acceptance deltas measures. A failure leaves the SWA override unset;
+another interval is a separate candidate that must pass the same gates. A runtime assertion that every drafter block
+read belongs to the current request is out of scope for this overlay (it would live in the attention backend's block-table
+validation); the block-table plumbing above is the guarantee.

--- a/docs/apc-retention-qualification.md
+++ b/docs/apc-retention-qualification.md
@@ -1,0 +1,176 @@
+# Opt-in APC retention: qualification and tradeoffs
+
+## Scope
+
+The implementation extends [PR #83](https://github.com/MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks/pull/83)
+by nood-co1 / Blockbrain Labs. Its per-group retention and launcher tests are
+included with their commit attribution. The additional behavior is:
+
+- Explicit SWA `0` gives draft-only cached blocks lower eviction priority and
+  frees draft managers before target managers. Unset SWA inherits the global
+  retention value without opting into that priority policy.
+- Sparse Mamba retention preserves the prior checkpoint needed for replay.
+- DFlash current-boundary reuse requires a successful EAGLE-pop lookup at the
+  reconciled hit and a complete, non-null visible window. Otherwise the hit
+  backs up until the fresh suffix can rebuild the draft window. Failed EAGLE
+  lookups cannot mark a group verified on a subsequent reconciliation pass.
+- Overlay composition and rank wiring are checked before use: both overlays
+  apply to pristine sources in either order (idempotent, AST-equal), and the
+  launcher validates mounted artifacts before a restart stops the ranks.
+  Launcher changes also enforce an immutable DFlash snapshot, preserve caller
+  overrides, and validate mounted artifacts before a restart stops the ranks.
+
+This is a draft contribution for maintainer discussion, not a recommendation
+to make all-zero retention the default. Global and SWA retention remain
+unset by default. Neither the 390-block qualification budget nor the tested
+262,144 context / 2,048 MNBT settings are new launcher defaults. The fine-grained
+lookup proposals in #84 and #125 are not included.
+
+## Measured runtime pair
+
+Tests used one 2× DGX Spark GB10 pair over CX7, stock EXL3/TR3 4bpw, target TP2,
+DFlash2 k=7 / draft TP2, target FP8 (`fp8_ds_mla`) and draft auto/BF16 KV.
+The target revision was `61e26e1484e16d7a603f77040cda9b43cc4a31d6` and the draft
+revision was `dc77ff1c99eeb2df044ee3d4f0094eb033fee410`.
+
+| Field | Old | Candidate |
+|---|---|---|
+| Recipe source | `eb0469fbb2b49fd7c025f594a3339a121e58f7a9` | `3d01c7b7fa85a4b1419621a2b0657a2cde48a27e` |
+| Image ID | `sha256:277f348d5afe2a48c025c0b270afb89c4f0ca67e6dab192ccef9f3e223328004` | `sha256:29bb99dc2c9ffb34e216743b5714bbfd2dddd25216289654e581af3e6d2f4901` |
+| Retention | Original dense/default policy | Explicit global/SWA `0/0`; vector `[0,0,0,0,0,0,0]`; low-priority group `[6]` |
+| Physical blocks / nominal KV tokens | 390 / 491,520 | 390 / 491,520 |
+| Context / MNBT / max sequences | 262,144 / 2,048 / 4 | Same |
+| GPU utilization / indexer workspace | 0.82 / rightsize | Same |
+| Execution | E2 fat kernel, mixed-prefill skip, CUDA graphs `1,2,4,8,16,24,32` | Same |
+
+The candidate image was built from `cfcceedbecd5778d7acd6109be2c22f305567ab4`.
+Later host/patcher changes render byte-identical model/cache runtime files.
+The image IDs identify retained local images, not publicly pullable registry
+digests. The tested runtime hashes are:
+
+| File | SHA-256 |
+|---|---|
+| `kv_cache_coordinator.py` | `507685d5a135f3777b2b3157fbbebcace5c4d81f67969db624756bffaa832056` |
+| `block_pool.py` | `176f6abe48471e617af8ac538ac12b578a51f864fc8637c9b640336bf6858472` |
+| `single_type_kv_cache_manager.py` | `143c8a822ebf100f3507ee2a648b10e9b0e2d4ac43e4fbd9345d6162a45131e8` |
+
+The old runtime was temporarily capped at 390 blocks to match the candidate,
+rather than reproducing its historical automatic allocation. These are
+runtime-plus-policy comparisons, not isolation of a single changed line.
+
+## 128K edits and branches: matched comparison
+
+The [archived harness](qualification/apc-2026-09-05/branch_matrix.py) constructs
+ten synthetic ledger segments with known values and exactly 128,000 tokens.
+For every case, it resets an idle cache, primes that same complete history,
+then submits one probe. An edit changes a value while preserving subsequent
+history; a branch truncates at the selected point and adds a question. The
+assistant continuation is fixed text, not a generated old/new prime answer.
+Each old/new probe has identical message and token hashes and token-level LCP.
+
+One trial per case, sequential requests, candidate first and old second;
+temperature 0, seed 7391, thinking off, prime maximum 8 output tokens and probe
+maximum 24. TTFT is measured to first non-empty streamed text. Required local
+compute/cache-hit counters must sum to both tokenized and server-reported
+prompt counts; absent counters fail the harness. Every prime computed exactly
+128,000 tokens with zero hits.
+
+| Probe | Prompt tokens | LCP tokens | Old hit / compute | Candidate hit / compute | Old TTFT (s) | Candidate TTFT (s) |
+|---|---:|---:|---|---|---:|---:|
+| Unchanged append | 128,019 | 128,000 | 125,440 / 2,579 | 125,440 / 2,579 | 2.801 | 2.796 |
+| Edit at 10% | 128,025 | 12,761 | 0 / 128,025 | 0 / 128,025 | 108.178 | 109.982 |
+| Edit at 50% | 128,024 | 63,713 | 0 / 128,024 | 0 / 128,024 | 107.855 | 111.755 |
+| Edit at 90% | 128,024 | 114,666 | 111,104 / 16,920 | 0 / 128,024 | 14.700 | 112.491 |
+| Branch at 10% | 12,794 | 12,767 | 0 / 12,794 | 0 / 12,794 | 11.409 | 11.016 |
+| Branch at 50% | 63,747 | 63,720 | 0 / 63,747 | 0 / 63,747 | 53.857 | 56.312 |
+| Branch at 90% | 114,701 | 114,674 | 111,104 / 3,597 | 0 / 114,701 | 3.351 | 99.885 |
+
+All 14 probes returned the expected value with no stale value; preemptions
+were zero. **The late edit and branch are regressions:** the candidate loses
+111,104 tokens of reuse and takes approximately 7.65× / 29.81× as long. Early
+and middle changes missed on both runtimes; unchanged append was equivalent.
+
+Seven cold-prime TTFT medians were 108.074 s old and 111.262 s candidate
+(~2.95% longer). The fixed run order and lack of repeated alternation prevent
+a general kernel-performance conclusion. Short answers do not qualify decode
+throughput. These measurements do not qualify SWA-only sparse / dense-target
+retention or other context sizes, hardware, or concurrency levels.
+
+### Reproduction boundary
+
+The harness is preserved byte-for-byte as measurement evidence, not a generic
+production benchmark. It targets loopback port 32105 and served ID
+`glm-5.3-flash-exl3`; inspect those constants before adapting it. It resets the
+whole prefix cache and requires exclusive use of a disposable test deployment.
+The pinned engine exposes that reset through developer mode, which enables
+other developer routes too. The test server must bind loopback and be
+unreachable through public or gateway routes. An unloaded gateway entry is
+not isolation if it can start the model on demand. The harness does not set up
+isolation, start monitors, launch models, or restore production for you.
+
+On an already isolated, monitored test deployment, `--prepare-only` records
+input identities without inference; `--reference-prepared` checks the second
+runtime's token identities. Equivalent invocations for the measured matrix are:
+
+```bash
+python3 docs/qualification/apc-2026-09-05/branch_matrix.py --runtime new --prepare-only --output new-prepared.json
+python3 docs/qualification/apc-2026-09-05/branch_matrix.py --runtime new --output new.json
+# Switch the isolated test deployment to the matched old runtime before continuing.
+python3 docs/qualification/apc-2026-09-05/branch_matrix.py --runtime old --prepare-only --reference-prepared new-prepared.json --output old-prepared.json
+python3 docs/qualification/apc-2026-09-05/branch_matrix.py --runtime old --reference-prepared new-prepared.json --output old.json
+```
+
+Both measured boots had per-node memory/rank/swap monitoring before launch.
+Minimum available memory was 7.915 / 11.247 GiB head/worker for the candidate
+and 7.692 / 11.430 GiB for old. No OOM, restart, swap use, or intervention was
+observed. A discarded setup boot had a 4m48s monitoring gap before any test
+traffic; it is not included in those measurements. Developer mode and all
+temporary settings were removed after testing.
+
+## Long-history retention and DFlash checks
+
+Separate candidate qualification used four independent exact 210,000-token
+histories, filled sequentially, then revisited oldest-first without clearing
+between them. Cold times were 212.923 / 209.013 / 207.078 / 207.040 s, each
+0 cached / 210,000 computed. Revisits took 2.506 / 2.453 / 2.475 / 2.586 s,
+each 207,872 cached / 2,128 computed, with zero preemptions. This demonstrates
+four retained histories, **not four simultaneous full-context streams**.
+
+DFlash suffix checks exercised 0, 1, 64, 2,047 and 2,048 token extensions.
+Warm/cold draft-acceptance ratios were 1.1771 / 1.24307 / 1.02396 / 1.0 / 1.0.
+Three warm throughput rates were 54.864 / 54.510 / 54.872 tok/s against a
+cold median of 54.783 tok/s. These are warm/cold comparisons on the candidate,
+not old/new decode comparisons. Valid-current suffix-64 reused 21,504 tokens
+and computed 65; forced missing-draft suffix-64 backed up to 17,920 cached /
+3,649 computed. API, cancellation, tools, thinking and 120K key+Vision checks
+passed for stock and abliterated profiles; the four-history test was stock.
+
+The [pinned deployment receipt](https://github.com/ratulsarna/spark-serve/blob/3c295a723aaa7750faef95cee758da2f76896dc1/services/glm-5.3-flash-exl3/qualification/2026-09-05-apc-global0-dflash-replay-v2.md)
+records the 2026-09-05 qualification runs (then including an exact-image
+migration step since removed), both-order overlay composition, runtime hashes,
+acceptance, boot facts and artifact hashes. Its host-local raw paths are not
+public downloads. This PR preserves the 128K comparison artifacts below.
+
+## Limits and maintainer decision
+
+Cache-hit correctness tests do not establish universal cold/cached output
+equality: both cold/cached and repeated-run output variation remain recorded.
+Manager release ordering also does not guarantee that every pre-existing
+unhashed free block precedes every draft-cache block in the global queue.
+The exact cause of a consecutive valid-then-fallback draft eviction is not
+proven. TP=4 sparse SWA is rejected, not qualified. A full boot using the
+maintainer's default 1M/7168 geometry is not part of this qualification.
+
+The useful decision is whether to accept the reusable replay/priority work
+as an opt-in extension to #83, and whether to split the launcher/pin work into
+a separate change. All-zero retention should not become the default on the
+strength of the four-history result; edited and branching workloads need the
+tradeoff above. No ideal checkpoint interval is claimed.
+
+## Public evidence identities
+
+| Artifact | SHA-256 |
+|---|---|
+| [Harness](qualification/apc-2026-09-05/branch_matrix.py) | `7c41494bb6011ef33ec0851d52ae656731921b1d10edf669d63f3fa046db6656` |
+| [Candidate raw matrix](qualification/apc-2026-09-05/new.json) | `82078a09861d9ee9ea07fc7d0976f1c56ad075e118c20a6d701987422070766b` |
+| [Old raw matrix](qualification/apc-2026-09-05/old.json) | `bdbedaccd02c7be608329e8aed8a02456e4acbc17ab80da3ceee21fa1767c52a` |

--- a/docs/apc-retention-qualification.md
+++ b/docs/apc-retention-qualification.md
@@ -17,8 +17,6 @@ included with their commit attribution. The additional behavior is:
 - Overlay composition and rank wiring are checked before use: both overlays
   apply to pristine sources in either order (idempotent, AST-equal), and the
   launcher validates mounted artifacts before a restart stops the ranks.
-  Launcher changes also enforce an immutable DFlash snapshot, preserve caller
-  overrides, and validate mounted artifacts before a restart stops the ranks.
 
 This is a draft contribution for maintainer discussion, not a recommendation
 to make all-zero retention the default. Global and SWA retention remain
@@ -44,7 +42,7 @@ revision was `dc77ff1c99eeb2df044ee3d4f0094eb033fee410`.
 | Execution | E2 fat kernel, mixed-prefill skip, CUDA graphs `1,2,4,8,16,24,32` | Same |
 
 The candidate image was built from `cfcceedbecd5778d7acd6109be2c22f305567ab4`.
-Later host/patcher changes render byte-identical model/cache runtime files.
+These archived measurements describe the recipe and runtime hashes in this section.
 The image IDs identify retained local images, not publicly pullable registry
 digests. The tested runtime hashes are:
 
@@ -162,8 +160,7 @@ proven. TP=4 sparse SWA is rejected, not qualified. A full boot using the
 maintainer's default 1M/7168 geometry is not part of this qualification.
 
 The useful decision is whether to accept the reusable replay/priority work
-as an opt-in extension to #83, and whether to split the launcher/pin work into
-a separate change. All-zero retention should not become the default on the
+as an opt-in extension to #83. All-zero retention should not become the default on the
 strength of the four-history result; edited and branching workloads need the
 tradeoff above. No ideal checkpoint interval is claimed.
 
@@ -171,6 +168,6 @@ tradeoff above. No ideal checkpoint interval is claimed.
 
 | Artifact | SHA-256 |
 |---|---|
-| [Harness](qualification/apc-2026-09-05/branch_matrix.py) | `7c41494bb6011ef33ec0851d52ae656731921b1d10edf669d63f3fa046db6656` |
+| [Harness](qualification/apc-2026-09-05/branch_matrix.py) | `ccdaf602ef5b378dc275f70d627b0276626fb81ff7aceec4831665e2679e173b` |
 | [Candidate raw matrix](qualification/apc-2026-09-05/new.json) | `82078a09861d9ee9ea07fc7d0976f1c56ad075e118c20a6d701987422070766b` |
 | [Old raw matrix](qualification/apc-2026-09-05/old.json) | `bdbedaccd02c7be608329e8aed8a02456e4acbc17ab80da3ceee21fa1767c52a` |

--- a/docs/qualification/apc-2026-09-05/branch_matrix.py
+++ b/docs/qualification/apc-2026-09-05/branch_matrix.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Bounded synthetic 128K APC edit/branch comparison."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+MODEL = "glm-5.3-flash-exl3"
+BASE = "http://127.0.0.1:32105"
+POSITIONS = (1, 5, 9)
+ORIGINAL = {1: "PINE-1017", 5: "EMBER-5051", 9: "QUARTZ-9097"}
+EDITED = {1: "CEDAR-1183", 5: "FLAME-5279", 9: "ONYX-9311"}
+
+
+def digest(value: object) -> str:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(raw).hexdigest()
+
+
+def request(path: str, payload: dict | None = None, timeout: float = 1800):
+    data = json.dumps(payload, separators=(",", ":")).encode() if payload is not None else None
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"},
+        method="POST" if payload is not None else "GET")
+    started = time.perf_counter()
+    try:
+        return urllib.request.urlopen(req, timeout=timeout), started
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")
+        raise RuntimeError(f"HTTP {exc.code} {path}: {body[:500]}") from exc
+
+
+def tokenize(messages: list[dict]) -> list[int]:
+    response, _ = request("/tokenize", {
+        "model": MODEL, "messages": messages,
+        "chat_template_kwargs": {"enable_thinking": False}})
+    with response:
+        body = json.loads(response.read())
+    return body["tokens"]
+
+
+def metric_snapshot() -> dict[str, float]:
+    response, _ = request("/metrics")
+    with response:
+        source = response.read().decode("utf-8", "replace")
+    patterns = {
+        "local_compute": re.compile(r'^vllm:prompt_tokens_by_source_total\{[^}]*source="local_compute"[^}]*\}\s+(\S+)$'),
+        "local_cache_hit": re.compile(r'^vllm:prompt_tokens_by_source_total\{[^}]*source="local_cache_hit"[^}]*\}\s+(\S+)$'),
+        "preemptions": re.compile(r'^vllm:num_preemptions_total\{[^}]*\}\s+(\S+)$'),
+        "running": re.compile(r'^vllm:num_requests_running\{[^}]*\}\s+(\S+)$'),
+        "waiting": re.compile(r'^vllm:num_requests_waiting\{[^}]*\}\s+(\S+)$'),
+    }
+    result: dict[str, float] = {}
+    for line in source.splitlines():
+        for key, pattern in patterns.items():
+            match = pattern.match(line)
+            if match:
+                result[key] = result.get(key, 0.0) + float(match.group(1))
+    missing = sorted(set(patterns) - set(result))
+    if missing:
+        raise RuntimeError(f"required metrics absent: {missing}")
+    return result
+
+
+def delta(before: dict[str, float], after: dict[str, float]) -> dict[str, float]:
+    return {key: round(after[key] - before[key], 3) for key in before}
+
+
+def reset_cache() -> dict:
+    idle = metric_snapshot()
+    if idle["running"] != 0 or idle["waiting"] != 0:
+        raise RuntimeError(f"refusing reset with active requests: {idle}")
+    response, started = request("/reset_prefix_cache", {})
+    with response:
+        body_raw = response.read().decode("utf-8", "replace")
+        status = response.status
+    try:
+        body = json.loads(body_raw)
+    except json.JSONDecodeError:
+        body = body_raw
+    after = metric_snapshot()
+    if status != 200 or not isinstance(body, dict) or body.get("success") is not True:
+        raise RuntimeError(f"cache reset failed: HTTP {status}: {body!r}")
+    if after["running"] != 0 or after["waiting"] != 0:
+        raise RuntimeError(f"requests appeared during reset: {after}")
+    return {"http": status, "body": body,
+            "seconds": round(time.perf_counter() - started, 3), "idle": idle}
+
+
+def segment(index: int, repeats: int) -> dict:
+    key = ORIGINAL.get(index, f"AUX-{index:02d}42")
+    content = (
+        f"Synthetic ledger segment {index:02d}. Checkpoint S{index:02d} has value {key}. "
+        "All checkpoint assignments are authoritative and independent."
+        + " alpha" * repeats)
+    return {"role": "user", "content": content}
+
+
+def build_base(target: int = 128000) -> list[dict]:
+    messages: list[dict] = []
+    for index in range(10):
+        messages.append(segment(index, 12700))
+        messages.append({"role": "assistant", "content": f"Recorded synthetic segment {index:02d}."})
+    messages.append({"role": "user", "content": "Acknowledge the complete synthetic ledger in three words."})
+    for _ in range(8):
+        tokens = tokenize(messages)
+        gap = target - len(tokens)
+        if gap == 0:
+            return messages
+        if 12700 + gap < 1:
+            raise RuntimeError(f"target adjustment invalid: gap={gap}")
+        messages[18] = segment(9, 12700 + gap)
+    raise RuntimeError(f"could not construct exact {target} tokens; got {len(tokenize(messages))}")
+
+
+def identity(messages: list[dict]) -> dict:
+    tokens = tokenize(messages)
+    return {
+        "count": len(tokens), "messages_sha256": digest(messages),
+        "token_ids_sha256": digest(tokens), "first_token_ids": tokens[:8],
+        "last_token_ids": tokens[-8:], "tokens": tokens,
+    }
+
+
+def lcp(left: list[int], right: list[int]) -> int:
+    for index, pair in enumerate(zip(left, right)):
+        if pair[0] != pair[1]:
+            return index
+    return min(len(left), len(right))
+
+
+def stream_chat(messages: list[dict], max_tokens: int) -> dict:
+    payload = {
+        "model": MODEL, "messages": messages, "temperature": 0, "seed": 7391,
+        "max_tokens": max_tokens, "stream": True,
+        "stream_options": {"include_usage": True},
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    before = metric_snapshot()
+    response, started = request("/v1/chat/completions", payload)
+    first = None
+    chunks: list[str] = []
+    usage: dict = {}
+    finish_reason = None
+    with response:
+        status = response.status
+        for raw in response:
+            line = raw.decode("utf-8", "replace").strip()
+            if not line.startswith("data:") or line == "data: [DONE]":
+                continue
+            obj = json.loads(line[5:].strip())
+            if obj.get("usage"):
+                usage = obj["usage"]
+            choices = obj.get("choices") or []
+            if not choices:
+                continue
+            finish_reason = choices[0].get("finish_reason") or finish_reason
+            part = choices[0].get("delta") or {}
+            value = part.get("content") or part.get("reasoning") or part.get("reasoning_content") or ""
+            if value:
+                first = first or time.perf_counter()
+                chunks.append(value)
+    ended = time.perf_counter()
+    prompt_tokens = usage.get("prompt_tokens")
+    if not isinstance(prompt_tokens, int):
+        raise RuntimeError(f"stream usage omitted prompt_tokens: {usage}")
+    after = metric_snapshot()
+    for _ in range(20):
+        metrics = delta(before, after)
+        if round(metrics["local_compute"] + metrics["local_cache_hit"]) >= prompt_tokens:
+            break
+        time.sleep(0.1)
+        after = metric_snapshot()
+    metrics = delta(before, after)
+    accounted = round(metrics["local_compute"] + metrics["local_cache_hit"])
+    if accounted != prompt_tokens:
+        raise RuntimeError(
+            f"prompt accounting mismatch: compute+hit={accounted}, usage={prompt_tokens}")
+    return {
+        "ok": status == 200 and first is not None, "http": status,
+        "ttft_s": round(first - started, 3) if first else None,
+        "wall_s": round(ended - started, 3), "usage": usage,
+        "metric_delta": metrics, "finish_reason": finish_reason,
+        "content": "".join(chunks),
+    }
+
+
+def cases(base: list[dict], prime_answer: str) -> list[tuple[str, list[dict], str]]:
+    suffix = [{"role": "assistant", "content": prime_answer}]
+    rows = [("append_control", base + suffix + [{"role": "user", "content":
+        "Append control: reply with exactly APPEND-OK."}], "APPEND-OK")]
+    for position in POSITIONS:
+        edited = json.loads(json.dumps(base))
+        edited[2 * position]["content"] = edited[2 * position]["content"].replace(
+            ORIGINAL[position], EDITED[position])
+        rows.append((f"edit_{position * 10}pct", edited + suffix + [{"role": "user", "content":
+            f"What is the current value of checkpoint S{position:02d}? Reply with the value only."}],
+            EDITED[position]))
+    for position in POSITIONS:
+        branch = json.loads(json.dumps(base[:2 * position]))
+        marker = f"Checkpoint S{position:02d} has value {ORIGINAL[position]}."
+        source = base[2 * position]["content"]
+        marker_end = source.index(marker) + len(marker)
+        branch.append({"role": "user", "content": source[:marker_end]})
+        branch.append({"role": "assistant", "content": f"Recorded synthetic segment {position:02d}."})
+        branch.append({"role": "user", "content":
+            f"From the retained branch, give checkpoint S{position:02d}'s value only."})
+        rows.append((f"branch_{position * 10}pct", branch, ORIGINAL[position]))
+    return rows
+
+
+def persist(path: Path, value: dict) -> None:
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+    temporary.replace(path)
+
+
+def self_test() -> None:
+    assert lcp([1, 2, 3], [1, 2, 4]) == 2
+    assert lcp([1, 2], [1, 2, 3]) == 2
+    toy = [{"role": "user", "content": "x"}]
+    assert json.loads(json.dumps(toy)) == toy
+    assert set(ORIGINAL) == set(EDITED) == set(POSITIONS)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--runtime", required=True, choices=("new", "old"))
+    parser.add_argument("--prepare-only", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--reference-prepared")
+    args = parser.parse_args()
+    self_test()
+    if args.self_test:
+        print("self-test passed")
+        return 0
+    output = Path(args.output)
+    base = build_base()
+    base_id = identity(base)
+    prepared = {"runtime": args.runtime, "base_identity": dict(base_id), "cases": []}
+    prepared["base_identity"].pop("tokens")
+    synthetic_cases = cases(base, "Ledger acknowledged.")
+    for label, messages, expected in synthetic_cases:
+        item = identity(messages)
+        tokens = item.pop("tokens")
+        prepared["cases"].append({"label": label, "expected": expected,
+            "identity": item, "lcp_tokens": lcp(base_id["tokens"], tokens),
+            "lcp_fraction": round(lcp(base_id["tokens"], tokens) / len(base_id["tokens"]), 6)})
+    if args.reference_prepared:
+        reference = json.loads(Path(args.reference_prepared).read_text())
+        reference_shape = (
+            reference["base_identity"]["count"],
+            reference["base_identity"]["token_ids_sha256"],
+            [(row["label"], row["identity"]["count"], row["identity"]["token_ids_sha256"])
+             for row in reference["cases"]],
+        )
+        current_shape = (
+            prepared["base_identity"]["count"],
+            prepared["base_identity"]["token_ids_sha256"],
+            [(row["label"], row["identity"]["count"], row["identity"]["token_ids_sha256"])
+             for row in prepared["cases"]],
+        )
+        if current_shape != reference_shape:
+            raise RuntimeError("old/new tokenized inputs differ")
+        prepared["reference_inputs_match"] = True
+    if args.prepare_only:
+        persist(output, prepared)
+        print(json.dumps(prepared, indent=2, sort_keys=True))
+        return 0
+
+    result = {"started_unix": time.time(), **prepared, "rows": []}
+    persist(output, result)
+    for case_index in range(7):
+        reset = reset_cache()
+        prime = stream_chat(base, 8)
+        if prime["metric_delta"]["local_cache_hit"] != 0:
+            raise RuntimeError(f"cold prime had cached tokens: {prime['metric_delta']}")
+        if prime["metric_delta"]["local_compute"] != 128000:
+            raise RuntimeError(f"cold prime compute was not 128000: {prime['metric_delta']}")
+        actual_cases = cases(base, "Ledger acknowledged.")
+        label, messages, expected = actual_cases[case_index]
+        probe_id = identity(messages)
+        probe_tokens = probe_id.pop("tokens")
+        probe = stream_chat(messages, 24)
+        content = probe["content"]
+        row = {
+            "label": label, "reset": reset, "prime": prime,
+            "probe_identity": probe_id,
+            "lcp_tokens": lcp(base_id["tokens"], probe_tokens),
+            "lcp_fraction": round(lcp(base_id["tokens"], probe_tokens) / len(base_id["tokens"]), 6),
+            "expected": expected, "expected_found": expected.lower() in content.lower(),
+            "stale_values_found": [value for value in ORIGINAL.values()
+                if value != expected and value.lower() in content.lower()],
+            "probe": probe,
+        }
+        result["rows"].append(row)
+        persist(output, result)
+    result["finished_unix"] = time.time()
+    result["elapsed_s"] = round(result["finished_unix"] - result["started_unix"], 3)
+    result["pass"] = all(r["prime"]["ok"] and r["probe"]["ok"] and
+        r["expected_found"] and not r["stale_values_found"] and
+        r["prime"]["metric_delta"]["local_cache_hit"] == 0 and
+        r["probe"]["metric_delta"]["preemptions"] == 0 for r in result["rows"])
+    persist(output, result)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/qualification/apc-2026-09-05/branch_matrix.py
+++ b/docs/qualification/apc-2026-09-05/branch_matrix.py
@@ -147,6 +147,7 @@ def stream_chat(messages: list[dict], max_tokens: int) -> dict:
     response, started = request("/v1/chat/completions", payload)
     first = None
     chunks: list[str] = []
+    reasoning_chunks: list[str] = []
     usage: dict = {}
     finish_reason = None
     with response:
@@ -163,10 +164,12 @@ def stream_chat(messages: list[dict], max_tokens: int) -> dict:
                 continue
             finish_reason = choices[0].get("finish_reason") or finish_reason
             part = choices[0].get("delta") or {}
-            value = part.get("content") or part.get("reasoning") or part.get("reasoning_content") or ""
-            if value:
+            content = part.get("content") or ""
+            reasoning = part.get("reasoning") or part.get("reasoning_content") or ""
+            if content or reasoning:
                 first = first or time.perf_counter()
-                chunks.append(value)
+            chunks.append(content)
+            reasoning_chunks.append(reasoning)
     ended = time.perf_counter()
     prompt_tokens = usage.get("prompt_tokens")
     if not isinstance(prompt_tokens, int):
@@ -188,7 +191,7 @@ def stream_chat(messages: list[dict], max_tokens: int) -> dict:
         "ttft_s": round(first - started, 3) if first else None,
         "wall_s": round(ended - started, 3), "usage": usage,
         "metric_delta": metrics, "finish_reason": finish_reason,
-        "content": "".join(chunks),
+        "content": "".join(chunks), "reasoning": "".join(reasoning_chunks),
     }
 
 
@@ -296,7 +299,7 @@ def main() -> int:
             "probe_identity": probe_id,
             "lcp_tokens": lcp(base_id["tokens"], probe_tokens),
             "lcp_fraction": round(lcp(base_id["tokens"], probe_tokens) / len(base_id["tokens"]), 6),
-            "expected": expected, "expected_found": expected.lower() in content.lower(),
+            "expected": expected, "expected_found": expected.casefold() == content.strip().casefold(),
             "stale_values_found": [value for value in ORIGINAL.values()
                 if value != expected and value.lower() in content.lower()],
             "probe": probe,

--- a/docs/qualification/apc-2026-09-05/new.json
+++ b/docs/qualification/apc-2026-09-05/new.json
@@ -1,0 +1,862 @@
+{
+  "base_identity": {
+    "count": 128000,
+    "first_token_ids": [
+      154822,
+      154824,
+      154826,
+      25062,
+      287,
+      29905,
+      371,
+      25
+    ],
+    "last_token_ids": [
+      46645,
+      304,
+      2326,
+      4244,
+      13,
+      154828,
+      154841,
+      154842
+    ],
+    "messages_sha256": "dda4a94e79039694c00d29dbea3a7d8b2d85de1ef7afbec00cb3a766e898f3d2",
+    "token_ids_sha256": "eee16ca8b28485239ecb4cfed71a1633380ac1d023644b5e3f2d83f41e6878f5"
+  },
+  "cases": [
+    {
+      "expected": "APPEND-OK",
+      "identity": {
+        "count": 128019,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          17885,
+          4689,
+          12,
+          3925,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "5ff7396183ea3d675ffaf952c15d874c83255678b60637bd669b4efae5dd4eaf",
+        "token_ids_sha256": "9df43f4dbb4472f7d8a4b5db34bad45dfd6eb10aa86f238f97a51ce71525242e"
+      },
+      "label": "append_control",
+      "lcp_fraction": 1.0,
+      "lcp_tokens": 128000
+    },
+    {
+      "expected": "CEDAR-1183",
+      "identity": {
+        "count": 128025,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          448,
+          279,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "31345f14da438c2ec41d1e275b5b166f574d0111e8cd769acd868732c8ba55a3",
+        "token_ids_sha256": "f0027d1e514b8a0d4f3cb864dbf6a96fea67b26012cec0ee258b5773351a2056"
+      },
+      "label": "edit_10pct",
+      "lcp_fraction": 0.099695,
+      "lcp_tokens": 12761
+    },
+    {
+      "expected": "FLAME-5279",
+      "identity": {
+        "count": 128024,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          448,
+          279,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "b37c237c4814de3012a4f8c79a51368e7915a3ad075c31829e7b7e0334fc640b",
+        "token_ids_sha256": "9d55b69452f7abc78d0bb202180ea10b7142061b334f72efa50b1ef5b6536ebd"
+      },
+      "label": "edit_50pct",
+      "lcp_fraction": 0.497758,
+      "lcp_tokens": 63713
+    },
+    {
+      "expected": "ONYX-9311",
+      "identity": {
+        "count": 128024,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          448,
+          279,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "f945696d641d2e2c83b16b62492baebfcbac72de8fb9c37ccebac1c5ae6c763b",
+        "token_ids_sha256": "dd9ac5e9b0cd9c7f8ddf24df754e5ab90d1d0a5b1a96be4dddca52939d02a70d"
+      },
+      "label": "edit_90pct",
+      "lcp_fraction": 0.895828,
+      "lcp_tokens": 114666
+    },
+    {
+      "expected": "PINE-1017",
+      "identity": {
+        "count": 12794,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          100286,
+          594,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "c04e1623bf0e3c610fac5c2766fec1c05c20a62eaec35863034952622ead1462",
+        "token_ids_sha256": "ae589db4410ebc7bc20aba5536d93b6b816b46b08f5b663556b04ec75a757da5"
+      },
+      "label": "branch_10pct",
+      "lcp_fraction": 0.099742,
+      "lcp_tokens": 12767
+    },
+    {
+      "expected": "EMBER-5051",
+      "identity": {
+        "count": 63747,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          100002,
+          594,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "8a82ca9a35c5af9074a62d570ef90d375a18ce1f138f6d884e42dd4c6ca8f8e5",
+        "token_ids_sha256": "8f8788e3c417bc150f700b613c05b6fec85d10010d617d5c6cdb0597c38d7835"
+      },
+      "label": "branch_50pct",
+      "lcp_fraction": 0.497812,
+      "lcp_tokens": 63720
+    },
+    {
+      "expected": "QUARTZ-9097",
+      "identity": {
+        "count": 114701,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          100614,
+          594,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "5a8abc8ac38f6a60acf10cc3486198500aed9a5e388997b43ae33bbb53f0b012",
+        "token_ids_sha256": "4ef9b239e582101000b5885e25784c22d105d6dfbb60389c292521a4587f56d9"
+      },
+      "label": "branch_90pct",
+      "lcp_fraction": 0.895891,
+      "lcp_tokens": 114674
+    }
+  ],
+  "elapsed_s": 1285.57,
+  "finished_unix": 1788600827.5875907,
+  "pass": true,
+  "rows": [
+    {
+      "expected": "APPEND-OK",
+      "expected_found": true,
+      "label": "append_control",
+      "lcp_fraction": 1.0,
+      "lcp_tokens": 128000,
+      "prime": {
+        "content": "Ledger fully acknowledged.",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 128000.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 112.284,
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 128000,
+          "total_tokens": 128006
+        },
+        "wall_s": 112.557
+      },
+      "probe": {
+        "content": "APPEND-OK",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 125440.0,
+          "local_compute": 2579.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 2.796,
+        "usage": {
+          "completion_tokens": 5,
+          "prompt_tokens": 128019,
+          "total_tokens": 128024
+        },
+        "wall_s": 2.851
+      },
+      "probe_identity": {
+        "count": 128019,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          17885,
+          4689,
+          12,
+          3925,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "5ff7396183ea3d675ffaf952c15d874c83255678b60637bd669b4efae5dd4eaf",
+        "token_ids_sha256": "9df43f4dbb4472f7d8a4b5db34bad45dfd6eb10aa86f238f97a51ce71525242e"
+      },
+      "reset": {
+        "body": {
+          "success": true
+        },
+        "http": 200,
+        "idle": {
+          "local_cache_hit": 0.0,
+          "local_compute": 1331.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "seconds": 0.005
+      },
+      "stale_values_found": []
+    },
+    {
+      "expected": "CEDAR-1183",
+      "expected_found": true,
+      "label": "edit_10pct",
+      "lcp_fraction": 0.099695,
+      "lcp_tokens": 12761,
+      "prime": {
+        "content": "Ledger fully acknowledged.",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 128000.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 109.76,
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 128000,
+          "total_tokens": 128006
+        },
+        "wall_s": 110.01
+      },
+      "probe": {
+        "content": "CEDAR-1183",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 128025.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 109.982,
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 128025,
+          "total_tokens": 128031
+        },
+        "wall_s": 110.253
+      },
+      "probe_identity": {
+        "count": 128025,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          448,
+          279,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "31345f14da438c2ec41d1e275b5b166f574d0111e8cd769acd868732c8ba55a3",
+        "token_ids_sha256": "f0027d1e514b8a0d4f3cb864dbf6a96fea67b26012cec0ee258b5773351a2056"
+      },
+      "reset": {
+        "body": {
+          "success": true
+        },
+        "http": 200,
+        "idle": {
+          "local_cache_hit": 125440.0,
+          "local_compute": 131910.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "seconds": 0.099
+      },
+      "stale_values_found": []
+    },
+    {
+      "expected": "FLAME-5279",
+      "expected_found": true,
+      "label": "edit_50pct",
+      "lcp_fraction": 0.497758,
+      "lcp_tokens": 63713,
+      "prime": {
+        "content": "Ledger fully acknowledged.",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 128000.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 112.688,
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 128000,
+          "total_tokens": 128006
+        },
+        "wall_s": 112.964
+      },
+      "probe": {
+        "content": "FLAME-5279",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 128024.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 111.755,
+        "usage": {
+          "completion_tokens": 7,
+          "prompt_tokens": 128024,
+          "total_tokens": 128031
+        },
+        "wall_s": 111.919
+      },
+      "probe_identity": {
+        "count": 128024,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          448,
+          279,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "b37c237c4814de3012a4f8c79a51368e7915a3ad075c31829e7b7e0334fc640b",
+        "token_ids_sha256": "9d55b69452f7abc78d0bb202180ea10b7142061b334f72efa50b1ef5b6536ebd"
+      },
+      "reset": {
+        "body": {
+          "success": true
+        },
+        "http": 200,
+        "idle": {
+          "local_cache_hit": 125440.0,
+          "local_compute": 387935.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "seconds": 0.12
+      },
+      "stale_values_found": []
+    },
+    {
+      "expected": "ONYX-9311",
+      "expected_found": true,
+      "label": "edit_90pct",
+      "lcp_fraction": 0.895828,
+      "lcp_tokens": 114666,
+      "prime": {
+        "content": "Ledger fully acknowledged.",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 128000.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 111.536,
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 128000,
+          "total_tokens": 128006
+        },
+        "wall_s": 111.817
+      },
+      "probe": {
+        "content": "ONYX-9311",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 128024.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 112.491,
+        "usage": {
+          "completion_tokens": 7,
+          "prompt_tokens": 128024,
+          "total_tokens": 128031
+        },
+        "wall_s": 112.817
+      },
+      "probe_identity": {
+        "count": 128024,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          448,
+          279,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "f945696d641d2e2c83b16b62492baebfcbac72de8fb9c37ccebac1c5ae6c763b",
+        "token_ids_sha256": "dd9ac5e9b0cd9c7f8ddf24df754e5ab90d1d0a5b1a96be4dddca52939d02a70d"
+      },
+      "reset": {
+        "body": {
+          "success": true
+        },
+        "http": 200,
+        "idle": {
+          "local_cache_hit": 125440.0,
+          "local_compute": 643959.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "seconds": 0.116
+      },
+      "stale_values_found": []
+    },
+    {
+      "expected": "PINE-1017",
+      "expected_found": true,
+      "label": "branch_10pct",
+      "lcp_fraction": 0.099742,
+      "lcp_tokens": 12767,
+      "prime": {
+        "content": "Ledger fully acknowledged.",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 128000.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 110.6,
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 128000,
+          "total_tokens": 128006
+        },
+        "wall_s": 110.852
+      },
+      "probe": {
+        "content": "PINE-1017",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 12794.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 11.016,
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 12794,
+          "total_tokens": 12800
+        },
+        "wall_s": 11.136
+      },
+      "probe_identity": {
+        "count": 12794,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          100286,
+          594,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "c04e1623bf0e3c610fac5c2766fec1c05c20a62eaec35863034952622ead1462",
+        "token_ids_sha256": "ae589db4410ebc7bc20aba5536d93b6b816b46b08f5b663556b04ec75a757da5"
+      },
+      "reset": {
+        "body": {
+          "success": true
+        },
+        "http": 200,
+        "idle": {
+          "local_cache_hit": 125440.0,
+          "local_compute": 899983.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "seconds": 0.187
+      },
+      "stale_values_found": []
+    },
+    {
+      "expected": "EMBER-5051",
+      "expected_found": true,
+      "label": "branch_50pct",
+      "lcp_fraction": 0.497812,
+      "lcp_tokens": 63720,
+      "prime": {
+        "content": "Ledger fully acknowledged.",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 128000.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 107.786,
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 128000,
+          "total_tokens": 128006
+        },
+        "wall_s": 108.028
+      },
+      "probe": {
+        "content": "EMBER-5051",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 63747.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 56.312,
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 63747,
+          "total_tokens": 63753
+        },
+        "wall_s": 56.411
+      },
+      "probe_identity": {
+        "count": 63747,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          100002,
+          594,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "8a82ca9a35c5af9074a62d570ef90d375a18ce1f138f6d884e42dd4c6ca8f8e5",
+        "token_ids_sha256": "8f8788e3c417bc150f700b613c05b6fec85d10010d617d5c6cdb0597c38d7835"
+      },
+      "reset": {
+        "body": {
+          "success": true
+        },
+        "http": 200,
+        "idle": {
+          "local_cache_hit": 125440.0,
+          "local_compute": 1040777.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "seconds": 0.123
+      },
+      "stale_values_found": []
+    },
+    {
+      "expected": "QUARTZ-9097",
+      "expected_found": true,
+      "label": "branch_90pct",
+      "lcp_fraction": 0.895891,
+      "lcp_tokens": 114674,
+      "prime": {
+        "content": "Ledger fully acknowledged.",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 128000.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 111.262,
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 128000,
+          "total_tokens": 128006
+        },
+        "wall_s": 111.538
+      },
+      "probe": {
+        "content": "QUARTZ-9097",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 114701.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 99.885,
+        "usage": {
+          "completion_tokens": 8,
+          "prompt_tokens": 114701,
+          "total_tokens": 114709
+        },
+        "wall_s": 99.953
+      },
+      "probe_identity": {
+        "count": 114701,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          100614,
+          594,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "5a8abc8ac38f6a60acf10cc3486198500aed9a5e388997b43ae33bbb53f0b012",
+        "token_ids_sha256": "4ef9b239e582101000b5885e25784c22d105d6dfbb60389c292521a4587f56d9"
+      },
+      "reset": {
+        "body": {
+          "success": true
+        },
+        "http": 200,
+        "idle": {
+          "local_cache_hit": 125440.0,
+          "local_compute": 1232524.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "seconds": 0.114
+      },
+      "stale_values_found": []
+    }
+  ],
+  "runtime": "new",
+  "started_unix": 1788599542.0175025
+}

--- a/docs/qualification/apc-2026-09-05/old.json
+++ b/docs/qualification/apc-2026-09-05/old.json
@@ -1,0 +1,863 @@
+{
+  "base_identity": {
+    "count": 128000,
+    "first_token_ids": [
+      154822,
+      154824,
+      154826,
+      25062,
+      287,
+      29905,
+      371,
+      25
+    ],
+    "last_token_ids": [
+      46645,
+      304,
+      2326,
+      4244,
+      13,
+      154828,
+      154841,
+      154842
+    ],
+    "messages_sha256": "dda4a94e79039694c00d29dbea3a7d8b2d85de1ef7afbec00cb3a766e898f3d2",
+    "token_ids_sha256": "eee16ca8b28485239ecb4cfed71a1633380ac1d023644b5e3f2d83f41e6878f5"
+  },
+  "cases": [
+    {
+      "expected": "APPEND-OK",
+      "identity": {
+        "count": 128019,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          17885,
+          4689,
+          12,
+          3925,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "5ff7396183ea3d675ffaf952c15d874c83255678b60637bd669b4efae5dd4eaf",
+        "token_ids_sha256": "9df43f4dbb4472f7d8a4b5db34bad45dfd6eb10aa86f238f97a51ce71525242e"
+      },
+      "label": "append_control",
+      "lcp_fraction": 1.0,
+      "lcp_tokens": 128000
+    },
+    {
+      "expected": "CEDAR-1183",
+      "identity": {
+        "count": 128025,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          448,
+          279,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "31345f14da438c2ec41d1e275b5b166f574d0111e8cd769acd868732c8ba55a3",
+        "token_ids_sha256": "f0027d1e514b8a0d4f3cb864dbf6a96fea67b26012cec0ee258b5773351a2056"
+      },
+      "label": "edit_10pct",
+      "lcp_fraction": 0.099695,
+      "lcp_tokens": 12761
+    },
+    {
+      "expected": "FLAME-5279",
+      "identity": {
+        "count": 128024,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          448,
+          279,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "b37c237c4814de3012a4f8c79a51368e7915a3ad075c31829e7b7e0334fc640b",
+        "token_ids_sha256": "9d55b69452f7abc78d0bb202180ea10b7142061b334f72efa50b1ef5b6536ebd"
+      },
+      "label": "edit_50pct",
+      "lcp_fraction": 0.497758,
+      "lcp_tokens": 63713
+    },
+    {
+      "expected": "ONYX-9311",
+      "identity": {
+        "count": 128024,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          448,
+          279,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "f945696d641d2e2c83b16b62492baebfcbac72de8fb9c37ccebac1c5ae6c763b",
+        "token_ids_sha256": "dd9ac5e9b0cd9c7f8ddf24df754e5ab90d1d0a5b1a96be4dddca52939d02a70d"
+      },
+      "label": "edit_90pct",
+      "lcp_fraction": 0.895828,
+      "lcp_tokens": 114666
+    },
+    {
+      "expected": "PINE-1017",
+      "identity": {
+        "count": 12794,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          100286,
+          594,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "c04e1623bf0e3c610fac5c2766fec1c05c20a62eaec35863034952622ead1462",
+        "token_ids_sha256": "ae589db4410ebc7bc20aba5536d93b6b816b46b08f5b663556b04ec75a757da5"
+      },
+      "label": "branch_10pct",
+      "lcp_fraction": 0.099742,
+      "lcp_tokens": 12767
+    },
+    {
+      "expected": "EMBER-5051",
+      "identity": {
+        "count": 63747,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          100002,
+          594,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "8a82ca9a35c5af9074a62d570ef90d375a18ce1f138f6d884e42dd4c6ca8f8e5",
+        "token_ids_sha256": "8f8788e3c417bc150f700b613c05b6fec85d10010d617d5c6cdb0597c38d7835"
+      },
+      "label": "branch_50pct",
+      "lcp_fraction": 0.497812,
+      "lcp_tokens": 63720
+    },
+    {
+      "expected": "QUARTZ-9097",
+      "identity": {
+        "count": 114701,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          100614,
+          594,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "5a8abc8ac38f6a60acf10cc3486198500aed9a5e388997b43ae33bbb53f0b012",
+        "token_ids_sha256": "4ef9b239e582101000b5885e25784c22d105d6dfbb60389c292521a4587f56d9"
+      },
+      "label": "branch_90pct",
+      "lcp_fraction": 0.895891,
+      "lcp_tokens": 114674
+    }
+  ],
+  "elapsed_s": 1064.576,
+  "finished_unix": 1788602689.5178049,
+  "pass": true,
+  "reference_inputs_match": true,
+  "rows": [
+    {
+      "expected": "APPEND-OK",
+      "expected_found": true,
+      "label": "append_control",
+      "lcp_fraction": 1.0,
+      "lcp_tokens": 128000,
+      "prime": {
+        "content": "Ledger fully acknowledged.",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 128000.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 109.196,
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 128000,
+          "total_tokens": 128006
+        },
+        "wall_s": 109.454
+      },
+      "probe": {
+        "content": "APPEND-OK",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 125440.0,
+          "local_compute": 2579.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 2.801,
+        "usage": {
+          "completion_tokens": 5,
+          "prompt_tokens": 128019,
+          "total_tokens": 128024
+        },
+        "wall_s": 2.844
+      },
+      "probe_identity": {
+        "count": 128019,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          17885,
+          4689,
+          12,
+          3925,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "5ff7396183ea3d675ffaf952c15d874c83255678b60637bd669b4efae5dd4eaf",
+        "token_ids_sha256": "9df43f4dbb4472f7d8a4b5db34bad45dfd6eb10aa86f238f97a51ce71525242e"
+      },
+      "reset": {
+        "body": {
+          "success": true
+        },
+        "http": 200,
+        "idle": {
+          "local_cache_hit": 0.0,
+          "local_compute": 1316.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "seconds": 0.009
+      },
+      "stale_values_found": []
+    },
+    {
+      "expected": "CEDAR-1183",
+      "expected_found": true,
+      "label": "edit_10pct",
+      "lcp_fraction": 0.099695,
+      "lcp_tokens": 12761,
+      "prime": {
+        "content": "Ledger fully acknowledged.",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 128000.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 108.302,
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 128000,
+          "total_tokens": 128006
+        },
+        "wall_s": 108.562
+      },
+      "probe": {
+        "content": "CEDAR-1183",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 128025.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 108.178,
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 128025,
+          "total_tokens": 128031
+        },
+        "wall_s": 108.461
+      },
+      "probe_identity": {
+        "count": 128025,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          448,
+          279,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "31345f14da438c2ec41d1e275b5b166f574d0111e8cd769acd868732c8ba55a3",
+        "token_ids_sha256": "f0027d1e514b8a0d4f3cb864dbf6a96fea67b26012cec0ee258b5773351a2056"
+      },
+      "reset": {
+        "body": {
+          "success": true
+        },
+        "http": 200,
+        "idle": {
+          "local_cache_hit": 125440.0,
+          "local_compute": 131895.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "seconds": 0.104
+      },
+      "stale_values_found": []
+    },
+    {
+      "expected": "FLAME-5279",
+      "expected_found": true,
+      "label": "edit_50pct",
+      "lcp_fraction": 0.497758,
+      "lcp_tokens": 63713,
+      "prime": {
+        "content": "Ledger fully acknowledged.",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 128000.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 108.074,
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 128000,
+          "total_tokens": 128006
+        },
+        "wall_s": 108.332
+      },
+      "probe": {
+        "content": "FLAME-5279",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 128024.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 107.855,
+        "usage": {
+          "completion_tokens": 7,
+          "prompt_tokens": 128024,
+          "total_tokens": 128031
+        },
+        "wall_s": 108.046
+      },
+      "probe_identity": {
+        "count": 128024,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          448,
+          279,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "b37c237c4814de3012a4f8c79a51368e7915a3ad075c31829e7b7e0334fc640b",
+        "token_ids_sha256": "9d55b69452f7abc78d0bb202180ea10b7142061b334f72efa50b1ef5b6536ebd"
+      },
+      "reset": {
+        "body": {
+          "success": true
+        },
+        "http": 200,
+        "idle": {
+          "local_cache_hit": 125440.0,
+          "local_compute": 387920.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "seconds": 0.121
+      },
+      "stale_values_found": []
+    },
+    {
+      "expected": "ONYX-9311",
+      "expected_found": true,
+      "label": "edit_90pct",
+      "lcp_fraction": 0.895828,
+      "lcp_tokens": 114666,
+      "prime": {
+        "content": "Ledger fully acknowledged.",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 128000.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 108.269,
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 128000,
+          "total_tokens": 128006
+        },
+        "wall_s": 108.423
+      },
+      "probe": {
+        "content": "ONYX-9311",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 111104.0,
+          "local_compute": 16920.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 14.7,
+        "usage": {
+          "completion_tokens": 7,
+          "prompt_tokens": 128024,
+          "total_tokens": 128031
+        },
+        "wall_s": 14.883
+      },
+      "probe_identity": {
+        "count": 128024,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          448,
+          279,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "f945696d641d2e2c83b16b62492baebfcbac72de8fb9c37ccebac1c5ae6c763b",
+        "token_ids_sha256": "dd9ac5e9b0cd9c7f8ddf24df754e5ab90d1d0a5b1a96be4dddca52939d02a70d"
+      },
+      "reset": {
+        "body": {
+          "success": true
+        },
+        "http": 200,
+        "idle": {
+          "local_cache_hit": 125440.0,
+          "local_compute": 643944.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "seconds": 0.114
+      },
+      "stale_values_found": []
+    },
+    {
+      "expected": "PINE-1017",
+      "expected_found": true,
+      "label": "branch_10pct",
+      "lcp_fraction": 0.099742,
+      "lcp_tokens": 12767,
+      "prime": {
+        "content": "Ledger fully acknowledged.",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 128000.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 107.796,
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 128000,
+          "total_tokens": 128006
+        },
+        "wall_s": 108.046
+      },
+      "probe": {
+        "content": "PINE-1017",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 12794.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 11.409,
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 12794,
+          "total_tokens": 12800
+        },
+        "wall_s": 11.535
+      },
+      "probe_identity": {
+        "count": 12794,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          100286,
+          594,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "c04e1623bf0e3c610fac5c2766fec1c05c20a62eaec35863034952622ead1462",
+        "token_ids_sha256": "ae589db4410ebc7bc20aba5536d93b6b816b46b08f5b663556b04ec75a757da5"
+      },
+      "reset": {
+        "body": {
+          "success": true
+        },
+        "http": 200,
+        "idle": {
+          "local_cache_hit": 236544.0,
+          "local_compute": 788864.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "seconds": 0.112
+      },
+      "stale_values_found": []
+    },
+    {
+      "expected": "EMBER-5051",
+      "expected_found": true,
+      "label": "branch_50pct",
+      "lcp_fraction": 0.497812,
+      "lcp_tokens": 63720,
+      "prime": {
+        "content": "Ledger fully acknowledged.",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 128000.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 107.923,
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 128000,
+          "total_tokens": 128006
+        },
+        "wall_s": 108.2
+      },
+      "probe": {
+        "content": "EMBER-5051",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 63747.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 53.857,
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 63747,
+          "total_tokens": 63753
+        },
+        "wall_s": 53.943
+      },
+      "probe_identity": {
+        "count": 63747,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          100002,
+          594,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "8a82ca9a35c5af9074a62d570ef90d375a18ce1f138f6d884e42dd4c6ca8f8e5",
+        "token_ids_sha256": "8f8788e3c417bc150f700b613c05b6fec85d10010d617d5c6cdb0597c38d7835"
+      },
+      "reset": {
+        "body": {
+          "success": true
+        },
+        "http": 200,
+        "idle": {
+          "local_cache_hit": 236544.0,
+          "local_compute": 929658.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "seconds": 0.114
+      },
+      "stale_values_found": []
+    },
+    {
+      "expected": "QUARTZ-9097",
+      "expected_found": true,
+      "label": "branch_90pct",
+      "lcp_fraction": 0.895891,
+      "lcp_tokens": 114674,
+      "prime": {
+        "content": "Ledger fully acknowledged.",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 0.0,
+          "local_compute": 128000.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 107.863,
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 128000,
+          "total_tokens": 128006
+        },
+        "wall_s": 108.115
+      },
+      "probe": {
+        "content": "QUARTZ-9097",
+        "finish_reason": "stop",
+        "http": 200,
+        "metric_delta": {
+          "local_cache_hit": 111104.0,
+          "local_compute": 3597.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "ok": true,
+        "ttft_s": 3.351,
+        "usage": {
+          "completion_tokens": 8,
+          "prompt_tokens": 114701,
+          "total_tokens": 114709
+        },
+        "wall_s": 3.427
+      },
+      "probe_identity": {
+        "count": 114701,
+        "first_token_ids": [
+          154822,
+          154824,
+          154826,
+          25062,
+          287,
+          29905,
+          371,
+          25
+        ],
+        "last_token_ids": [
+          100614,
+          594,
+          897,
+          1172,
+          13,
+          154828,
+          154841,
+          154842
+        ],
+        "messages_sha256": "5a8abc8ac38f6a60acf10cc3486198500aed9a5e388997b43ae33bbb53f0b012",
+        "token_ids_sha256": "4ef9b239e582101000b5885e25784c22d105d6dfbb60389c292521a4587f56d9"
+      },
+      "reset": {
+        "body": {
+          "success": true
+        },
+        "http": 200,
+        "idle": {
+          "local_cache_hit": 236544.0,
+          "local_compute": 1121405.0,
+          "preemptions": 0.0,
+          "running": 0.0,
+          "waiting": 0.0
+        },
+        "seconds": 0.107
+      },
+      "stale_values_found": []
+    }
+  ],
+  "runtime": "old",
+  "started_unix": 1788601624.9419725
+}

--- a/overlay/patch_apc_per_group_retention.py
+++ b/overlay/patch_apc_per_group_retention.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+"""Per-KV-cache-group prefix-cache retention (stop the DFlash2 drafter evicting APC).
+
+Recipe-overlay style: fail-closed, idempotent, MARK/anchor, matching
+overlay/patch_hybrid_prefix_hit.py. See docs/DESIGN-apc-per-group-retention.md for the analysis.
+
+Problem (all line refs = the live fork, read-only):
+
+  The drafter group (exact SlidingWindowSpec, window 2048, block 64, EAGLE) hashes
+  ``_contiguous_blocks_for_hit(2048, 64, use_eagle=True) == 33`` block ids at EVERY
+  3584-token hit boundary (single_type_kv_cache_manager.py:998-1057), i.e. 33 of the
+  38 ids a cached 3584-token segment costs (MLA 1 + mamba 4 + drafter 33). Those
+  blocks are freed *cached* by remove_skipped_blocks -> _remove_blocks_in_range ->
+  BlockPool.free_blocks (block_pool.py:719-743), which appends hashed blocks to the
+  LRU **tail** — the most protected end — while the MLA/mamba blocks that actually
+  carry the hit are freed later and sit ahead of them. Priority inversion: 87% of
+  the 642-id pool is spent on a group whose hit length is discarded by the hybrid
+  min() anyway (kv_cache_coordinator.py:856-868).
+
+  The current mitigation passes ONE VLLM_PREFIX_CACHE_RETENTION_INTERVAL to every
+  manager (kv_cache_coordinator.py:154, :316, :753), so buying capacity also
+  coarsens the mamba/MLA hit grid to that interval (subagent hits fell to 45%).
+
+This patch: make ``retention_interval`` per group. The EAGLE-exempt drafter group
+gets its own explicit value from ``VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA``;
+when the variable is unset, every group keeps the global value. No manager-side
+change is needed: ``SingleTypeKVCacheManager.cache_blocks`` already takes
+retention_interval per call (single_type_kv_cache_manager.py:429-434) and each
+reachable_block_mask already honours None / 0 / >0.
+
+Env contract:
+  VLLM_PREFIX_CACHE_RETENTION_INTERVAL      unchanged (global; None = dense)
+  VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA  ""/unset = inherit the global value
+                                            "0"     = reachable boundaries only (recommended)
+                                            N       = multiple of scheduler_block_size,
+                                                      0 <= N <= 1,000,000
+
+  The raw value is validated **unconditionally** at coordinator init (integer,
+  non-negative, scheduler-block multiple, <= 1,000,000) — an unusable value is a
+  boot failure even on a model with no sliding-window group.
+
+  It is applied **only** to groups the coordinator itself has singled out as the
+  EAGLE-exempt drafter (``_glm53_min_exempt_group_ids``, derived from
+  ``eagle_group_ids`` — the narrowing overlay/patch_hybrid_prefix_hit.py performs —
+  not from a class name alone). Setting it when no such group exists is a
+  fail-closed boot error, not a silent no-op.
+
+Fail closed if the vLLM coordinator anchors drift.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+P = Path(
+    os.environ.get(
+        "GLM53_KV_COORDINATOR_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/kv_cache_coordinator.py",
+    )
+)
+BP = Path(
+    os.environ.get(
+        "GLM53_BLOCK_POOL_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/block_pool.py",
+    )
+)
+STM = Path(
+    os.environ.get(
+        "GLM53_SINGLE_TYPE_KV_CACHE_MANAGER_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/"
+        "single_type_kv_cache_manager.py",
+    )
+)
+MARK = "# [glm53-apc-per-group]"
+CONTRACT = "glm53-apc-per-group-contract:explicit-v1"
+BP_PRIORITY_MARK = "# [glm53-apc-drafter-priority]"
+PRIOR_HELPER_MARK = "# [glm53-dflash-prior-helper-v2]"
+PRIOR_MANAGER_MARK = "# [glm53-dflash-prior-manager-v1]"
+
+# ---------------------------------------------------------------- anchors ----
+
+IMPORT_OLD = """from abc import ABC, abstractmethod
+from collections.abc import Sequence
+"""
+
+IMPORT_NEW = """import os  # [glm53-apc-per-group]
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+"""
+
+# Shared with overlay/patch_hybrid_prefix_hit.py; inserted only if absent, so the
+# two overlays may be applied in either order.
+BASE_HELPER = '''
+def _glm53_inner_kv_spec(spec):
+    specs = getattr(spec, "kv_cache_specs", None)
+    if isinstance(specs, dict) and specs:
+        return next(iter(specs.values()))
+    return spec
+
+
+def _glm53_is_draft_swa_spec(spec) -> bool:
+    """DFlash2 drafter: exact SlidingWindowSpec, not KpoolTailSpec."""
+    return type(_glm53_inner_kv_spec(spec)).__name__ == "SlidingWindowSpec"
+
+
+'''
+
+RETENTION_HELPER = '''
+def _glm53_swa_retention_env(  # [glm53-apc-per-group]
+    scheduler_block_size,
+    max_interval=1_000_000,
+):
+    """Parse + validate VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA.
+
+    Unset/empty -> None (inherit the global value). Otherwise the raw value is validated
+    *unconditionally* — before any group is inspected — so a typo is a boot
+    failure rather than a silent no-op on a model without a drafter group:
+    integer, non-negative, a multiple of ``scheduler_block_size`` (the base
+    cache-hit granularity, so a retained tail lands on a real hit boundary),
+    and <= ``max_interval``.
+    """
+    key = "VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA"
+    raw = os.environ.get(key, "")
+    if raw.strip() == "":
+        return None
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        raise ValueError(
+            f"{key} must be an integer (got {raw!r}); "
+            "leave it unset to inherit the global value."
+        ) from None
+    if value < 0:
+        raise ValueError(f"{key} ({value}) must be non-negative.")
+    if scheduler_block_size and value % scheduler_block_size != 0:
+        raise ValueError(
+            f"{key} ({value}) must be a multiple of scheduler_block_size "
+            f"({scheduler_block_size}); 0 means reachable boundaries only."
+        )
+    if value > max_interval:
+        raise ValueError(
+            f"{key} ({value}) exceeds the maximum supported retention "
+            f"interval ({max_interval})."
+        )
+    return value
+
+
+def _glm53_min_exempt_group_ids(  # [glm53-apc-per-group]
+    kv_cache_groups,
+    eagle_group_ids,
+    is_hybrid_coordinator,
+):
+    """Group ids a hybrid coordinator treats as EAGLE-exempt drafter groups.
+
+    Derived from coordinator type and state, never from a spec class name alone.
+    A group qualifies only when
+
+      (a) the active coordinator is ``HybridKVCacheCoordinator``,
+      (b) its inner spec is an *exact* ``SlidingWindowSpec`` (the DFlash2
+          drafter; ``KpoolTailSpec`` subclasses it and never prefix-caches), and
+      (c) ``eagle_group_ids`` is *exactly* that set of drafter groups.
+
+    (c) is the state overlay/patch_hybrid_prefix_hit.py establishes: it narrows
+    ``eagle_group_ids`` from the upstream all-groups fallback down to the drafter
+    SWA groups and, driven by the same discriminator, makes those groups skip the
+    hybrid hit ``min()``. A base coordinator has no hybrid ``min()`` even when a
+    unitary SWA model happens to have matching EAGLE ids, so it is never exempt.
+    An undiscriminating all-groups fallback or an annotation over another group
+    also returns the empty set.
+    """
+    if not is_hybrid_coordinator:
+        return frozenset()
+    eagle = set(eagle_group_ids)
+    swa = {
+        i
+        for i, g in enumerate(kv_cache_groups)
+        if _glm53_is_draft_swa_spec(g.kv_cache_spec)
+    }
+    if not swa or eagle != swa:
+        return frozenset()
+    return frozenset(swa)
+
+
+def _glm53_retention_for_group(  # [glm53-apc-per-group]
+    spec,
+    global_interval,
+    swa_interval,
+    is_min_exempt,
+):
+    """Prefix-cache retention interval for one KV cache group.
+
+    Only a group that is both an exact ``SlidingWindowSpec`` **and** EAGLE/
+    min-exempt per ``_glm53_min_exempt_group_ids`` diverges from the global
+    value. An unset SWA interval preserves the global policy. An explicit value
+    applies only to a min-exempt drafter group; the caller validates it and
+    refuses the setting outright if no such group exists.
+    """
+    if (
+        swa_interval is None
+        or not _glm53_is_draft_swa_spec(spec)
+        or not is_min_exempt
+    ):
+        return global_interval
+    return swa_interval
+
+
+def _glm53_resolve_retention_by_group(  # [glm53-apc-per-group]
+    kv_cache_groups,
+    eagle_group_ids,
+    is_hybrid_coordinator,
+    global_interval,
+    swa_interval,
+):
+    """Resolve the per-group retention vector, failing closed on a misdirected
+    SWA override.
+
+    An explicit ``VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA`` is only meaningful
+    for the EAGLE-exempt drafter group. If the coordinator has not singled such a
+    group out, refuse to boot rather than ignore the setting (which would look
+    like the knob worked) or apply it by class name (which would sparsify a group
+    that is still inside the hit ``min()``).
+    """
+    min_exempt = _glm53_min_exempt_group_ids(
+        kv_cache_groups, eagle_group_ids, is_hybrid_coordinator
+    )
+    if swa_interval is not None and not min_exempt:
+        raise ValueError(
+            "VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA is set "
+            f"({swa_interval}) but this coordinator has no hybrid-min-exempt drafter "
+            "sliding-window group: is_hybrid_coordinator="
+            f"{is_hybrid_coordinator}, eagle_group_ids={sorted(set(eagle_group_ids))}. "
+            "Applying it would sparsify a group that still determines prefix hits. "
+            "Unset the variable to inherit the global retention policy."
+        )
+    return tuple(
+        _glm53_retention_for_group(
+            g.kv_cache_spec,
+            global_interval,
+            swa_interval,
+            i in min_exempt,
+        )
+        for i, g in enumerate(kv_cache_groups)
+    )
+
+
+def _glm53_validate_retention_intervals(  # [glm53-apc-per-group]
+    intervals,
+    scheduler_block_size,
+):
+    """Per-group counterpart of _validate_prefix_cache_retention_interval.
+
+    Defence in depth over the resolved vector: every non-``None`` entry is either
+    0 or a non-negative multiple of ``scheduler_block_size``. No upper bound here
+    — inherited *global* values are upstream's to bound; the 1,000,000 cap
+    applies to the SWA value this overlay introduces (``_glm53_swa_retention_env``).
+    """
+    for group_id, value in enumerate(intervals):
+        if value is None or value == 0:
+            continue
+        if value < 0 or value % scheduler_block_size != 0:
+            raise ValueError(
+                f"prefix-cache retention interval for KV cache group {group_id} "
+                f"({value}) must be non-negative and a multiple of "
+                f"scheduler_block_size ({scheduler_block_size})."
+            )
+
+
+def _glm53_format_retention_vector(intervals):  # [glm53-apc-per-group]
+    """Compact, greppable rendering of the resolved vector: ``[None,None,0]``."""
+    return "[" + ",".join("None" if v is None else str(v) for v in intervals) + "]"
+
+
+'''
+
+DFLASH_PRIOR_HELPER = '''
+def _glm53_dflash_prior_mamba_group_ids(  # [glm53-dflash-prior-helper-v2]
+    kv_cache_groups,
+    retention_intervals,
+    is_hybrid_coordinator,
+):
+    """Sparse Mamba groups needing one prior state for full DFlash SWA replay."""
+    if not is_hybrid_coordinator:
+        return frozenset()
+    has_dflash_swa = any(
+        type(_glm53_inner_kv_spec(g.kv_cache_spec)).__name__ == "SlidingWindowSpec"
+        for g in kv_cache_groups
+    )
+    if not has_dflash_swa:
+        return frozenset()
+    group_ids = set()
+    for i, group in enumerate(kv_cache_groups):
+        spec = _glm53_inner_kv_spec(group.kv_cache_spec)
+        if type(spec).__name__ != "MambaSpec":
+            continue
+        interval = retention_intervals[i]
+        # None is dense, and an interval at/below the Mamba state block size
+        # also caches every state. Boundary-only (0) and positive intervals
+        # larger than one state block are sparse and need the backed-up replay
+        # boundary retained explicitly.
+        if interval == 0 or (
+            interval is not None
+            and interval > int(getattr(spec, "block_size", 0) or 0)
+        ):
+            group_ids.add(i)
+    return frozenset(group_ids)
+
+
+'''
+
+INIT_OLD = """        self.retention_interval = envs.VLLM_PREFIX_CACHE_RETENTION_INTERVAL
+        _validate_prefix_cache_retention_interval(
+            self.retention_interval, self.scheduler_block_size, kv_cache_config
+        )
+"""
+
+INIT_FINAL = """        self.retention_interval = envs.VLLM_PREFIX_CACHE_RETENTION_INTERVAL
+        _validate_prefix_cache_retention_interval(
+            self.retention_interval, self.scheduler_block_size, kv_cache_config
+        )
+        # [glm53-apc-per-group] Per-group retention. The DFlash2 drafter SWA group
+        # hashes cdiv(window - 1, block) + 1 == 33 block ids at EVERY hit boundary
+        # and frees them *cached* onto the LRU tail (BlockPool.free_blocks), i.e.
+        # 33 of the 38 ids a cached 3584-token segment costs -- for a group that is
+        # exempted from the hybrid hit min(). Give it its own sparse interval so
+        # MLA and mamba can stay dense and keep the fine hit grid. The raw env
+        # value is validated unconditionally; it is applied only when the hybrid
+        # coordinator itself flagged the drafter group EAGLE-exempt, else boot fails.
+        _glm53_swa_interval = _glm53_swa_retention_env(self.scheduler_block_size)
+        _glm53_is_hybrid = isinstance(self, HybridKVCacheCoordinator)
+        _glm53_min_exempt = _glm53_min_exempt_group_ids(
+            kv_cache_config.kv_cache_groups,
+            self.eagle_group_ids,
+            _glm53_is_hybrid,
+        )
+        self.retention_interval_by_group = _glm53_resolve_retention_by_group(
+            kv_cache_config.kv_cache_groups,
+            self.eagle_group_ids,
+            _glm53_is_hybrid,
+            self.retention_interval,
+            _glm53_swa_interval,
+        )
+        _glm53_validate_retention_intervals(
+            self.retention_interval_by_group, self.scheduler_block_size
+        )
+        # Explicit boundary-only retention keeps the min-exempt drafter's
+        # replay window available for immediate reuse, but those blocks must
+        # not evict target MLA/Mamba state under shared-pool pressure.
+        self.block_pool.low_priority_cache_group_ids = (  # [glm53-apc-drafter-priority]
+            frozenset(_glm53_min_exempt)
+            if _glm53_swa_interval == 0
+            else frozenset()
+        )
+        # [glm53-dflash-prior-policy-v1] A cache switch with a short fresh suffix
+        # cannot rebuild the DFlash drafter's full 2048-token sliding-attention
+        # window. The hybrid lookup backs up one scheduler boundary for that
+        # replay. Under Mamba retention=0 the earlier target state would not
+        # otherwise exist, so retain exactly one prior Mamba checkpoint. The
+        # target KpoolTail is a separate 4-token request-local scratch group.
+        self.dflash_replay_prior_group_ids = _glm53_dflash_prior_mamba_group_ids(
+            kv_cache_config.kv_cache_groups,
+            self.retention_interval_by_group,
+            _glm53_is_hybrid,
+        )
+        for i in self.dflash_replay_prior_group_ids:
+            self.single_type_managers[i]._glm53_retain_previous_dflash_boundary = True
+        # [glm53-apc-free-order-v1] BlockPool.free_blocks is called once per
+        # manager. Free low-priority cached drafter blocks first, so later target
+        # unhashed prepends stay globally ahead of them; target cached blocks
+        # still append at the protected LRU tail.
+        self._glm53_free_manager_order = (
+            tuple(sorted(self.block_pool.low_priority_cache_group_ids))
+            + tuple(
+                i
+                for i in range(len(self.single_type_managers))
+                if i not in self.block_pool.low_priority_cache_group_ids
+            )
+        )
+        logger.info(  # [glm53-apc-per-group]
+            "[glm53-apc-per-group] retention_by_group=%s "
+            "(global=%s swa_env=%s eagle_min_exempt=%s low_priority=%s "
+            "dflash_prior_mamba=%s)",
+            _glm53_format_retention_vector(self.retention_interval_by_group),
+            self.retention_interval,
+            _glm53_swa_interval,
+            sorted(_glm53_min_exempt),
+            sorted(self.block_pool.low_priority_cache_group_ids),
+            sorted(self.dflash_replay_prior_group_ids),
+        )
+"""
+
+BASE_CACHE_OLD = """        for manager in self.single_type_managers:
+            manager.cache_blocks(
+                request,
+                num_computed_tokens,
+                retention_interval=self.retention_interval,
+            )
+"""
+
+BASE_CACHE_NEW = """        for i, manager in enumerate(self.single_type_managers):
+            manager.cache_blocks(
+                request,
+                num_computed_tokens,
+                # [glm53-apc-per-group] per-group, not the single global value
+                retention_interval=self.retention_interval_by_group[i],
+            )
+"""
+
+HYBRID_LOOP_OLD = """        for manager in self.single_type_managers:
+            num_tokens_to_cache = aligned_num_computed_tokens
+"""
+
+HYBRID_LOOP_NEW = """        for i, manager in enumerate(self.single_type_managers):
+            num_tokens_to_cache = aligned_num_computed_tokens
+"""
+
+HYBRID_CACHE_OLD = """            manager.cache_blocks(
+                request,
+                num_tokens_to_cache,
+                retention_interval=self.retention_interval,
+            )
+"""
+
+HYBRID_CACHE_NEW = """            manager.cache_blocks(
+                request,
+                num_tokens_to_cache,
+                # [glm53-apc-per-group] per-group, not the single global value
+                retention_interval=self.retention_interval_by_group[i],
+            )
+"""
+
+FREE_OLD = """    def free(self, request_id: str) -> None:
+        \"\"\"
+        Free the blocks for the request.
+
+        Args:
+            request_id: The request ID.
+        \"\"\"
+        for manager in self.single_type_managers:
+            manager.free(request_id)
+"""
+
+FREE_METHOD_NEW = """    def free(self, request_id: str) -> None:
+        \"\"\"
+        Free the blocks for the request.
+
+        Args:
+            request_id: The request ID.
+        \"\"\"
+        for i in self._glm53_free_manager_order:  # [glm53-apc-free-order-v1]
+            self.single_type_managers[i].free(request_id)
+"""
+
+STM_REACHABLE_OLD = """        reachable_boundaries = [request.num_prompt_tokens - 1]
+        if request.shared_prefix_boundary:
+            reachable_boundaries.append(request.shared_prefix_boundary)
+"""
+
+STM_REACHABLE_NEW = """        reachable_boundaries = [request.num_prompt_tokens - 1]
+        if request.shared_prefix_boundary:
+            reachable_boundaries.append(request.shared_prefix_boundary)
+        if getattr(  # [glm53-dflash-prior-manager-v1]
+            self, "_glm53_retain_previous_dflash_boundary", False
+        ):
+            replay_boundary = (
+                (request.num_prompt_tokens - 1)
+                // self.scheduler_block_size
+                * self.scheduler_block_size
+            )
+            previous_replay_boundary = replay_boundary - self.scheduler_block_size
+            if previous_replay_boundary > 0:
+                reachable_boundaries.append(previous_replay_boundary)
+"""
+
+REMOVE_SKIPPED_OLD = """        for manager in self.single_type_managers:
+            manager.remove_skipped_blocks(
+                request_id, processed_computed_tokens, num_prompt_tokens
+            )
+"""
+
+REMOVE_SKIPPED_NEW = """        for i in self._glm53_free_manager_order:  # [glm53-apc-free-order-v1]
+            self.single_type_managers[i].remove_skipped_blocks(
+                request_id, processed_computed_tokens, num_prompt_tokens
+            )
+"""
+
+BP_INIT_OLD = """        self.metrics_collector = metrics_collector
+"""
+
+BP_INIT_NEW = """        self.metrics_collector = metrics_collector
+        # Populated only by the hybrid coordinator's explicit drafter policy.
+        self.low_priority_cache_group_ids: frozenset[int] = (  # [glm53-apc-drafter-priority]
+            frozenset()
+        )
+"""
+
+BP_FREE_OLD = """        # Identify blocks with hash (LRU cache) and without it (never match APC)
+        blocks_to_evict_last = []
+        blocks_to_evict_first = []
+        for block in ordered_blocks:
+            block.ref_cnt -= 1
+            if block.ref_cnt == 0 and not block.is_null:
+                if block.block_hash is None or not self.enable_caching:
+                    # LIFO reuse of non-cached blocks for better GPU locality.
+                    blocks_to_evict_first.append(block)
+                else:
+                    # FIFO reuse of cached blocks for LRU eviction behavior.
+                    blocks_to_evict_last.append(block)
+
+        # Blocks to reuse first are prepended to the front of the free queue.
+        self.free_block_queue.prepend_n(blocks_to_evict_first)
+        # Blocks to reuse last are appended to the end of the free queue.
+        self.free_block_queue.append_n(blocks_to_evict_last)
+"""
+
+BP_FREE_NEW = """        # Identify blocks with hash (LRU cache) and without it (never match APC).
+        # An explicitly min-exempt drafter group may be cached for immediate
+        # replay while remaining lower priority than target MLA/Mamba state.
+        blocks_to_evict_last = []
+        blocks_to_evict_first = []
+        blocks_to_evict_before_normal_cache = []  # [glm53-apc-drafter-priority]
+        for block in ordered_blocks:
+            block.ref_cnt -= 1
+            if block.ref_cnt == 0 and not block.is_null:
+                if block.block_hash is None or not self.enable_caching:
+                    # LIFO reuse of non-cached blocks for better GPU locality.
+                    blocks_to_evict_first.append(block)
+                else:
+                    block_hashes = [block.block_hash]
+                    block_hashes.extend(
+                        self.cached_block_hashes_by_block.get(block.block_id, ())
+                    )
+                    if self.low_priority_cache_group_ids and all(
+                        get_group_id(key) in self.low_priority_cache_group_ids
+                        for key in block_hashes
+                    ):
+                        blocks_to_evict_before_normal_cache.append(block)
+                    else:
+                        # FIFO reuse of ordinary cached blocks for LRU behavior.
+                        blocks_to_evict_last.append(block)
+
+        # Low-priority cached blocks sit behind immediately reusable unhashed
+        # blocks, but ahead of ordinary cached target state.
+        self.free_block_queue.prepend_n(blocks_to_evict_before_normal_cache)
+        self.free_block_queue.prepend_n(blocks_to_evict_first)
+        self.free_block_queue.append_n(blocks_to_evict_last)
+"""
+
+# ------------------------------------------------------------------ apply ----
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f"{P}: expected one {label} target, found {n}")
+    return text.replace(old, new, 1)
+
+
+def main() -> int:
+    if not P.is_file() or not BP.is_file() or not STM.is_file():
+        raise SystemExit(
+            f"missing coordinator/block pool/single-type manager: {P} / {BP} / {STM}"
+        )
+    text = P.read_text()
+    block_pool_text = BP.read_text()
+    single_type_text = STM.read_text()
+    if MARK not in text:
+        needle = "def _validate_prefix_cache_retention_interval(\n"
+        if text.count(needle) != 1:
+            raise SystemExit(f"{P}: helper insert point not unique")
+
+        if "\nimport os\n" not in text:
+            text = replace_once(text, IMPORT_OLD, IMPORT_NEW, "import")
+        if "def _glm53_inner_kv_spec(" not in text:
+            text = text.replace(needle, BASE_HELPER + needle, 1)
+        text = text.replace(needle, RETENTION_HELPER + needle, 1)
+
+        text = replace_once(text, INIT_OLD, INIT_FINAL, "retention-init")
+        text = replace_once(text, BASE_CACHE_OLD, BASE_CACHE_NEW, "base-cache_blocks")
+        text = replace_once(text, HYBRID_LOOP_OLD, HYBRID_LOOP_NEW, "hybrid-loop")
+        text = replace_once(text, HYBRID_CACHE_OLD, HYBRID_CACHE_NEW, "hybrid-cache_blocks")
+        text = replace_once(text, FREE_OLD, FREE_METHOD_NEW, "free-order release")
+        text = replace_once(
+            text,
+            REMOVE_SKIPPED_OLD,
+            REMOVE_SKIPPED_NEW,
+            "free-order skipped-block release",
+        )
+
+    if "def _glm53_dflash_prior_mamba_group_ids(" not in text:
+        needle = "def _validate_prefix_cache_retention_interval(\n"
+        if text.count(needle) != 1:
+            raise SystemExit(f"{P}: DFlash helper insert point not unique")
+        text = text.replace(needle, DFLASH_PRIOR_HELPER + needle, 1)
+    if PRIOR_MANAGER_MARK not in single_type_text:
+        n = single_type_text.count(STM_REACHABLE_OLD)
+        if n != 1:
+            raise SystemExit(
+                f"{STM}: expected one reachable-boundary target, found {n}"
+            )
+        single_type_text = single_type_text.replace(
+            STM_REACHABLE_OLD, STM_REACHABLE_NEW, 1
+        )
+    if BP_PRIORITY_MARK not in block_pool_text:
+        block_pool_text = replace_once(
+            block_pool_text, BP_INIT_OLD, BP_INIT_NEW, "block-pool priority init"
+        )
+        block_pool_text = replace_once(
+            block_pool_text, BP_FREE_OLD, BP_FREE_NEW, "block-pool priority free"
+        )
+
+    P.write_text(text)
+    BP.write_text(block_pool_text)
+    STM.write_text(single_type_text)
+    print(
+        f"patched {P.name} (per-group APC retention + DFlash replay/free ordering; "
+        "VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA drives the DFlash2 drafter group)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/overlay/patch_hybrid_prefix_hit.py
+++ b/overlay/patch_hybrid_prefix_hit.py
@@ -20,8 +20,15 @@ mamba miss is a correctness hole (vLLM #47491 / #43090).
 This patch: flag only exact SlidingWindowSpec groups as EAGLE, and do not
 let that drafter group shrink ``curr_hit_length``. If the drafter window
 does not cover the MLA/mamba hit, leave its blocks empty so a fresh
-window is allocated (zeros / new pages). Wrong indexer tail state is
-fatal — we do not touch KpoolTailManager.
+window is allocated (zeros / new pages).
+
+KpoolTail is deliberately per-request scratch and cannot prefix-cache. A
+resumed request therefore starts with an empty indexer-tail ring. Replaying
+fewer than one complete kpool leaves the ring incomplete and changes sparse
+attention selection. Clamp the shared hit back to an earlier scheduler
+boundary when necessary so at least one complete kpool is rebuilt before
+decode. This preserves the older MLA/Mamba prefix hit while making the
+non-shareable target state deterministic.
 
 Fail closed if the vLLM coordinator anchors drift.
 """
@@ -38,8 +45,9 @@ P = Path(
     )
 )
 MARK = "# [glm53-hybrid-apc]"
+DFLASH_REPLAY_MARK = "# [glm53-dflash-swa-replay-v1]"
 
-HELPER = '''
+BASE_HELPER = '''
 def _glm53_inner_kv_spec(spec):
     specs = getattr(spec, "kv_cache_specs", None)
     if isinstance(specs, dict) and specs:
@@ -50,6 +58,38 @@ def _glm53_inner_kv_spec(spec):
 def _glm53_is_draft_swa_spec(spec) -> bool:
     """DFlash2 drafter: exact SlidingWindowSpec, not KpoolTailSpec."""
     return type(_glm53_inner_kv_spec(spec)).__name__ == "SlidingWindowSpec"
+
+
+'''
+
+DFLASH_REPLAY_HELPER = '''
+def _glm53_dflash_swa_replay_tokens(kv_cache_groups) -> int:
+    """Fresh tokens required to rebuild the DFlash sliding-attention window."""
+    replay = 0
+    for group in kv_cache_groups:
+        spec = _glm53_inner_kv_spec(group.kv_cache_spec)
+        if type(spec).__name__ == "SlidingWindowSpec":
+            replay = max(replay, int(getattr(spec, "sliding_window", 0) or 0))
+    return replay
+
+
+def _glm53_dflash_replay_safe_hit(
+    hit_length: int,
+    max_cache_hit_length: int,
+    replay_tokens: int,
+    alignment_tokens: int,
+) -> int:
+    """Move an APC hit back until the fresh suffix rebuilds DFlash SWA."""
+    if hit_length <= 0 or replay_tokens <= 0:
+        return hit_length
+    # max_cache_hit_length is prompt_tokens - 1 because the final prompt token
+    # is always recomputed for logits. Include that token in the fresh replay.
+    fresh_tokens = max_cache_hit_length + 1 - hit_length
+    if fresh_tokens >= replay_tokens:
+        return hit_length
+    deficit = replay_tokens - fresh_tokens
+    pages = (deficit + alignment_tokens - 1) // alignment_tokens
+    return max(0, hit_length - pages * alignment_tokens)
 
 
 '''
@@ -88,12 +128,23 @@ MIN_OLD = """                if drop_eagle_block:
                 longest_hit_length = max(longest_hit_length, curr_hit_length)
 """
 
-MIN_NEW = """                if drop_eagle_block:
-                    eagle_verified.add(idx)
+MIN_NEW = """                _glm53_draft_swa = _glm53_is_draft_swa_spec(spec)
+                if drop_eagle_block:
+                    # [glm53-dflash-eagle-verify-v3]
+                    # A failed DFlash lookup is an attempted EAGLE pop, not a
+                    # verified one. The convergence loop may run again after a
+                    # different group shortens the initial candidate; carrying
+                    # a failed verification into that pass would suppress the
+                    # pop and mistake an ordinary 32-block tail for valid
+                    # reconciled-boundary state.
+                    if _glm53_draft_swa and _new_hit_length < curr_hit_length:
+                        eagle_verified.discard(idx)
+                    else:
+                        eagle_verified.add(idx)
                 elif _new_hit_length < curr_hit_length:
                     # length shrunk; invalidate previous eagle verifications
                     eagle_verified.clear()
-                if _glm53_is_draft_swa_spec(spec):  # [glm53-hybrid-apc]
+                if _glm53_draft_swa:  # [glm53-hybrid-apc]
                     # Drafter SWA must not min() the hybrid hit. Its EAGLE pop
                     # re-aligns by LCM(window block, MLA page) = 3584. If the
                     # cached window does not cover the MLA/mamba hit, leave
@@ -139,6 +190,115 @@ LOG_NEW = """        # Propagate the eagle bit to each manager (default to ``use
         )
 """
 
+INIT_OLD = """        self.verify_and_split_kv_cache_groups()
+"""
+
+INIT_NEW = """        self.verify_and_split_kv_cache_groups()
+        # [glm53-dflash-swa-replay-v1] The DFlash drafter needs a complete fresh
+        # sliding-attention window after an APC switch. The target KpoolTail is a
+        # separate 4-token request-local scratch group and is not this 2048-token
+        # replay requirement.
+        self.dflash_swa_replay_tokens = _glm53_dflash_swa_replay_tokens(
+            kv_cache_config.kv_cache_groups
+        )
+        logger.info(
+            "[glm53-dflash-swa-replay-v1] replay_tokens=%d alignment=%d",
+            self.dflash_swa_replay_tokens,
+            self._cache_hit_alignment_tokens,
+        )
+"""
+
+CONVERGE_OLD = """            if curr_hit_length >= hit_length:
+                break
+"""
+
+CONVERGE_FINAL = """            if curr_hit_length >= hit_length:
+                # [glm53-dflash-swa-replay-v2] Reuse the current boundary when
+                # every DFlash group actually returned a complete, EAGLE-popped
+                # sliding window at exactly that reconciled target length. This
+                # avoids backing a valid short-suffix hit up by a full scheduler
+                # page. Length equality alone is insufficient: the returned
+                # prefix is mostly null blocks, so verify the complete visible
+                # window is materialized at its tail.
+                draft_replay_ready = True
+                draft_groups_seen = 0
+                for draft_group_index, (
+                    draft_spec,
+                    draft_group_ids,
+                    _,
+                    draft_use_eagle,
+                ) in enumerate(self.attention_groups):
+                    if not _glm53_is_draft_swa_spec(draft_spec):
+                        continue
+                    draft_groups_seen += len(draft_group_ids)
+                    draft_block_size = self.single_type_managers[
+                        draft_group_ids[0]
+                    ].block_size
+                    required_tail_blocks = (
+                        int(getattr(draft_spec, "sliding_window", 0) or 0) - 1
+                        + draft_block_size - 1
+                    ) // draft_block_size
+                    expected_blocks = curr_hit_length // draft_block_size
+                    for draft_group_id in draft_group_ids:
+                        draft_blocks = hit_blocks_by_group[draft_group_id]
+                        if (
+                            not draft_use_eagle
+                            or draft_group_index not in eagle_verified
+                            or required_tail_blocks <= 0
+                            or hit_length_by_group[draft_group_id] != curr_hit_length
+                            or draft_blocks is None
+                            or len(draft_blocks) != expected_blocks
+                            or len(draft_blocks) < required_tail_blocks
+                            or any(
+                                block.is_null
+                                for block in draft_blocks[-required_tail_blocks:]
+                            )
+                        ):
+                            draft_replay_ready = False
+                            break
+                    if not draft_replay_ready:
+                        break
+                if draft_groups_seen and draft_replay_ready:
+                    logger.info(
+                        "[glm53-dflash-swa-replay-v2] reusing reconciled "
+                        "DFlash boundary hit=%d fresh=%d required=%d",
+                        curr_hit_length,
+                        max_cache_hit_length + 1 - curr_hit_length,
+                        self.dflash_swa_replay_tokens,
+                    )
+                    break
+                replay_safe_hit = _glm53_dflash_replay_safe_hit(
+                    curr_hit_length,
+                    max_cache_hit_length,
+                    self.dflash_swa_replay_tokens,
+                    self._cache_hit_alignment_tokens,
+                )
+                if replay_safe_hit < curr_hit_length:
+                    logger.info(
+                        "[glm53-dflash-swa-replay-v2] replay clamp hit=%d->%d "
+                        "fresh=%d required=%d alignment=%d",
+                        curr_hit_length,
+                        replay_safe_hit,
+                        max_cache_hit_length + 1 - curr_hit_length,
+                        self.dflash_swa_replay_tokens,
+                        self._cache_hit_alignment_tokens,
+                    )
+                    hit_length = replay_safe_hit
+                    # Cached drafter blocks were looked up at the larger target
+                    # hit and cannot be paired with a backed-up target state.
+                    # Discard them so the fresh replay rebuilds the complete
+                    # DFlash sliding-attention window at the new boundary.
+                    for draft_spec, draft_group_ids, _, _ in self.attention_groups:
+                        if _glm53_is_draft_swa_spec(draft_spec):
+                            for draft_group_id in draft_group_ids:
+                                hit_blocks_by_group[draft_group_id] = None
+                                hit_length_by_group[draft_group_id] = 0
+                    eagle_verified.clear()
+                    continue
+                break
+"""
+
+
 
 def replace_once(text: str, old: str, new: str, label: str) -> str:
     n = text.count(old)
@@ -151,19 +311,37 @@ def main() -> int:
     if not P.is_file():
         raise SystemExit(f"missing {P}")
     text = P.read_text()
-    if MARK in text:
-        print(f"{P.name}: {MARK} already present — skipping")
-        return 0
     needle = "def _validate_prefix_cache_retention_interval(\n"
     if text.count(needle) != 1:
         raise SystemExit(f"{P}: helper insert point not unique")
-    if "def _glm53_inner_kv_spec(" not in text:
-        text = text.replace(needle, HELPER + needle, 1)
-    text = replace_once(text, EAGLE_OLD, EAGLE_NEW, "eagle-fallback")
-    text = replace_once(text, MIN_OLD, MIN_NEW, "hybrid-min")
-    text = replace_once(text, LOG_OLD, LOG_NEW, "group-log")
+    if MARK not in text:
+        if "def _glm53_inner_kv_spec(" not in text:
+            text = text.replace(needle, BASE_HELPER + needle, 1)
+        text = replace_once(text, EAGLE_OLD, EAGLE_NEW, "eagle-fallback")
+        text = replace_once(text, MIN_OLD, MIN_NEW, "hybrid-min")
+        text = replace_once(text, LOG_OLD, LOG_NEW, "group-log")
+    if DFLASH_REPLAY_MARK not in text:
+        if "def _glm53_dflash_swa_replay_tokens(" not in text:
+            # Compose with the per-group overlay in a consistent helper order
+            # (Kpool helpers precede its retention helpers) regardless of
+            # which overlay runs first; whitespace between the blobs may
+            # differ, the AST may not.
+            replay_needle = (
+                "def _glm53_swa_retention_env("
+                if "def _glm53_swa_retention_env(" in text
+                else needle
+            )
+            text = text.replace(
+                replay_needle, DFLASH_REPLAY_HELPER + replay_needle, 1
+            )
+        text = replace_once(text, INIT_OLD, INIT_NEW, "dflash-replay-init")
+        text = replace_once(
+            text, CONVERGE_OLD, CONVERGE_FINAL, "dflash-replay-clamp"
+        )
     P.write_text(text)
-    print(f"patched {P.name} (hybrid APC: drafter SWA skipped in min, eagle on SWA only)")
+    print(
+        f"patched {P.name} (hybrid APC + versioned DFlash SWA replay clamp)"
+    )
     return 0
 
 

--- a/start-tp4.sh
+++ b/start-tp4.sh
@@ -81,6 +81,8 @@ _cli_indexer_workspace_set="${GLM53_INDEXER_WORKSPACE+1}"
 _cli_indexer_workspace="${GLM53_INDEXER_WORKSPACE-}"
 _cli_spinwait_ms_set="${GLM53_SPINWAIT_MS+1}"
 _cli_spinwait_ms="${GLM53_SPINWAIT_MS-}"
+_cli_apc_swa_set="${GLM53_APC_RETENTION_INTERVAL_SWA+1}"
+_cli_apc_swa="${GLM53_APC_RETENTION_INTERVAL_SWA-}"
 set -a
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/.env"
@@ -110,6 +112,7 @@ set +a
 [ -n "${_cli_ablit_mtp}" ] && ABLIT_INCLUDE_MTP="$_cli_ablit_mtp"
 [ -n "${_cli_indexer_workspace_set}" ] && GLM53_INDEXER_WORKSPACE="$_cli_indexer_workspace"
 [ -n "${_cli_spinwait_ms_set}" ] && GLM53_SPINWAIT_MS="$_cli_spinwait_ms"
+[ -n "${_cli_apc_swa_set}" ] && GLM53_APC_RETENTION_INTERVAL_SWA="$_cli_apc_swa"
 
 # ----------------------------- configuration -------------------------------
 MODEL="${MODEL:-Mia-AiLab/GLM-5.3-Flash-EXL3-TR3-4bpw}"
@@ -400,6 +403,10 @@ validate_numeric_config() {
     _glm53_validate_enum GLM53_INDEXER_WORKSPACE "${GLM53_INDEXER_WORKSPACE-stock}" \
         stock rightsize || return
     _glm53_validate_spinwait_ms || return
+    if [ -n "${GLM53_APC_RETENTION_INTERVAL_SWA:-}" ]; then
+        echo "GLM53_APC_RETENTION_INTERVAL_SWA is supported only by start.sh (TP=2); unset it for start-tp4.sh" >&2
+        return 2
+    fi
 }
 # GLM53 numeric config guard (end)
 

--- a/start-tp4.sh
+++ b/start-tp4.sh
@@ -403,6 +403,10 @@ validate_numeric_config() {
     _glm53_validate_enum GLM53_INDEXER_WORKSPACE "${GLM53_INDEXER_WORKSPACE-stock}" \
         stock rightsize || return
     _glm53_validate_spinwait_ms || return
+    if [ -n "${GLM53_APC_RETENTION_INTERVAL:-}" ]; then
+        echo "GLM53_APC_RETENTION_INTERVAL is supported only by start.sh (TP=2); unset it for start-tp4.sh" >&2
+        return 2
+    fi
     if [ -n "${GLM53_APC_RETENTION_INTERVAL_SWA:-}" ]; then
         echo "GLM53_APC_RETENTION_INTERVAL_SWA is supported only by start.sh (TP=2); unset it for start-tp4.sh" >&2
         return 2

--- a/start.sh
+++ b/start.sh
@@ -438,6 +438,7 @@ validate_overlay_artifacts() {
     local video_end='    print("glm53: overlay install ok aligned=True", file=sys.stderr)'
     local ablit_marker='MARKER = "ABLIT-HOOK"'
     local -a artifacts=(
+        "$EXL3_OVERLAY_HOST|class Exl3Config(QuantizationConfig):|        )"
         "$VIDEO_PATCH_HOST|vllm/model_executor/layers/|$video_end"
         "$STOP_PATCH_HOST|[suppress-stops-in-reasoning]|    raise SystemExit(main(sys.argv))"
         "$SCHED_PATCH_HOST|[glm53-decode-floor]|$main_guard"

--- a/start.sh
+++ b/start.sh
@@ -164,6 +164,7 @@ STOP_PATCH_HOST="${STOP_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_suppress_stops_in_
 SCHED_PATCH_HOST="${SCHED_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_scheduler_decode_floor.py}"
 DRAFTER_PATCH_HOST="${DRAFTER_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm5_drafter_group.py}"
 APC_PATCH_HOST="${APC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_hybrid_prefix_hit.py}"
+PERGROUP_PATCH_HOST="${PERGROUP_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_apc_per_group_retention.py}"
 XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_xgrammar_termination.py}"
 KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kpool_tail_slotmap.py}"
 SPINWAIT_PATCH_HOST="${SPINWAIT_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_spinwait.py}"
@@ -328,6 +329,39 @@ _glm53_canonical_positive_int() {
     export "$name"
 }
 
+# Prefix-cache retention intervals are token counts on the scheduler-block
+# grid. "" (unset = inherit the global policy) and 0 pass as-is; anything
+# else must be a positive multiple of GLM53_APC_BLOCK_TOKENS no larger than
+# GLM53_APC_RETENTION_MAX -- the same rule overlay/patch_apc_per_group_retention.py
+# re-checks at coordinator init against the live scheduler_block_size. main()
+# runs this guard before `restart` stops anything, so a typo is a launcher
+# error with the healthy pair still serving, not a boot failure after the old
+# containers are already gone. The canonical value (leading zeros stripped) is
+# what both ranks receive.
+GLM53_APC_BLOCK_TOKENS=3584
+GLM53_APC_RETENTION_MAX=1000000
+_glm53_validate_retention_interval() {
+    local name="$1" value="$2" canonical
+    [ -n "$value" ] || return 0
+    if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+        echo "$name must be empty, 0, or a positive multiple of $GLM53_APC_BLOCK_TOKENS <= $GLM53_APC_RETENTION_MAX (got: $value)" >&2
+        return 2
+    fi
+    canonical="$value"
+    while [ "${canonical#0}" != "$canonical" ]; do canonical="${canonical#0}"; done
+    [ -n "$canonical" ] || canonical=0
+    if [ "$canonical" != 0 ] \
+       && { [ "${#canonical}" -gt "${#GLM53_APC_RETENTION_MAX}" ] \
+            || [ "$canonical" -gt "$GLM53_APC_RETENTION_MAX" ] \
+            || [ $((canonical % GLM53_APC_BLOCK_TOKENS)) -ne 0 ]; }; then
+        echo "$name must be empty, 0, or a positive multiple of $GLM53_APC_BLOCK_TOKENS <= $GLM53_APC_RETENTION_MAX (got: $value)" >&2
+        return 2
+    fi
+    printf -v "$name" '%s' "$canonical"
+    # shellcheck disable=SC2163
+    export "$name"
+}
+
 # Enum knobs are exactly one of a fixed set. Not "non-empty means on": a
 # typo'd knob must not silently pick a serving mode. GLM53_INDEXER_WORKSPACE
 # sizes the sparse-indexer prefill workspace, and the patched
@@ -376,8 +410,100 @@ validate_numeric_config() {
         _glm53_validate_enum GLM53_DEFAULT_REASONING_EFFORT \
             "$GLM53_DEFAULT_REASONING_EFFORT" low high max || return
     fi
+    _glm53_validate_retention_interval GLM53_APC_RETENTION_INTERVAL "${GLM53_APC_RETENTION_INTERVAL-}" || return
+    _glm53_validate_retention_interval GLM53_APC_RETENTION_INTERVAL_SWA "${GLM53_APC_RETENTION_INTERVAL_SWA-}" || return
+    if [ -n "${GLM53_APC_RETENTION_INTERVAL_SWA:-}" ] && [ "$SPEC_METHOD" != "dflash" ]; then
+        echo "GLM53_APC_RETENTION_INTERVAL_SWA requires SPEC_METHOD=dflash (got: $SPEC_METHOD)" >&2
+        return 2
+    fi
 }
 # GLM53 numeric config guard (end)
+
+# GLM53 overlay artifact guard (begin)
+# Every file both rank containers mount. main() runs validate_overlay_artifacts
+# on start|restart BEFORE `restart` stops anything: a missing, empty,
+# mis-pointed, truncated or syntactically broken input is a launcher error
+# with the healthy pair left serving, not a container that dies at boot after
+# the old one is gone. Python overlays: path|identity string|last line -
+# the identity string (MARK / target path / hook marker) is distinct per file
+# so a *_PATCH_HOST pointed at a different overlay is caught, and the last
+# non-blank line must match exactly so a copy truncated anywhere before EOF
+# (even one that still parses) is caught too. This guards against operator
+# error (wrong path, stale checkout, truncated copy); it is not a
+# tamper-proof manifest. Needs python3 on the head (DGX OS ships it).
+# preflight() re-checks existence later; this is the fail-closed early gate.
+validate_overlay_artifacts() {
+    # Sentinels that contain quotes live in single-quoted locals.
+    local main_guard='    sys.exit(main())'
+    local video_end='    print("glm53: overlay install ok aligned=True", file=sys.stderr)'
+    local ablit_marker='MARKER = "ABLIT-HOOK"'
+    local -a artifacts=(
+        "$VIDEO_PATCH_HOST|vllm/model_executor/layers/|$video_end"
+        "$STOP_PATCH_HOST|[suppress-stops-in-reasoning]|    raise SystemExit(main(sys.argv))"
+        "$SCHED_PATCH_HOST|[glm53-decode-floor]|$main_guard"
+        "$DRAFTER_PATCH_HOST|vllm/v1/core/kv_cache_utils.py|$main_guard"
+        "$APC_PATCH_HOST|[glm53-hybrid-apc]|$main_guard"
+        "$PERGROUP_PATCH_HOST|glm53-apc-per-group-contract:explicit-v1|$main_guard"
+        "$XGRAMMAR_PATCH_HOST|vllm/v1/structured_output/|$main_guard"
+        "$KPOOL_TAIL_PATCH_HOST|[glm53-kpool-tail-slotmap]|$main_guard"
+        "$SPINWAIT_PATCH_HOST|device_communicators/shm_broadcast.py|$main_guard"
+        "$ADAPTIVE_K_PATCH_HOST|[glm53-adaptive-k]|$main_guard"
+        "$DENSE_FP8_PATCH_HOST|[glm53-dense-fp8]|$main_guard"
+        "$SCRIPT_DIR/overlay/patch_ablit.py|$ablit_marker|    main()"
+        "$SCRIPT_DIR/overlay/ablit_runtime.py|o_proj abliteration (ABLIT)|    return report"
+    )
+    local entry path rest tag tail last
+    if [ "${#artifacts[@]}" -eq 0 ]; then
+        echo "overlay artifact list is empty - refusing to launch" >&2
+        return 2
+    fi
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "python3 is required on the head to verify overlay artifacts before launch" >&2
+        return 2
+    fi
+    for entry in "${artifacts[@]}"; do
+        path="${entry%%|*}"
+        rest="${entry#*|}"
+        tag="${rest%%|*}"
+        tail="${rest#*|}"
+        if [ ! -f "$path" ] || [ ! -r "$path" ] || [ ! -s "$path" ]; then
+            echo "overlay artifact missing, unreadable or empty: $path" >&2
+            return 2
+        fi
+        if ! grep -qF -- "$tag" "$path"; then
+            echo "overlay artifact $path does not carry its identity string '$tag' (wrong file?)" >&2
+            return 2
+        fi
+        # `|| true`: under pipefail a whitespace-only file makes grep exit 1,
+        # which must surface as the rc=2 diagnostic below, not a bare exit 1.
+        last="$(grep -v '^[[:space:]]*$' "$path" | tail -n 1 || true)"
+        if [ "$last" != "$tail" ]; then
+            echo "overlay artifact $path does not end with '$tail' (truncated copy? last line: '$last')" >&2
+            return 2
+        fi
+        # Parse-only: proves the file is importable Python without executing it
+        # or leaving __pycache__ litter in the checkout.
+        if ! python3 -c 'import ast, sys; ast.parse(open(sys.argv[1], encoding="utf-8").read(), sys.argv[1])' "$path" 2>/dev/null; then
+            echo "overlay artifact does not parse as Python: $path" >&2
+            return 2
+        fi
+    done
+    # Non-Python inputs both ranks mount: the chat template and the ablit
+    # layer map (the .pt payloads are ABLIT's own concern at hook time).
+    if [ ! -f "$CHAT_TEMPLATE_HOST" ] || [ ! -r "$CHAT_TEMPLATE_HOST" ] || [ ! -s "$CHAT_TEMPLATE_HOST" ]; then
+        echo "chat template missing, unreadable, empty or not a regular file: $CHAT_TEMPLATE_HOST" >&2
+        return 2
+    fi
+    if ! python3 -c 'from jinja2 import Environment; import sys; Environment(extensions=["jinja2.ext.loopcontrols"]).parse(open(sys.argv[1], encoding="utf-8").read())' "$CHAT_TEMPLATE_HOST" 2>/dev/null; then
+        echo "chat template is invalid or python3 cannot import jinja2: $CHAT_TEMPLATE_HOST" >&2
+        return 2
+    fi
+    if ! python3 -c 'import json, sys; json.load(open(sys.argv[1], encoding="utf-8"))' "$SCRIPT_DIR/ablit/LAYER_MAP.json" 2>/dev/null; then
+        echo "ablit layer map missing or not JSON: $SCRIPT_DIR/ablit/LAYER_MAP.json" >&2
+        return 2
+    fi
+}
+# GLM53 overlay artifact guard (end)
 
 banner() {
     local label="${1:-start.sh}"
@@ -524,6 +650,7 @@ preflight() {
     [ -f "$SCHED_PATCH_HOST" ] || die "$SCHED_PATCH_HOST missing"
     [ -f "$DRAFTER_PATCH_HOST" ] || die "$DRAFTER_PATCH_HOST missing"
     [ -f "$APC_PATCH_HOST" ] || die "$APC_PATCH_HOST missing"
+    [ -f "$PERGROUP_PATCH_HOST" ] || die "$PERGROUP_PATCH_HOST missing"
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "$XGRAMMAR_PATCH_HOST missing"
     [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "$KPOOL_TAIL_PATCH_HOST missing"
     [ -f "$SPINWAIT_PATCH_HOST" ] || die "$SPINWAIT_PATCH_HOST missing"
@@ -972,6 +1099,40 @@ sync_weights() {
 }
 
 # ------------------------ inner container scripts --------------------------
+# Overlay application order inside BOTH rank containers. write_inner_scripts
+# emits this one list verbatim into the head and the worker inner script, so
+# the two ranks cannot drift apart. Pinned for the prefix-cache overlays,
+# which share the kv_cache_coordinator.py helper insert point:
+#   patch_hybrid_prefix_hit -> patch_apc_per_group_retention -> patch_apc_fine_grained_hits
+# (hybrid = Mia's partial-hit base, per-group = PR #83, fine-grained = PR #84).
+# Entries that are not mounted are skipped in-container (`[ -f ]`); which ones
+# MUST exist is decided by the overlay artifact guard above, not here.
+GLM53_OVERLAY_ORDER=(
+    patch_glm_video_placeholders.py
+    patch_suppress_stops_in_reasoning.py
+    patch_scheduler_decode_floor.py
+    patch_glm5_drafter_group.py
+    patch_hybrid_prefix_hit.py
+    patch_apc_per_group_retention.py
+    patch_apc_fine_grained_hits.py
+    patch_xgrammar_termination.py
+    patch_kpool_tail_slotmap.py
+    patch_spinwait.py
+    patch_adaptive_k.py
+    patch_dense_fp8.py
+    patch_indexer_workspace.py
+    patch_ablit.py
+)
+
+# Emits the in-container apply block for GLM53_OVERLAY_ORDER (same bytes for
+# both ranks).
+emit_overlay_block() {
+    local p
+    for p in "${GLM53_OVERLAY_ORDER[@]}"; do
+        printf 'if [ -f /opt/glm53/%s ]; then\n    python3 /opt/glm53/%s\nfi\n' "$p" "$p"
+    done
+}
+
 write_inner_scripts() {
     cat > "$HEAD_SCRIPT" <<'EOF'
 #!/bin/bash
@@ -1035,42 +1196,9 @@ if [ -n "${EXTRA_ARGS:-}" ]; then
 fi
 
 [ -f "${MODEL_DIR}/config.json" ] || { say "FATAL: ${MODEL_DIR}/config.json missing"; ls -la "${MODEL_DIR}" | head; exit 1; }
-if [ -f /opt/glm53/patch_glm_video_placeholders.py ]; then
-    python3 /opt/glm53/patch_glm_video_placeholders.py
-fi
-if [ -f /opt/glm53/patch_suppress_stops_in_reasoning.py ]; then
-    python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
-fi
-if [ -f /opt/glm53/patch_scheduler_decode_floor.py ]; then
-    python3 /opt/glm53/patch_scheduler_decode_floor.py
-fi
-if [ -f /opt/glm53/patch_glm5_drafter_group.py ]; then
-    python3 /opt/glm53/patch_glm5_drafter_group.py
-fi
-if [ -f /opt/glm53/patch_hybrid_prefix_hit.py ]; then
-    python3 /opt/glm53/patch_hybrid_prefix_hit.py
-fi
-if [ -f /opt/glm53/patch_xgrammar_termination.py ]; then
-    python3 /opt/glm53/patch_xgrammar_termination.py
-fi
-if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
-    python3 /opt/glm53/patch_kpool_tail_slotmap.py
-fi
-if [ -f /opt/glm53/patch_spinwait.py ]; then
-    python3 /opt/glm53/patch_spinwait.py
-fi
-if [ -f /opt/glm53/patch_adaptive_k.py ]; then
-    python3 /opt/glm53/patch_adaptive_k.py
-fi
-if [ -f /opt/glm53/patch_dense_fp8.py ]; then
-    python3 /opt/glm53/patch_dense_fp8.py
-fi
-if [ -f /opt/glm53/patch_indexer_workspace.py ]; then
-    python3 /opt/glm53/patch_indexer_workspace.py
-fi
-if [ -f /opt/glm53/patch_ablit.py ]; then
-    python3 /opt/glm53/patch_ablit.py
-fi
+EOF
+    emit_overlay_block >> "$HEAD_SCRIPT"
+    cat >> "$HEAD_SCRIPT" <<'EOF'
 if [ "${ABLIT:-0}" = "1" ]; then
     say "ablit: o_proj orthogonalization ON (method=${ABLIT_METHOD:-auto} direction=${ABLIT_DIRECTION:-dealign} layers=${ABLIT_LAYERS:-15-45} alpha=${ABLIT_ALPHA:-3.0})"
 else
@@ -1141,42 +1269,9 @@ if [ -n "${EXTRA_ARGS:-}" ]; then
 fi
 
 [ -f "${MODEL_DIR}/config.json" ] || { say "FATAL: ${MODEL_DIR}/config.json missing"; ls -la "${MODEL_DIR}" | head; exit 1; }
-if [ -f /opt/glm53/patch_glm_video_placeholders.py ]; then
-    python3 /opt/glm53/patch_glm_video_placeholders.py
-fi
-if [ -f /opt/glm53/patch_suppress_stops_in_reasoning.py ]; then
-    python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
-fi
-if [ -f /opt/glm53/patch_scheduler_decode_floor.py ]; then
-    python3 /opt/glm53/patch_scheduler_decode_floor.py
-fi
-if [ -f /opt/glm53/patch_glm5_drafter_group.py ]; then
-    python3 /opt/glm53/patch_glm5_drafter_group.py
-fi
-if [ -f /opt/glm53/patch_hybrid_prefix_hit.py ]; then
-    python3 /opt/glm53/patch_hybrid_prefix_hit.py
-fi
-if [ -f /opt/glm53/patch_xgrammar_termination.py ]; then
-    python3 /opt/glm53/patch_xgrammar_termination.py
-fi
-if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
-    python3 /opt/glm53/patch_kpool_tail_slotmap.py
-fi
-if [ -f /opt/glm53/patch_spinwait.py ]; then
-    python3 /opt/glm53/patch_spinwait.py
-fi
-if [ -f /opt/glm53/patch_adaptive_k.py ]; then
-    python3 /opt/glm53/patch_adaptive_k.py
-fi
-if [ -f /opt/glm53/patch_dense_fp8.py ]; then
-    python3 /opt/glm53/patch_dense_fp8.py
-fi
-if [ -f /opt/glm53/patch_indexer_workspace.py ]; then
-    python3 /opt/glm53/patch_indexer_workspace.py
-fi
-if [ -f /opt/glm53/patch_ablit.py ]; then
-    python3 /opt/glm53/patch_ablit.py
-fi
+EOF
+    emit_overlay_block >> "$WORKER_SCRIPT"
+    cat >> "$WORKER_SCRIPT" <<'EOF'
 if [ "${ABLIT:-0}" = "1" ]; then
     say "ablit: o_proj orthogonalization ON (method=${ABLIT_METHOD:-auto} direction=${ABLIT_DIRECTION:-dealign} layers=${ABLIT_LAYERS:-15-45} alpha=${ABLIT_ALPHA:-3.0})"
 else
@@ -1208,6 +1303,8 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$DRAFTER_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_glm5_drafter_group.py"
     [ -f "$APC_PATCH_HOST" ] || die "missing $APC_PATCH_HOST"
     scp -q -o BatchMode=yes "$APC_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_hybrid_prefix_hit.py"
+    [ -f "$PERGROUP_PATCH_HOST" ] || die "missing $PERGROUP_PATCH_HOST"
+    scp -q -o BatchMode=yes "$PERGROUP_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_apc_per_group_retention.py"
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "missing $XGRAMMAR_PATCH_HOST"
     scp -q -o BatchMode=yes "$XGRAMMAR_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_xgrammar_termination.py"
     [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "missing $KPOOL_TAIL_PATCH_HOST"
@@ -1259,6 +1356,19 @@ launch_cluster() {
         -e DO_NOT_TRACK=1
         -e "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=$CG_ESTIMATE"
     )
+    # Global sparse retention is implemented by the pinned vLLM runtime.  Full
+    # attention remains dense; Mamba managers use this value.  Keep this an
+    # explicit deployer setting and forward it identically to both ranks.
+    if [ -n "${GLM53_APC_RETENTION_INTERVAL:-}" ]; then
+        nccl_common+=(-e "VLLM_PREFIX_CACHE_RETENTION_INTERVAL=$GLM53_APC_RETENTION_INTERVAL")
+        log "global prefix-cache retention interval: ${GLM53_APC_RETENTION_INTERVAL} (both ranks)"
+    fi
+    # Per-group APC retention for the DFlash2 drafter SWA group (overlay patch_apc_per_group_retention.py).
+    # "" = inherit global, 0 = boundaries only, N = multiple of the scheduler block.
+    if [ -n "${GLM53_APC_RETENTION_INTERVAL_SWA:-}" ]; then
+        nccl_common+=(-e "VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA=$GLM53_APC_RETENTION_INTERVAL_SWA")
+        log "drafter (SWA) prefix-cache retention interval: ${GLM53_APC_RETENTION_INTERVAL_SWA} (both ranks)"
+    fi
     local worker_nccl="" e
     for e in "${nccl_common[@]}"; do
         [ "$e" = "-e" ] && continue
@@ -1314,6 +1424,7 @@ launch_cluster() {
         -v '/tmp/patch_scheduler_decode_floor.py:/opt/glm53/patch_scheduler_decode_floor.py:ro' \
         -v '/tmp/patch_glm5_drafter_group.py:/opt/glm53/patch_glm5_drafter_group.py:ro' \
         -v '/tmp/patch_hybrid_prefix_hit.py:/opt/glm53/patch_hybrid_prefix_hit.py:ro' \
+        -v '/tmp/patch_apc_per_group_retention.py:/opt/glm53/patch_apc_per_group_retention.py:ro' \
         -v '/tmp/patch_xgrammar_termination.py:/opt/glm53/patch_xgrammar_termination.py:ro' \
         -v '/tmp/patch_kpool_tail_slotmap.py:/opt/glm53/patch_kpool_tail_slotmap.py:ro' \
         -v '/tmp/patch_spinwait.py:/opt/glm53/patch_spinwait.py:ro' \
@@ -1349,6 +1460,7 @@ launch_cluster() {
         -v "$SCHED_PATCH_HOST:/opt/glm53/patch_scheduler_decode_floor.py:ro" \
         -v "$DRAFTER_PATCH_HOST:/opt/glm53/patch_glm5_drafter_group.py:ro" \
         -v "$APC_PATCH_HOST:/opt/glm53/patch_hybrid_prefix_hit.py:ro" \
+        -v "$PERGROUP_PATCH_HOST:/opt/glm53/patch_apc_per_group_retention.py:ro" \
         -v "$XGRAMMAR_PATCH_HOST:/opt/glm53/patch_xgrammar_termination.py:ro" \
         -v "$KPOOL_TAIL_PATCH_HOST:/opt/glm53/patch_kpool_tail_slotmap.py:ro" \
         -v "$SPINWAIT_PATCH_HOST:/opt/glm53/patch_spinwait.py:ro" \
@@ -1604,7 +1716,7 @@ logs() {
 main() {
     local cmd="${1:-start}"
     case "$cmd" in
-        start|restart) validate_numeric_config ;;
+        start|restart) validate_numeric_config; validate_overlay_artifacts ;;
     esac
     case "$cmd" in
         stop)     banner stop.sh ;;

--- a/start.sh
+++ b/start.sh
@@ -1100,14 +1100,8 @@ sync_weights() {
 }
 
 # ------------------------ inner container scripts --------------------------
-# Overlay application order inside BOTH rank containers. write_inner_scripts
-# emits this one list verbatim into the head and the worker inner script, so
-# the two ranks cannot drift apart. Pinned for the prefix-cache overlays,
-# which share the kv_cache_coordinator.py helper insert point:
-#   patch_hybrid_prefix_hit -> patch_apc_per_group_retention -> patch_apc_fine_grained_hits
-# (hybrid = Mia's partial-hit base, per-group = PR #83, fine-grained = PR #84).
-# Entries that are not mounted are skipped in-container (`[ -f ]`); which ones
-# MUST exist is decided by the overlay artifact guard above, not here.
+# Both ranks apply the same checked overlays. Hybrid replay precedes retention
+# because they share the coordinator helper insertion point.
 GLM53_OVERLAY_ORDER=(
     patch_glm_video_placeholders.py
     patch_suppress_stops_in_reasoning.py
@@ -1115,7 +1109,6 @@ GLM53_OVERLAY_ORDER=(
     patch_glm5_drafter_group.py
     patch_hybrid_prefix_hit.py
     patch_apc_per_group_retention.py
-    patch_apc_fine_grained_hits.py
     patch_xgrammar_termination.py
     patch_kpool_tail_slotmap.py
     patch_spinwait.py

--- a/tests/test_apc_per_group_retention.py
+++ b/tests/test_apc_per_group_retention.py
@@ -1,0 +1,1279 @@
+#!/usr/bin/env python3
+"""Host test for patch_apc_per_group_retention.py (no GPU, no vLLM import).
+
+Applies the overlay to *copies* of kv_cache_coordinator.py and block_pool.py,
+then exercises the injected helpers and eviction policy directly. Fails closed:
+any problem exits non-zero.
+
+    GLM53_KV_COORDINATOR_PY_SRC=/path/to/fork/kv_cache_coordinator.py \\
+    GLM53_BLOCK_POOL_PY_SRC=/path/to/fork/block_pool.py \\
+        python3 test_apc_per_group_retention.py
+
+`..._SRC` may already carry overlay/patch_hybrid_prefix_hit.py. The overlay
+*composition* case additionally needs a pristine (unpatched) copy of the same
+file; it is taken from `GLM53_KV_COORDINATOR_PY_PRISTINE`, else from `..._SRC`
+itself when that is unpatched, else from /tmp/kv_cache_coordinator_pristine.py.
+Default source is the in-container path.
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+from collections import namedtuple
+from collections.abc import Iterable
+import difflib
+import os
+import py_compile
+import shutil
+import subprocess
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+
+def _find(*names: str) -> Path | None:
+    for name in names:
+        for cand in (HERE / name, HERE.parent / "overlay" / name):
+            if cand.is_file():
+                return cand
+    return None
+
+
+PATCH = _find("patch_apc_per_group_retention.py")
+MIA_PATCH = _find("patch_hybrid_prefix_hit.py")
+DEFAULT_SRC = Path(
+    "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/kv_cache_coordinator.py"
+)
+DEFAULT_BP_SRC = Path(
+    "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/block_pool.py"
+)
+DEFAULT_STM_SRC = Path(
+    "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/"
+    "single_type_kv_cache_manager.py"
+)
+FALLBACK_PRISTINE = Path("/tmp/kv_cache_coordinator_pristine.py")
+
+MARKER = "# [glm53-apc-per-group]"
+MIA_MARKER = "# [glm53-hybrid-apc]"
+PRIORITY_MARKER = "# [glm53-apc-drafter-priority]"
+PRIOR_HELPER_MARKER = "# [glm53-dflash-prior-helper-v2]"
+PRIOR_POLICY_MARKER = "# [glm53-dflash-prior-policy-v1]"
+PRIOR_MANAGER_MARKER = "# [glm53-dflash-prior-manager-v1]"
+FREE_ORDER_MARKER = "# [glm53-apc-free-order-v1]"
+
+HELPERS = (
+    "_glm53_inner_kv_spec",
+    "_glm53_is_draft_swa_spec",
+    "_glm53_swa_retention_env",
+    "_glm53_min_exempt_group_ids",
+    "_glm53_retention_for_group",
+    "_glm53_resolve_retention_by_group",
+    "_glm53_validate_retention_intervals",
+    "_glm53_format_retention_vector",
+    "_glm53_dflash_prior_mamba_group_ids",
+)
+COMPOSED_HELPERS = HELPERS + (
+    "_glm53_dflash_swa_replay_tokens",
+    "_glm53_dflash_replay_safe_hit",
+)
+
+ALIGN = 3584  # scheduler_block_size on this kit
+DRAFT_WINDOW = 2048
+DRAFT_BLOCK = 64
+KPOOL_TAIL_TOKENS = 4
+SWA_ENV = "VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA"
+
+
+# --------------------------------------------------------------- stub specs --
+
+
+class SlidingWindowSpec:  # exact type name is the discriminator
+    def __init__(self, sliding_window=DRAFT_WINDOW, block_size=DRAFT_BLOCK):
+        self.sliding_window = sliding_window
+        self.block_size = block_size
+        self.participates_in_prefix_caching = True
+
+
+class KpoolTailSpec(SlidingWindowSpec):
+    """Subclasses SlidingWindowSpec upstream; must NOT be treated as the drafter."""
+
+    def __init__(self):
+        super().__init__(
+            sliding_window=KPOOL_TAIL_TOKENS, block_size=KPOOL_TAIL_TOKENS
+        )
+        self.participates_in_prefix_caching = False
+
+
+class MambaSpec:
+    def __init__(self, block_size=ALIGN):
+        self.block_size = block_size
+        self.mamba_cache_mode = "align"
+        self.participates_in_prefix_caching = True
+
+
+class MLAAttentionSpec:
+    def __init__(self, block_size=ALIGN):
+        self.block_size = block_size
+        self.participates_in_prefix_caching = True
+
+
+class UniformTypeKVCacheSpecs:
+    def __init__(self, inner):
+        self.kv_cache_specs = {"layer.0": inner}
+        self.block_size = inner.block_size
+        self.participates_in_prefix_caching = inner.participates_in_prefix_caching
+
+
+class Group:
+    """Stand-in for KVCacheGroupSpec (only .kv_cache_spec is read)."""
+
+    def __init__(self, spec):
+        self.kv_cache_spec = spec
+        self.is_eagle_group = False
+
+
+def uniform(inner):
+    return UniformTypeKVCacheSpecs(inner)
+
+
+def live_layout():
+    """The seven groups of the live GLM-5.3 kit (DESIGN §1)."""
+    return [
+        Group(uniform(MLAAttentionSpec())),  # 0 MLA + indexer
+        Group(uniform(KpoolTailSpec())),  # 1 kpool tail
+        Group(MambaSpec()),  # 2
+        Group(MambaSpec()),  # 3
+        Group(MambaSpec()),  # 4
+        Group(MambaSpec()),  # 5
+        Group(uniform(SlidingWindowSpec())),  # 6 DFlash2 drafter
+    ]
+
+
+LIVE_EAGLE = {6}  # what patch_hybrid_prefix_hit.py narrows eagle_group_ids to
+
+
+# ------------------------------------------------------- reference formulas --
+
+
+def contiguous_blocks_for_hit(window, block, use_eagle):
+    """Replica of SlidingWindowManager._contiguous_blocks_for_hit (S:886-895)."""
+    blocks = -(-(window - 1) // block)
+    return blocks + 1 if use_eagle else blocks
+
+
+def swa_ids_per_segment(window, block, align, retention, use_eagle=True):
+    """Replica of SlidingWindowManager.reachable_block_mask (S:998-1057),
+    counted over one `align`-token segment far from any reachable boundary."""
+    need = contiguous_blocks_for_hit(window, block, use_eagle)
+    shift = 1 if use_eagle else 0
+    segment_tokens = align if retention is None else (None if retention == 0 else retention)
+    if segment_tokens is None:
+        return 0
+    per_segment = segment_tokens // block
+    if need >= per_segment:
+        return per_segment  # mask None -> every block cached
+    # cache_blocks caches [num_cached_blocks, num_full_blocks); for an EAGLE
+    # group num_full_blocks == aligned/block + 1, so each steady-state range is
+    # [k*per_segment + shift, (k+1)*per_segment + shift). Count over that.
+    total = 0
+    for i in range(shift, shift + align // block):
+        if i >= shift and (i - shift) % per_segment >= per_segment - need:
+            total += 1
+    return total
+
+
+def mamba_ids_per_segment(block, align, retention):
+    """Replica of MambaManager.reachable_block_mask (S:1487-1542)."""
+    if retention is None:
+        return align // block  # dense
+    if retention == 0:
+        return 0
+    per_segment = retention // block
+    if per_segment <= 1:
+        return align // block
+    return (align // block) / per_segment
+
+
+# The ONE capacity formula of DESIGN §4. A conversation of S segments and t turn
+# boundaries caches C = c*S + b*t ids, of which D = d*S + b_d*t are the drafter's
+# (freed cached mid-prefill, so already parked on the protected LRU tail before
+# the next conversation prefills). A's MLA/mamba survive B iff P >= 2C - D.
+def max_segments(c, d, b, b_d, turns=3, pool=642):
+    denom = 2 * c - d
+    return int((pool - (2 * b - b_d) * turns) // denom)
+
+
+# ----------------------------------------------------------------- helpers --
+
+
+def load_helpers(patched_text: str, helpers=HELPERS) -> dict:
+    """Exec only the injected helper functions in an isolated namespace."""
+    tree = ast.parse(patched_text)
+    wanted = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in helpers
+    }
+    missing = set(helpers) - set(wanted)
+    if missing:
+        raise AssertionError(f"patched file is missing helpers: {sorted(missing)}")
+    module = ast.Module(body=[wanted[name] for name in helpers], type_ignores=[])
+    ast.fix_missing_locations(module)
+    ns: dict = {"os": os}
+    exec(compile(module, "<glm53-helpers>", "exec"), ns)  # noqa: S102
+    return ns
+
+
+def check(cond, msg):
+    if not cond:
+        raise AssertionError(msg)
+
+
+def raises(fn, *args, **kwargs):
+    try:
+        fn(*args, **kwargs)
+    except ValueError:
+        return True
+    return False
+
+
+def apply_patch(
+    patch: Path,
+    target: Path,
+    block_pool: Path,
+    single_type_manager: Path,
+) -> None:
+    env = os.environ.copy()
+    env["GLM53_KV_COORDINATOR_PY"] = str(target)
+    env["GLM53_BLOCK_POOL_PY"] = str(block_pool)
+    env["GLM53_SINGLE_TYPE_KV_CACHE_MANAGER_PY"] = str(single_type_manager)
+    subprocess.check_call([sys.executable, str(patch)], env=env)
+
+
+# ------------------------------------------------------------------- cases --
+
+
+def test_min_exemption(ns):
+    """Min-exemption is derived from coordinator state, not from a class name."""
+    fn = ns["_glm53_min_exempt_group_ids"]
+    groups = live_layout()
+
+    check(fn(groups, LIVE_EAGLE, True) == frozenset({6}), "live layout: gid 6 is min-exempt")
+    check(fn(groups, LIVE_EAGLE, False) == frozenset(), "base coordinator -> empty")
+    # Upstream all-groups EAGLE fallback distinguishes nothing -> nothing exempt.
+    check(fn(groups, set(range(7)), True) == frozenset(), "all-groups fallback -> empty")
+    # EAGLE flagged somewhere else -> the drafter is not the exempted group.
+    check(fn(groups, {0}, True) == frozenset(), "eagle on MLA -> empty")
+    check(fn(groups, {0, 6}, True) == frozenset(), "eagle superset -> empty")
+    check(fn(groups, set(), True) == frozenset(), "no eagle group -> empty")
+    # No exact SlidingWindowSpec at all (kpool tail subclass does not count).
+    check(fn(groups[:6], {1}, True) == frozenset(), "kpool tail is not a drafter group")
+    unitary = [Group(uniform(SlidingWindowSpec()))]
+    check(
+        fn(unitary, {0}, False) == frozenset(),
+        "unitary SWA/EAGLE base coordinator -> empty",
+    )
+    print("  min-exemption derivation OK")
+
+
+def test_routing(ns):
+    """The per-group routing matrix."""
+    fn = ns["_glm53_retention_for_group"]
+    drafter = uniform(SlidingWindowSpec())
+    tail = uniform(KpoolTailSpec())
+    mamba = MambaSpec()
+    mla = uniform(MLAAttentionSpec())
+
+    # Explicit SWA value: only the min-exempt drafter diverges.
+    for global_v in (None, 0, 3584, 14336):
+        for swa_v in (0, 14336, 118272):
+            check(
+                fn(drafter, global_v, swa_v, True) == swa_v,
+                f"min-exempt drafter should take swa={swa_v} (global={global_v})",
+            )
+            # Codex #4: the explicit path must honour min-exemption too.
+            check(
+                fn(drafter, global_v, swa_v, False) == global_v,
+                "a SWA group that is NOT min-exempt must keep the global value "
+                "even under an explicit override",
+            )
+            for other, name in ((tail, "kpool"), (mamba, "mamba"), (mla, "mla")):
+                check(
+                    fn(other, global_v, swa_v, False) == global_v,
+                    f"{name} must keep global={global_v}",
+                )
+            # even if a non-drafter group were eagle-flagged
+            check(fn(mamba, global_v, swa_v, True) == global_v, "mamba/eagle")
+            check(fn(mla, global_v, swa_v, True) == global_v, "mla/eagle")
+
+    # Unset is deliberately inert, including for a min-exempt drafter.
+    for global_v in (None, 14336):
+        check(fn(drafter, global_v, None, True) == global_v, "unset: drafter")
+        check(fn(drafter, global_v, None, False) == global_v, "unset: non-exempt SWA")
+        check(fn(mamba, global_v, None, False) == global_v, "unset: mamba")
+        check(fn(tail, global_v, None, False) == global_v, "unset: kpool tail")
+    print("  routing matrix OK")
+
+
+def test_resolve(ns):
+    """The resolved vector, and the fail-closed override guard (Codex #4/#6)."""
+    fn = ns["_glm53_resolve_retention_by_group"]
+    fmt = ns["_glm53_format_retention_vector"]
+    groups = live_layout()
+
+    # The deployment acceptance criterion: [None,...,None,0] on the head.
+    vec = fn(groups, LIVE_EAGLE, True, None, 0)
+    check(vec == (None,) * 6 + (0,), f"proposed config vector wrong: {vec}")
+    check(
+        fmt(vec) == "[None,None,None,None,None,None,0]",
+        f"log rendering must be greppable, got {fmt(vec)}",
+    )
+    # Unset keeps the global policy; sparse retention requires explicit opt-in.
+    check(
+        fn(groups, LIVE_EAGLE, True, None, None) == (None,) * 7,
+        "unset SWA interval must remain dense",
+    )
+    # Codex #6: the global knob still being set must not silently win/lose.
+    check(
+        fn(groups, LIVE_EAGLE, True, 14336, 0) == (14336,) * 6 + (0,),
+        "a leftover global 14336 must show up in the vector, not be hidden",
+    )
+    check(
+        fmt(fn(groups, LIVE_EAGLE, True, 14336, None))
+        == "[14336,14336,14336,14336,14336,14336,14336]",
+        "unset SWA interval must inherit global 14336",
+    )
+
+    # Fail closed: an explicit override with no EAGLE-exempt drafter group.
+    for eagle in (set(range(7)), {0}, {0, 6}, set()):
+        check(
+            raises(fn, groups, eagle, True, None, 0),
+            f"explicit SWA override must fail closed for eagle_group_ids={eagle}",
+        )
+        inherited = fn(groups, eagle, True, None, None)
+        check(
+            inherited == (None,) * 7,
+            f"unset must inherit global for eagle={eagle}, got {inherited}",
+        )
+
+    # A model with no sliding-window group at all: override refused, unset inert.
+    plain = [Group(uniform(MLAAttentionSpec())), Group(MambaSpec())]
+    check(raises(fn, plain, {0, 1}, True, None, 3584), "no SWA group -> refuse")
+    check(fn(plain, {0, 1}, True, 3584, None) == (3584, 3584), "no SWA group -> inherit")
+    unitary = [Group(uniform(SlidingWindowSpec()))]
+    check(
+        raises(fn, unitary, {0}, False, None, 0),
+        "unitary SWA/EAGLE base coordinator -> refuse explicit override",
+    )
+    check(
+        fn(unitary, {0}, False, None, None) == (None,),
+        "unitary SWA/EAGLE base coordinator -> unset is inert",
+    )
+    print("  resolved vector + fail-closed override OK")
+
+
+def test_dflash_prior_groups(ns):
+    """Only sparse Mamba groups in a hybrid DFlash layout get the extra state."""
+    fn = ns["_glm53_dflash_prior_mamba_group_ids"]
+    groups = live_layout()
+    check(
+        fn(groups, (0,) * 7, True) == frozenset({2, 3, 4, 5}),
+        "live all-zero layout must retain one prior checkpoint in four Mamba groups",
+    )
+    check(
+        fn(groups, (None, None, 0, 14336, 3584, None, 0), True)
+        == frozenset({2, 3}),
+        "boundary-only and positive-sparse Mamba groups qualify; dense groups do not",
+    )
+    check(fn(groups, (0,) * 7, False) == frozenset(), "base coordinator -> none")
+    without_dflash = groups[:-1]
+    check(
+        fn(without_dflash, (0,) * len(without_dflash), True) == frozenset(),
+        "hybrid layout without DFlash SWA -> none",
+    )
+    print("  DFlash prior-Mamba group selection OK")
+
+
+def test_env(ns):
+    """Codex #5: the raw env value is validated unconditionally."""
+    fn = ns["_glm53_swa_retention_env"]
+    saved = os.environ.pop(SWA_ENV, None)
+    try:
+        check(fn(ALIGN) is None, "unset -> None (inherit global)")
+        for blank in ("", "  "):
+            os.environ[SWA_ENV] = blank
+            check(fn(ALIGN) is None, f"{blank!r} -> None (inherit global)")
+        os.environ[SWA_ENV] = "0"
+        check(fn(ALIGN) == 0, "'0' -> 0 (boundary-only)")
+        os.environ[SWA_ENV] = " 14336 "
+        check(fn(ALIGN) == 14336, "'14336' -> 14336")
+
+        for bad, why in (
+            ("nope", "junk"),
+            ("3584.0", "float-ish junk"),
+            ("-3584", "negative"),
+            ("-1", "negative non-multiple"),
+            ("3000", "non-multiple"),
+            ("1", "non-multiple"),
+            ("1003520", "over cap (280 * 3584 > 1_000_000)"),
+        ):
+            os.environ[SWA_ENV] = bad
+            check(raises(fn, ALIGN), f"{why}: {bad!r} must be rejected")
+
+        # The cap is the documented 1,000,000 and is enforced independently of
+        # whether the model even has a sliding-window group.
+        cap = fn.__defaults__[0]
+        check(cap == 1_000_000, f"documented cap is 1,000,000, got {cap}")
+        os.environ[SWA_ENV] = "999936"  # 279 * 3584, the largest legal value
+        check(fn(ALIGN) == 999936, "largest legal value accepted")
+    finally:
+        os.environ.pop(SWA_ENV, None)
+        if saved is not None:
+            os.environ[SWA_ENV] = saved
+    print("  env parsing + unconditional validation OK")
+
+
+def test_validator(ns):
+    fn = ns["_glm53_validate_retention_intervals"]
+    fn((None, 0, 3584, 14336, None), ALIGN)  # all legal
+    for bad in ((3000,), (-3584,), (None, 5000), (1,)):
+        check(raises(fn, bad, ALIGN), f"validator accepted illegal intervals {bad}")
+    print("  per-group validator OK")
+
+
+def test_id_cost():
+    """The arithmetic the whole design rests on (DESIGN §2 / §4)."""
+    need = contiguous_blocks_for_hit(DRAFT_WINDOW, DRAFT_BLOCK, use_eagle=True)
+    check(need == 33, f"need should be 33, got {need}")
+
+    dense = swa_ids_per_segment(DRAFT_WINDOW, DRAFT_BLOCK, ALIGN, None)
+    check(dense == 33, f"dense drafter should hash 33 of 56 per 3584, got {dense}")
+
+    boundary_only = swa_ids_per_segment(DRAFT_WINDOW, DRAFT_BLOCK, ALIGN, 0)
+    check(boundary_only == 0, f"retention 0 must hash no segment tails, got {boundary_only}")
+
+    r14336 = swa_ids_per_segment(DRAFT_WINDOW, DRAFT_BLOCK, ALIGN, 14336)
+    check(0 <= r14336 <= 33, "retention 14336 keeps at most one tail per 4 segments")
+    # 33 ids per 14336 tokens == 8.25 per 3584 on average
+    per = 14336 // DRAFT_BLOCK  # 224 drafter blocks per retention interval
+    total = sum(1 for i in range(1, 1 + per) if (i - 1) % per >= per - 33)
+    check(total == 33, f"retention 14336 should hash 33 per interval, got {total}")
+    check(abs(total * ALIGN / 14336 - 8.25) < 1e-9, "== 8.25 ids per 3584 tokens")
+
+    check(mamba_ids_per_segment(ALIGN, ALIGN, None) == 1, "mamba dense = 1/segment/group")
+    check(mamba_ids_per_segment(ALIGN, ALIGN, 0) == 0, "mamba 0 = boundaries only")
+    check(mamba_ids_per_segment(ALIGN, ALIGN, 14336) == 0.25, "mamba 14336 = 1 per 4")
+
+    # Totals quoted in docs/DESIGN-apc-per-group-retention.md §2.5 / §4.
+    dense_total = 1 + 4 * 1 + 33
+    check(dense_total == 38, "dense segment cost")
+    r14336_total = 1 + 4 * 0.25 + 33 / 4
+    check(abs(r14336_total - 10.25) < 1e-9, "retention 14336 segment cost")
+    proposed_total = 1 + 4 * 1 + 0
+    check(proposed_total == 5, "proposed (dense mamba/MLA, boundary-only drafter)")
+
+    # DESIGN §4, one formula, t = 3 turns, P = 642 usable ids. Rows are
+    # (label, c, d, b, b_d, expected S). Boundary tails b exist only when the
+    # group's retention is not None: dense caches every block already, and in
+    # the proposed mode only the drafter has a boundary tail (33).
+    rows = (
+        ("dense", 38, 33, 0, 0, 14),
+        ("R=7168", 19.5, 16.5, 37, 33, 23),
+        ("R=14336", 10.25, 8.25, 37, 33, 42),
+        ("R=28672", 5.625, 4.125, 37, 33, 72),
+        ("proposed", 5, 0, 33, 33, 54),
+    )
+    for label, c, d, b, b_d, expected in rows:
+        got = max_segments(c, d, b, b_d)
+        check(got == expected, f"capacity model {label}: expected {expected}, got {got}")
+    # The dense row is the one with a measured knee (14 OK / 17 fail).
+    check(max_segments(38, 33, 0, 0) == 14, "dense knee must land on the measured 14/17")
+    # 80K needs cdiv(80000, 3584) = 23 segments: R=7168 sits exactly on its knee.
+    check(-(-80000 // ALIGN) == 23, "80K = 23 segments")
+    check(54 * ALIGN == 193536, "proposed mode ~193.5K tokens per conversation")
+    print("  id-cost + capacity arithmetic OK")
+
+
+def test_call_sites(pristine: str, text: str):
+    loop = "for i, manager in enumerate(self.single_type_managers):"
+    check(pristine.count("retention_interval=self.retention_interval,") == 2,
+          "expected exactly two global-interval cache_blocks call sites before the patch")
+    check(text.count("retention_interval=self.retention_interval,") == 0,
+          "no cache_blocks call may still pass the single global interval")
+    check(text.count("retention_interval=self.retention_interval_by_group[i]") == 2,
+          "both cache_blocks call sites must pass the per-group interval")
+    check(text.count(loop) == pristine.count(loop) + 2,
+          "both cache_blocks loops must be enumerated (and no other loop touched)")
+    check("self.retention_interval_by_group = _glm53_resolve_retention_by_group(" in text,
+          "per-group resolution missing")
+    # Codex #6: the resolved vector must be greppable in `docker logs`.
+    check("retention_by_group=%s" in text, "init must log retention_by_group=<vector>")
+    check("_glm53_format_retention_vector(self.retention_interval_by_group)" in text,
+          "the logged vector must be the resolved one")
+    check(text.count(MARKER) >= 6, "MARK must annotate every edit")
+    print("  call sites + boot log line OK")
+
+
+def test_drafter_priority(block_pool_text: str, coordinator_text: str):
+    """Exercise one-batch policy and real per-manager free call ordering."""
+    tree = ast.parse(block_pool_text)
+    block_pool_class = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "BlockPool"
+    )
+    free_blocks = next(
+        node
+        for node in block_pool_class.body
+        if isinstance(node, ast.FunctionDef) and node.name == "free_blocks"
+    )
+    module = ast.Module(body=[free_blocks], type_ignores=[])
+    ast.fix_missing_locations(module)
+
+    class FakeBlock:
+        def __init__(self, block_id, block_hash, ref_cnt=1, is_null=False):
+            self.block_id = block_id
+            self.block_hash = block_hash
+            self.ref_cnt = ref_cnt
+            self.is_null = is_null
+
+    class FakeQueue:
+        def __init__(self):
+            self.items = ["existing"]
+
+        def prepend_n(self, blocks):
+            self.items[:0] = blocks
+
+        def append_n(self, blocks):
+            self.items.extend(blocks)
+
+    ns = {
+        "Iterable": Iterable,
+        "KVCacheBlock": FakeBlock,
+        "get_group_id": lambda key: key[0],
+    }
+    exec(compile(module, "<glm53-block-pool>", "exec"), ns)  # noqa: S102
+
+    pool = types.SimpleNamespace(
+        enable_caching=True,
+        low_priority_cache_group_ids=frozenset({6}),
+        cached_block_hashes_by_block={4: {(2, "mamba")}},
+        free_block_queue=FakeQueue(),
+    )
+    unhashed = FakeBlock(1, None)
+    drafter = FakeBlock(2, (6, "draft"))
+    target = FakeBlock(3, (0, "mla"))
+    mixed = FakeBlock(4, (6, "draft-shared"))
+    still_used = FakeBlock(5, (6, "active"), ref_cnt=2)
+    ns["free_blocks"](pool, [unhashed, drafter, target, mixed, still_used])
+    check(
+        pool.free_block_queue.items == [unhashed, drafter, "existing", target, mixed],
+        "eviction order must be unhashed, drafter-only, existing, then target/mixed",
+    )
+    check(still_used.ref_cnt == 1, "referenced block must not enter the free queue")
+
+    inherited = types.SimpleNamespace(
+        enable_caching=True,
+        low_priority_cache_group_ids=frozenset(),
+        cached_block_hashes_by_block={},
+        free_block_queue=FakeQueue(),
+    )
+    ordinary_draft = FakeBlock(6, (6, "ordinary"))
+    ns["free_blocks"](inherited, [ordinary_draft])
+    check(
+        inherited.free_block_queue.items == ["existing", ordinary_draft],
+        "without explicit SWA=0, drafter blocks must retain ordinary LRU priority",
+    )
+
+    # Coordinator.free invokes BlockPool.free_blocks once per manager. The
+    # low-priority drafter must be called first: otherwise its later prepend
+    # overtakes target unhashed blocks that were already placed at the front.
+    multi_pool = types.SimpleNamespace(
+        enable_caching=True,
+        low_priority_cache_group_ids=frozenset({6}),
+        cached_block_hashes_by_block={},
+        free_block_queue=FakeQueue(),
+        blocks=[],
+    )
+    multi_pool.get_num_free_blocks = lambda: len(multi_pool.free_block_queue.items)
+    multi_pool.free_blocks = types.MethodType(ns["free_blocks"], multi_pool)
+    target_unhashed = FakeBlock(10, None)
+    draft_cached = FakeBlock(11, (6, "draft"))
+    multi_pool.blocks = [target_unhashed, draft_cached]
+
+    class ReleaseManager:
+        def __init__(self, block=None):
+            self.block = block
+            self.req_to_blocks = {"r": [] if block is None else [block]}
+
+        def free(self, request_id):
+            blocks = self.req_to_blocks.pop(request_id)
+            if blocks:
+                multi_pool.free_blocks(blocks)
+
+    managers = [ReleaseManager(target_unhashed)]
+    managers.extend(ReleaseManager() for _ in range(5))
+    managers.append(ReleaseManager(draft_cached))
+    free_name, free_module = _method_from_source(
+        coordinator_text, "KVCacheCoordinator", "free"
+    )
+
+    class FakeLogger:
+        def info(self, *args):
+            pass
+
+    free_ns = {
+        "KVCacheBlock": FakeBlock,
+        "logger": FakeLogger(),
+    }
+    exec(compile(free_module, "<glm53-coordinator-free>", "exec"), free_ns)  # noqa: S102
+    coordinator = types.SimpleNamespace(
+        block_pool=multi_pool,
+        single_type_managers=managers,
+        _glm53_free_manager_order=(6, 0, 1, 2, 3, 4, 5),
+    )
+    free_ns[free_name](coordinator, "r")
+    check(
+        multi_pool.free_block_queue.items
+        == [target_unhashed, draft_cached, "existing"],
+        "multi-call order must keep target unhashed globally ahead of cached drafter",
+    )
+    check(
+        all("r" not in manager.req_to_blocks for manager in managers),
+        "coordinator free must release every manager exactly once",
+    )
+    check(
+        "[glm53-apc-retention-diag]" not in coordinator_text
+        and "[glm53-apc-hit-diag]" not in coordinator_text
+        and "get_group_id," not in coordinator_text,
+        "temporary qualification diagnostics must be absent from composed runtime",
+    )
+    print("  drafter priority + global per-manager free ordering OK")
+
+
+def test_prior_boundary_cache_call(single_type_text: str):
+    """Execute cache_blocks and inspect the boundaries passed to Mamba masking."""
+    tree = ast.parse(single_type_text)
+    manager_class = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "SingleTypeKVCacheManager"
+    )
+    cache_blocks = next(
+        node
+        for node in manager_class.body
+        if isinstance(node, ast.FunctionDef) and node.name == "cache_blocks"
+    )
+    cache_blocks.decorator_list = []
+    module = ast.Module(body=[cache_blocks], type_ignores=[])
+    ast.fix_missing_locations(module)
+    ns = {"Request": object}
+    exec(compile(module, "<glm53-single-type>", "exec"), ns)  # noqa: S102
+
+    seen = []
+
+    class Pool:
+        def cache_full_blocks(self, **kwargs):
+            seen.append(kwargs["block_mask"])
+
+    def make_manager(enabled):
+        manager = types.SimpleNamespace(
+            num_cached_block={"r": 0},
+            block_size=ALIGN,
+            scheduler_block_size=ALIGN,
+            kv_cache_spec=MambaSpec(),
+            use_eagle=False,
+            block_pool=Pool(),
+            req_to_blocks={"r": [object()] * 6},
+            kv_cache_group_id=2,
+        )
+        if enabled:
+            manager._glm53_retain_previous_dflash_boundary = True
+
+        def reachable_block_mask(**kwargs):
+            return tuple(kwargs["reachable_boundaries"])
+
+        manager.reachable_block_mask = reachable_block_mask
+        return manager
+
+    request = types.SimpleNamespace(
+        request_id="r", num_prompt_tokens=21505, shared_prefix_boundary=14336
+    )
+    ns["cache_blocks"](make_manager(True), request, 21504, retention_interval=0)
+    check(
+        seen.pop() == (21504, 14336, 17920),
+        "non-aligned prompt must retain final, junction, and one prior replay boundary",
+    )
+    ns["cache_blocks"](make_manager(False), request, 21504, retention_interval=0)
+    check(
+        seen.pop() == (21504, 14336),
+        "groups without the scoped policy must retain upstream boundaries only",
+    )
+    print("  prior-boundary cache_blocks append/edit/junction inputs OK")
+
+
+def _method_from_source(text: str, class_name: str, method_name: str):
+    tree = ast.parse(text)
+    cls = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    )
+    method = copy.deepcopy(
+        next(
+            node
+            for node in cls.body
+            if isinstance(node, ast.FunctionDef) and node.name == method_name
+        )
+    )
+    method.decorator_list = []
+    method.name = f"_{class_name}_{method_name}"
+    module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(module)
+    return method.name, module
+
+
+def test_composed_runtime_paths(
+    coordinator_text: str,
+    block_pool_text: str,
+    single_type_text: str,
+):
+    """Execute the injected init/cache/hit/free paths on the live seven groups.
+
+    This is deliberately stubbed below GPU/model loading but uses the methods
+    extracted from the fully composed runtime files. It catches unresolved
+    injected names and marker-only migration mistakes before a production boot.
+    """
+    for marker in (
+        "# [glm53-hybrid-apc]",
+        "# [glm53-dflash-swa-replay-v1]",
+        "# [glm53-dflash-swa-replay-v2]",
+        PRIOR_HELPER_MARKER,
+        PRIOR_POLICY_MARKER,
+        FREE_ORDER_MARKER,
+    ):
+        check(marker in coordinator_text, f"composed coordinator missing {marker}")
+    check(
+        PRIOR_MANAGER_MARKER in single_type_text,
+        "composed single-type manager missing prior-boundary hook",
+    )
+
+    helper_ns = load_helpers(coordinator_text, COMPOSED_HELPERS)
+
+    class FakeBlockPool:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.low_priority_cache_group_ids = frozenset()
+
+    class FakeManager:
+        supports_fine_grained_hash_lookup = False
+
+        def __init__(self, spec, group_id):
+            self.block_size = spec.block_size
+            self.group_id = group_id
+            self.use_eagle = False
+            self.cache_calls = []
+
+        def cache_blocks(self, request, num_tokens, retention_interval=None):
+            self.cache_calls.append((request, num_tokens, retention_interval))
+
+    def get_manager_for_kv_cache_spec(kv_cache_spec, kv_cache_group_id, **kwargs):
+        return FakeManager(kv_cache_spec, kv_cache_group_id)
+
+    class HybridKVCacheCoordinator:
+        """Temporary discriminator while the exact base initializer is compiled."""
+
+    class FakeLogger:
+        def __init__(self):
+            self.records = []
+
+        def info(self, *args):
+            self.records.append(args)
+
+        def warning_once(self, *args):
+            self.records.append(args)
+
+    init_name, init_module = _method_from_source(
+        coordinator_text, "KVCacheCoordinator", "__init__"
+    )
+    logger = FakeLogger()
+    ns = {
+        **helper_ns,
+        "KVCacheConfig": object,
+        "KVCacheMetricsCollector": object,
+        "BlockPool": FakeBlockPool,
+        "get_manager_for_kv_cache_spec": get_manager_for_kv_cache_spec,
+        "_validate_prefix_cache_retention_interval": lambda *args: None,
+        "envs": types.SimpleNamespace(VLLM_PREFIX_CACHE_RETENTION_INTERVAL=0),
+        "HybridKVCacheCoordinator": HybridKVCacheCoordinator,
+        "logger": logger,
+    }
+    exec(compile(init_module, "<exact-image-coordinator-init>", "exec"), ns)  # noqa: S102
+
+    base_init = ns[init_name]
+
+    class KVCacheCoordinator:
+        def __init__(self, *args, **kwargs):
+            base_init(self, *args, **kwargs)
+
+        def verify_and_split_kv_cache_groups(self):
+            pass
+
+    tree = ast.parse(coordinator_text)
+    exact_hybrid = copy.deepcopy(
+        next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef)
+            and node.name == "HybridKVCacheCoordinator"
+        )
+    )
+    exact_hybrid.bases = [ast.Name(id="KVCacheCoordinator", ctx=ast.Load())]
+    exact_hybrid.keywords = []
+    exact_hybrid.body = [
+        node
+        for node in exact_hybrid.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name in {"__init__", "_cache_hit_alignment_tokens"}
+    ]
+    hybrid_module = ast.Module(body=[exact_hybrid], type_ignores=[])
+    ast.fix_missing_locations(hybrid_module)
+    hybrid_ns = {
+        "KVCacheCoordinator": KVCacheCoordinator,
+        "KVCacheConfig": object,
+        "KVCacheMetricsCollector": object,
+        "FullAttentionSpec": MLAAttentionSpec,
+        "MambaSpec": MambaSpec,
+        "logger": logger,
+        **helper_ns,
+    }
+    exec(compile(hybrid_module, "<exact-image-hybrid-init>", "exec"), hybrid_ns)  # noqa: S102
+    HybridKVCacheCoordinator = hybrid_ns["HybridKVCacheCoordinator"]
+    base_init.__globals__["HybridKVCacheCoordinator"] = HybridKVCacheCoordinator
+
+    config = types.SimpleNamespace(
+        kv_cache_groups=live_layout(),
+        num_blocks=390,
+        needs_kv_cache_zeroing=False,
+    )
+    saved = os.environ.get(SWA_ENV)
+    os.environ[SWA_ENV] = "0"
+    try:
+        coordinator = HybridKVCacheCoordinator(
+            config,
+            max_model_len=262144,
+            max_in_flight_tokens=2048,
+            use_eagle=True,
+            enable_caching=True,
+            enable_kv_cache_events=False,
+            dcp_world_size=1,
+            pcp_world_size=1,
+            scheduler_block_size=ALIGN,
+            hash_block_size=64,
+        )
+    finally:
+        if saved is None:
+            os.environ.pop(SWA_ENV, None)
+        else:
+            os.environ[SWA_ENV] = saved
+
+    check(coordinator.eagle_group_ids == {6}, "runtime init must isolate drafter gid 6")
+    check(
+        coordinator.retention_interval_by_group == (0,) * 7,
+        "runtime init must resolve the experimental all-zero vector",
+    )
+    check(
+        coordinator.dflash_replay_prior_group_ids == frozenset({2, 3, 4, 5}),
+        "runtime init must select all four sparse Mamba groups",
+    )
+    check(
+        coordinator.dflash_swa_replay_tokens == DRAFT_WINDOW,
+        "runtime init must derive DFlash's 2048-token SWA replay window",
+    )
+    check(
+        coordinator._glm53_free_manager_order == (6, 0, 1, 2, 3, 4, 5),
+        "runtime init must release low-priority drafter manager before target managers",
+    )
+    check(
+        {
+            i
+            for i, manager in enumerate(coordinator.single_type_managers)
+            if getattr(manager, "_glm53_retain_previous_dflash_boundary", False)
+        }
+        == {2, 3, 4, 5},
+        "runtime init must arm only the four Mamba managers",
+    )
+
+    cache_name, cache_module = _method_from_source(
+        coordinator_text, "HybridKVCacheCoordinator", "cache_blocks"
+    )
+    cache_ns = {"Request": object}
+    exec(compile(cache_module, "<exact-image-coordinator-cache>", "exec"), cache_ns)  # noqa: S102
+    coordinator.enable_partial_hash_hits = False
+    coordinator.single_type_managers[6].use_eagle = True
+    request = types.SimpleNamespace(request_id="r")
+    cache_ns[cache_name](coordinator, request, 21569)
+    check(
+        [m.cache_calls[-1][2] for m in coordinator.single_type_managers] == [0] * 7,
+        "cache path must forward the resolved interval to every group",
+    )
+    check(
+        coordinator.single_type_managers[6].cache_calls[-1][1] == 21568,
+        "drafter cache path must preserve the one-block EAGLE lookahead",
+    )
+
+    class FullAttentionSpec:
+        pass
+
+    class HitMambaSpec:
+        pass
+
+    HitMambaSpec.__name__ = "MambaSpec"
+
+    class HitSlidingWindowSpec:
+        sliding_window = DRAFT_WINDOW
+
+    HitSlidingWindowSpec.__name__ = "SlidingWindowSpec"
+
+    class HitManager:
+        supports_fine_grained_hash_lookup = False
+
+        @classmethod
+        def find_longest_cache_hit(cls, max_length, kv_cache_group_ids, **kwargs):
+            length = max_length // ALIGN * ALIGN
+            blocks = [[object()] * (length // ALIGN) for _ in kv_cache_group_ids]
+            return tuple(blocks), length
+
+    class HitBlock:
+        def __init__(self, is_null=False):
+            self.is_null = is_null
+
+    class DraftInvalidAtCurrentManager(HitManager):
+        @classmethod
+        def find_longest_cache_hit(cls, max_length, kv_cache_group_ids, **kwargs):
+            # Length alone claims the latest boundary, but the visible tail is
+            # incomplete. The coordinator must clamp and discard these blocks.
+            if max_length < 21504:
+                return tuple([] for _ in kv_cache_group_ids), 0
+            blocks = [HitBlock() for _ in range(21504 // DRAFT_BLOCK)]
+            blocks[-1] = HitBlock(is_null=True)
+            return tuple(
+                list(blocks) for _ in kv_cache_group_ids
+            ), 21504
+
+    class DraftEagleManager(HitManager):
+        allow_dropped_hit = True
+
+        @classmethod
+        def find_longest_cache_hit(
+            cls, max_length, kv_cache_group_ids, drop_eagle_block, **kwargs
+        ):
+            if drop_eagle_block and (
+                not cls.allow_dropped_hit or max_length < 21568
+            ):
+                return tuple([] for _ in kv_cache_group_ids), 0
+            # A successful dropped lookup and an ordinary undropped lookup both
+            # land on the 21504 target boundary. The coordinator must remember
+            # which one actually established EAGLE semantics across convergence
+            # passes rather than accepting the ordinary tail by shape alone.
+            blocks = [HitBlock() for _ in range(21504 // DRAFT_BLOCK)]
+            return tuple(
+                list(blocks) for _ in kv_cache_group_ids
+            ), 21504
+
+    SpecGroup = namedtuple("SpecGroup", "spec group_ids manager_cls use_eagle")
+    coordinator.attention_groups = [
+        SpecGroup(FullAttentionSpec(), [0], HitManager, False),
+        SpecGroup(HitMambaSpec(), [2, 3, 4, 5], HitManager, False),
+        SpecGroup(HitSlidingWindowSpec(), [6], DraftInvalidAtCurrentManager, True),
+    ]
+    coordinator.dflash_swa_replay_tokens = DRAFT_WINDOW
+    coordinator.hash_block_size = 64
+    coordinator.dcp_world_size = 1
+    for i in (0, 2, 3, 4, 5):
+        coordinator.single_type_managers[i].block_size = ALIGN
+    coordinator.single_type_managers[6].block_size = 64
+
+    hit_name, hit_module = _method_from_source(
+        coordinator_text, "HybridKVCacheCoordinator", "find_longest_cache_hit"
+    )
+    hit_ns = {
+        "BlockHash": object,
+        "KVCacheBlock": object,
+        "FullAttentionSpec": FullAttentionSpec,
+        "MambaSpec": HitMambaSpec,
+        "cdiv": lambda a, b: (a + b - 1) // b,
+        "logger": logger,
+        **helper_ns,
+    }
+    exec(compile(hit_module, "<exact-image-coordinator-hit>", "exec"), hit_ns)  # noqa: S102
+    blocks, hit, uncached = hit_ns[hit_name](coordinator, [object()] * 400, 21568)
+    check(hit == 17920, f"hit path must clamp 21504 to prior state, got {hit}")
+    check(uncached == 3584, f"hit path uncached delta must be 3584, got {uncached}")
+    check(len(blocks) == 7 and len(blocks[0]) == 5, "hit path must return 7 groups")
+    check(
+        blocks[6] == [],
+        "backed-up target hit must discard incomplete later-boundary DFlash blocks, "
+        f"got {len(blocks[6])}",
+    )
+
+    coordinator.attention_groups[-1] = SpecGroup(
+        HitSlidingWindowSpec(), [6], DraftEagleManager, False
+    )
+    blocks, hit, uncached = hit_ns[hit_name](coordinator, [object()] * 400, 21568)
+    check(
+        hit == 17920 and uncached == 3584,
+        "a complete draft tail without EAGLE-pop semantics must still clamp",
+    )
+
+    coordinator.attention_groups[-1] = SpecGroup(
+        HitSlidingWindowSpec(), [6], DraftEagleManager, True
+    )
+    DraftEagleManager.allow_dropped_hit = True
+    # The target shortens max=21568 to 21504; a genuine dropped draft lookup
+    # at that reconciled boundary must survive the second convergence pass.
+    blocks, hit, uncached = hit_ns[hit_name](
+        coordinator, [object()] * 400, 21568
+    )
+    check(
+        hit == 21504,
+        f"complete reconciled DFlash boundary must avoid 3584-token clamp, got {hit}",
+    )
+    check(uncached == 0, f"complete current-boundary hit must not report gap, got {uncached}")
+    check(
+        len(blocks[6]) == 21504 // DRAFT_BLOCK
+        and all(not block.is_null for block in blocks[6][-32:]),
+        "reused DFlash hit must carry the complete 2048-token visible tail",
+    )
+
+    blocks, hit, uncached = hit_ns[hit_name](
+        coordinator, [object()] * 400, 21504
+    )
+    check(
+        hit == 17920 and uncached == 3584 and blocks[6] == [],
+        "suffix-0 lookup bound cannot prove an EAGLE pop and must clamp: "
+        f"hit={hit} uncached={uncached}",
+    )
+
+    # max=21505 starts one token above the scheduler boundary. Full attention
+    # first converges to 21504, forcing a second outer pass. A failed EAGLE
+    # lookup in the first pass must not suppress the drop in the second pass.
+    blocks, hit, uncached = hit_ns[hit_name](
+        coordinator, [object()] * 400, 21505
+    )
+    check(
+        hit == 17920 and uncached == 3584 and blocks[6] == [],
+        "failed suffix-1 EAGLE lookup must clamp instead of accepting an "
+        f"undropped second-pass tail: hit={hit} uncached={uncached}",
+    )
+
+    # At max=21568 the lookup bound permits the EAGLE unit, but a missing unit
+    # (for example after low-priority draft eviction) must still take fallback.
+    DraftEagleManager.allow_dropped_hit = False
+    blocks, hit, uncached = hit_ns[hit_name](
+        coordinator, [object()] * 400, 21568
+    )
+    check(
+        hit == 17920 and uncached == 3584 and blocks[6] == [],
+        "missing suffix-64 EAGLE unit must clamp despite a complete ordinary "
+        f"tail on a later pass: hit={hit} uncached={uncached}",
+    )
+
+    test_prior_boundary_cache_call(single_type_text)
+    test_drafter_priority(block_pool_text, coordinator_text)
+    print("  exact composed init/cache/hit/free execution OK")
+
+
+def test_composition(
+    pristine_src: Path,
+    pristine_bp_src: Path,
+    pristine_stm_src: Path,
+    tmp: Path,
+):
+    """Codex #8: both overlays, both application orders, on a pristine source."""
+    if MIA_PATCH is None:
+        raise SystemExit("missing patch_hybrid_prefix_hit.py (overlay composition)")
+    results = {}
+    for label, order in (
+        ("mia-then-ours", (MIA_PATCH, PATCH)),
+        ("ours-then-mia", (PATCH, MIA_PATCH)),
+    ):
+        dst = tmp / f"compose_{label}.py"
+        bp_dst = tmp / f"block_pool_{label}.py"
+        stm_dst = tmp / f"single_type_{label}.py"
+        shutil.copyfile(pristine_src, dst)
+        shutil.copyfile(pristine_bp_src, bp_dst)
+        shutil.copyfile(pristine_stm_src, stm_dst)
+        for patch in order:
+            apply_patch(patch, dst, bp_dst, stm_dst)
+        text = dst.read_text()
+        bp_text = bp_dst.read_text()
+        stm_text = stm_dst.read_text()
+        py_compile.compile(str(dst), cfile=str(tmp / f"{label}.pyc"), doraise=True)
+        py_compile.compile(
+            str(bp_dst), cfile=str(tmp / f"block-pool-{label}.pyc"), doraise=True
+        )
+        py_compile.compile(
+            str(stm_dst), cfile=str(tmp / f"single-type-{label}.pyc"), doraise=True
+        )
+        check(MARKER in text and MIA_MARKER in text, f"{label}: a MARK is missing")
+        check(PRIORITY_MARKER in bp_text, f"{label}: block-pool priority patch missing")
+        check(PRIOR_HELPER_MARKER in text, f"{label}: coordinator prior helper missing")
+        check(PRIOR_POLICY_MARKER in text, f"{label}: coordinator prior policy missing")
+        check(PRIOR_MANAGER_MARKER in stm_text, f"{label}: manager prior policy missing")
+        check(text.count("def _glm53_inner_kv_spec(") == 1,
+              f"{label}: shared helper duplicated")
+        check(text.count("def _glm53_is_draft_swa_spec(") == 1,
+              f"{label}: shared discriminator duplicated")
+        check(text.count("import os  # [glm53-apc-per-group]") == 1,
+              f"{label}: os import missing or duplicated")
+        # Re-applying either patch in either order must be a no-op.
+        for patch in order + tuple(reversed(order)):
+            apply_patch(patch, dst, bp_dst, stm_dst)
+        check(dst.read_text() == text, f"{label}: composition is not idempotent")
+        check(bp_dst.read_text() == bp_text, f"{label}: block-pool patch is not idempotent")
+        check(stm_dst.read_text() == stm_text, f"{label}: manager patch is not idempotent")
+        # Both overlays' behaviour survives composition.
+        ns = load_helpers(text)
+        check(
+            ns["_glm53_resolve_retention_by_group"](
+                live_layout(), LIVE_EAGLE, True, None, 0
+            )
+            == (None,) * 6 + (0,),
+            f"{label}: resolved vector wrong after composition",
+        )
+        check("if _glm53_draft_swa:  # [glm53-hybrid-apc]" in text,
+              f"{label}: Mia's hybrid-min skip is missing")
+        check("swa_ids or set(" in text,
+              f"{label}: Mia's eagle_group_ids narrowing is missing")
+        test_prior_boundary_cache_call(stm_text)
+        test_composed_runtime_paths(text, bp_text, stm_text)
+        results[label] = text
+
+    import ast
+
+    def ast_dump(source_text: str) -> str:
+        return ast.dump(ast.parse(source_text))
+
+    if ast_dump(results["mia-then-ours"]) != ast_dump(results["ours-then-mia"]):
+        print(
+            "".join(
+                difflib.unified_diff(
+                    results["mia-then-ours"].splitlines(keepends=True),
+                    results["ours-then-mia"].splitlines(keepends=True),
+                    fromfile="mia-then-ours",
+                    tofile="ours-then-mia",
+                )
+            )
+        )
+        raise AssertionError(
+            "the two overlays must compose to the same AST in either order"
+        )
+    print("  overlay composition (both orders, AST-equal, idempotent) OK")
+
+
+def resolve_pristine(src: Path) -> Path:
+    env = os.environ.get("GLM53_KV_COORDINATOR_PY_PRISTINE", "").strip()
+    if env:
+        p = Path(env)
+        if not p.is_file():
+            raise SystemExit(f"GLM53_KV_COORDINATOR_PY_PRISTINE points at nothing: {p}")
+        return p
+    if MIA_MARKER not in src.read_text() and MARKER not in src.read_text():
+        return src
+    if FALLBACK_PRISTINE.is_file():
+        return FALLBACK_PRISTINE
+    raise SystemExit(
+        f"{src} already carries an overlay; the composition test needs a pristine "
+        "copy of the same file. Set GLM53_KV_COORDINATOR_PY_PRISTINE (or drop one "
+        f"at {FALLBACK_PRISTINE})."
+    )
+
+
+def main() -> int:
+    if PATCH is None:
+        raise SystemExit("missing patch_apc_per_group_retention.py")
+    src = Path(os.environ.get("GLM53_KV_COORDINATOR_PY_SRC", DEFAULT_SRC))
+    bp_src = Path(os.environ.get("GLM53_BLOCK_POOL_PY_SRC", DEFAULT_BP_SRC))
+    stm_src = Path(
+        os.environ.get("GLM53_SINGLE_TYPE_KV_CACHE_MANAGER_PY_SRC", DEFAULT_STM_SRC)
+    )
+    if not src.is_file():
+        raise SystemExit(
+            f"missing kv_cache_coordinator.py at {src}; "
+            "set GLM53_KV_COORDINATOR_PY_SRC to a copy of the fork's file"
+        )
+    if not bp_src.is_file():
+        raise SystemExit(
+            f"missing block_pool.py at {bp_src}; "
+            "set GLM53_BLOCK_POOL_PY_SRC to a copy of the fork's file"
+        )
+    if not stm_src.is_file():
+        raise SystemExit(
+            f"missing single_type_kv_cache_manager.py at {stm_src}; "
+            "set GLM53_SINGLE_TYPE_KV_CACHE_MANAGER_PY_SRC to the fork source copy"
+        )
+    if PRIORITY_MARKER in bp_src.read_text():
+        raise SystemExit(f"{bp_src} already carries {PRIORITY_MARKER}; use a pristine copy")
+    pristine_src = resolve_pristine(src)
+    if MIA_MARKER in pristine_src.read_text() or MARKER in pristine_src.read_text():
+        raise SystemExit(f"{pristine_src} is not pristine (it carries an overlay MARK)")
+    print(
+        f"  source: {src}\n  pristine: {pristine_src}\n"
+        f"  block pool: {bp_src}\n  single-type manager: {stm_src}"
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        dst = tmp / "kv_cache_coordinator.py"
+        bp_dst = tmp / "block_pool.py"
+        stm_dst = tmp / "single_type_kv_cache_manager.py"
+        shutil.copyfile(src, dst)
+        shutil.copyfile(bp_src, bp_dst)
+        shutil.copyfile(stm_src, stm_dst)
+
+        pristine = dst.read_text()
+        apply_patch(PATCH, dst, bp_dst, stm_dst)
+        text = dst.read_text()
+        bp_text = bp_dst.read_text()
+        stm_text = stm_dst.read_text()
+        check(MARKER in text, "MARK missing after apply")
+        check(PRIORITY_MARKER in bp_text, "block-pool priority MARK missing after apply")
+        check(PRIOR_HELPER_MARKER in text, "coordinator prior-helper MARK missing")
+        check(PRIOR_POLICY_MARKER in text, "coordinator prior-policy MARK missing")
+        check(PRIOR_MANAGER_MARKER in stm_text, "manager prior-policy MARK missing")
+
+        py_compile.compile(str(dst), cfile=str(tmp / "out.pyc"), doraise=True)
+        py_compile.compile(str(bp_dst), cfile=str(tmp / "block-pool.pyc"), doraise=True)
+        py_compile.compile(str(stm_dst), cfile=str(tmp / "single-type.pyc"), doraise=True)
+        print("  applies and compiles OK")
+
+        apply_patch(PATCH, dst, bp_dst, stm_dst)
+        check(dst.read_text() == text, "patch is not idempotent")
+        check(bp_dst.read_text() == bp_text, "block-pool patch is not idempotent")
+        check(stm_dst.read_text() == stm_text, "single-type patch is not idempotent")
+        print("  idempotent OK")
+
+        test_call_sites(pristine, text)
+        ns = load_helpers(text)
+        test_min_exemption(ns)
+        test_routing(ns)
+        test_resolve(ns)
+        test_dflash_prior_groups(ns)
+        test_env(ns)
+        test_validator(ns)
+        test_drafter_priority(bp_text, text)
+        test_prior_boundary_cache_call(stm_text)
+        test_composition(pristine_src, bp_src, stm_src, tmp)
+
+    test_id_cost()
+    print("drafter-retention patch OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_indexer_workspace.py
+++ b/tests/test_indexer_workspace.py
@@ -794,7 +794,12 @@ def test_recipe_wiring_if_present() -> None:
         assert _run_preamble(f"{key}=rightsize\n", caller, probe) == f"[{expected}]"
     assert '_glm53_validate_enum GLM53_INDEXER_WORKSPACE' in launcher
     assert '-e "GLM53_INDEXER_WORKSPACE=$GLM53_INDEXER_WORKSPACE"' in launcher
-    assert launcher.count("python3 /opt/glm53/patch_indexer_workspace.py") == 2
+    # Both ranks apply the one pinned list (GLM53_OVERLAY_ORDER) that
+    # write_inner_scripts emits into the head and worker inner scripts.
+    order = launcher[launcher.index("GLM53_OVERLAY_ORDER=(") : launcher.index(")", launcher.index("GLM53_OVERLAY_ORDER=("))]
+    assert "\n    patch_indexer_workspace.py\n" in order
+    assert 'emit_overlay_block >> "$HEAD_SCRIPT"' in launcher
+    assert 'emit_overlay_block >> "$WORKER_SCRIPT"' in launcher
     assert "COPY overlay/patch_indexer_workspace.py" in image
     assert "COPY tests/test_indexer_workspace.py" in image
     assert "RUN python3 /opt/glm53/patch_indexer_workspace.py" in image

--- a/tests/test_kpool_tail_slotmap.py
+++ b/tests/test_kpool_tail_slotmap.py
@@ -182,7 +182,12 @@ def test_recipe_wiring_if_present() -> None:
     launcher = start.read_text()
     image = dockerfile.read_text()
     assert 'KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-' in launcher
-    assert launcher.count("python3 /opt/glm53/patch_kpool_tail_slotmap.py") == 2
+    # Both ranks apply the one pinned list (GLM53_OVERLAY_ORDER) that
+    # write_inner_scripts emits into the head and worker inner scripts.
+    order = launcher[launcher.index("GLM53_OVERLAY_ORDER=(") : launcher.index(")", launcher.index("GLM53_OVERLAY_ORDER=("))]
+    assert "\n    patch_kpool_tail_slotmap.py\n" in order
+    assert 'emit_overlay_block >> "$HEAD_SCRIPT"' in launcher
+    assert 'emit_overlay_block >> "$WORKER_SCRIPT"' in launcher
     assert (
         "-v '/tmp/patch_kpool_tail_slotmap.py:"
         "/opt/glm53/patch_kpool_tail_slotmap.py:ro'" in launcher

--- a/tests/test_launcher_rank_parity.py
+++ b/tests/test_launcher_rank_parity.py
@@ -132,7 +132,7 @@ def host_vars() -> dict[str, str]:
     assignment in start.sh, from the real assignment, not from substring hits."""
     out: dict[str, str] = {}
     for m in re.finditer(
-        r'^([A-Z_]+_PATCH_HOST)="\$\{\1:-\$SCRIPT_DIR/overlay/([A-Za-z0-9_.]+)\}"$', source(), re.M
+        r'^([A-Z_]+_(?:PATCH|OVERLAY)_HOST)="\$\{\1:-\$SCRIPT_DIR/overlay/([A-Za-z0-9_.]+)\}"$', source(), re.M
     ):
         out[m.group(1)] = m.group(2)
     return out

--- a/tests/test_launcher_rank_parity.py
+++ b/tests/test_launcher_rank_parity.py
@@ -73,12 +73,10 @@ CONTAINER_NAMES = LAUNCHER_KNOBS + (
 PINNED = (
     "patch_hybrid_prefix_hit.py",
     "patch_apc_per_group_retention.py",
-    "patch_apc_fine_grained_hits.py",
 )
 APC_HOST_VARS = {
     "APC_PATCH_HOST": "patch_hybrid_prefix_hit.py",
     "PERGROUP_PATCH_HOST": "patch_apc_per_group_retention.py",
-    "FINEHIT_PATCH_HOST": "patch_apc_fine_grained_hits.py",
 }
 
 SEP = "\x1f"
@@ -506,10 +504,10 @@ def part_c(h: Harness) -> None:
     text = source()
     order = overlay_order()
     idx = {name: order.index(name) for name in PINNED if name in order}
-    check(len(idx) == 3, f"C1 all three prefix-cache overlays are listed: {sorted(idx)}")
+    check(len(idx) == 2, f"C1 both prefix-cache overlays are listed: {sorted(idx)}")
     check(
-        len(idx) == 3 and idx[PINNED[0]] < idx[PINNED[1]] < idx[PINNED[2]],
-        "C1 pinned order hybrid -> per-group -> fine-grained",
+        len(idx) == 2 and idx[PINNED[0]] < idx[PINNED[1]],
+        "C1 pinned order hybrid -> per-group",
     )
     check(
         'emit_overlay_block >> "$HEAD_SCRIPT"' in text and 'emit_overlay_block >> "$WORKER_SCRIPT"' in text,
@@ -533,9 +531,8 @@ def part_c(h: Harness) -> None:
             body = s.read_text()
             check(
                 body.index("/opt/glm53/patch_hybrid_prefix_hit.py")
-                < body.index("/opt/glm53/patch_apc_per_group_retention.py")
-                < body.index("/opt/glm53/patch_apc_fine_grained_hits.py"),
-                f"C3 {s.name}: hybrid -> per-group -> fine-grained in the generated script",
+                < body.index("/opt/glm53/patch_apc_per_group_retention.py"),
+                f"C3 {s.name}: hybrid -> per-group in the generated script",
             )
             check(
                 "python3 /opt/glm53/patch_ablit.py" in body

--- a/tests/test_launcher_rank_parity.py
+++ b/tests/test_launcher_rank_parity.py
@@ -132,7 +132,7 @@ def host_vars() -> dict[str, str]:
     assignment in start.sh, from the real assignment, not from substring hits."""
     out: dict[str, str] = {}
     for m in re.finditer(
-        r'^([A-Z_]+_(?:PATCH|OVERLAY)_HOST)="\$\{\1:-\$SCRIPT_DIR/overlay/([A-Za-z0-9_.]+)\}"$', source(), re.M
+        r'^([A-Z0-9_]+_(?:PATCH|OVERLAY)_HOST)="\$\{\1:-\$SCRIPT_DIR/overlay/([A-Za-z0-9_.]+)\}"$', source(), re.M
     ):
         out[m.group(1)] = m.group(2)
     return out

--- a/tests/test_launcher_rank_parity.py
+++ b/tests/test_launcher_rank_parity.py
@@ -1,0 +1,725 @@
+#!/usr/bin/env python3
+"""Static + dry-run regression for the two-rank launcher (start.sh).
+
+Hardening asked for by the production-like tester run on PRs #83/#84:
+
+  A  GLM53_APC_RETENTION_INTERVAL_SWA guard -- "" (inherit global) passes in every
+     serving mode. Non-empty values require SPEC_METHOD=dflash; 0 passes and
+     anything else must be a positive multiple of 3584 no larger than
+     1,000,000. The canonical value is what the ranks receive. Runs on the
+     checkout whose launcher actually forwards that knob to the containers
+     (detected from the `-e VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA=` line,
+     not guessed).
+  B  Pre-stop gate -- `./start.sh restart` with a bad knob, or with ANY
+     mounted overlay missing / empty / unparseable / pointed at a different
+     overlay, exits 2 BEFORE the first docker or ssh call, so healthy
+     containers are never stopped for a launch that cannot succeed.
+  C  Overlay order -- one list (GLM53_OVERLAY_ORDER) pinned
+     hybrid -> per-group -> fine-grained is emitted verbatim into BOTH rank
+     inner scripts.
+  D  Rank parity -- for every /opt/glm53 patch the head bind-mounts host
+     file S, the worker's mount is fed from /tmp/X and the scp that produced
+     /tmp/X read the same S; both ranks receive identical effective values
+     for GLM53_APC_RETENTION_INTERVAL, GLM53_APC_RETENTION_INTERVAL_SWA and
+     GLM53_FINEGRAINED_APC (launcher names) and the container-side names they
+     map to (VLLM_PREFIX_CACHE_RETENTION_INTERVAL[_SWA], GLM53_FINEGRAINED_APC);
+     a knob the launcher wires must be PRESENT on both ranks, not merely
+     equal. The comparison itself is exercised with a synthetic one-rank
+     mismatch so a silent pass cannot hide behind equality.
+
+Everything drives the shipped start.sh under bash from an allow-listed
+environment (PATH with docker / ssh / scp / rsync / curl / ip / nvidia-smi
+stubbed first, HOME pointed at a temp dir, no BASH_ENV / PYTHONPATH / HF_*
+/ GLM53_* / VLLM_* leakage). Nothing talks to a real host. The test is
+branch-agnostic: it discovers which prefix-cache overlays this checkout
+ships from the `*_PATCH_HOST="${*_PATCH_HOST:-` assignments and reports it.
+
+Run:  python3 tests/test_launcher_rank_parity.py   (or pytest)
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+START = ROOT / "start.sh"
+
+FAILURES: list[str] = []
+
+BLOCK = 3584
+RETENTION_MAX = 1_000_000
+SWA = "GLM53_APC_RETENTION_INTERVAL_SWA"
+SWA_FORWARD = '-e "VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA=$GLM53_APC_RETENTION_INTERVAL_SWA"'
+FG = "GLM53_FINEGRAINED_APC"
+FG_FORWARD = '-e "GLM53_FINEGRAINED_APC=$GLM53_FINEGRAINED_APC"'
+
+# Launcher knobs the tester asked to see reach both ranks identically, and the
+# container-side names the launcher maps them to.
+LAUNCHER_KNOBS = ("GLM53_APC_RETENTION_INTERVAL", SWA, FG)
+CONTAINER_NAMES = LAUNCHER_KNOBS + (
+    "VLLM_PREFIX_CACHE_RETENTION_INTERVAL",
+    "VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA",
+)
+
+PINNED = (
+    "patch_hybrid_prefix_hit.py",
+    "patch_apc_per_group_retention.py",
+    "patch_apc_fine_grained_hits.py",
+)
+APC_HOST_VARS = {
+    "APC_PATCH_HOST": "patch_hybrid_prefix_hit.py",
+    "PERGROUP_PATCH_HOST": "patch_apc_per_group_retention.py",
+    "FINEHIT_PATCH_HOST": "patch_apc_fine_grained_hits.py",
+}
+
+SEP = "\x1f"
+
+STUB = """#!/usr/bin/env bash
+# Records every invocation; never touches a host.
+{ printf '%s\\x1f' "$(basename "$0")" "$@"; printf '\\n'; } >> "$GLM53_STUB_LOG"
+case "$(basename "$0")" in
+    ip) printf 'inet %s/24\\n' "${GLM53_STUB_HEAD_IP:-10.0.0.1}" ;;
+esac
+exit 0
+"""
+
+
+def check(cond: bool, label: str) -> None:
+    print(("  ok   " if cond else "  FAIL ") + label)
+    if not cond:
+        FAILURES.append(label)
+
+
+def source() -> str:
+    return START.read_text()
+
+
+def guard_source() -> str:
+    """start.sh's numeric-config guard, lifted out by its sentinels (same
+    technique as tests/test_numeric_config.py)."""
+    text = source()
+    begin = text.index("# GLM53 numeric config guard (begin)")
+    end_marker = "# GLM53 numeric config guard (end)"
+    end = text.index(end_marker, begin) + len(end_marker)
+    return text[begin:end]
+
+
+def base_env(**extra: str) -> dict[str, str]:
+    """Allow-listed environment: nothing from the developer/CI shell leaks in
+    (no BASH_ENV, PYTHONPATH, HF_HOME, EXTRA_ARGS, SKIP_*, *_PATCH_HOST ...)."""
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", "/"),
+        "USER": "glm53-parity",
+        "LC_ALL": "C",
+        "TERM": "dumb",
+    }
+    env.update(extra)
+    return env
+
+
+def host_vars() -> dict[str, str]:
+    """Every `<NAME>_PATCH_HOST="${<NAME>_PATCH_HOST:-$SCRIPT_DIR/overlay/<file>}"`
+    assignment in start.sh, from the real assignment, not from substring hits."""
+    out: dict[str, str] = {}
+    for m in re.finditer(
+        r'^([A-Z_]+_PATCH_HOST)="\$\{\1:-\$SCRIPT_DIR/overlay/([A-Za-z0-9_.]+)\}"$', source(), re.M
+    ):
+        out[m.group(1)] = m.group(2)
+    return out
+
+
+def shipped_apc_vars() -> dict[str, str]:
+    return {v: b for v, b in host_vars().items() if v in APC_HOST_VARS}
+
+
+def wires_swa() -> bool:
+    return SWA_FORWARD in source()
+
+
+def wires_fg() -> bool:
+    return FG_FORWARD in source()
+
+
+# ------------------------------------------------------------------ part A --
+
+
+def run_retention_guard(
+    value: str | None, spec_method: str = "dflash"
+) -> tuple[int, str, str]:
+    script = (
+        guard_source()
+        + "\nGPU_MEM_UTIL=0.87; MAX_MODEL_LEN=1000000; MAX_NUM_SEQS=4\n"
+        + "MAX_NUM_BATCHED_TOKENS=1024\n"
+        + "GLM53_INDEXER_WORKSPACE=stock; GLM53_SPINWAIT_MS=stock\n"
+        + f"{FG}=1\n"
+        + "validate_numeric_config || exit $?\n"
+        + f'printf "%s\\n" "${{{SWA}-unset}}"\n'
+    )
+    env = base_env(SPEC_METHOD=spec_method)
+    if value is not None:
+        env[SWA] = value
+    r = subprocess.run(["bash", "-c", script], text=True, capture_output=True, env=env)
+    return r.returncode, r.stdout.strip(), r.stderr.strip()
+
+
+def part_a() -> None:
+    print("Part A: GLM53_APC_RETENTION_INTERVAL_SWA guard (numeric config block)")
+    if not wires_swa():
+        check(
+            f"_glm53_validate_retention_interval {SWA}" not in guard_source(),
+            "A0 this launcher does not forward the SWA knob and does not pretend to validate it",
+        )
+        print("  skip A1-A3 (knob not forwarded by this checkout; validate-what-you-forward)")
+        return
+    text = guard_source()
+    check(
+        f"_glm53_validate_retention_interval {SWA}" in text,
+        "A1 the forwarded SWA knob is validated inside the numeric config guard",
+    )
+    check(
+        f"GLM53_APC_BLOCK_TOKENS={BLOCK}" in text and f"GLM53_APC_RETENTION_MAX={RETENTION_MAX}" in text,
+        f"A1 grid {BLOCK} and cap {RETENTION_MAX:,} are the documented constants",
+    )
+    accepted = {
+        None: "unset",
+        "": "",
+        "0": "0",
+        "00": "0",
+        str(BLOCK): str(BLOCK),
+        "0014336": "14336",
+        str(279 * BLOCK): str(279 * BLOCK),  # 999,936 = largest legal value
+    }
+    for value, canonical in accepted.items():
+        rc, out, err = run_retention_guard(value)
+        check(
+            rc == 0 and out == canonical,
+            f"A2 {SWA}={value!r} accepted, ranks receive {canonical!r} (rc={rc} out={out!r} {err})",
+        )
+    rejected = [
+        "1", "3000", "3585", "1000000", str(280 * BLOCK), "-3584", "+3584",
+        "3584.0", "1e3", " 3584", "3584 ", "3584\r", "nope", "0x", "0 ",
+        "99999999999999999999",
+    ]
+    for value in rejected:
+        rc, out, err = run_retention_guard(value)
+        check(
+            rc == 2 and SWA in err,
+            f"A3 {SWA}={value!r} rejected with rc=2 and a named error (rc={rc} err={err[:60]!r})",
+        )
+    for spec_method in ("mtp", "none"):
+        for value, expected in ((None, "unset"), ("", "")):
+            rc, out, err = run_retention_guard(value, spec_method)
+            check(
+                rc == 0 and out == expected,
+                f"A4 {SWA}={value!r} accepted with SPEC_METHOD={spec_method} "
+                f"(rc={rc} out={out!r} {err})",
+            )
+        for value in ("0", str(BLOCK)):
+            rc, out, err = run_retention_guard(value, spec_method)
+            check(
+                rc == 2 and SWA in err and "SPEC_METHOD=dflash" in err,
+                f"A4 {SWA}={value!r} rejected with SPEC_METHOD={spec_method} "
+                f"before launch (rc={rc} err={err[:80]!r})",
+            )
+
+
+# --------------------------------------------------------------- harness --
+
+
+class Harness:
+    """A throwaway copy of the launcher checkout plus a stub PATH."""
+
+    def __init__(self, tmp: Path) -> None:
+        self.tmp = tmp
+        self.repo = tmp / "repo"
+        self.repo.mkdir()
+        shutil.copy2(START, self.repo / "start.sh")
+        shutil.copy2(ROOT / ".env.example", self.repo / ".env.example")
+        (self.repo / ".env").write_text((ROOT / ".env.example").read_text())
+        for sub in ("overlay", "files", "ablit"):
+            if (ROOT / sub).is_dir():
+                shutil.copytree(ROOT / sub, self.repo / sub)
+        self.home = tmp / "home"
+        self.home.mkdir()
+        self.bin = tmp / "bin"
+        self.bin.mkdir()
+        for tool in ("docker", "ssh", "scp", "rsync", "curl", "ip", "nvidia-smi"):
+            p = self.bin / tool
+            p.write_text(STUB)
+            p.chmod(p.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        self.log = tmp / "calls.log"
+
+        # A copy whose trailing `main "$@"` is replaced by `"$@"`, so a single
+        # launcher function can be driven with the real configuration preamble.
+        text = (self.repo / "start.sh").read_text()
+        assert text.rstrip().endswith('\nmain "$@"'), "start.sh must end with main \"$@\""
+        (self.repo / "start.fn.sh").write_text(text.rstrip()[: -len('main "$@"')] + '"$@"\n')
+
+    def env(self, **extra: str) -> dict[str, str]:
+        return base_env(
+            PATH=f"{self.bin}{os.pathsep}{os.environ.get('PATH', '/usr/bin:/bin')}",
+            HOME=str(self.home),
+            GLM53_STUB_LOG=str(self.log),
+            **extra,
+        )
+
+    def calls(self) -> list[list[str]]:
+        if not self.log.exists():
+            return []
+        out = []
+        for line in self.log.read_text().splitlines():
+            argv = line.split(SEP)
+            if argv and argv[-1] == "":
+                argv.pop()
+            out.append(argv)
+        return out
+
+    def run(self, cmd: str, entry: str = "start.sh", **extra: str) -> subprocess.CompletedProcess[str]:
+        if self.log.exists():
+            self.log.unlink()
+        return subprocess.run(
+            ["bash", f"./{entry}", cmd],
+            cwd=self.repo,
+            text=True,
+            capture_output=True,
+            check=False,
+            env=self.env(**extra),
+        )
+
+    def host_touching_calls(self) -> list[list[str]]:
+        return [c for c in self.calls() if c and c[0] in ("docker", "ssh", "scp", "rsync")]
+
+
+# ------------------------------------------------------------------ part B --
+
+
+def parses(text: str) -> bool:
+    import ast
+    try:
+        ast.parse(text)
+        return True
+    except SyntaxError:
+        return False
+
+
+def longest_parseable_prefix(text: str) -> str | None:
+    lines = text.splitlines(keepends=True)
+    for cut in range(len(lines) - 1, 0, -1):
+        candidate = "".join(lines[:cut])
+        if candidate.strip() and parses(candidate):
+            return candidate
+    return None
+
+
+
+def control(h: Harness, label: str, **env: str) -> None:
+    r = h.run("restart", **env)
+    calls = h.host_touching_calls()
+    head_rm = any(c[:3] == ["docker", "rm", "-f"] for c in calls)
+    worker_rm = any(c[0] == "ssh" and "docker rm -f" in c[-1] for c in calls)
+    last = (r.stderr.strip().splitlines() or [""])[-1]
+    check(
+        head_rm and worker_rm,
+        f"{label} (head rm={head_rm} worker rm={worker_rm}; later rc={r.returncode} is the stubbed preflight: {last[:100]!r})",
+    )
+
+
+def part_b(h: Harness) -> None:
+    print("Part B: restart fails closed before any container is stopped")
+    text = source()
+    main_at = text.index("main() {")
+    v_num = text.index("validate_numeric_config", main_at)
+    v_art = text.index("validate_overlay_artifacts", main_at)
+    restart = text.index("restart)  stop; start", main_at)
+    check(
+        v_num < restart and v_art < restart,
+        "B1 main() runs the numeric and artifact validators before `restart) stop; start`",
+    )
+    check(
+        "start|restart) validate_numeric_config; validate_overlay_artifacts ;;" in text,
+        "B1 numeric and artifact validators share the start|restart arm",
+    )
+    guard_begin = text.index("# GLM53 overlay artifact guard (begin)")
+    guard_end = text.index("# GLM53 overlay artifact guard (end)")
+    guard = text[guard_begin:guard_end]
+    check(guard_begin < guard_end, "B1 the artifact guard has its own sentinel block")
+    check("|-\"" not in guard and '|-"' not in guard, "B1 every artifact carries an identity string (no untagged entries)")
+    check(
+        guard.count("|$main_guard\"") >= 6 and '|    return report"' in guard and "| tail -n 1 || true)" in guard,
+        "B1 every artifact carries its exact last line as an EOF sentinel (checked against the last non-blank line)",
+    )
+    check(
+        '"$CHAT_TEMPLATE_HOST"' in guard and "ablit/LAYER_MAP.json" in guard,
+        "B1 the chat template and the ablit layer map are gated too",
+    )
+
+    vars_ = host_vars()
+    shipped = shipped_apc_vars()
+    check("APC_PATCH_HOST" in shipped, "B2 checkout ships patch_hybrid_prefix_hit.py")
+    check(
+        "PERGROUP_PATCH_HOST" in shipped or "FINEHIT_PATCH_HOST" in shipped,
+        "B2 checkout ships at least one of per-group / fine-grained",
+    )
+    for var in vars_:
+        check(f'"${var}|' in guard, f"B2 {var} ({vars_[var]}) is in the artifact guard")
+    check("overlay/patch_ablit.py|" in guard and "overlay/ablit_runtime.py|" in guard, "B2 ablit hook + runtime are in the artifact guard")
+    check(
+        'for entry in "${artifacts[@]}"' in guard and "artifacts[@]}\" -eq 0" in guard,
+        "B2 the guard iterates a bash array and refuses an empty list (no process-substitution status gap)",
+    )
+
+    # Control FIRST: with a valid configuration the entrypoint gets PAST the
+    # validators and reaches stop (the stubs then fail preflight, which is
+    # fine). Without this, every negative case below could pass for the
+    # wrong reason (a guard that refuses everything).
+    control(h, "B3 control: valid restart passes the gate and reaches stop on both ranks")
+    if wires_swa():
+        control(
+            h,
+            "B3 empty SWA override with MTP reaches stop on both ranks",
+            SPEC_METHOD="mtp",
+            **{SWA: ""},
+        )
+
+    def fails_closed(label: str, **env: str) -> None:
+        r = h.run("restart", **env)
+        calls = h.host_touching_calls()
+        last = r.stderr.strip().splitlines()[-1] if r.stderr.strip() else ""
+        check(
+            r.returncode == 2 and not calls,
+            f"{label}: rc={r.returncode}, host-touching calls={len(calls)} ({last[:90]!r})",
+        )
+
+    if wires_swa():
+        fails_closed(f"B3 restart with {SWA}=3000 exits 2 with nothing stopped", **{SWA: "3000"})
+        fails_closed(f"B3 restart with {SWA}=1003520 exits 2 with nothing stopped", **{SWA: "1003520"})
+        fails_closed(
+            f"B3 restart with MTP and {SWA}=0 exits 2 with nothing stopped",
+            SPEC_METHOD="mtp",
+            **{SWA: "0"},
+        )
+        fails_closed(
+            f"B3 restart without speculation and {SWA}={BLOCK} exits 2 with nothing stopped",
+            SPEC_METHOD="none",
+            **{SWA: str(BLOCK)},
+        )
+    if wires_fg():
+        fails_closed(f"B3 restart with {FG}=yes exits 2 with nothing stopped", **{FG: "yes"})
+
+    broken = h.tmp / "broken_patch.py"
+    broken.write_text("def (:\n    pass\n")
+    empty = h.tmp / "empty_patch.py"
+    empty.write_text("")
+    video = h.repo / "overlay" / "patch_glm_video_placeholders.py"
+    hybrid = h.repo / "overlay" / "patch_hybrid_prefix_hit.py"
+    for var, base in vars_.items():
+        wrong = hybrid if base == video.name else video
+        fails_closed(f"B4 {var} missing ({base})", **{var: str(h.tmp / "does-not-exist.py")})
+        fails_closed(f"B4 {var} pointed at a different overlay ({wrong.name})", **{var: str(wrong)})
+    blank = h.tmp / "whitespace_only.py"
+    blank.write_text("\n   \n\t\n")
+    for var, base in shipped.items():
+        fails_closed(f"B4 {var} empty file ({base})", **{var: str(empty)})
+        fails_closed(f"B4 {var} whitespace-only file ({base}; pipefail-safe rc=2 diagnostic)", **{var: str(blank)})
+        fails_closed(f"B4 {var} unparseable file ({base})", **{var: str(broken)})
+    if wires_swa():
+        current = h.repo / "overlay" / "patch_apc_per_group_retention.py"
+        stale = h.tmp / "stale_pergroup_patch.py"
+        stale.write_text(
+            current.read_text().replace(
+                "glm53-apc-per-group-contract:explicit-v1",
+                "glm53-apc-per-group-contract:auto-v0",
+            )
+        )
+        fails_closed(
+            "B4 stale per-group retention contract",
+            PERGROUP_PATCH_HOST=str(stale),
+        )
+    # Truncation: for EVERY guarded Python artifact, the longest strict prefix
+    # (by lines) that still parses. It carries the identity string and is
+    # valid Python, so only the EOF-sentinel check can refuse it -- and must.
+    guarded = {var: h.repo / "overlay" / base for var, base in vars_.items()}
+    guarded["overlay/patch_ablit.py"] = h.repo / "overlay" / "patch_ablit.py"
+    guarded["overlay/ablit_runtime.py"] = h.repo / "overlay" / "ablit_runtime.py"
+    for var, path in guarded.items():
+        prefix_text = longest_parseable_prefix(path.read_text())
+        check(prefix_text is not None and parses(prefix_text), f"B4 {path.name}: a strict prefix that still parses exists ({len(prefix_text.splitlines()) if prefix_text else 0} lines)")
+        if prefix_text is None:
+            continue
+        if var.startswith("overlay/"):
+            original = path.read_text()
+            path.write_text(prefix_text)
+            try:
+                fails_closed(f"B4 {path.name} truncated to its longest parseable prefix (fixed-path artifact)")
+            finally:
+                path.write_text(original)
+        else:
+            prefix = h.tmp / f"truncated_{path.name}"
+            prefix.write_text(prefix_text)
+            fails_closed(f"B4 {var} truncated to its longest parseable prefix ({path.name})", **{var: str(prefix)})
+    fails_closed("B4 CHAT_TEMPLATE_HOST missing", CHAT_TEMPLATE_HOST=str(h.tmp / "no-template.jinja"))
+    (h.tmp / "template-dir").mkdir(exist_ok=True)
+    (h.tmp / "template-dir" / "x").write_text("x")
+    fails_closed("B4 CHAT_TEMPLATE_HOST is a (non-empty) directory", CHAT_TEMPLATE_HOST=str(h.tmp / "template-dir"))
+    invalid_template = h.tmp / "invalid-template.jinja"
+    invalid_template.write_text("{% if broken %}\n")
+    fails_closed(
+        "B4 CHAT_TEMPLATE_HOST has invalid Jinja syntax",
+        CHAT_TEMPLATE_HOST=str(invalid_template),
+    )
+    layer_map = h.repo / "ablit" / "LAYER_MAP.json"
+    saved = layer_map.read_text()
+    layer_map.write_text("{ not json")
+    try:
+        fails_closed("B4 ablit/LAYER_MAP.json not JSON")
+    finally:
+        layer_map.write_text(saved)
+
+    control(h, "B5 control after the negative cases (the harness copy is intact)")
+
+
+# ------------------------------------------------------------------ part C --
+
+
+def overlay_order() -> list[str]:
+    m = re.search(r"^GLM53_OVERLAY_ORDER=\(\n(.*?)^\)\n", source(), re.S | re.M)
+    assert m, "GLM53_OVERLAY_ORDER=( ... ) not found in start.sh"
+    return [ln.strip().split()[0] for ln in m.group(1).splitlines() if ln.strip() and not ln.strip().startswith("#")]
+
+
+def apply_sequence(script: Path) -> list[str]:
+    return re.findall(r"^\s*python3 /opt/glm53/(patch_[a-z0-9_]+\.py)$", script.read_text(), re.M)
+
+
+def part_c(h: Harness) -> None:
+    print("Part C: overlay order pinned once, emitted to both ranks")
+    text = source()
+    order = overlay_order()
+    idx = {name: order.index(name) for name in PINNED if name in order}
+    check(len(idx) == 3, f"C1 all three prefix-cache overlays are listed: {sorted(idx)}")
+    check(
+        len(idx) == 3 and idx[PINNED[0]] < idx[PINNED[1]] < idx[PINNED[2]],
+        "C1 pinned order hybrid -> per-group -> fine-grained",
+    )
+    check(
+        'emit_overlay_block >> "$HEAD_SCRIPT"' in text and 'emit_overlay_block >> "$WORKER_SCRIPT"' in text,
+        "C2 both inner scripts take the block from emit_overlay_block",
+    )
+    check("python3 /opt/glm53/patch_" not in text, "C2 no literal per-rank patch ladder remains in start.sh")
+
+    r = h.run("write_inner_scripts", entry="start.fn.sh")
+    head = h.repo / ".glm53-exl3-head.inner.sh"
+    worker = h.repo / ".glm53-exl3-worker.inner.sh"
+    check(
+        r.returncode == 0 and head.is_file() and worker.is_file(),
+        f"C3 write_inner_scripts produced both inner scripts (rc={r.returncode} {r.stderr.strip()[:80]!r})",
+    )
+    if head.is_file() and worker.is_file():
+        hs, ws = apply_sequence(head), apply_sequence(worker)
+        check(hs == order, f"C3 head applies exactly GLM53_OVERLAY_ORDER ({len(hs)} entries)")
+        check(ws == order, f"C3 worker applies exactly GLM53_OVERLAY_ORDER ({len(ws)} entries)")
+        check(hs == ws, "C3 head and worker apply sequences are identical")
+        for s in (head, worker):
+            body = s.read_text()
+            check(
+                body.index("/opt/glm53/patch_hybrid_prefix_hit.py")
+                < body.index("/opt/glm53/patch_apc_per_group_retention.py")
+                < body.index("/opt/glm53/patch_apc_fine_grained_hits.py"),
+                f"C3 {s.name}: hybrid -> per-group -> fine-grained in the generated script",
+            )
+            check(
+                "python3 /opt/glm53/patch_ablit.py" in body
+                and body.index("patch_kpool_tail_slotmap.py") < body.index("python3 /opt/glm53/patch_ablit.py"),
+                f"C3 {s.name}: ablit still applies last",
+            )
+            check(
+                re.search(r"if \[ -f /opt/glm53/patch_apc_per_group_retention\.py \]; then\n\s+python3", body) is not None,
+                f"C3 {s.name}: every slot is `[ -f ]`-guarded (unmounted sibling slot is a no-op)",
+            )
+
+
+# ------------------------------------------------------------------ part D --
+
+
+class Rank:
+    def __init__(self, argv: list[str]) -> None:
+        self.env: dict[str, str] = {}
+        self.mounts: dict[str, str] = {}  # container path -> source path
+        i = 0
+        while i < len(argv):
+            tok = argv[i]
+            if tok == "-e" and i + 1 < len(argv):
+                k, _, v = argv[i + 1].partition("=")
+                self.env[k] = v
+                i += 2
+                continue
+            if tok == "-v" and i + 1 < len(argv):
+                parts = argv[i + 1].split(":")
+                if len(parts) >= 2 and parts[1].startswith("/opt/glm53/") and parts[1].endswith(".py"):
+                    self.mounts[parts[1]] = parts[0]
+                i += 2
+                continue
+            i += 1
+
+
+def parity_issues(head: Rank, worker: Rank, scp: dict[str, str], required: dict[str, str]) -> list[str]:
+    """Everything that would make the two ranks differ. `scp` maps the
+    worker-side /tmp file to the host file it was copied from; `required`
+    maps container env names the launcher wires to the value expected."""
+    issues = []
+    for name in CONTAINER_NAMES:
+        if head.env.get(name) != worker.env.get(name):
+            issues.append(f"env {name}: head={head.env.get(name)!r} worker={worker.env.get(name)!r}")
+    for name, value in required.items():
+        if head.env.get(name) != value or worker.env.get(name) != value:
+            issues.append(f"env {name} expected {value!r} on both ranks: head={head.env.get(name)!r} worker={worker.env.get(name)!r}")
+    if set(head.mounts) != set(worker.mounts):
+        issues.append(f"mount set differs: head-only={sorted(set(head.mounts) - set(worker.mounts))} worker-only={sorted(set(worker.mounts) - set(head.mounts))}")
+    for dest, head_src in head.mounts.items():
+        worker_tmp = worker.mounts.get(dest)
+        worker_src = scp.get(worker_tmp or "")
+        if worker_src != head_src:
+            issues.append(f"{dest}: head mounts {head_src}, worker mounts {worker_tmp} which scp fed from {worker_src}")
+    return issues
+
+
+def rank_runs(h: Harness, **env: str) -> tuple[Rank, Rank, dict[str, str]] | None:
+    r = h.run("launch_cluster", entry="start.fn.sh", MODEL_DIR="/root/.cache/huggingface/x", **env)
+    if r.returncode != 0:
+        print(f"    launch_cluster rc={r.returncode}: {r.stderr.strip()[-300:]}")
+        return None
+    head = worker = None
+    scp: dict[str, str] = {}
+    for c in h.calls():
+        if c[:2] == ["docker", "run"]:
+            head = Rank(c[2:])
+        elif c[0] == "ssh" and c[-1].lstrip().startswith("docker run"):
+            worker = Rank(shlex.split(c[-1])[2:])
+        elif c[0] == "scp" and len(c) >= 3 and ":" in c[-1]:
+            scp[c[-1].split(":", 1)[1]] = c[-2]
+    if head is None or worker is None:
+        print(f"    could not find both docker run lines (head={head is not None} worker={worker is not None})")
+        return None
+    return head, worker, scp
+
+
+def part_d(h: Harness) -> None:
+    print("Part D: both ranks mount the same host artifacts and get identical effective values")
+    shipped = shipped_apc_vars()
+    order = overlay_order()
+
+    scenarios: list[tuple[str, dict[str, str]]] = [("defaults", {})]
+    if wires_swa():
+        scenarios += [("SWA=14336", {SWA: "14336"}), ("SWA=0", {SWA: "0"}), ("SWA unset", {})]
+    if wires_fg():
+        scenarios += [("FINEGRAINED=0", {FG: "0"}), ("FINEGRAINED=1", {FG: "1"})]
+    if wires_swa() and wires_fg():
+        scenarios.append(("SWA=14336 + FINEGRAINED=0", {SWA: "14336", FG: "0"}))
+
+    first = None
+    for label, env in scenarios:
+        got = rank_runs(h, **env)
+        check(got is not None, f"D1 [{label}] launch_cluster dry-run captured both docker run lines")
+        if got is None:
+            continue
+        head, worker, scp = got
+        first = first or got
+        required: dict[str, str] = {}
+        if wires_swa() and env.get(SWA, ""):
+            required["VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA"] = env[SWA]
+        if wires_fg():
+            required[FG] = env.get(FG, "1")
+        issues = parity_issues(head, worker, scp, required)
+        check(not issues, f"D2 [{label}] rank parity: " + ("; ".join(issues) if issues else "no differences"))
+        for name in CONTAINER_NAMES:
+            hv, wv = head.env.get(name), worker.env.get(name)
+            print(f"         {name}: head={hv!r} worker={wv!r}" + ("  (not wired by this launcher)" if hv is None and wv is None else ""))
+        if wires_swa() and not env.get(SWA, ""):
+            check(
+                "VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA" not in head.env and "VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA" not in worker.env,
+                f"D2 [{label}] empty SWA override is forwarded to neither rank",
+            )
+        mounted = {Path(p).name for p in head.mounts}
+        check(len(head.mounts) >= 9, f"D3 [{label}] {len(head.mounts)} /opt/glm53 patch mounts, identical chain head-mount = scp source = worker-mount")
+        # Expected source -> destination map for EVERY *_PATCH_HOST: the head
+        # mount, the scp source and the worker mount must all be that file.
+        wrong_map = []
+        for var, base in host_vars().items():
+            dest = f"/opt/glm53/{base}"
+            src = head.mounts.get(dest, "")
+            if Path(src).resolve() != (h.repo / "overlay" / base).resolve() or dest not in worker.mounts:
+                wrong_map.append(f"{var}: {dest} <- {src or 'unmounted'}")
+        check(not wrong_map, f"D3 [{label}] every *_PATCH_HOST maps to its own /opt/glm53 destination on both ranks (wrong={wrong_map})")
+        for var, base in shipped.items():
+            src = head.mounts.get(f"/opt/glm53/{base}", "")
+            check(
+                base in mounted and Path(src).resolve() == (h.repo / "overlay" / base).resolve(),
+                f"D3 [{label}] {base} ({var}) mounted on both ranks from the checkout's overlay/ copy ({src})",
+            )
+        unlisted = sorted(m for m in mounted if m.startswith("patch_") and m not in order)
+        check(not unlisted, f"D3 [{label}] every mounted patch_*.py is in GLM53_OVERLAY_ORDER (unlisted={unlisted})")
+
+    # Negative self-check: the comparison must notice a one-rank difference.
+    if first is not None:
+        head, worker, scp = first
+        tampered = Rank([])
+        tampered.env = dict(worker.env)
+        tampered.mounts = dict(worker.mounts)
+        tampered.env["VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA"] = (
+            "0" if tampered.env.get("VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA") != "0" else "1"
+        )
+        dest = next(iter(sorted(tampered.mounts)))
+        del tampered.mounts[dest]
+        issues = parity_issues(head, tampered, scp, {})
+        check(
+            any("env VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA" in i for i in issues)
+            and any("mount set differs" in i for i in issues),
+            f"D4 synthetic one-rank mismatch is reported ({len(issues)} issues: {issues[:2]})",
+        )
+        bad_scp = dict(scp)
+        wdest = sorted(worker.mounts)[0]
+        bad_scp[worker.mounts[wdest]] = "/somewhere/else.py"
+        issues = parity_issues(head, worker, bad_scp, {})
+        check(any(wdest in i for i in issues), f"D4 a worker scp fed from a different host file is reported ({issues[:1]})")
+
+
+# ------------------------------------------------------------------- main --
+
+
+def main() -> int:
+    if not START.is_file():
+        raise SystemExit(f"missing {START}")
+    print(f"launcher: {START}")
+    print(f"ships: {', '.join(f'{v}={b}' for v, b in shipped_apc_vars().items())}; forwards SWA={wires_swa()} FINEGRAINED={wires_fg()}")
+    part_a()
+    with tempfile.TemporaryDirectory() as raw:
+        h = Harness(Path(raw))
+        part_b(h)
+        part_c(h)
+        part_d(h)
+    print()
+    if FAILURES:
+        print(f"FAILED ({len(FAILURES)}): " + "; ".join(FAILURES))
+        return 1
+    print("launcher rank-parity / order / pre-stop gate OK")
+    return 0
+
+
+def test_launcher_rank_parity() -> None:
+    """pytest entry point (the script form above is what the README documents)."""
+    FAILURES.clear()
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_numeric_config.py
+++ b/tests/test_numeric_config.py
@@ -10,10 +10,11 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 START = ROOT / "start.sh"
+START_TP4 = ROOT / "start-tp4.sh"
 
 
-def guard_source() -> str:
-    source = START.read_text()
+def guard_source(path: Path = START) -> str:
+    source = path.read_text()
     begin = source.index("# GLM53 numeric config guard (begin)")
     end_marker = "# GLM53 numeric config guard (end)"
     end = source.index(end_marker, begin) + len(end_marker)
@@ -137,10 +138,34 @@ def test_restart_validates_before_stop() -> None:
     assert validation < restart
 
 
+def test_tp4_rejects_swa_override() -> None:
+    script = (
+        guard_source(START_TP4)
+        + '\nGPU_MEM_UTIL=0.87; MAX_MODEL_LEN=1000000; MAX_NUM_SEQS=4; '
+        + 'MAX_NUM_BATCHED_TOKENS=1024; GLM53_INDEXER_WORKSPACE=stock; '
+        + 'GLM53_SPINWAIT_MS=stock; GLM53_APC_RETENTION_INTERVAL_SWA="$1"\n'
+        + 'validate_numeric_config\n'
+    )
+    for value, expected in (("", 0), ("0", 2), ("14336", 2)):
+        result = subprocess.run(
+            ["bash", "-c", script, "test", value],
+            text=True,
+            capture_output=True,
+            check=False,
+            env={**os.environ, "LC_ALL": "C"},
+        )
+        assert result.returncode == expected, (value, result.stderr)
+
+    source = START_TP4.read_text()
+    assert '_cli_apc_swa_set="${GLM53_APC_RETENTION_INTERVAL_SWA+1}"' in source
+    assert '[ -n "${_cli_apc_swa_set}" ] && GLM53_APC_RETENTION_INTERVAL_SWA="$_cli_apc_swa"' in source
+
+
 if __name__ == "__main__":
     test_matrix()
     test_decimal_normalization()
     test_indexer_workspace_enum()
     test_spinwait_numeric_contract()
     test_restart_validates_before_stop()
+    test_tp4_rejects_swa_override()
     print("numeric config tests: PASS")

--- a/tests/test_numeric_config.py
+++ b/tests/test_numeric_config.py
@@ -138,23 +138,24 @@ def test_restart_validates_before_stop() -> None:
     assert validation < restart
 
 
-def test_tp4_rejects_swa_override() -> None:
+def test_tp4_rejects_retention_override() -> None:
     script = (
         guard_source(START_TP4)
         + '\nGPU_MEM_UTIL=0.87; MAX_MODEL_LEN=1000000; MAX_NUM_SEQS=4; '
         + 'MAX_NUM_BATCHED_TOKENS=1024; GLM53_INDEXER_WORKSPACE=stock; '
-        + 'GLM53_SPINWAIT_MS=stock; GLM53_APC_RETENTION_INTERVAL_SWA="$1"\n'
+        + 'GLM53_SPINWAIT_MS=stock; export "$1=$2"\n'
         + 'validate_numeric_config\n'
     )
-    for value, expected in (("", 0), ("0", 2), ("14336", 2)):
-        result = subprocess.run(
-            ["bash", "-c", script, "test", value],
-            text=True,
-            capture_output=True,
-            check=False,
-            env={**os.environ, "LC_ALL": "C"},
-        )
-        assert result.returncode == expected, (value, result.stderr)
+    for knob in ("GLM53_APC_RETENTION_INTERVAL", "GLM53_APC_RETENTION_INTERVAL_SWA"):
+        for value, expected in (("", 0), ("0", 2), ("14336", 2)):
+            result = subprocess.run(
+                ["bash", "-c", script, "test", knob, value],
+                text=True,
+                capture_output=True,
+                check=False,
+                env={**os.environ, "LC_ALL": "C"},
+            )
+            assert result.returncode == expected, (value, result.stderr)
 
     source = START_TP4.read_text()
     assert '_cli_apc_swa_set="${GLM53_APC_RETENTION_INTERVAL_SWA+1}"' in source
@@ -167,5 +168,5 @@ if __name__ == "__main__":
     test_indexer_workspace_enum()
     test_spinwait_numeric_contract()
     test_restart_validates_before_stop()
-    test_tp4_rejects_swa_override()
+    test_tp4_rejects_retention_override()
     print("numeric config tests: PASS")

--- a/tests/test_spinwait_patch.py
+++ b/tests/test_spinwait_patch.py
@@ -159,13 +159,17 @@ def test_recipe_wiring() -> None:
         'SPINWAIT_PATCH_HOST="${SPINWAIT_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_spinwait.py}"',
         'GLM53_SPINWAIT_MS="${GLM53_SPINWAIT_MS-stock}"',
         "_glm53_validate_spinwait_ms",
-        'python3 /opt/glm53/patch_spinwait.py',
         '"GLM53_SPINWAIT_MS=$GLM53_SPINWAIT_MS"',
         '/opt/glm53/patch_spinwait.py:ro',
     )
     for needle in required_start:
         assert needle in start, needle
-    assert start.count("python3 /opt/glm53/patch_spinwait.py") == 2
+    # Both ranks apply the one pinned list (GLM53_OVERLAY_ORDER) that
+    # write_inner_scripts emits into the head and worker inner scripts.
+    order = start[start.index("GLM53_OVERLAY_ORDER=(") : start.index(")", start.index("GLM53_OVERLAY_ORDER=("))]
+    assert "\n    patch_spinwait.py\n" in order
+    assert 'emit_overlay_block >> "$HEAD_SCRIPT"' in start
+    assert 'emit_overlay_block >> "$WORKER_SCRIPT"' in start
     assert start.count("/opt/glm53/patch_spinwait.py:ro") == 2
     assert "COPY overlay/patch_spinwait.py /opt/glm53/patch_spinwait.py" in dockerfile
     assert "tests/test_spinwait_patch.py" in dockerfile

--- a/tests/test_xgrammar_termination.py
+++ b/tests/test_xgrammar_termination.py
@@ -385,7 +385,12 @@ def test_recipe_wiring_if_present() -> None:
     launcher = start.read_text()
     image = dockerfile.read_text()
     assert 'XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-' in launcher
-    assert launcher.count("python3 /opt/glm53/patch_xgrammar_termination.py") == 2
+    # Both ranks apply the one pinned list (GLM53_OVERLAY_ORDER) that
+    # write_inner_scripts emits into the head and worker inner scripts.
+    order = launcher[launcher.index("GLM53_OVERLAY_ORDER=(") : launcher.index(")", launcher.index("GLM53_OVERLAY_ORDER=("))]
+    assert "\n    patch_xgrammar_termination.py\n" in order
+    assert 'emit_overlay_block >> "$HEAD_SCRIPT"' in launcher
+    assert 'emit_overlay_block >> "$WORKER_SCRIPT"' in launcher
     assert (
         "-v '/tmp/patch_xgrammar_termination.py:"
         "/opt/glm53/patch_xgrammar_termination.py:ro'" in launcher


### PR DESCRIPTION
Adds opt-in per-group prefix-cache retention and safe DFlash replay, building on #83.

- `GLM53_APC_RETENTION_INTERVAL_SWA=0`, with the global interval unset, preserves target-history checkpoints while prioritizing draft-cache eviction.
- Reconciles reused draft windows with the final hybrid-cache replay boundary.
- Leaves retention behavior unchanged when the new option is unset.
- Applies the cache overlays consistently on both ranks alongside adaptive-k and dense-FP8.
- Credits nood-co1 / BlockbrainLabs for the per-group retention foundation in #83.

Validation: per-group retention, hybrid replay, launcher parity/pre-stop guards, and numeric configuration suites pass against pristine pinned vLLM sources.
[Fresh two-Spark serving check](https://github.com/ratulsarna/spark-serve/blob/c87355cd1406eccc79943ba1941fd53389df3ba3/services/glm-5.3-flash-exl3/qualification/2026-09-11-refresh.md): API/tools/vision pass; two 100K histories and a late edit return correct facts with retained prefixes.
