### PR TITLE
fix: keep API credentials out of launcher argv and off the worker

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1300,12 +1300,8 @@ launch_cluster() {
              GLM53_ADAPTIVE_K_MIN_STEPS GLM53_ADAPTIVE_K_SATURATE GLM53_ADAPTIVE_K_HIST GLM53_DENSE_FP8; do
         serve_env+=" -e $v='${!v:-}'"
     done
-    # VLLM_API_KEY is read by the head (rank 0) API server for bearer auth; the
-    # worker runs --headless so it only needs the var for argv-parity, and
-    # start.sh below passes it explicitly on the head. Keep it out of the
-    # generic loop so the key never shows in process listings of either node
-    # beyond the container env (same as the DeepSeek deployment).
-    serve_env+=" -e VLLM_API_KEY='${VLLM_API_KEY:-}'"
+    # The worker is headless and serves no API, so do not propagate the API
+    # credential into its remote docker command or container environment.
 
     log "starting worker on ${WORKER_SSH} (NCCL if=${WORKER_CX7_IF} hca=${WORKER_CX7_IB}) ..."
     worker_ssh "docker run -d --name '$CONTAINER_WORKER' \
@@ -1343,7 +1339,7 @@ launch_cluster() {
         --entrypoint bash '$IMAGE' /start.sh" >/dev/null
 
     log "starting head (vLLM API :${PORT}; NCCL if=${HEAD_CX7_IF} hca=${HEAD_CX7_IB}) ..."
-    docker run -d --name "$CONTAINER_HEAD" \
+    VLLM_API_KEY="$VLLM_API_KEY" docker run -d --name "$CONTAINER_HEAD" \
         --gpus all --network host --ipc=host --shm-size 32g --stop-timeout 60 \
         --device /dev/infiniband --cap-add IPC_LOCK \
         --ulimit memlock=-1 --ulimit stack=67108864 \
@@ -1413,7 +1409,7 @@ launch_cluster() {
         -e GLM53_ADAPTIVE_K_HIST="$GLM53_ADAPTIVE_K_HIST" \
         -e GLM53_DENSE_FP8="$GLM53_DENSE_FP8" \
         -e MODEL_DIR="$MODEL_DIR" \
-        -e VLLM_API_KEY="$VLLM_API_KEY" \
+        -e VLLM_API_KEY \
         -e EXTRA_ARGS="${EXTRA_ARGS:-}" \
         --entrypoint bash "$IMAGE" /start.sh >/dev/null
 

--- a/tests/test_api_key_argv.py
+++ b/tests/test_api_key_argv.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Regression guard: VLLM_API_KEY stays out of argv and off the worker.
+
+Merged PR #30 promised the bearer token never lands in argv and is passed to
+the head container only (the worker runs --headless and serves no API). This
+locks in both properties.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+START = ROOT / "start.sh"
+
+
+def function(name: str) -> str:
+    text = START.read_text(encoding="utf-8")
+    match = re.search(rf"(?ms)^{re.escape(name)}\(\) \{{\n.*?^\}}\n", text)
+    assert match, f"missing function {name}"
+    return match.group(0)
+
+
+def test_api_key_is_head_only_and_not_in_docker_argv() -> None:
+    launch = function("launch_cluster")
+    # worker: no credential in the remote docker command at all
+    assert "serve_env+=\" -e VLLM_API_KEY=" not in launch
+    # head: value must come from the docker client's environment, not argv
+    assert '-e VLLM_API_KEY="$VLLM_API_KEY"' not in launch
+    assert 'VLLM_API_KEY="$VLLM_API_KEY" docker run' in launch
+    assert "-e VLLM_API_KEY \\" in launch
+
+
+if __name__ == "__main__":
+    test_api_key_is_head_only_and_not_in_docker_argv()
+    print("api-key argv guard OK")

--- a/tests/test_api_key_argv.py
+++ b/tests/test_api_key_argv.py
@@ -1,37 +1,78 @@
 #!/usr/bin/env python3
-"""Regression guard: VLLM_API_KEY stays out of argv and off the worker.
-
-Merged PR #30 promised the bearer token never lands in argv and is passed to
-the head container only (the worker runs --headless and serves no API). This
-locks in both properties.
-"""
+"""Host regression: bearer auth reaches only the head, outside process argv."""
 
 from __future__ import annotations
 
+import json
+import os
 import re
+import shlex
+import subprocess
+import tempfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 START = ROOT / "start.sh"
 
 
-def function(name: str) -> str:
-    text = START.read_text(encoding="utf-8")
-    match = re.search(rf"(?ms)^{re.escape(name)}\(\) \{{\n.*?^\}}\n", text)
-    assert match, f"missing function {name}"
-    return match.group(0)
-
-
 def test_api_key_is_head_only_and_not_in_docker_argv() -> None:
-    launch = function("launch_cluster")
-    # worker: no credential in the remote docker command at all
-    assert "serve_env+=\" -e VLLM_API_KEY=" not in launch
-    # head: value must come from the docker client's environment, not argv
-    assert '-e VLLM_API_KEY="$VLLM_API_KEY"' not in launch
-    assert 'VLLM_API_KEY="$VLLM_API_KEY" docker run' in launch
-    assert "-e VLLM_API_KEY \\" in launch
+    source = START.read_text(encoding="utf-8")
+    match = re.search(r"(?ms)^launch_cluster\(\) \{\n.*?^\}\n", source)
+    assert match, "missing launch_cluster"
+    launch = match.group(0)
+    for key in ("fixture bearer 'with spaces' $literal", ""):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixture = root / "fixture"
+            fixture.touch()
+            docker = root / "docker"
+            docker.write_text(
+                "#!/usr/bin/env python3\n"
+                "import json, os, sys\n"
+                "with open(os.environ['CAPTURE'], 'a') as output:\n"
+                "    output.write(json.dumps([sys.argv[1:], os.getenv('VLLM_API_KEY')]) + '\\n')\n"
+            )
+            docker.chmod(0o755)
+            values = {
+                name: "fixture"
+                for name in re.findall(r"\$(?:\{)?([A-Z][A-Z0-9_]*)", launch)
+            }
+            for name in re.findall(r'\[ -f "\$([A-Z0-9_]+)" \]', launch):
+                values[name] = str(fixture)
+            for name in ("CACHE_ROOT", "TRITON_HOST_CACHE", "TILELANG_HOST_CACHE"):
+                values[name] = str(root / "cache")
+            values.update(USE_HOST_NCCL="0", VLLM_API_KEY=key)
+            script = (
+                "set -eo pipefail\n"
+                "log() { :; }\n"
+                "die() { printf '%s\\n' \"$*\" >&2; exit 1; }\n"
+                "scp() { :; }\n"
+                "worker_ssh() { printf '%s\\0' \"$@\" >> \"$WORKER_CAPTURE\"; }\n"
+                + "\n".join(f"{name}={shlex.quote(value)}" for name, value in values.items())
+                + "\n" + launch + "\nlaunch_cluster\n"
+            )
+            env = {name: value for name, value in os.environ.items() if name != "VLLM_API_KEY"}
+            env.update(
+                PATH=f"{tmp}:{os.environ['PATH']}",
+                CAPTURE=str(root / "head.jsonl"),
+                WORKER_CAPTURE=str(root / "worker.args"),
+            )
+            result = subprocess.run(["bash", "-c", script], env=env, capture_output=True, text=True)
+            assert result.returncode == 0, result.stderr
+            calls = [json.loads(line) for line in (root / "head.jsonl").read_text().splitlines()]
+            runs = [(args, bearer) for args, bearer in calls if args[0] == "run"]
+            assert len(runs) == 1, runs
+            args, bearer = runs[0]
+            assert bearer == key
+            assert any(args[index:index + 2] == ["-e", "VLLM_API_KEY"] for index in range(len(args)))
+            worker = (root / "worker.args").read_text()
+            assert "VLLM_API_KEY" not in worker, worker
+            if key:
+                assert all(key not in arg for argv, _ in calls for arg in argv)
+                assert key not in worker
+                assert key not in result.stdout + result.stderr
 
 
 if __name__ == "__main__":
     test_api_key_is_head_only_and_not_in_docker_argv()
-    print("api-key argv guard OK")
+    print("api-key argv guard OK (stubbed launch, configured and empty auth)")


### PR DESCRIPTION
## What
Pass the API credential through the head Docker process environment with a value-less environment option, and stop forwarding it to the headless worker.

## Why
The old launcher expanded the credential into both local Docker arguments and the remote worker command. The worker does not serve the API and does not need the credential.

## Verification
The behavioral launcher regression passed with configured and empty authentication. Isolated executable recorders observed head environment inheritance, credential-free arguments and output, and no worker credential propagation. No actual Docker or SSH process ran.
The full host-safe tests directory traversal recorded each command and exit status. Bash syntax and the explicit image-recipe check passed. Image-source-dependent tests, the torch/CUDA checks, and the live serving test were explicitly skipped; optional live indexer SSH was disabled.
The unchanged indexer workspace source assertion failed on both this branch and a read-only snapshot of base `dc6936cea8fd7b2e7ee5b7a48a5aa193857ca489`: it expects `stock`, while upstream defaults to `rightsize`. This is a pre-existing upstream test defect, not a clean full-suite pass; no assertion or default was changed to hide it.

## Operational consequences and limits
The credential remains available in the head process/container environment to suitably privileged readers. This change protects argv, not environment inspection or shell tracing. Live bearer-auth behavior was not exercised.
Changes under `tests/` change `overlay_recipe_hash`. Against an image carrying the previous recipe stamp, `start.sh` will REBUILD the image on next start unless `SKIP_BUILD=1`; explicitly requesting a build still builds. No changes are made under `overlay/`, `files/`, `ablit/`, or `Dockerfile`. A matching newly rebuilt image does not rebuild solely because of this change.
No live-serving, performance, or GPU-memory improvement is claimed. Contributor authorship is preserved in the rebased commits. Merge this replacement or its separate/combined alternative, not both.
