### PR TITLE
fix: pin drafter selection without losing explicit revision overrides

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,7 @@ SERVED_MODEL_NAME=GLM-5.3-Flash-EXL3
 SPEC_METHOD=dflash
 DFLASH_MODEL=incoai/GLM-5.3-Flash-DFlash2
 # Exact checkpoint behind the published 2026-08-30 TP=2 receipts.
+# Override with an exact commit; empty follows the cached main ref (refresh to update).
 DFLASH_REVISION=dc77ff1c99eeb2df044ee3d4f0094eb033fee410
 DFLASH_TOKENS=7
 # Drafter TP. 2 = measured keep on this 2× GB10 kit (shard draft across ranks).

--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,8 @@ SERVED_MODEL_NAME=GLM-5.3-Flash-EXL3
 # Rollback: SPEC_METHOD=mtp
 SPEC_METHOD=dflash
 DFLASH_MODEL=incoai/GLM-5.3-Flash-DFlash2
+# Exact checkpoint behind the published 2026-08-30 TP=2 receipts.
+DFLASH_REVISION=dc77ff1c99eeb2df044ee3d4f0094eb033fee410
 DFLASH_TOKENS=7
 # Drafter TP. 2 = measured keep on this 2× GB10 kit (shard draft across ranks).
 # 1 = rank 0 only (skip CX7 on a 2.3 GiB draft). Empty = inherit TP.

--- a/start.sh
+++ b/start.sh
@@ -60,6 +60,8 @@ fi
 # Caller exports (MTP_TOKENS=2 ./start.sh restart) must win over .env.
 _cli_mtp="${MTP_TOKENS-}"
 _cli_spec="${SPEC_METHOD-}"
+_cli_dflash_revision_set="${DFLASH_REVISION+1}"
+_cli_dflash_revision="${DFLASH_REVISION-}"
 _cli_eager="${ENFORCE_EAGER-}"
 _cli_fused="${EXL3_FUSED_MOE-}"
 _cli_row_tile="${EXL3_MOE_ROW_TILE-}"
@@ -95,6 +97,7 @@ source "$SCRIPT_DIR/.env"
 set +a
 [ -n "${_cli_mtp}" ] && MTP_TOKENS="$_cli_mtp"
 [ -n "${_cli_spec}" ] && SPEC_METHOD="$_cli_spec"
+[ -n "${_cli_dflash_revision_set}" ] && DFLASH_REVISION="$_cli_dflash_revision"
 [ -n "${_cli_eager}" ] && ENFORCE_EAGER="$_cli_eager"
 [ -n "${_cli_fused}" ] && EXL3_FUSED_MOE="$_cli_fused"
 [ -n "${_cli_row_tile}" ] && EXL3_MOE_ROW_TILE="$_cli_row_tile"
@@ -182,7 +185,7 @@ DFLASH_CACHE_NAME="${DFLASH_CACHE_NAME:-models--${DFLASH_MODEL//\//--}}"
 # Receipt-matched DFlash2 checkpoint used by the 2026-08-30 TP=2 results.
 # A mutable Hub main has already changed weights, so fresh and warm installs
 # must resolve the same snapshot unless the operator deliberately overrides it.
-DFLASH_REVISION="${DFLASH_REVISION:-dc77ff1c99eeb2df044ee3d4f0094eb033fee410}"
+DFLASH_REVISION="${DFLASH_REVISION-dc77ff1c99eeb2df044ee3d4f0094eb033fee410}"
 DFLASH_TOKENS="${DFLASH_TOKENS:-7}"
 # 2 = shard the ~2.3 GiB DFlash2 drafter across TP (C4 keep, 2026-08-30:
 # idle 8k 938 / 16k 972 / 100k 997; decode structured 65.1 / prose 27.1).
