### PR TITLE
fix: port upstream GLM chat-template corrections

### DIFF
--- a/files/chat_template.jinja
+++ b/files/chat_template.jinja
@@ -73,8 +73,8 @@ For each function call, output the function name and arguments within the follow
                 {{- emit_audio() -}}
             {%- endif -%}
         {%- endfor -%}
-    {%- else -%}
-        {{- content }}
+    {%- elif content is not none -%}
+        {{- content -}}
     {%- endif -%}
 {%- endmacro -%}
 {%- macro tool_response(text) -%}
@@ -164,7 +164,7 @@ For each function call, output the function name and arguments within the follow
 {%- if tc.function %}
     {%- set tc = tc.function %}
 {%- endif %}
-{{- '<tool_call>' + tc.name -}}
+{{- '<tool_call>' ~ tc.name -}}
 {% set _args = tc.arguments %}{% for k, v in _args.items() %}<arg_key>{{ k }}</arg_key><arg_value>{{ v | tojson(ensure_ascii=False) if v is not string else v }}</arg_value>{% endfor %}</tool_call>{% endfor %}
 {% endif %}
 {%- elif m.role == 'tool' -%}
@@ -188,9 +188,11 @@ For each function call, output the function name and arguments within the follow
         {%- set ns_chk.can_sort = false -%}
     {%- else -%}
         {%- for k in range(block_start, ns_blk.end + 1) -%}
+            {%- if not ns_chk.can_sort -%}{%- break -%}{%- endif -%}
             {%- set m = messages[k] -%}
             {%- if is_list_of_outputs(m) -%}
                 {%- for entry in m.content -%}
+                    {%- if not ns_chk.can_sort -%}{%- break -%}{%- endif -%}
                     {%- set eid = id_of(entry) -%}
                     {%- if not eid -%}
                         {%- set ns_chk.can_sort = false -%}
@@ -212,6 +214,7 @@ For each function call, output the function name and arguments within the follow
             {%- endif -%}
         {%- endfor -%}
         {%- for i in range(ns_a.tool_calls | length) -%}
+            {%- if not ns_chk.can_sort -%}{%- break -%}{%- endif -%}
             {%- set tc_id = id_of(ns_a.tool_calls[i]) -%}
             {%- if not tc_id -%}
                 {%- set ns_chk.can_sort = false -%}
@@ -219,9 +222,10 @@ For each function call, output the function name and arguments within the follow
             {%- for j in range(i + 1, ns_a.tool_calls | length) -%}
                 {%- if id_of(ns_a.tool_calls[j]) == tc_id -%}
                     {%- set ns_chk.can_sort = false -%}
+                    {%- break -%}
                 {%- endif -%}
             {%- endfor -%}
-    {%- endfor -%}
+        {%- endfor -%}
     {%- endif -%}
     {%- if ns_chk.can_sort -%}
         {%- for tc in ns_a.tool_calls -%}
@@ -238,8 +242,8 @@ For each function call, output the function name and arguments within the follow
                                 {{- tool_response(visible_text(entry.output)) -}}
                             {%- endif -%}
                         {%- endif -%}
-    {%- endfor -%}
-{%- else -%}
+                    {%- endfor -%}
+                {%- else -%}
                     {%- set tk_id = id_of(m) -%}
                     {%- if tk_id == tc_id -%}
                         {{- render_tool_response(m) -}}


### PR DESCRIPTION
## What and why

Ports the chat-template corrections from zai-org/GLM-5.3-Flash commit 690b705278a3a58e538fcb37c2ca8b5f9511213c. Assistant history with null content no longer emits literal `None`. Tool-name concatenation uses Jinja string coercion, and result-order validation stops when sorting is already impossible. Existing thinking controls and parser delimiters are preserved.

All 6 changed hunk bodies match upstream exactly. The change is limited to files/chat_template.jinja. This is the rebased maintainer replacement for #127; contributor attribution is retained.

## Verification

Reused the standalone upstream-hunk/render comparison: all assertions passed, including null-content reproduction, unchanged marker sequences, and 8 invalid-ID fallback cases. The existing chat-template test file passed all 7 tests.

The host-side tests directory run reported 62 passed, 2 live checks deselected, and 1 existing unrelated failure: the indexer recipe test pins an obsolete default. Its test and launcher are unchanged from the base. No test was weakened or removed. GPU, installed-image, and serving checks were explicitly excluded from this local run.

## Limits and release gate

The live tool/reasoning smoke is a separate orchestrator gate; attach its reviewed evidence before merge. Local rendering does not establish streaming parser behavior, generated parallel-call reliability, or installed-image behavior. No performance improvement is claimed.

The template belongs to the image recipe-stamp inputs, so a normal post-merge launch may rebuild on stamp drift. A candidate read-only template mount can isolate the live smoke from image rebuilding, but does not verify the rebuild path. No image build was performed in this review.
