### PR TITLE
fix(launcher): make long prefill threshold an explicit opt-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,6 +140,12 @@ MAX_NUM_SEQS=4
 # throughput/KV balance. Re-run 2048 vs 7168 before changing; never 8192
 # (indexer smem).
 MAX_NUM_BATCHED_TOKENS=7168
+# Empty = stock scheduler (no --long-prefill-token-threshold flag).
+# Measured A/B/A at MNBT=7168 with LONG_PREFILL_TOKEN_THRESHOLD=3584 (MNBT/2):
+# warm-session freeze 131/108 s stock -> 15 s; contended prefill +6%;
+# solo prefill +3..+11%, within baseline drift. Re-measure for other kits.
+# Positive integer <= MAX_NUM_BATCHED_TOKENS, or empty.
+LONG_PREFILL_TOKEN_THRESHOLD=
 GPU_MEM_UTIL=0.85
 KV_CACHE_DTYPE=fp8
 # 0 = load vision tower (image + video). 1 = language-only.

--- a/start.sh
+++ b/start.sh
@@ -71,6 +71,8 @@ _cli_fat_batched="${EXL3_FAT_BATCHED-}"
 _cli_fat_kernel="${EXL3_FAT_KERNEL-}"
 _cli_fat_grouped="${EXL3_FAT_GROUPED-}"
 _cli_mnbt="${MAX_NUM_BATCHED_TOKENS-}"
+_cli_long_prefill_set="${LONG_PREFILL_TOKEN_THRESHOLD+1}"
+_cli_long_prefill="${LONG_PREFILL_TOKEN_THRESHOLD-}"
 _cli_image="${IMAGE-}"
 _cli_util="${GPU_MEM_UTIL-}"
 _cli_lm="${LANGUAGE_MODEL_ONLY-}"
@@ -107,6 +109,7 @@ set +a
 [ -n "${_cli_fat_kernel}" ] && EXL3_FAT_KERNEL="$_cli_fat_kernel"
 [ -n "${_cli_fat_grouped}" ] && EXL3_FAT_GROUPED="$_cli_fat_grouped"
 [ -n "${_cli_mnbt}" ] && MAX_NUM_BATCHED_TOKENS="$_cli_mnbt"
+[ -n "${_cli_long_prefill_set}" ] && LONG_PREFILL_TOKEN_THRESHOLD="$_cli_long_prefill"
 [ -n "${_cli_image}" ] && IMAGE="$_cli_image"
 [ -n "${_cli_util}" ] && GPU_MEM_UTIL="$_cli_util"
 [ -n "${_cli_lm}" ] && LANGUAGE_MODEL_ONLY="$_cli_lm"
@@ -204,6 +207,8 @@ MAX_NUM_SEQS="${MAX_NUM_SEQS:-4}"
 # 8192 chunk × long history oversubscribes GB10 persistent_topk smem (300k crash).
 # E2 one-shot 2026-09-01: 7168 keep (100k ~1148 / 300k ~1107); 2048/3548 similar or slower.
 MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-7168}"
+# Empty preserves the stock scheduler; opt in after measuring contention.
+LONG_PREFILL_TOKEN_THRESHOLD="${LONG_PREFILL_TOKEN_THRESHOLD:-}"
 CHAT_TEMPLATE_HOST="${CHAT_TEMPLATE_HOST:-$SCRIPT_DIR/files/chat_template.jinja}"
 CHAT_TEMPLATE="${CHAT_TEMPLATE:-/opt/glm53/chat_template.jinja}"
 VIDEO_PATCH_HOST="${VIDEO_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm_video_placeholders.py}"
