### PR TITLE
Add pinned launcher for prebuilt abliterated EXL3 weights

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,8 @@ WORKER_CX7_IB=rocep1s0f0
 # WORKER_GID=3
 
 # --- weights -----------------------------------------------------------
+# Pre-edited abliterated weights are available through start-abliterated.sh.
+# That preset pins its own MODEL values and forces ABLIT=0.
 # Durable public mirror (same bytes as brandonmusic snapshot 5ab363a8).
 # If that Hub id 404s, start.sh downloads MODEL_FALLBACK instead.
 MODEL=Mia-AiLab/GLM-5.3-Flash-EXL3-TR3-4bpw

--- a/README.md
+++ b/README.md
@@ -176,9 +176,10 @@ Kernels: `TORCH_CUDA_ARCH_LIST=12.1a`. ExLlamaV3 pin `c5d9c657` (0.0.43) exposes
 
 ## Abliteration (`ABLIT=1`)
 
-**Off by default.** Unset or `ABLIT=0` serves stock `o_proj`. `ABLIT=1` is
-opt-in refusal-direction ablation at weight-load on top of the EXL3 checkpoint
-— nothing on disk is rewritten.
+**Off by default.** With the default checkpoint, unset or `ABLIT=0` serves
+stock `o_proj`. The flag only controls the load-time edit; it does not identify
+whether a selected checkpoint was edited before download. `ABLIT=1` applies
+refusal-direction ablation at weight load. Nothing on disk is rewritten.
 
 Artifacts live in `ablit/` (from
 [drowzeys/keys-GLM-5.3-Flash-NVFP4-ablit-l15-45-anchorstock](https://huggingface.co/drowzeys/keys-GLM-5.3-Flash-NVFP4-ablit-l15-45-anchorstock),
@@ -220,17 +221,48 @@ CUDA-graph capture. The DFlash2 drafter is never touched (for the checkpoint's
 own MTP block, `ABLIT_INCLUDE_MTP=1` transplants its o_proj too — the
 publisher found a stock MTP draft head keeps proposing refusals).
 
-Disable with `ABLIT=0` (or unset) — hook is a no-op, stock weights. No
-rebuild: artifacts + hook are bind-mounted into both containers every start.
+Disable with `ABLIT=0` or leave it unset. The hook then leaves the selected
+checkpoint unchanged. No rebuild is needed; the launcher bind-mounts the
+artifacts and hook into both containers on every start.
 
 | Knob | Default | What |
 |---|---|---|
-| `ABLIT` | `0` (off) | `1` = apply the o_proj edit at load (both ranks). Default and unset = stock weights |
+| `ABLIT` | `0` (off) | `1` = apply the o_proj edit at load on both ranks. `0` leaves the selected checkpoint unchanged |
 | `ABLIT_METHOD` | `auto` | `auto` = transplant when `ablit/transplant/` is populated, else `proj` \| `transplant` \| `proj` |
 | `ABLIT_LAYERS` | `15-45` | inclusive range; `45` is the checkpoint MTP block |
 | `ABLIT_ALPHA` | `3.0` | proj-only: projection scale (`1.0` = plain projection) |
 | `ABLIT_DIRECTION` | `dealign` | proj-only: `dealign` \| `bf_oproj` \| path to a custom direction `.pt` |
 | `ABLIT_INCLUDE_MTP` | `1` | also edit the MTP block's o_proj when it loads (`SPEC_METHOD=mtp`) |
+
+### Prebuilt abliterated checkpoint
+
+To use the published EXL3 checkpoint instead of editing weights at load time:
+
+```bash
+./start-abliterated.sh download
+./start-abliterated.sh restart
+```
+
+The preset selects
+[`bullerwins/GLM-5.3-Flash-exl3-4bpw-ablit`](https://huggingface.co/bullerwins/GLM-5.3-Flash-exl3-4bpw-ablit)
+at commit `14858211ed81d7fa773f8a0db02f38f36d230252`. It sets the fallback to
+the same repository, so an incomplete download fails instead of starting the
+original model. It also forces `ABLIT=0`; these weights already contain the
+Keys transplant at layers 15-43 and MTP layer 45, while layer 44 remains from
+the EXL3 parent. Applying the runtime edit again would produce a different
+model.
+
+The preset does not rewrite `.env`. DFlash2, vision, context, API naming, and
+other serve settings still come from the regular launcher. Run
+`./start.sh restart` to return to the model configured in `.env`.
+
+A matched TP=2 deployment passed all 10 functional checks. These included a
+synthetic-image request, 9,128-token retrieval, three concurrent requests,
+streaming, tools, and active DFlash drafting. The donor's Refusal32 script
+reported 32/32 bypass, 0 refuse, and 0 garble in one greedy thinking-off run.
+The model card records the method, integrity checks, and measured quality
+tradeoffs. Teacher KLD was higher than the original model, so this is an
+alternative checkpoint, not a quality-equivalent replacement.
 
 Caveats: the KLD quality panel above was measured **without** ablit; expect
 behavioral drift and re-run `tests/bench_decode.py` after enabling (DFlash2
@@ -586,7 +618,7 @@ that are now documented/enforced:
 | `GHCR_TOKEN` / `GHCR_USER` | *(unset)* | optional login if anonymous GHCR pull is rate-limited |
 | `PORT` | `8888` | OpenAI API on the head |
 | `VLLM_API_KEY` | *(unset)* | opt-in Bearer token for `/v1`. Empty = open API. `/health` stays keyless |
-| `ABLIT` | `0` (off) | opt-in. `1` = apply o_proj edit at load (both ranks). Unset = stock weights |
+| `ABLIT` | `0` (off) | opt-in. `1` = apply o_proj edit at load on both ranks. Unset leaves checkpoint weights unchanged |
 | `ABLIT_METHOD` | `auto` | `auto` = transplant when `ablit/transplant/` is populated, else `proj` |
 | `ABLIT_LAYERS` | `15-45` | inclusive range; `45` is the checkpoint MTP block |
 | `ABLIT_DIRECTION` | `dealign` | proj-only: `dealign` \| `bf_oproj` \| path to a custom `.pt` |
@@ -649,6 +681,7 @@ After CUDA compile, Python overlay edits (`overlay/exl3.py`, tests) are a cheap 
 | `tests/test_exl3_overlay.py` | registry, TP shard, `sm_121a` cubin, fused vs loop GEMM, `EXL3_FUSED_MOE=0`, E2 diag schema, E3 grouped tables/parity/graph-replay/fallback checks |
 | `tests/bench_decode.py` | streaming decode + coherence; `--structured` is the count-1→200 median |
 | `start.sh` / `stop.sh` / `download.sh` | 2-node launch; Hub fetch on the head only |
+| `start-abliterated.sh` | pinned, fail-closed preset for the pre-edited EXL3 checkpoint |
 | `start-tp4.sh` / `.env.tp4.example` | experimental 4-node TP=4 launch; knobs stay out of `.env` |
 | `files/chat_template.jinja` | GLM-5.3 MM template (`<|image|>` / `<|video|>`); checkpoint jinja is language-only |
 | `overlay/qwen3_dflash2.py` | DFlash2 draft (grouped conv + candidate selector) |
@@ -696,7 +729,8 @@ offer its source to users of that service. Contributions made before
 checkpoint stays [ShapleyMCG License 1.0](https://huggingface.co/Mia-AiLab/GLM-5.3-Flash-EXL3-TR3-4bpw/blob/main/LICENSE)
 (unmodified upstream LICENSE; also on
 [brandonmusic/GLM-5.3-Flash-tr3-4bpw](https://huggingface.co/brandonmusic/GLM-5.3-Flash-tr3-4bpw)).
-DFlash2 stays [CC BY-NC-ND 4.0](https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2).
+The [prebuilt derivative](https://huggingface.co/bullerwins/GLM-5.3-Flash-exl3-4bpw-ablit)
+retains that license and the parent's third-party notices. DFlash2 stays [CC BY-NC-ND 4.0](https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2).
 
 ## Credits
 
@@ -711,5 +745,8 @@ DFlash2 stays [CC BY-NC-ND 4.0](https://huggingface.co/incoai/GLM-5.3-Flash-DFla
   (CC BY-NC-ND 4.0, research/eval)
 - **KLD panel:** [malaiwah](https://huggingface.co/malaiwah) —
   [discussion #1](https://huggingface.co/brandonmusic/GLM-5.3-Flash-tr3-4bpw/discussions/1#6a9144846b0bdba943bfe86f)
+- **Prebuilt EXL3 derivative:** [bullerwins](https://huggingface.co/bullerwins) published
+  [GLM-5.3-Flash-exl3-4bpw-ablit](https://huggingface.co/bullerwins/GLM-5.3-Flash-exl3-4bpw-ablit),
+  using the [Keys L15-43/MTP-L45 transplant](https://huggingface.co/drowzeys/keys-GLM-5.3-Flash-NVFP4-ablit-l15-43-mtp-l45)
 - **Abliteration recipe / direction artifacts:** [drowzeys](https://huggingface.co/drowzeys) —
   [keys-GLM-5.3-Flash-NVFP4-ablit-l15-45-anchorstock](https://huggingface.co/drowzeys/keys-GLM-5.3-Flash-NVFP4-ablit-l15-45-anchorstock)

--- a/start-abliterated.sh
+++ b/start-abliterated.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Serve the pre-edited EXL3 checkpoint with the regular TP=2 launcher.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export GLM53_MODEL_PRESET=abliterated
+exec "$SCRIPT_DIR/start.sh" "$@"

--- a/start.sh
+++ b/start.sh
@@ -58,6 +58,8 @@ if [ ! -f "$SCRIPT_DIR/.env" ]; then
     printf '\033[1;36m[glm53-exl3]\033[0m wrote .env from .env.example — edit HEAD_IP / WORKER_IP if needed\n'
 fi
 # Caller exports (MTP_TOKENS=2 ./start.sh restart) must win over .env.
+_cli_model_preset_set="${GLM53_MODEL_PRESET+1}"
+_cli_model_preset="${GLM53_MODEL_PRESET-}"
 _cli_mtp="${MTP_TOKENS-}"
 _cli_spec="${SPEC_METHOD-}"
 _cli_eager="${ENFORCE_EAGER-}"
@@ -90,6 +92,7 @@ set -a
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/.env"
 set +a
+[ -n "${_cli_model_preset_set}" ] && GLM53_MODEL_PRESET="$_cli_model_preset"
 [ -n "${_cli_mtp}" ] && MTP_TOKENS="$_cli_mtp"
 [ -n "${_cli_spec}" ] && SPEC_METHOD="$_cli_spec"
 [ -n "${_cli_eager}" ] && ENFORCE_EAGER="$_cli_eager"
@@ -123,6 +126,25 @@ MODEL_CACHE_NAME="${MODEL_CACHE_NAME:-models--${MODEL//\//--}}"
 MODEL_FALLBACK_CACHE_NAME="${MODEL_FALLBACK_CACHE_NAME:-models--${MODEL_FALLBACK//\//--}}"
 # Hub commit on the Mia-AiLab mirror (the 5ab363a8-byte-identical upload).
 MODEL_REVISION="${MODEL_REVISION:-25a44fdbf16862a46b7cc9921142c6c81350af2f}"
+MODEL_SNAPSHOT=""
+MODEL_FALLBACK_SNAPSHOT=""
+GLM53_MODEL_PRESET="${GLM53_MODEL_PRESET:-}"
+case "$GLM53_MODEL_PRESET" in
+    "") ;;
+    abliterated)
+        MODEL="bullerwins/GLM-5.3-Flash-exl3-4bpw-ablit"
+        MODEL_FALLBACK="$MODEL"
+        MODEL_REVISION="14858211ed81d7fa773f8a0db02f38f36d230252"
+        MODEL_SNAPSHOT="$MODEL_REVISION"
+        MODEL_FALLBACK_SNAPSHOT="$MODEL_SNAPSHOT"
+        MODEL_CACHE_NAME="models--bullerwins--GLM-5.3-Flash-exl3-4bpw-ablit"
+        MODEL_FALLBACK_CACHE_NAME="$MODEL_CACHE_NAME"
+        ;;
+    *)
+        printf 'FATAL: unknown GLM53_MODEL_PRESET: %s\n' "$GLM53_MODEL_PRESET" >&2
+        exit 2
+        ;;
+esac
 IMAGE="${IMAGE:-ghcr.io/miaai-lab/glm-5.3-flash-2x-dgx-sparks:exl3}"
 SERVED_MODEL_NAME="${SERVED_MODEL_NAME:-GLM-5.3-Flash-EXL3}"
 GHCR_USER="${GHCR_USER:-MiaAI-Lab}"
@@ -257,14 +279,17 @@ EXL3_FAT_KERNEL="${EXL3_FAT_KERNEL:-1}"
 # --- abliteration (ablit/) --------------------------------------------------
 # Load-time o_proj orthogonalization (overlay/ablit_runtime.py). Published
 # recipe: layers 15-45 edited with the dealign direction, 0-14 stay stock
-# safety anchors, MTP block included. 0 = stock weights. Applied identically
-# on both TP ranks; the DFlash2 drafter is never touched.
+# safety anchors, MTP block included. 0 leaves checkpoint weights unchanged.
+# Applied identically on both TP ranks; the DFlash2 drafter is never touched.
 ABLIT="${ABLIT:-0}"
 ABLIT_METHOD="${ABLIT_METHOD:-auto}"           # auto | transplant | proj
 ABLIT_DIRECTION="${ABLIT_DIRECTION:-dealign}"  # dealign | bf_oproj | /path/dir.pt
 ABLIT_LAYERS="${ABLIT_LAYERS:-15-45}"          # inclusive; 45 = checkpoint MTP block
 ABLIT_ALPHA="${ABLIT_ALPHA:-3.0}"              # 1.0 = plain projection, >1 over-projects
 ABLIT_INCLUDE_MTP="${ABLIT_INCLUDE_MTP:-1}"
+if [ "$GLM53_MODEL_PRESET" = "abliterated" ]; then
+    ABLIT=0
+fi
 
 READY_TIMEOUT="${READY_TIMEOUT:-3600}"
 # 1 = suppress client stop strings until </think> (DSpark #42 class).
@@ -405,6 +430,26 @@ count_shards() {
     find "$1/snapshots" -name '*.safetensors' 2>/dev/null | wc -l | tr -d '[:space:]' || true
 }
 
+count_model_shards() {
+    local repo="$1" snapshot="${2:-}"
+    if [ -n "$snapshot" ]; then
+        find "$repo/snapshots/$snapshot" -maxdepth 1 -name '*.safetensors' 2>/dev/null \
+            | wc -l | tr -d '[:space:]' || true
+    else
+        count_shards "$repo"
+    fi
+}
+
+model_tree_complete() {
+    local repo="$1" snapshot="${2:-}" have
+    have="$(count_model_shards "$repo" "$snapshot")"
+    [ "${have:-0}" -ge "$EXPECTED_SHARDS" ] || return 1
+    [ -z "$snapshot" ] || {
+        [ -f "$repo/snapshots/$snapshot/config.json" ] \
+            && [ -f "$repo/snapshots/$snapshot/model.safetensors.index.json" ]
+    }
+}
+
 ensure_refs_main() {
     local ref="$MODEL_PATH/refs/main" snap
     [ -f "$ref" ] && [ -n "$(<"$ref")" ] && return 0
@@ -417,8 +462,14 @@ ensure_refs_main() {
 
 resolve_model_dir() {
     local ref="$MODEL_PATH/refs/main" hash dir
-    ensure_refs_main
-    hash="$(<"$ref")"
+    if [ -n "$MODEL_SNAPSHOT" ]; then
+        model_tree_complete "$MODEL_PATH" "$MODEL_SNAPSHOT" \
+            || die "pinned model snapshot is incomplete: $MODEL_PATH/snapshots/$MODEL_SNAPSHOT"
+        hash="$MODEL_SNAPSHOT"
+    else
+        ensure_refs_main
+        hash="$(<"$ref")"
+    fi
     dir="$MODEL_PATH/snapshots/$hash"
     [ -f "$dir/config.json" ] || die "config.json missing in $dir — re-run with REFRESH_WEIGHTS=1"
     printf '/root/.cache/huggingface/hub/%s/snapshots/%s' "$MODEL_CACHE_NAME" "$hash"
@@ -770,18 +821,19 @@ ensure_image() {
 # brandonmusic cache folder without a second 164 GiB pull.
 adopt_complete_weights() {
     local have
-    have="$(count_shards "$MODEL_PATH")"
-    if [ "${have:-0}" -ge "$EXPECTED_SHARDS" ]; then
-        ensure_refs_main
+    have="$(count_model_shards "$MODEL_PATH" "$MODEL_SNAPSHOT")"
+    if model_tree_complete "$MODEL_PATH" "$MODEL_SNAPSHOT"; then
+        [ -n "$MODEL_SNAPSHOT" ] || ensure_refs_main
         log "weights already present: $MODEL_PATH ($have shards)"
         return 0
     fi
-    have="$(count_shards "$FALLBACK_MODEL_PATH")"
-    if [ "${have:-0}" -ge "$EXPECTED_SHARDS" ]; then
+    have="$(count_model_shards "$FALLBACK_MODEL_PATH" "$MODEL_FALLBACK_SNAPSHOT")"
+    if model_tree_complete "$FALLBACK_MODEL_PATH" "$MODEL_FALLBACK_SNAPSHOT"; then
         log "primary cache incomplete — using fallback ${MODEL_FALLBACK} at $FALLBACK_MODEL_PATH ($have shards)"
         MODEL_PATH="$FALLBACK_MODEL_PATH"
         MODEL_CACHE_NAME="$MODEL_FALLBACK_CACHE_NAME"
-        ensure_refs_main
+        MODEL_SNAPSHOT="$MODEL_FALLBACK_SNAPSHOT"
+        [ -n "$MODEL_SNAPSHOT" ] || ensure_refs_main
         return 0
     fi
     return 1
@@ -848,7 +900,7 @@ download_weights() {
             || die "download of ${MODEL} and ${MODEL_FALLBACK} both failed"
     fi
     adopt_complete_weights \
-        || die "download finished with $(count_shards "$MODEL_PATH") / $EXPECTED_SHARDS shards"
+        || die "download finished with $(count_model_shards "$MODEL_PATH" "$MODEL_SNAPSHOT") / $EXPECTED_SHARDS shards in the selected snapshot"
 }
 
 download_dflash() {
@@ -885,7 +937,7 @@ download_only() {
     download_weights
     download_dflash
 
-    have="$(count_shards "$MODEL_PATH")"
+    have="$(count_model_shards "$MODEL_PATH" "$MODEL_SNAPSHOT")"
     log "======================================================================"
     log "head HF cache : ${HF_CACHE_DIR}"
     log "  target      : ${MODEL}  (${have} / ${EXPECTED_SHARDS} shards)"
@@ -901,16 +953,20 @@ download_only() {
 }
 
 # ------------------------------ weight sync --------------------------------
-# Keyed on the snapshot commit (refs/main, with the same repair fallback as
-# ensure_refs_main), not on MODEL_REVISION: the marker lives inside each
-# synced repo folder, so a MODEL / revision switch re-syncs automatically.
+# Keyed on the selected snapshot commit. Presets with an exact snapshot do not
+# trust refs/main; regular launches keep the existing refs/main repair path.
 # Without it, every ./start.sh pays a full size+mtime re-verification walk
 # over ~164 GiB / 120 shards on both ends for zero bytes of difference
 # (issue #22, item 2). FORCE_SYNC=1 bypasses the marker; deleting the
 # marker file on the worker has the same effect.
 sync_repo_marker_rev() {
-    local src="$1"
-    local rev
+    local src="$1" selected="${2:-}" rev
+    if [ -n "$selected" ]; then
+        model_tree_complete "$src" "$selected" \
+            || die "selected snapshot is incomplete: $src/snapshots/$selected"
+        printf '%s' "$selected"
+        return
+    fi
     rev="$(cat "$src/refs/main" 2>/dev/null || true)"
     [ -n "$rev" ] || rev="$(ls -1t "$src/snapshots" 2>/dev/null | head -n 1 || true)"
     [ -n "$rev" ] || rev="unknown"
@@ -918,10 +974,10 @@ sync_repo_marker_rev() {
 }
 
 sync_repo_to_worker() {
-    local src="$1" cache_name="$2" label="$3"
+    local src="$1" cache_name="$2" label="$3" selected="${4:-}"
     local marker rev
     marker="${WORKER_CACHE_DIR}/hub/${cache_name}/.glm53-exl3-synced"
-    rev="$(sync_repo_marker_rev "$src")"
+    rev="$(sync_repo_marker_rev "$src" "$selected")"
     if [ "${FORCE_SYNC:-0}" != "1" ] \
        && [ "$(worker_ssh "cat '$marker' 2>/dev/null" || true)" = "$rev" ]; then
         log "worker ${cache_name} already at ${rev} — rsync skipped (FORCE_SYNC=1 to force)"
@@ -934,14 +990,32 @@ sync_repo_to_worker() {
     worker_ssh "printf '%s' '$rev' > '$marker'"
 }
 
+verify_worker_model_snapshot() {
+    [ -n "$MODEL_SNAPSHOT" ] || return 0
+    local dir="${WORKER_CACHE_DIR}/hub/${MODEL_CACHE_NAME}/snapshots/${MODEL_SNAPSHOT}"
+    worker_ssh "test -f '$dir/config.json' \
+        && test -f '$dir/model.safetensors.index.json' \
+        && [ \"\$(find '$dir' -maxdepth 1 -name '*.safetensors' 2>/dev/null | wc -l | tr -d '[:space:]')\" -ge '$EXPECTED_SHARDS' ]" \
+        || die "pinned model snapshot is incomplete on worker: $dir"
+}
+
 sync_weights() {
-    [ "${SKIP_SYNC:-0}" = "1" ] && { log "SKIP_SYNC=1 — not syncing to worker"; return; }
     [ -d "$MODEL_PATH" ] || die "weights missing at $MODEL_PATH — run without SKIP_DOWNLOAD first"
-    sync_repo_to_worker "$MODEL_PATH" "$MODEL_CACHE_NAME" "weights"
+    if [ -n "$MODEL_SNAPSHOT" ]; then
+        model_tree_complete "$MODEL_PATH" "$MODEL_SNAPSHOT" \
+            || die "pinned model snapshot is incomplete: $MODEL_PATH/snapshots/$MODEL_SNAPSHOT"
+    fi
+    if [ "${SKIP_SYNC:-0}" = "1" ]; then
+        verify_worker_model_snapshot
+        log "SKIP_SYNC=1 — not syncing to worker"
+        return
+    fi
+    sync_repo_to_worker "$MODEL_PATH" "$MODEL_CACHE_NAME" "weights" "$MODEL_SNAPSHOT"
     if [ "$SPEC_METHOD" = "dflash" ]; then
         [ -d "$DFLASH_PATH" ] || die "DFlash2 weights missing at $DFLASH_PATH"
         sync_repo_to_worker "$DFLASH_PATH" "$DFLASH_CACHE_NAME" "DFlash2 draft"
     fi
+    verify_worker_model_snapshot
     log "worker weights in sync"
 }
 
@@ -1038,7 +1112,7 @@ fi
 if [ "${ABLIT:-0}" = "1" ]; then
     say "ablit: o_proj orthogonalization ON (method=${ABLIT_METHOD:-auto} direction=${ABLIT_DIRECTION:-dealign} layers=${ABLIT_LAYERS:-15-45} alpha=${ABLIT_ALPHA:-3.0})"
 else
-    say "ablit: off — stock o_proj weights"
+    say "runtime ablit: off; checkpoint o_proj unchanged"
 fi
 say "launching: vllm serve ${MODEL_DIR} ${ARGS[*]}"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
@@ -1134,7 +1208,7 @@ fi
 if [ "${ABLIT:-0}" = "1" ]; then
     say "ablit: o_proj orthogonalization ON (method=${ABLIT_METHOD:-auto} direction=${ABLIT_DIRECTION:-dealign} layers=${ABLIT_LAYERS:-15-45} alpha=${ABLIT_ALPHA:-3.0})"
 else
-    say "ablit: off — stock o_proj weights"
+    say "runtime ablit: off; checkpoint o_proj unchanged"
 fi
 say "joining TP2 at ${HEAD_IP}:${MASTER_PORT} as rank 1"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
@@ -1434,7 +1508,7 @@ on_ready() {
     local spec="MTP k=${MTP_TOKENS}"
     [ "$SPEC_METHOD" = "dflash" ] && spec="DFlash2 k=${DFLASH_TOKENS} (${DFLASH_MODEL})"
     [ "$SPEC_METHOD" = "none" ] && spec=off
-    local ablit="off (stock weights)"
+    local ablit="off (checkpoint weights unchanged)"
     [ "$ABLIT" = "1" ] && ablit="ON method=${ABLIT_METHOD} direction=${ABLIT_DIRECTION} layers=${ABLIT_LAYERS} alpha=${ABLIT_ALPHA}"
     log "  features   : tools=glm47+auto, reasoning=glm45, spec=${spec}, vision=${vision}, ablit=${ablit}"
     local auth_line="none (VLLM_API_KEY empty)"

--- a/tests/test_abliterated_preset.py
+++ b/tests/test_abliterated_preset.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""CPU-only tests for the prebuilt abliterated model preset."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODEL = "bullerwins/GLM-5.3-Flash-exl3-4bpw-ablit"
+REVISION = "14858211ed81d7fa773f8a0db02f38f36d230252"
+CACHE = "models--bullerwins--GLM-5.3-Flash-exl3-4bpw-ablit"
+CONTROLLED_ENV = {
+    "GLM53_MODEL_PRESET",
+    "SKIP_DOWNLOAD",
+    "SKIP_SYNC",
+    "SPEC_METHOD",
+    "HF_HOME",
+    "WORKER_HOME",
+}
+
+
+def _prefix(marker: str) -> str:
+    source = (ROOT / "start.sh").read_text()
+    prefix, found, _rest = source.partition(marker)
+    assert found, f"start.sh marker missing: {marker}"
+    return prefix
+
+
+def _run(script: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    process_env = {k: v for k, v in os.environ.items() if k not in CONTROLLED_ENV}
+    process_env.update(env)
+    return subprocess.run(
+        ["bash", str(script)], capture_output=True, text=True, env=process_env
+    )
+
+
+def test_wrapper_selects_preset_and_forwards_arguments() -> None:
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        tmp = Path(raw_tmp)
+        wrapper = tmp / "start-abliterated.sh"
+        wrapper.write_text((ROOT / "start-abliterated.sh").read_text())
+        wrapper.chmod(0o755)
+        delegate = tmp / "start.sh"
+        delegate.write_text(
+            "#!/usr/bin/env bash\n"
+            "printf 'PRESET=%s\\n' \"$GLM53_MODEL_PRESET\"\n"
+            "printf 'ARG=%s\\n' \"$@\"\n"
+        )
+        delegate.chmod(0o755)
+        result = subprocess.run(
+            [str(wrapper), "restart", "sentinel"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "GLM53_MODEL_PRESET": "wrong"},
+        )
+    assert result.stdout.splitlines() == [
+        "PRESET=abliterated",
+        "ARG=restart",
+        "ARG=sentinel",
+    ]
+
+
+def test_preset_is_pinned_and_preserves_regular_serve_settings() -> None:
+    probe = r'''
+printf '%s\n' "$MODEL" "$MODEL_FALLBACK" "$MODEL_REVISION" "$MODEL_SNAPSHOT"
+printf '%s\n' "$MODEL_CACHE_NAME" "$MODEL_FALLBACK_CACHE_NAME" "$ABLIT" "$PORT"
+'''
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        tmp = Path(raw_tmp)
+        script = tmp / "start.sh"
+        script.write_text(
+            _prefix("# ------------------------------- helpers -----------------------------------")
+            + probe
+        )
+        script.chmod(0o755)
+        (tmp / ".env").write_text(
+            "MODEL=wrong/model\nMODEL_FALLBACK=wrong/fallback\n"
+            "MODEL_REVISION=wrong\nMODEL_CACHE_NAME=wrong-cache\n"
+            "MODEL_FALLBACK_CACHE_NAME=wrong-fallback-cache\nABLIT=1\nPORT=9123\n"
+        )
+        selected = _run(script, {"GLM53_MODEL_PRESET": "abliterated"})
+        regular = _run(script, {"GLM53_MODEL_PRESET": ""})
+
+    assert selected.returncode == 0, selected.stderr
+    assert selected.stdout.splitlines() == [
+        MODEL,
+        MODEL,
+        REVISION,
+        REVISION,
+        CACHE,
+        CACHE,
+        "0",
+        "9123",
+    ]
+    assert regular.returncode == 0, regular.stderr
+    assert regular.stdout.splitlines()[:3] == [
+        "wrong/model",
+        "wrong/fallback",
+        "wrong",
+    ]
+    assert regular.stdout.splitlines()[-2:] == ["1", "9123"]
+
+
+def _make_snapshot(repo: Path, revision: str, shards: int = 120) -> None:
+    snapshot = repo / "snapshots" / revision
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_text("{}\n")
+    (snapshot / "model.safetensors.index.json").write_text("{}\n")
+    for index in range(1, shards + 1):
+        (snapshot / f"model-{index:05d}-of-00120.safetensors").touch()
+
+
+def test_exact_snapshot_wins_over_refs_and_is_required_on_both_nodes() -> None:
+    probe = r'''
+worker_ssh() { bash -c "$*"; }
+sync_weights
+resolved="$(resolve_model_dir)"
+marker_rev="$(sync_repo_marker_rev "$MODEL_PATH" "$MODEL_SNAPSHOT")"
+printf '%s\n' "$resolved" "$marker_rev"
+'''
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        tmp = Path(raw_tmp)
+        hf_home = tmp / "hf"
+        head_repo = hf_home / "hub" / CACHE
+        worker_home = tmp / "worker"
+        worker_repo = worker_home / ".cache" / "huggingface" / "hub" / CACHE
+        other = "f" * 40
+        _make_snapshot(head_repo, REVISION)
+        _make_snapshot(head_repo, other)
+        _make_snapshot(worker_repo, REVISION)
+        (head_repo / "refs").mkdir()
+        (head_repo / "refs" / "main").write_text(other)
+        (worker_repo / ".glm53-exl3-synced").write_text(REVISION)
+
+        script = tmp / "start.sh"
+        script.write_text(
+            _prefix(
+                "# ------------------------ inner container scripts --------------------------"
+            )
+            + probe
+        )
+        script.chmod(0o755)
+        (tmp / ".env").write_text(
+            f"HF_HOME={hf_home}\nWORKER_HOME={worker_home}\n"
+        )
+        env = {
+            "GLM53_MODEL_PRESET": "abliterated",
+            "SKIP_DOWNLOAD": "1",
+            "SPEC_METHOD": "none",
+        }
+        passed = _run(script, env)
+        assert passed.returncode == 0, passed.stderr
+        assert passed.stdout.splitlines()[-2:] == [
+            f"/root/.cache/huggingface/hub/{CACHE}/snapshots/{REVISION}",
+            REVISION,
+        ]
+        skipped = _run(script, {**env, "SKIP_SYNC": "1"})
+        assert skipped.returncode == 0, skipped.stderr
+
+        worker_shard = (
+            worker_repo / "snapshots" / REVISION / "model-00120-of-00120.safetensors"
+        )
+        worker_shard.unlink()
+        failed_worker = _run(script, env)
+        assert failed_worker.returncode != 0
+        assert "incomplete on worker" in failed_worker.stderr
+        worker_shard.touch()
+
+        head_shard = head_repo / "snapshots" / REVISION / "model-00120-of-00120.safetensors"
+        head_shard.unlink()
+        failed_head = _run(script, env)
+        assert failed_head.returncode != 0
+        assert "pinned model snapshot is incomplete" in failed_head.stderr
+
+
+def test_failed_download_cannot_adopt_another_cached_revision() -> None:
+    probe = r'''
+resolve_hf_bin() { return 0; }
+hf_download_repo() { return 1; }
+download_weights
+'''
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        tmp = Path(raw_tmp)
+        hf_home = tmp / "hf"
+        repo = hf_home / "hub" / CACHE
+        _make_snapshot(repo, REVISION, shards=119)
+        _make_snapshot(repo, "f" * 40)
+        script = tmp / "start.sh"
+        script.write_text(
+            _prefix(
+                "# ------------------------ inner container scripts --------------------------"
+            )
+            + probe
+        )
+        script.chmod(0o755)
+        (tmp / ".env").write_text(f"HF_HOME={hf_home}\n")
+        result = _run(
+            script,
+            {
+                "GLM53_MODEL_PRESET": "abliterated",
+                "SKIP_DOWNLOAD": "0",
+                "SPEC_METHOD": "none",
+            },
+        )
+    assert result.returncode != 0
+    assert "119 / 120 shards in the selected snapshot" in result.stderr
+
+
+if __name__ == "__main__":
+    test_wrapper_selects_preset_and_forwards_arguments()
+    test_preset_is_pinned_and_preserves_regular_serve_settings()
+    test_exact_snapshot_wins_over_refs_and_is_required_on_both_nodes()
+    test_failed_download_cannot_adopt_another_cached_revision()
+    print("abliterated preset tests: PASS")


### PR DESCRIPTION
## Description and motivation

This adds `start-abliterated.sh`, a small preset for [`bullerwins/GLM-5.3-Flash-exl3-4bpw-ablit`](https://huggingface.co/bullerwins/GLM-5.3-Flash-exl3-4bpw-ablit). It delegates download, sync, and TP=2 startup to the existing launcher.

The preset selects commit `14858211ed81d7fa773f8a0db02f38f36d230252`. Primary and fallback point to the same repository, so a failed derivative download cannot start the original model. `start.sh` checks that exact snapshot on the head and worker, ignores `refs/main` for this preset, keys the sync marker to the pinned commit, and launches the pinned snapshot path. A complete different revision in the cache does not satisfy the check.

The preset forces `ABLIT=0` because this checkpoint already contains the Keys tensor transplant. Applying the runtime edit again would create a different model. The regular `./start.sh` path and its existing `.env` precedence are unchanged. The preset also keeps the served model name and every non-weight setting from `.env`.

I changed the `ABLIT=0` status text from "stock weights" to "checkpoint weights unchanged." The old wording was wrong for a pre-edited checkpoint.

## Related issues

Follow-up to #29. That report found that the direction-projection path did not change refusal behavior on EXL3. This preset uses a published checkpoint with an exact BF16 `o_proj` transplant at layers 15-43 and MTP layer 45. Layer 44 remains from the EXL3 parent.

## Testing

Historical author local checks at `dc8d4f8` (not exact-head qualification of the integrated candidate):

- `bash -n start.sh start-abliterated.sh stop.sh download.sh start-tp4.sh`
- `python3 tests/test_abliterated_preset.py`
- `python3 tests/test_start_overrides.py`
- `python3 tests/test_bringup_robustness.py`
- `python3 tests/test_numeric_config.py`
- `python3 tests/test_chat_template.py`
- `python3 tests/test_image_recipe.py`
- `python3 tests/test_warm_restart_stdout.py`
- `python3 tests/test_xgrammar_termination.py`
- `python3 tests/test_ablit.py` in the project environment with PyTorch
- `git diff --check`

The new preset test covers argument forwarding, conflicting `.env` values, forced `ABLIT=0`, stale `refs/main`, a stale worker sync marker, a failed download, another complete cached revision, and missing files in the pinned snapshot on either node. It also checks that the normal launcher keeps the model and port from `.env`.

Hub preflight at the pinned commit passed. The repository is public and ungated, with 120 safetensors shards plus `config.json`, `model.safetensors.index.json`, and `ABLIT_META.json`.

The author reports the checkpoint ran on two GB10 systems with TP=2 using Mia runtime commit `6599585`. That boot used the already staged checkpoint files rather than downloading another 164 GiB through this preset. Both ranks loaded the derivative with `ABLIT=0`; neither container restarted or reported an OOM.

The author reports the derivative passed 10/10 functional checks, including tools, a synthetic-image request, 9,128-token retrieval, three concurrent requests, streaming, and active DFlash drafting. The donor's unmodified Refusal32 script returned 32/32 bypass, 0 refuse, 0 garble, and 0 empty in one greedy thinking-off run. The model card includes the full quality comparison and its limitations. Teacher KLD was higher than the original model.

## Checklist

- [x] I have read the README and kept my changes consistent with it.
- [x] My pull request has a specific title and description.
- [x] My change is reproducible and verified. The test details above separate the preset checks from the staged-checkpoint boot.
- [x] Defaults still work out of the box. The new preset fails closed and leaves normal `./start.sh` behavior unchanged.
- [x] I updated the README and `.env.example` for the new preset and status wording.

### Maintainer final source/integration review

Exact head `e270165acf459c1537d5f6804f22604a98ecd7dc` normally integrates current main `74bcd0ef6e565e3ba4188fc243601a40ebf47518` and was fast-forward published without rewriting author history. The README integration retains both the current cache-reset route row and precise wording that `ABLIT=0` leaves the selected checkpoint unchanged.

Main's exact-head preset, numeric, rank-parity, extra-environment, lifecycle and cache-reset CPU checks all returned zero. The corrected counterprobe uses the same inert USER environment: the unmodified exact-snapshot control passes; changing only the snapshot-count call to ignore its selected revision makes the existing incomplete-head rejection assertion fail. This replaces the earlier invalid USER-unset counterprobe, not a checkpoint qualification run. No hosted workflows or head check/status contexts are configured/present; absence is not a hosted green run.

The optional preset source/integration hold is cleared. Scope remains a pinned alternate-checkpoint launcher, with no default-model change. Admission checks a 120-shard floor, resolved regular files and config/index presence; it does not verify permission readability, manifest filenames, shard hashes, tensor contents or checkpoint quality. NFS relies on the shared head tree; combined NFS/SKIP_SYNC mount reachability is not established by these host checks. Historical model/boot observations above are not fresh qualification.

Maintainer plotarmordev owns any future checkpoint/live-resource qualification; no new author benchmark or rebase is requested. This source landing does not authorize weights downloads or GPU/node/service operations.
