### PR TITLE
perf: fuse EXL3 input gather and Hadamard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -437,6 +437,7 @@ RUN set -eux; \
 # rebuild exllamav3_ext. Exl3Config.override_quantization_method requires
 # "exl3" in ModelConfig's ordered overrides list.
 COPY overlay/exl3.py /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/exl3.py
+COPY overlay/exl3_swiglu.py /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/exl3_swiglu.py
 COPY overlay/patch_model_overrides.py /opt/glm53/patch_model_overrides.py
 COPY overlay/qwen3_dflash2.py /opt/glm53/qwen3_dflash2.py
 COPY overlay/dflash2_speculator.py /opt/glm53/dflash2_speculator.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -438,6 +438,7 @@ RUN set -eux; \
 # "exl3" in ModelConfig's ordered overrides list.
 COPY overlay/exl3.py /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/exl3.py
 COPY overlay/exl3_swiglu.py /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/exl3_swiglu.py
+COPY overlay/exl3_gather_hadamard.py /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/exl3_gather_hadamard.py
 COPY overlay/patch_model_overrides.py /opt/glm53/patch_model_overrides.py
 COPY overlay/qwen3_dflash2.py /opt/glm53/qwen3_dflash2.py
 COPY overlay/dflash2_speculator.py /opt/glm53/dflash2_speculator.py

