### PR TITLE
fix: scope shard completeness to the active snapshot and follow valid blob links

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -429,7 +429,7 @@ count_shards() {
         printf '0'
         return
     fi
-    find "$repo_path/snapshots/$ref" -maxdepth 1 -type f -name '*.safetensors' 2>/dev/null \
+    find -L "$repo_path/snapshots/$ref" -maxdepth 1 -type f -name '*.safetensors' 2>/dev/null \
         | wc -l | tr -d '[:space:]' || true
 }
 

--- a/start.sh
+++ b/start.sh
@@ -422,7 +422,15 @@ worker_ssh() { ssh -T -o BatchMode=yes -o ConnectTimeout=15 "$WORKER_SSH" "$@"; 
 usage() { sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
 
 count_shards() {
-    find "$1/snapshots" -name '*.safetensors' 2>/dev/null | wc -l | tr -d '[:space:]' || true
+    local repo_path="$1" ref
+    ref="$(cat "$repo_path/refs/main" 2>/dev/null || true)"
+    [ -n "$ref" ] || ref="$(ls -1t "$repo_path/snapshots" 2>/dev/null | head -n 1 || true)"
+    if [ -z "$ref" ]; then
+        printf '0'
+        return
+    fi
+    find "$repo_path/snapshots/$ref" -maxdepth 1 -type f -name '*.safetensors' 2>/dev/null \
+        | wc -l | tr -d '[:space:]' || true
 }
 
 ensure_refs_main() {

--- a/tests/test_snapshot_scoped_count.py
+++ b/tests/test_snapshot_scoped_count.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Regression guard: weight completeness is scoped to the active snapshot.
+
+A repo-wide count can accept 119 stale shards in snapshots/old plus one shard
+in the active snapshot as "120 present", then resolve the incomplete active
+snapshot and fail deep in vLLM load. Related: issue #52 (stale refs/main).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+START = ROOT / "start.sh"
+
+
+def function(name: str) -> str:
+    text = START.read_text(encoding="utf-8")
+    match = re.search(rf"(?ms)^{re.escape(name)}\(\) \{{\n.*?^\}}\n", text)
+    assert match, f"missing function {name}"
+    return match.group(0)
+
+
+def run_bash(script: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=False
+    )
+
+
+def test_target_completeness_is_scoped_to_active_snapshot() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp) / "repo"
+        active = repo / "snapshots" / "active"
+        old = repo / "snapshots" / "old"
+        active.mkdir(parents=True)
+        old.mkdir(parents=True)
+        (repo / "refs").mkdir()
+        (repo / "refs" / "main").write_text("active", encoding="utf-8")
+        (active / "model-00120-of-00120.safetensors").touch()
+        for index in range(1, 120):
+            (old / f"model-{index:05d}-of-00120.safetensors").touch()
+
+        result = run_bash(
+            "set -euo pipefail\n"
+            + function("count_shards")
+            + f"count_shards {str(repo)!r}\n"
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "1", result.stdout
+
+
+def test_empty_repo_counts_zero() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp) / "repo"
+        repo.mkdir()
+        result = run_bash(
+            "set -euo pipefail\n"
+            + function("count_shards")
+            + f"count_shards {str(repo)!r}\n"
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "0", result.stdout
+
+
+if __name__ == "__main__":
+    test_target_completeness_is_scoped_to_active_snapshot()
+    test_empty_repo_counts_zero()
+    print("snapshot-scoped count guard OK")

--- a/tests/test_snapshot_scoped_count.py
+++ b/tests/test_snapshot_scoped_count.py
@@ -65,7 +65,28 @@ def test_empty_repo_counts_zero() -> None:
         assert result.stdout.strip() == "0", result.stdout
 
 
+def test_cached_blob_links_count_but_dangling_links_do_not() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        active = repo / "snapshots" / "active"
+        active.mkdir(parents=True)
+        (repo / "refs").mkdir()
+        (repo / "refs" / "main").write_text("active", encoding="utf-8")
+        (repo / "blobs").mkdir()
+        (repo / "blobs" / "present").touch()
+        (active / "present.safetensors").symlink_to("../../blobs/present")
+        (active / "missing.safetensors").symlink_to("../../blobs/missing")
+        result = run_bash(
+            "set -euo pipefail\n"
+            + function("count_shards")
+            + f"count_shards {str(repo)!r}\n"
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "1", result.stdout
+
+
 if __name__ == "__main__":
     test_target_completeness_is_scoped_to_active_snapshot()
     test_empty_repo_counts_zero()
+    test_cached_blob_links_count_but_dangling_links_do_not()
     print("snapshot-scoped count guard OK")


### PR DESCRIPTION
## What
Count direct safetensor files in the active target snapshot, following valid Hugging Face blob symlinks while excluding dangling links.

## Why
Stale snapshots previously inflated the completeness count even when the snapshot selected for loading was incomplete. The submitted snapshot-scoping change also missed valid cache symlinks until the retained rework enabled link following.

## Verification
The behavioral snapshot regression passed for stale shards outside the active snapshot, an empty repository, a valid blob link, and a dangling blob link. These were temporary local filesystem fixtures, not model loads.
The full host-safe tests directory traversal recorded each command and exit status. Bash syntax and the explicit image-recipe check passed. Image-source-dependent tests, the torch/CUDA checks, and the live serving test were explicitly skipped; optional live indexer SSH was disabled.
The unchanged indexer workspace source assertion failed on both this branch and a read-only snapshot of base `dc6936cea8fd7b2e7ee5b7a48a5aa193857ca489`: it expects `stock`, while upstream defaults to `rightsize`. This is a pre-existing upstream test defect, not a clean full-suite pass; no assertion or default was changed to hide it.

## Operational consequences and limits
This remains a shard-count completeness check, not a manifest or content-integrity check. Missing refs retain the existing latest-snapshot fallback convention. No model loading or remote cache synchronization ran.
Changes under `tests/` change `overlay_recipe_hash`. Against an image carrying the previous recipe stamp, `start.sh` will REBUILD the image on next start unless `SKIP_BUILD=1`; explicitly requesting a build still builds. No changes are made under `overlay/`, `files/`, `ablit/`, or `Dockerfile`. A matching newly rebuilt image does not rebuild solely because of this change.
No live-serving, performance, or GPU-memory improvement is claimed. Contributor authorship is preserved in the rebased commits. Merge this replacement or its separate/combined alternative, not both.