@@ -409,6 +414,10 @@ validate_numeric_config() {
     _glm53_canonical_positive_int MAX_MODEL_LEN "$MAX_MODEL_LEN" 1000000 || return
     _glm53_canonical_positive_int MAX_NUM_SEQS "$MAX_NUM_SEQS" 4096 || return
     _glm53_canonical_positive_int MAX_NUM_BATCHED_TOKENS "$MAX_NUM_BATCHED_TOKENS" 8388608 || return
+    if [ -n "${LONG_PREFILL_TOKEN_THRESHOLD:-}" ]; then
+        _glm53_canonical_positive_int LONG_PREFILL_TOKEN_THRESHOLD \
+            "$LONG_PREFILL_TOKEN_THRESHOLD" "$MAX_NUM_BATCHED_TOKENS" || return
+    fi
     _glm53_validate_enum GLM53_INDEXER_WORKSPACE "${GLM53_INDEXER_WORKSPACE-rightsize}" \
         stock rightsize || return
     _glm53_validate_spinwait_ms || return
@@ -1036,6 +1045,7 @@ ARGS=(
 [ -n "${GPU_MEM_UTIL:-}" ]  && ARGS+=(--gpu-memory-utilization "${GPU_MEM_UTIL}")
 [ -n "${MAX_NUM_SEQS:-}" ] && ARGS+=(--max-num-seqs "${MAX_NUM_SEQS}")
 [ -n "${MAX_NUM_BATCHED_TOKENS:-}" ] && ARGS+=(--max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}")
+[ -n "${LONG_PREFILL_TOKEN_THRESHOLD:-}" ] && ARGS+=(--long-prefill-token-threshold "${LONG_PREFILL_TOKEN_THRESHOLD}")
 [ -n "${KV_CACHE_DTYPE:-}" ] && ARGS+=(--kv-cache-dtype "${KV_CACHE_DTYPE}")
 if [ "${SPEC_METHOD:-mtp}" = "dflash" ]; then
     ARGS+=(--speculative-config "$(python3 -S -c 'import json,os
@@ -1140,6 +1150,7 @@ ARGS=(
 [ -n "${GPU_MEM_UTIL:-}" ]  && ARGS+=(--gpu-memory-utilization "${GPU_MEM_UTIL}")
 [ -n "${MAX_NUM_SEQS:-}" ] && ARGS+=(--max-num-seqs "${MAX_NUM_SEQS}")
 [ -n "${MAX_NUM_BATCHED_TOKENS:-}" ] && ARGS+=(--max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}")
+[ -n "${LONG_PREFILL_TOKEN_THRESHOLD:-}" ] && ARGS+=(--long-prefill-token-threshold "${LONG_PREFILL_TOKEN_THRESHOLD}")
 [ -n "${KV_CACHE_DTYPE:-}" ] && ARGS+=(--kv-cache-dtype "${KV_CACHE_DTYPE}")
 if [ "${SPEC_METHOD:-mtp}" = "dflash" ]; then
     ARGS+=(--speculative-config "$(python3 -S -c 'import json,os
@@ -1312,6 +1323,7 @@ launch_cluster() {
     local v
     for v in SERVED_MODEL_NAME PORT TP NNODES HEAD_IP MASTER_PORT QUANTIZATION \
              MAX_MODEL_LEN GPU_MEM_UTIL MAX_NUM_SEQS MAX_NUM_BATCHED_TOKENS \
+             LONG_PREFILL_TOKEN_THRESHOLD \
              KV_CACHE_DTYPE MTP_TOKENS SPEC_METHOD DFLASH_TOKENS DFLASH_MODEL_DIR \
              DFLASH_DRAFT_TP \
              LANGUAGE_MODEL_ONLY SKIP_MM_PROFILING \
@@ -1398,6 +1410,7 @@ launch_cluster() {
         -e MAX_MODEL_LEN="$MAX_MODEL_LEN" -e GPU_MEM_UTIL="$GPU_MEM_UTIL" \
         -e MAX_NUM_SEQS="$MAX_NUM_SEQS" \
         -e MAX_NUM_BATCHED_TOKENS="$MAX_NUM_BATCHED_TOKENS" \
+        -e LONG_PREFILL_TOKEN_THRESHOLD="${LONG_PREFILL_TOKEN_THRESHOLD:-}" \
         -e KV_CACHE_DTYPE="$KV_CACHE_DTYPE" -e MTP_TOKENS="$MTP_TOKENS" \
         -e SPEC_METHOD="$SPEC_METHOD" \
         -e DFLASH_TOKENS="${DFLASH_TOKENS:-7}" \

--- a/tests/test_long_prefill_threshold.py
+++ b/tests/test_long_prefill_threshold.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Host-only scheduler opt-in and both-rank argv regression."""
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from test_numeric_config import guard_source
+from test_start_overrides import _run_preamble
+
+ROOT = Path(__file__).resolve().parents[1]
+KEY = "LONG_PREFILL_TOKEN_THRESHOLD"
+FLAG = "--long-prefill-token-threshold"
+
+
+@pytest.mark.parametrize("value", [None, "", "3584"])
+def test_both_rank_argv(value: str | None) -> None:
+    source = (ROOT / "start.sh").read_text()
+    begin = source.index("write_inner_scripts() {")
+    end = source.index('\n}\n', begin) + 3
+    env = {"PATH": os.environ["PATH"], "SERVED_MODEL_NAME": "test",
+           "PORT": "8888", "TP": "2", "NNODES": "2", "HEAD_IP": "127.0.0.1",
+           "MASTER_PORT": "29500", "SPEC_METHOD": "none"}
+    if value is not None:
+        env[KEY] = value
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        tmp = Path(raw_tmp)
+        env.update(HEAD_SCRIPT=str(tmp / "head.sh"), WORKER_SCRIPT=str(tmp / "worker.sh"))
+        subprocess.run(["bash", "-c", source[begin:end] + '\nwrite_inner_scripts'],
+                       env=env, check=True, capture_output=True)
+        for rank, name in enumerate(("head.sh", "worker.sh")):
+            script = (tmp / name).read_text().split('[ -f "${MODEL_DIR}/config.json" ]')[0]
+            script += '\nprintf "%s\\0" "${ARGS[@]}"\n'
+            result = subprocess.run(["bash", "-c", script], env=env,
+                                    check=True, capture_output=True)
+            # Head status messages precede the NUL-delimited argv.
+            args = result.stdout.decode().splitlines()[-1].split("\0")[:-1]
+            assert args[args.index("--node-rank") + 1] == str(rank)
+            assert args.count(FLAG) == (1 if value else 0)
+            if value:
+                assert args[args.index(FLAG) + 1] == value
+
+
+@pytest.mark.parametrize("value,expected", [("", 0), ("3584", 0), ("003584", 0),
+                                             ("0", 2), ("-1", 2), ("1.5", 2),
+                                             (" 3584", 2), ("7169", 2)])
+def test_validation(value: str, expected: int) -> None:
+    script = (guard_source() + '\nGPU_MEM_UTIL=0.85; MAX_MODEL_LEN=850000; '
+              'MAX_NUM_SEQS=4; MAX_NUM_BATCHED_TOKENS=7168; GLM53_SPINWAIT_MS=stock\n'
+              'validate_numeric_config || exit $?\n'
+              'printf "%s" "$LONG_PREFILL_TOKEN_THRESHOLD"\n')
+    result = subprocess.run(["bash", "-c", script], capture_output=True, text=True,
+                            env={"PATH": os.environ["PATH"], KEY: value})
+    assert result.returncode == expected, result.stderr
+    if expected == 0:
+        assert result.stdout == ("3584" if value else "")
+
+
+def test_caller_can_restore_stock_over_env() -> None:
+    probe = '\nprintf "V=[%s]\\n" "${LONG_PREFILL_TOKEN_THRESHOLD-UNSET}"\n'
+    assert _run_preamble(f"{KEY}=3584\n", {KEY: ""}, probe) == "V=[]"
+    assert _run_preamble(f"{KEY}=1024\n", {KEY: "3584"}, probe) == "V=[3584]"


### PR DESCRIPTION
## What and why

Reworks #112 as an explicit scheduler opt-in. `LONG_PREFILL_TOKEN_THRESHOLD` defaults to empty, which emits no flag and preserves stock scheduling. A positive decimal value is validated against `MAX_NUM_BATCHED_TOKENS`, captured before `.env`, and forwarded to both ranks. An explicitly empty caller export overrides a configured value.

The example documents `3584` for `MAX_NUM_BATCHED_TOKENS=7168` (MNBT/2), not a launcher default of `1024`. The supplied A/B/A observation was warm-session freeze `131/108 s` stock to `15 s`, contended prefill `+6%`, and solo prefill `+3..+11%` within baseline drift. These are kit-specific observations, not a universal performance guarantee.

## Verification

Host regression renders both rank scripts: the flag appears exactly once per rank when set and never when unset or empty. Validation and caller-empty precedence are covered. Scoped suite: `20 passed`. Full `tests/`: `76 passed`, with the pre-existing upstream `test_indexer_workspace.py:788` assertion failing because it still expects `stock` while upstream defaults to `rightsize`. No tests or unrelated defaults were changed to hide that failure. `bash -n start.sh` passed.

## Limits

Default behavior is unchanged. No image build, cluster restart, or serving request was performed for this rework. Owner GO depends on reviewing the orchestrator's `PR-112-solo-reps.json` and accepting the known upstream test defect; the package alone does not certify a new live performance result.