--- a/overlay/exl3.py
+++ b/overlay/exl3.py
@@ -931,9 +931,6 @@ def _fat_scratch(
         "gate_up": torch.empty(
             (capacity, 2 * intermediate), dtype=torch.float32, device=device
         ),
-        "act": torch.empty(
-            (capacity, intermediate), dtype=torch.float32, device=device
-        ),
         "act_h": torch.empty(
             (capacity, intermediate), dtype=torch.float16, device=device
         ),
@@ -989,6 +986,8 @@ def apply_exl3_batched_fat(
     use_kernel: bool = False,
 ) -> torch.Tensor:
     """Run fat experts with persistent buffers and optional direct trellis GEMM."""
+    from .exl3_swiglu import fat_swiglu
+
     ext = load_exllamav3_ext()
     offset = 0
     for e, n_rows in enumerate(counts_host):
@@ -1033,15 +1032,8 @@ def apply_exl3_batched_fat(
             ext.hgemm(h13, w13, gate_up)
             ext.had_r_128(gate_up, gate_up, None, svh13, 1.0)
 
-        gate_out = gate_up[:, :intermediate]
-        up_out = gate_up[:, intermediate:]
-        gate_out.clamp_(max=limit)
-        up_out.clamp_(min=-limit, max=limit)
-        act = scratch["act"][:n_rows]
-        torch.sigmoid(gate_out, out=act)
-        act.mul_(gate_out).mul_(up_out)
         act_h = scratch["act_h"][:n_rows]
-        act_h.copy_(act)
+        fat_swiglu(gate_up, act_h, limit)
 
         h2 = scratch["h2"][:n_rows]
         ext.had_r_128(act_h, h2, down.suh, None, 1.0)

--- a/overlay/exl3.py
+++ b/overlay/exl3.py
@@ -903,7 +903,7 @@ def _fat_scratch(
         int(gate.trellis.shape[-1]),
     )
     scratch = _FAT_SCRATCH_CACHE.get(key)
-    if scratch is not None and int(scratch["h"].shape[0]) >= rows:
+    if scratch is not None and int(scratch["h13"].shape[0]) >= rows:
         return scratch
 
     in_tiles, out_tiles, k_words = map(int, gate.trellis.shape)
@@ -921,9 +921,6 @@ def _fat_scratch(
         ),
         "w2": torch.empty(
             (intermediate, hidden), dtype=torch.float16, device=device
-        ),
-        "h": torch.empty(
-            (capacity, hidden), dtype=torch.float16, device=device
         ),
         "h13": torch.empty(
             (capacity, hidden), dtype=torch.float16, device=device
@@ -987,6 +984,7 @@ def apply_exl3_batched_fat(
 ) -> torch.Tensor:
     """Run fat experts with persistent buffers and optional direct trellis GEMM."""
     from .exl3_swiglu import fat_swiglu
+    from .exl3_gather_hadamard import gather_hadamard
 
     ext = load_exllamav3_ext()
     offset = 0
@@ -1004,10 +1002,8 @@ def apply_exl3_batched_fat(
         scratch = _fat_scratch(xh.device, n_rows, gate)
         intermediate = int(gate.out_features)
 
-        h = scratch["h"][:n_rows]
         h13 = scratch["h13"][:n_rows]
-        torch.index_select(xh, 0, token_idx, out=h)
-        ext.had_r_128(h, h13, gate.suh, None, 1.0)
+        gather_hadamard(xh, token_idx, gate.suh, h13)
 
         packed13 = scratch["packed13"]
         out_tiles = int(gate.trellis.shape[1])

--- a/overlay/exl3_gather_hadamard.py
+++ b/overlay/exl3_gather_hadamard.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Gather fat-expert token rows directly into the pre-scaled Hadamard-128."""
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _gather_hadamard(
+    x, indices, scale, out, n_elements,
+    HIDDEN: tl.constexpr, SOURCE_ROWS: tl.constexpr,
+    INPUT_STRIDE: tl.constexpr, INDEX_STRIDE: tl.constexpr,
+    OUTPUT_STRIDE: tl.constexpr, LANES: tl.constexpr,
+):
+    lane = tl.arange(0, LANES)
+    offset = (tl.program_id(0).to(tl.int64) * LANES + lane) * 4
+    row, col = offset // HIDDEN, offset % HIDDEN
+    valid = offset < n_elements
+    token = tl.load(indices + row * INDEX_STRIDE, valid, other=0)
+    in_bounds = (token >= 0) & (token < SOURCE_ROWS)
+    tl.device_assert((~valid) | in_bounds, "token index out of bounds")
+    columns = col[:, None] + tl.arange(0, 4)[None, :]
+    value = tl.load(x + token[:, None] * INPUT_STRIDE + columns,
+                    valid[:, None] & in_bounds[:, None], other=0).to(tl.float32)
+    prescale = tl.load(scale + columns).to(tl.float32)
+    # Native had_r_128 multiplies in half before its FP32 butterflies.
+    values = (value * prescale).to(tl.float16).to(tl.float32)
+    even, odd = tl.split(tl.reshape(values, (LANES, 2, 2)))
+    v0, v2 = tl.split(even)
+    v1, v3 = tl.split(odd)
+    s0, d0 = v0 + v1, v0 - v1
+    s1, d1 = v2 + v3, v2 - v3
+    h0, h1 = s0 + s1, d0 + d1
+    h2, h3 = s0 - s1, d0 - d1
+    for shift in tl.static_range(5):
+        bit = 1 << shift
+        peer = lane ^ bit
+        p0 = tl.gather(h0, peer, axis=0)
+        p1 = tl.gather(h1, peer, axis=0)
+        p2 = tl.gather(h2, peer, axis=0)
+        p3 = tl.gather(h3, peer, axis=0)
+        high = (lane & bit) != 0
+        h0 = tl.where(high, -h0, h0) + p0
+        h1 = tl.where(high, -h1, h1) + p1
+        h2 = tl.where(high, -h2, h2) + p2
+        h3 = tl.where(high, -h3, h3) + p3
+    values = tl.reshape(tl.join(tl.join(h0, h2), tl.join(h1, h3)), (LANES, 4))
+    tl.store(out + row[:, None] * OUTPUT_STRIDE + columns,
+             values * 0.088388347648, valid[:, None])
+
+
+def gather_hadamard(x, indices, scale, out):
+    """Equivalent to index_select(x, 0, indices), then had_r_128(..., scale).
+
+    Inputs/output are FP16 with contiguous columns; row padding is allowed.
+    Indices are valid int64 token IDs (possibly strided/repeated). The caller
+    must supply output storage that does not overlap any input. No host reads
+    of the indices are introduced. Invalid IDs are outside this internal ABI;
+    debug Triton builds assert their bounds, and loads are always bounds-masked.
+    """
+    assert x.ndim == out.ndim == 2 and indices.ndim == scale.ndim == 1
+    rows, hidden = out.shape
+    assert hidden > 0 and hidden % 128 == 0 and x.shape[1] == hidden
+    assert indices.numel() == rows and indices.dtype == torch.long
+    assert x.dtype == scale.dtype == out.dtype == torch.float16
+    assert scale.shape == (hidden,) and scale.stride(0) == 1
+    assert x.stride(1) == out.stride(1) == 1
+    assert x.is_cuda and x.device == indices.device == scale.device == out.device
+    if rows == 0:
+        return
+    with torch.cuda.device(x.device):
+        _gather_hadamard[(triton.cdiv(rows * hidden, 1024),)](
+            x, indices, scale, out, rows * hidden,
+            HIDDEN=hidden, SOURCE_ROWS=x.shape[0], INPUT_STRIDE=x.stride(0),
+            INDEX_STRIDE=indices.stride(0), OUTPUT_STRIDE=out.stride(0),
+            LANES=256, num_warps=8, enable_fp_fusion=False,
+        )

--- a/overlay/exl3_swiglu.py
+++ b/overlay/exl3_swiglu.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Clamped SwiGLU for the EXL3 fat-expert FP32 gate/up output.
+
+Keep the two products in FP32, then cast once to FP16 for the down Hadamard.
+Unlike the thin MoE kernel, E2's gate/up GEMM materializes this intermediate.
+"""
+
+import torch
+import triton
+import triton.language as tl
+from triton.language.extra.cuda import libdevice
+
+
+@triton.jit
+def _fat_swiglu_kernel(
+    gate_up, out, n_elements,
+    INTERMEDIATE: tl.constexpr,
+    INPUT_STRIDE: tl.constexpr,
+    OUTPUT_STRIDE: tl.constexpr,
+    LIMIT: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    row = offsets // INTERMEDIATE
+    col = offsets % INTERMEDIATE
+    valid = offsets < n_elements
+    gate = tl.load(gate_up + row * INPUT_STRIDE + col, valid, other=0)
+    up = tl.load(gate_up + row * INPUT_STRIDE + INTERMEDIATE + col, valid, other=0)
+    gate = tl.minimum(gate, LIMIT, propagate_nan=tl.PropagateNan.ALL)
+    up = tl.maximum(
+        tl.minimum(up, LIMIT, propagate_nan=tl.PropagateNan.ALL),
+        -LIMIT, propagate_nan=tl.PropagateNan.ALL,
+    )
+    # Match torch.sigmoid's FP32 exp/divide, not the exp2 approximation.
+    sigmoid = libdevice.div_rn(1.0, 1.0 + libdevice.exp(-gate))
+    activation = (sigmoid * gate) * up
+    tl.store(out + row * OUTPUT_STRIDE + col, activation, valid)
+
+
+def fat_swiglu(gate_up: torch.Tensor, out: torch.Tensor, limit: float) -> None:
+    """Write clamp(gate)*sigmoid(clamp(gate))*clamp(up) to FP16 ``out``.
+
+    Input is the E2 row-major concatenated gate/up FP32 buffer. Row strides
+    may exceed the logical width; the input is not modified.
+    """
+    rows, intermediate = out.shape
+    assert gate_up.shape == (rows, 2 * intermediate)
+    assert gate_up.dtype == torch.float32 and out.dtype == torch.float16
+    assert gate_up.stride(1) == out.stride(1) == 1
+    assert gate_up.device == out.device and gate_up.is_cuda
+    if rows == 0:
+        return
+    _fat_swiglu_kernel[(triton.cdiv(rows * intermediate, 1024),)](
+        gate_up, out, rows * intermediate,
+        INTERMEDIATE=intermediate,
+        INPUT_STRIDE=gate_up.stride(0),
+        OUTPUT_STRIDE=out.stride(0),
+        LIMIT=limit,
+        BLOCK=1024,
+        enable_fp_fusion=False,
+    )

--- a/tests/test_exl3_gather_hadamard.py
+++ b/tests/test_exl3_gather_hadamard.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exact native gather + Hadamard oracle. Run only with inference stopped."""
+import importlib.util
+from pathlib import Path
+import torch
+import exllamav3_ext as ext
+
+spec=importlib.util.spec_from_file_location(
+    "gather_had",Path(__file__).resolve().parents[1]/"overlay/exl3_gather_hadamard.py")
+mod=importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+def reference(x,indices,scale):
+    gathered=torch.index_select(x,0,indices)
+    out=torch.empty_like(gathered)
+    if indices.numel():ext.had_r_128(gathered,out,scale,None,1.0)
+    return out
+
+
+def same(a,b):
+    torch.testing.assert_close(a,b,rtol=0,atol=0,equal_nan=True)
+    mask=~torch.isnan(b)
+    assert torch.equal(a[mask].view(torch.int16),b[mask].view(torch.int16)), "FP16 bits differ"
+
+
+def check(x,indices,scale,*,graph=False):
+    rows,hidden=indices.numel(),x.shape[1]
+    storage=torch.full((rows,hidden+32),123.,device=x.device,dtype=torch.float16)
+    out=storage[:,:hidden]
+    originals=[v.clone() for v in (x,indices,scale)]
+    mod.gather_hadamard(x,indices,scale,out)
+    same(out,reference(x,indices,scale))
+    for a,b in zip((x,indices,scale),originals):same(a,b) if a.dtype==torch.float16 else torch.testing.assert_close(a,b,rtol=0,atol=0)
+    assert torch.all(storage[:,hidden:]==123.)
+    if graph:
+        torch.cuda.synchronize()
+        g=torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):mod.gather_hadamard(x,indices,scale,out)
+        for v in [-0.,.125,-.25]:
+            x.fill_(v)
+            scale.fill_(1.)
+            indices.copy_(torch.arange(rows,device=x.device)%x.shape[0])
+            out.fill_(42.)
+            g.replay()
+            same(out,reference(x,indices,scale))
+            assert torch.all(storage[:,hidden:]==123.)
+
+
+def main():
+    torch.manual_seed(72319)
+    count=0
+    for rows,hidden in [(0,128),(1,128),(3,256),(7,4096),(129,4096),
+                        (257,1024),(1024,4096),(7168,4096),(513,8192),(5,384)]:
+        for magnitude in [.001,1.,100.]:
+            total=max(513,rows+13)
+            xstore=torch.randn(total,hidden+16,device='cuda',dtype=torch.float16)*magnitude
+            x=xstore[:,:hidden]
+            indices=torch.randint(total,(rows*2,),device='cuda')[::2]
+            scale=torch.randn(hidden,device='cuda',dtype=torch.float16)*magnitude
+            check(x,indices,scale,graph=rows in (7,257))
+            count+=1
+    for repeated in [False,True]:
+        x=torch.randn(17,256,device='cuda',dtype=torch.float16)
+        indices=torch.zeros(35,device='cuda',dtype=torch.long) if repeated else torch.arange(16,-1,-1,device='cuda')
+        check(x,indices,torch.ones(256,device='cuda',dtype=torch.float16),graph=True)
+        count+=1
+    values=[float('nan'),float('inf'),-float('inf'),0.,-0.,2**-24,-2**-24,
+            2**-14,1.,-1.,65504.,-65504.,100.,-100.]
+    for value in values:
+        x=torch.randn(5,256,device='cuda',dtype=torch.float16)
+        scale=torch.ones(256,device='cuda',dtype=torch.float16)
+        x[2,17]=value
+        indices=torch.tensor([4,2,0,2],device='cuda')
+        check(x,indices,scale)
+        scale[53]=value
+        check(x,indices,scale)
+        count+=2
+    for v in [-0.,2**-24,-2**-24]:
+        check(torch.full((2,128),v,device='cuda',dtype=torch.float16),
+              torch.tensor([1,0],device='cuda'),torch.ones(128,device='cuda',dtype=torch.float16))
+        count+=1
+    stream=torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        check(torch.randn(13,1024,device='cuda',dtype=torch.float16),
+              torch.tensor([12,0,4,3],device='cuda'),torch.randn(1024,device='cuda',dtype=torch.float16))
+    torch.cuda.current_stream().wait_stream(stream)
+    count+=1
+    torch.cuda.synchronize()
+    print(f'PASS {count} exact gather+Hadamard cases including bits, graph updates, strides and current stream')
+
+
+if __name__=='__main__':main()

--- a/tests/test_exl3_swiglu.py
+++ b/tests/test_exl3_swiglu.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""GPU reference checks for EXL3 fat activation; runnable without vLLM import."""
+import importlib.util
+from pathlib import Path
+
+import torch
+
+spec = importlib.util.spec_from_file_location(
+    "exl3_swiglu", Path(__file__).resolve().parents[1] / "overlay/exl3_swiglu.py"
+)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+def reference(x, limit):
+    gate, up = x.chunk(2, dim=-1)
+    gate = gate.clamp(max=limit)
+    up = up.clamp(min=-limit, max=limit)
+    return ((torch.sigmoid(gate) * gate) * up).half()
+
+
+def main():
+    torch.manual_seed(93715)
+    cases = 0
+    max_abs = 0.0
+    for rows, width in [(0, 1024), (1, 17), (129, 1024), (257, 512), (1024, 1024), (7168, 1024), (13, 2048)]:
+        for limit in (1.0, 10.0, 20.0):
+            for padded in (False, True):
+                padding = 11 if padded else 0
+                x = (torch.randn(rows, 2 * width + padding, device='cuda') * 15)[:, :2 * width]
+                out_base = torch.full((rows, width + padding), 123.0, device='cuda', dtype=torch.float16)
+                out = out_base[:, :width]
+                original = x.clone()
+                expected = reference(x, limit)
+                mod.fat_swiglu(x, out, limit)
+                # FP32 sigmoid implementations can round differently at half-ULP boundaries.
+                torch.testing.assert_close(out, expected, rtol=0.001, atol=0.000002)
+                assert torch.equal(x, original), 'input must not be modified'
+                assert torch.all(out_base[:, width:] == 123.0), 'row padding overwritten'
+                if rows:
+                    max_abs = max(max_abs, (out - expected).abs().max().item())
+                cases += 1
+    # Finite saturation, signed zeros, infinities and NaNs follow torch clamp/sigmoid.
+    v = torch.tensor([-float('inf'), -100., -20., -10., -1., -0., 0., 1., 10., 20., 100., float('inf'), float('nan')], device='cuda')
+    g,u = torch.meshgrid(v, v, indexing='ij')
+    x = torch.cat((g, u), dim=1).contiguous()
+    out = torch.empty_like(g, dtype=torch.float16)
+    mod.fat_swiglu(x, out, 10.0)
+    torch.testing.assert_close(out, reference(x, 10.0), rtol=0.001, atol=0.000002, equal_nan=True)
+    # Real decode/prefill use graph capture; validate graph output on changed data.
+    x = torch.randn(257, 2048, device='cuda')
+    out = torch.empty(257, 1024, device='cuda', dtype=torch.float16)
+    mod.fat_swiglu(x, out, 10.0)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        mod.fat_swiglu(x, out, 10.0)
+    x.normal_()
+    graph.replay()
+    torch.testing.assert_close(out, reference(x, 10.0), rtol=0.001, atol=0.000002)
+    print(f'PASS {cases + 2} activation reference cases, max_abs={max_abs}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Depends on #140. This branch adds one gather/Hadamard commit on top of the activation commit in that PR. It does not replace #140. Until #140 merges, GitHub's diff against `main` includes both commits. Merge #140 first, then rebase this PR if needed to drop the activation commit from the diff.

## What changes

Replace `torch.index_select` followed by `ext.had_r_128` with one Triton kernel in the fat-expert path. The kernel reads the indexed FP16 hidden-state rows directly into the pre-scaled Hadamard-128 transform.

It preserves the FP16 scale-product rounding, native FP32 butterfly order and final FP16 conversion. It also removes the separate `h` scratch buffer, which uses 64 MiB at 8192 rows and hidden width 4096. Routing, packed GEMM, down Hadamard and DFlash stay unchanged.

The new commit changes four files: the helper, its GPU tests, the call site in `exl3.py`, and the Dockerfile copy step. It leaves #140's activation helper unchanged.

## Measurements

I compared this against the activation-only code in #140 on two DGX Spark GB10 nodes. Each value of `EXL3_TEMP_ROWS_FUSED` used an A/B/A/B sequence with fresh deployments. These are incremental gains from input gather/Hadamard fusion, not total gains over the original unfused model.

| `EXL3_TEMP_ROWS_FUSED` | A1 tok/s | B1 tok/s | A2 tok/s | B2 tok/s | Gain across candidate/baseline pairs |
| --- | ---: | ---: | ---: | ---: | --- |
| 128 | 1333.18 | 1383.90 | 1324.52 | 1383.96 | 3.80% to 4.49% |
| 256 | 1339.86 | 1363.56 | 1330.15 | 1369.69 | 1.77% to 2.97% |

The metric is the geometric mean of the 4K, 16K and 64K prefill medians, with three measured repetitions after warmups. I used sparkDash's unchanged prompt builder and streaming request code, identical 25-request fixtures and fresh prefix caches. Every arm reported zero prefix hits.

At cap128, the real-document, code and mixed-text holdout medians improved by 1.58% to 4.40%. At cap256, code and mixed text improved modestly, while short documents ranged from -0.53% to +0.40%. This is not a speedup for every workload.

The isolated gather plus Hadamard operation fell from 3968.55 to 1861.12 microseconds, a 53.10% reduction in the sum of 16 case medians. That is an operation-level result, not a serving-throughput claim.

Both arms ran E2 with TP2, a 131,072-token context and GPU memory utilization set to 0.82. Serving was text-only, with DFlash k7 at draft TP2 and FP8 KV. Both used 7,168-token chunks and at most four sequences. NCCL settings stayed unchanged. The runtime was vLLM `0.1.dev20051+g487ecf187` with the installed M64 E2 kernel. I did not rebuild the native extension. These results do not establish a latest-default E3 or decode speedup.

## Checks

- 64 standalone GPU cases passed exact FP16 bit comparisons against the native gather plus Hadamard sequence, except NaN payloads. The tests check NaN semantics separately. They cover strides, padding, tails, empty inputs, repeated indices, exceptional values, current streams and graph replay with changed inputs.
- Full registered E2/E1, mixed-expert, row-tile, expert-map and CUDA graph checks passed on the tested runtime.
- All 25 token-usage records matched across paired deployments. Generated previews were not identical in every case, including between baseline runs. No bitwise generation-equivalence claim.

The branch merges cleanly with `main` at `9c0794b`, and the merged Python files pass syntax checks. The GPU and serving results above come from the pinned runtime, not that newer build.

Run the standalone test only with inference stopped:

```bash
python3 tests/test_exl3_gather_hadamard.py
```

It requires CUDA, Triton and the installed ExLlamaV3 extension. No NCCL tuning or other experimental kernels are included in this PR.