@@ -468,7 +471,7 @@ ensure_dflash_refs_main() {
 
 resolve_dflash_dir() {
     local ref="$DFLASH_PATH/refs/main" hash dir
-    if [ -n "${DFLASH_REVISION:-}" ] && [ -d "$DFLASH_PATH/snapshots/$DFLASH_REVISION" ]; then
+    if [ -n "${DFLASH_REVISION:-}" ]; then
         hash="$DFLASH_REVISION"
     else
         ensure_dflash_refs_main
@@ -922,9 +925,7 @@ download_dflash() {
     local -a dflash_args=("$DFLASH_MODEL")
     [ -n "${DFLASH_REVISION:-}" ] && dflash_args+=(--revision "$DFLASH_REVISION")
     HF_HOME="$HF_CACHE_DIR" "${HF_BIN_CMD[@]}" download "${dflash_args[@]}"
-    selected="$(resolve_dflash_dir)"
-    have=1
-    [ "${have:-0}" -ge 1 ] || die "DFlash2 download finished without model.safetensors"
+    resolve_dflash_dir >/dev/null
     log "DFlash2 download complete"
 }
 

--- a/start.sh
+++ b/start.sh
@@ -179,6 +179,10 @@ MTP_TOKENS="${MTP_TOKENS:-2}"
 SPEC_METHOD="${SPEC_METHOD:-dflash}"
 DFLASH_MODEL="${DFLASH_MODEL:-incoai/GLM-5.3-Flash-DFlash2}"
 DFLASH_CACHE_NAME="${DFLASH_CACHE_NAME:-models--${DFLASH_MODEL//\//--}}"
+# Receipt-matched DFlash2 checkpoint used by the 2026-08-30 TP=2 results.
+# A mutable Hub main has already changed weights, so fresh and warm installs
+# must resolve the same snapshot unless the operator deliberately overrides it.
+DFLASH_REVISION="${DFLASH_REVISION:-dc77ff1c99eeb2df044ee3d4f0094eb033fee410}"
 DFLASH_TOKENS="${DFLASH_TOKENS:-7}"
 # 2 = shard the ~2.3 GiB DFlash2 drafter across TP (C4 keep, 2026-08-30:
 # idle 8k 938 / 16k 972 / 100k 997; decode structured 65.1 / prose 27.1).
@@ -464,10 +468,15 @@ ensure_dflash_refs_main() {
 
 resolve_dflash_dir() {
     local ref="$DFLASH_PATH/refs/main" hash dir
-    ensure_dflash_refs_main
-    hash="$(<"$ref")"
+    if [ -n "${DFLASH_REVISION:-}" ] && [ -d "$DFLASH_PATH/snapshots/$DFLASH_REVISION" ]; then
+        hash="$DFLASH_REVISION"
+    else
+        ensure_dflash_refs_main
+        hash="$(<"$ref")"
+    fi
     dir="$DFLASH_PATH/snapshots/$hash"
     [ -f "$dir/config.json" ] || die "DFlash2 config.json missing in $dir"
+    [ -f "$dir/model.safetensors" ] || die "DFlash2 model.safetensors missing in $dir"
     printf '/root/.cache/huggingface/hub/%s/snapshots/%s' "$DFLASH_CACHE_NAME" "$hash"
 }
 
@@ -895,8 +904,13 @@ download_weights() {
 download_dflash() {
     [ "$SPEC_METHOD" = "dflash" ] || return 0
     [ "${SKIP_DOWNLOAD:-0}" = "1" ] && { log "SKIP_DOWNLOAD=1 — skipping DFlash2 download check"; return; }
-    local have
-    have="$(find "$DFLASH_PATH/snapshots" -name 'model.safetensors' 2>/dev/null | wc -l | tr -d '[:space:]' || true)"
+    local have=0 selected=""
+    if [ -n "${DFLASH_REVISION:-}" ]; then
+        selected="$DFLASH_PATH/snapshots/$DFLASH_REVISION"
+    elif [ -s "$DFLASH_PATH/refs/main" ]; then
+        selected="$DFLASH_PATH/snapshots/$(<"$DFLASH_PATH/refs/main")"
+    fi
+    [ -n "$selected" ] && [ -f "$selected/model.safetensors" ] && have=1
     if [ "${have:-0}" -ge 1 ] && [ "${REFRESH_WEIGHTS:-0}" != "1" ]; then
         log "DFlash2 already present: $DFLASH_PATH"
         ensure_dflash_refs_main
@@ -905,9 +919,11 @@ download_dflash() {
     resolve_hf_bin || die "no 'hf' / 'huggingface-cli' on PATH and no python huggingface_hub — pip install --user -U 'huggingface_hub[cli]' (or set HF_BIN=/path/to/hf)"
     mkdir -p "$HF_CACHE_DIR"
     log "downloading ${DFLASH_MODEL} (~2.3 GiB) into ${HF_CACHE_DIR} ..."
-    HF_HOME="$HF_CACHE_DIR" "${HF_BIN_CMD[@]}" download "$DFLASH_MODEL"
-    ensure_dflash_refs_main
-    have="$(find "$DFLASH_PATH/snapshots" -name 'model.safetensors' 2>/dev/null | wc -l | tr -d '[:space:]' || true)"
+    local -a dflash_args=("$DFLASH_MODEL")
+    [ -n "${DFLASH_REVISION:-}" ] && dflash_args+=(--revision "$DFLASH_REVISION")
+    HF_HOME="$HF_CACHE_DIR" "${HF_BIN_CMD[@]}" download "${dflash_args[@]}"
+    selected="$(resolve_dflash_dir)"
+    have=1
     [ "${have:-0}" -ge 1 ] || die "DFlash2 download finished without model.safetensors"
     log "DFlash2 download complete"
 }
@@ -950,19 +966,23 @@ download_only() {
 # (issue #22, item 2). FORCE_SYNC=1 bypasses the marker; deleting the
 # marker file on the worker has the same effect.
 sync_repo_marker_rev() {
-    local src="$1"
+    local src="$1" preferred="${2:-}"
     local rev
-    rev="$(cat "$src/refs/main" 2>/dev/null || true)"
+    if [ -n "$preferred" ] && [ -d "$src/snapshots/$preferred" ]; then
+        rev="$preferred"
+    else
+        rev="$(cat "$src/refs/main" 2>/dev/null || true)"
+    fi
     [ -n "$rev" ] || rev="$(ls -1t "$src/snapshots" 2>/dev/null | head -n 1 || true)"
     [ -n "$rev" ] || rev="unknown"
     printf '%s' "$rev"
 }
 
 sync_repo_to_worker() {
-    local src="$1" cache_name="$2" label="$3"
+    local src="$1" cache_name="$2" label="$3" preferred="${4:-}"
     local marker rev
     marker="${WORKER_CACHE_DIR}/hub/${cache_name}/.glm53-exl3-synced"
-    rev="$(sync_repo_marker_rev "$src")"
+    rev="$(sync_repo_marker_rev "$src" "$preferred")"
     if [ "${FORCE_SYNC:-0}" != "1" ] \
        && [ "$(worker_ssh "cat '$marker' 2>/dev/null" || true)" = "$rev" ]; then
         log "worker ${cache_name} already at ${rev} — rsync skipped (FORCE_SYNC=1 to force)"
@@ -981,7 +1001,7 @@ sync_weights() {
     sync_repo_to_worker "$MODEL_PATH" "$MODEL_CACHE_NAME" "weights"
     if [ "$SPEC_METHOD" = "dflash" ]; then
         [ -d "$DFLASH_PATH" ] || die "DFlash2 weights missing at $DFLASH_PATH"
-        sync_repo_to_worker "$DFLASH_PATH" "$DFLASH_CACHE_NAME" "DFlash2 draft"
+        sync_repo_to_worker "$DFLASH_PATH" "$DFLASH_CACHE_NAME" "DFlash2 draft" "$DFLASH_REVISION"
     fi
     log "worker weights in sync"
 }

--- a/tests/test_dflash_revision_pin.py
+++ b/tests/test_dflash_revision_pin.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Regression guard: the DFlash2 drafter resolves a pinned revision.
+
+incoai/GLM-5.3-Flash-DFlash2 has shipped three different model.safetensors
+under the same model ID (7d74cdd -> dc77ff1 -> bf582e4). Without a pin, a
+fresh install resolves whatever Hub main means that day, so fresh and warm
+deployments run different drafter bytes while claiming the same recipe. The
+default pin is the checkpoint behind the published 2026-08-30 TP=2 receipts.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+START = ROOT / "start.sh"
+
+PIN = "dc77ff1c99eeb2df044ee3d4f0094eb033fee410"
+
+
+def source() -> str:
+    return START.read_text(encoding="utf-8")
+
+
+def function(name: str) -> str:
+    text = source()
+    match = re.search(rf"(?ms)^{re.escape(name)}\(\) \{{\n.*?^\}}\n", text)
+    assert match, f"missing function {name}"
+    return match.group(0)
+
+
+def run_bash(script: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=False
+    )
+
+
+def test_pin_is_declared_and_threaded_through() -> None:
+    text = source()
+    assert f'DFLASH_REVISION="${{DFLASH_REVISION:-{PIN}}}"' in text
+    assert 'dflash_args+=(--revision "$DFLASH_REVISION")' in text
+    assert '[ -f "$dir/model.safetensors" ]' in function("resolve_dflash_dir")
+    # worker sync marker keyed on the pin so a ref flip cannot skip the rsync
+    assert 'sync_repo_to_worker "$DFLASH_PATH" "$DFLASH_CACHE_NAME" "DFlash2 draft" "$DFLASH_REVISION"' in text
+
+
+def test_download_and_resolution_use_the_pin() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        args_file = Path(tmp) / "hf-args"
+        script = f"""
+set -euo pipefail
+log() {{ :; }}
+die() {{ printf 'DIE:%s\\n' "$*" >&2; exit 97; }}
+{function("ensure_dflash_refs_main")}
+{function("resolve_dflash_dir")}
+{function("download_dflash")}
+resolve_hf_bin() {{ HF_BIN_CMD=(mock_hf); }}
+mock_hf() {{
+    printf '%s\\n' "$@" > "$ARGS_FILE"
+    mkdir -p "$DFLASH_PATH/snapshots/$DFLASH_REVISION"
+    touch "$DFLASH_PATH/snapshots/$DFLASH_REVISION/config.json"
+    touch "$DFLASH_PATH/snapshots/$DFLASH_REVISION/model.safetensors"
+}}
+ARGS_FILE={shlex.quote(str(args_file))}
+DFLASH_PATH={shlex.quote(str(Path(tmp) / "dflash"))}
+DFLASH_CACHE_NAME=models--incoai--DFlash
+DFLASH_MODEL=incoai/DFlash
+DFLASH_REVISION={PIN}
+HF_CACHE_DIR={shlex.quote(tmp)}
+SPEC_METHOD=dflash
+SKIP_DOWNLOAD=0
+REFRESH_WEIGHTS=0
+download_dflash
+printf 'resolved=%s\\n' "$(resolve_dflash_dir)"
+"""
+        result = run_bash(script)
+        assert result.returncode == 0, result.stderr
+        assert args_file.read_text(encoding="utf-8").splitlines() == [
+            "download",
+            "incoai/DFlash",
+            "--revision",
+            PIN,
+        ]
+        assert result.stdout.strip().endswith(f"/snapshots/{PIN}")
+
+
+if __name__ == "__main__":
+    test_pin_is_declared_and_threaded_through()
+    test_download_and_resolution_use_the_pin()
+    print("dflash revision-pin guard OK")

--- a/tests/test_dflash_revision_pin.py
+++ b/tests/test_dflash_revision_pin.py
@@ -1,15 +1,9 @@
 #!/usr/bin/env python3
-"""Regression guard: the DFlash2 drafter resolves a pinned revision.
-
-incoai/GLM-5.3-Flash-DFlash2 has shipped three different model.safetensors
-under the same model ID (7d74cdd -> dc77ff1 -> bf582e4). Without a pin, a
-fresh install resolves whatever Hub main means that day, so fresh and warm
-deployments run different drafter bytes while claiming the same recipe. The
-default pin is the checkpoint behind the published 2026-08-30 TP=2 receipts.
-"""
+"""Host regressions for drafter revision selection and download."""
 
 from __future__ import annotations
 
+import os
 import re
 import shlex
 import subprocess
@@ -39,13 +33,66 @@ def run_bash(script: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def test_pin_is_declared_and_threaded_through() -> None:
-    text = source()
-    assert f'DFLASH_REVISION="${{DFLASH_REVISION:-{PIN}}}"' in text
-    assert 'dflash_args+=(--revision "$DFLASH_REVISION")' in text
-    assert '[ -f "$dir/model.safetensors" ]' in function("resolve_dflash_dir")
-    # worker sync marker keyed on the pin so a ref flip cannot skip the rsync
-    assert 'sync_repo_to_worker "$DFLASH_PATH" "$DFLASH_CACHE_NAME" "DFlash2 draft" "$DFLASH_REVISION"' in text
+def test_revision_override_and_empty_value_survive_env() -> None:
+    preamble = source().split('DFLASH_TOKENS=')[0]
+    with tempfile.TemporaryDirectory() as tmp:
+        script = Path(tmp) / "start.sh"
+        script.write_text(preamble + '\nprintf "[%s]" "$DFLASH_REVISION"\n')
+        env_file = Path(tmp) / ".env"
+        env = {"PATH": os.environ["PATH"], "HOME": tmp, "USER": "fixture"}
+        for configured, caller, expected in (
+            ("", None, PIN),
+            (f"DFLASH_REVISION={PIN}\n", "override", "override"),
+            (f"DFLASH_REVISION={PIN}\n", "", ""),
+            ("DFLASH_REVISION=\n", None, ""),
+        ):
+            env_file.write_text(configured)
+            current = env.copy()
+            if caller is not None:
+                current["DFLASH_REVISION"] = caller
+            result = subprocess.run(
+                ["bash", str(script)], capture_output=True, text=True, env=current
+            )
+            assert result.returncode == 0, result.stderr
+            assert result.stdout == f"[{expected}]", result.stdout
+
+
+def test_resolution_and_sync_marker_ignore_stale_main() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        (repo / "refs").mkdir()
+        (repo / "refs" / "main").write_text("old")
+        for revision in ("old", PIN):
+            snapshot = repo / "snapshots" / revision
+            snapshot.mkdir(parents=True)
+            (snapshot / "config.json").touch()
+            (snapshot / "model.safetensors").touch()
+        script = f"""
+set -euo pipefail
+log() {{ :; }}
+die() {{ printf '%s\\n' "$*" >&2; exit 97; }}
+{function("ensure_dflash_refs_main")}
+{function("resolve_dflash_dir")}
+{function("sync_repo_marker_rev")}
+DFLASH_PATH={shlex.quote(tmp)}
+DFLASH_CACHE_NAME=fixture
+DFLASH_REVISION={PIN}
+resolve_dflash_dir
+printf '\\n'
+sync_repo_marker_rev "$DFLASH_PATH" "$DFLASH_REVISION"
+"""
+        result = run_bash(script)
+        assert result.returncode == 0, result.stderr
+        path, marker = result.stdout.splitlines()
+        assert path.endswith(f"/snapshots/{PIN}"), path
+        assert marker == PIN, marker
+        (repo / "snapshots" / PIN / "model.safetensors").unlink()
+        result = run_bash(script)
+        assert result.returncode == 97, result.stdout
+        (repo / "snapshots" / PIN / "config.json").unlink()
+        (repo / "snapshots" / PIN).rmdir()
+        result = run_bash(script)
+        assert result.returncode == 97, result.stdout
 
 
 def test_download_and_resolution_use_the_pin() -> None:
@@ -89,6 +136,7 @@ printf 'resolved=%s\\n' "$(resolve_dflash_dir)"
 
 
 if __name__ == "__main__":
-    test_pin_is_declared_and_threaded_through()
+    test_resolution_and_sync_marker_ignore_stale_main()
+    test_revision_override_and_empty_value_survive_env()
     test_download_and_resolution_use_the_pin()
     print("dflash revision-pin guard OK")


### PR DESCRIPTION
## What
Select the published exact drafter revision for download, resolution, and synchronization. Preserve caller overrides and explicit empty values across configuration loading. Reject missing pinned weights instead of falling back silently to cached main.

## Why
Mutable Hub main and a repo-wide draft-file check could select different weights on fresh and warm installs. Pinning must also control the selected snapshot and sync marker, not just the download command.

## Verification
The behavioral revision regression passed for stale main, missing pinned files and directories, caller precedence, explicit empty configuration, and an isolated HF download recorder. No Hub download or rank launch ran.
The full host-safe tests directory traversal recorded each command and exit status. Bash syntax and the explicit image-recipe check passed. Image-source-dependent tests, the torch/CUDA checks, and the live serving test were explicitly skipped; optional live indexer SSH was disabled.
The unchanged indexer workspace source assertion failed on both this branch and a read-only snapshot of base `dc6936cea8fd7b2e7ee5b7a48a5aa193857ca489`: it expects `stock`, while upstream defaults to `rightsize`. This is a pre-existing upstream test defect, not a clean full-suite pass; no assertion or default was changed to hide it.

## Operational consequences and limits
An unset revision now chooses the published pin. A custom drafter needs its own matching exact revision or an explicit empty revision. Empty follows cached main; refresh is needed to update it. Skipping downloads with a missing pin fails closed. Worker contents under deliberately skipped sync and live generation were not verified.
Changes under `tests/` change `overlay_recipe_hash`. Against an image carrying the previous recipe stamp, `start.sh` will REBUILD the image on next start unless `SKIP_BUILD=1`; explicitly requesting a build still builds. No changes are made under `overlay/`, `files/`, `ablit/`, or `Dockerfile`. A matching newly rebuilt image does not rebuild solely because of this change.
No live-serving, performance, or GPU-memory improvement is claimed. Contributor authorship is preserved in the rebased commits. Merge this replacement or its separate/combined alternative, not both.
