### PR TITLE
feat(launcher): add opt-in default reasoning effort

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -200,6 +200,11 @@ GLM53_SUPPRESS_STOPS_IN_REASONING=1
 # When a decode seq is running, do not mix a peer prefill into that step
 # (issue #6). skip = decode-only steps; N>0 = cap mixed prefill tokens; 0 = off.
 GLM53_MIXED_PREFILL_CHUNK=skip
+# Server default: empty (no flag), low, high, or max. Empty preserves the
+# template's Max fallback for omitted effort; medium is not a template level.
+# Example opt-in: GLM53_DEFAULT_REASONING_EFFORT=high
+# Per-request chat_template_kwargs.reasoning_effort overrides this default.
+GLM53_DEFAULT_REASONING_EFFORT=
 # Sparse-indexer prefill gather workspace sizing.
 #   stock     = max_model_len * 40 entries (5036.40 MB locked at 1M, measured)
 #   rightsize = the legal per-step maximum, ~+26% KV cache. Opt-in.

--- a/README.md
+++ b/README.md
@@ -535,7 +535,9 @@ curl -s http://127.0.0.1:8888/v1/chat/completions \
 
 Thinking defaults on. Disable it with the **top-level** JSON field
 `"chat_template_kwargs": {"enable_thinking": false}`. This closes the empty
-thinking block in the generation prompt and omits the reasoning-effort hint.
+thinking block in the generation prompt. The `Reasoning Effort:` line itself
+renders unconditionally since #63 (prefix-cache stability), thinking on or off.
+
 Do not send a literal nested `extra_body` object over raw HTTP; `extra_body` is
 an OpenAI Python SDK option that merges its contents into the top-level request.
 The Hub `generation_config.json` stamps `temperature=1.0` / `top_p=0.95` unless
@@ -648,6 +650,7 @@ that are now documented/enforced:
 | `KV_CACHE_DTYPE` | `fp8` | packed `fp8_ds_mla`; not `nvfp4`, not bf16 |
 | `GLM53_MIXED_PREFILL_CHUNK` | `skip` | do not mix a peer prefill into a decode step (issue #6). `N>0` = cap tokens; `0` = off. Solo prefill stays MNBT (7168) |
 | `GLM53_SUPPRESS_STOPS_IN_REASONING` | `1` | ignore client `stop` strings until `</think>` (thinking-on default) |
+| `GLM53_DEFAULT_REASONING_EFFORT` | *(empty)* | `low` / `high` / `max` via `--default-chat-template-kwargs` on both ranks. Empty sends no flag, so omitted effort renders Max. Per-request `chat_template_kwargs.reasoning_effort` overrides the default; `medium` is rejected because the template maps it to Max |
 | `GLM53_INDEXER_WORKSPACE` | `rightsize` (default since 2026-09-07; was `stock`) | sparse-indexer prefill gather workspace. `stock` = `max_model_len * 40` entries (**5036.40 MB** locked at 1M — measured, `VLLM_DEBUG_WORKSPACE=1`). `rightsize` = the legal per-step maximum `min(MAX_NUM_SEQS, MNBT) * cdiv(MAX_MODEL_LEN + k, index_kpool)` = 126 MB at `MAX_NUM_SEQS=4` / 504 MB at 16, so **~+26–28% KV**. Opt-in; see [docs/DESIGN-indexer-workspace.md](docs/DESIGN-indexer-workspace.md) |
 | `GLM53_SPINWAIT_MS` | `stock` | SpinCondition reader busy-loop window. `stock` preserves vLLM's 1 s default; `1..1000` selects milliseconds. A frozen TP=2 sweep selected `16` (+0.95% median decode vs stock, 85.3% less active EngineCore CPU) |
 | `GLM53_BOOT_SHAPE_WARMUP` | `1` | after `/health`, burn DFlash2 BLOCK / sampler / kpool shapes (nonfatal) |
@@ -706,6 +709,7 @@ After CUDA compile, Python overlay edits (`overlay/exl3.py`, tests) are a cheap 
 | `overlay/patch_ablit.py` | install the load_weights hook; bind-mounted and run on both ranks |
 | `ablit/` | direction vectors + `LAYER_MAP.json` from drowzeys' published recipe; `fetch_transplant.py` + `transplant/` for the donor o_proj byte-copy |
 | `tests/test_ablit.py` | recipe integrity, orthogonalization math, TP-shard equivalence, transplant byte-copy + TP slice, hook gating |
+| `tests/test_default_reasoning_effort.sh` | `GLM53_DEFAULT_REASONING_EFFORT` enum guard (`""`/`low`/`high`/`max`; `medium` rejected) and the `--default-chat-template-kwargs` flag at both rank sites, sliced out of `start.sh` and evaluated |
 | `scripts/boot-shape-warmup.sh` | post-`/health` DFlash2 k=7 BLOCK ladder + sampler/kpool arms |
 
 Image-build runs `EXL3_SELFCHECK_GPU=0`. `./start.sh` runs the GPU self-check

--- a/start.sh
+++ b/start.sh
@@ -93,6 +93,9 @@ _cli_indexer_workspace_set="${GLM53_INDEXER_WORKSPACE+1}"
 _cli_indexer_workspace="${GLM53_INDEXER_WORKSPACE-}"
 _cli_spinwait_ms_set="${GLM53_SPINWAIT_MS+1}"
 _cli_spinwait_ms="${GLM53_SPINWAIT_MS-}"
+# An empty caller value must disable a default set in .env.
+_cli_default_effort_set="${GLM53_DEFAULT_REASONING_EFFORT+1}"
+_cli_default_effort="${GLM53_DEFAULT_REASONING_EFFORT-}"
 set -a
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/.env"
@@ -126,6 +129,7 @@ set +a
 [ -n "${_cli_ablit_mtp}" ] && ABLIT_INCLUDE_MTP="$_cli_ablit_mtp"
 [ -n "${_cli_indexer_workspace_set}" ] && GLM53_INDEXER_WORKSPACE="$_cli_indexer_workspace"
 [ -n "${_cli_spinwait_ms_set}" ] && GLM53_SPINWAIT_MS="$_cli_spinwait_ms"
+[ -n "${_cli_default_effort_set}" ] && GLM53_DEFAULT_REASONING_EFFORT="$_cli_default_effort"
 
 # ----------------------------- configuration -------------------------------
 MODEL="${MODEL:-Mia-AiLab/GLM-5.3-Flash-EXL3-TR3-4bpw}"
@@ -304,6 +308,8 @@ GLM53_ADAPTIVE_K_HIST="${GLM53_ADAPTIVE_K_HIST:-200}"
 # Dense projections FP8 weight-only via Marlin (overlay/patch_dense_fp8.py). off = BF16 as shipped.
 # PROVISIONAL (changes target numerics; needs a KLD panel). Groups: shared,dense,kda,mla.
 GLM53_DENSE_FP8="${GLM53_DENSE_FP8:-off}"
+# Empty leaves the template's omitted-effort fallback unchanged.
+GLM53_DEFAULT_REASONING_EFFORT="${GLM53_DEFAULT_REASONING_EFFORT-}"
 # Sparse-indexer prefill gather workspace (overlay/patch_indexer_workspace.py).
 # stock = max_model_len * 40 entries (5036.40 MB locked at 1M, measured);
 # rightsize = the legal per-step maximum, ~+26% KV (default since 2026-09-07:
@@ -421,6 +427,11 @@ validate_numeric_config() {
     _glm53_validate_enum GLM53_INDEXER_WORKSPACE "${GLM53_INDEXER_WORKSPACE-rightsize}" \
         stock rightsize || return
     _glm53_validate_spinwait_ms || return
+    # The template treats medium as max, so do not advertise it as a level.
+    if [ -n "${GLM53_DEFAULT_REASONING_EFFORT-}" ]; then
+        _glm53_validate_enum GLM53_DEFAULT_REASONING_EFFORT \
+            "$GLM53_DEFAULT_REASONING_EFFORT" low high max || return
+    fi
 }
 # GLM53 numeric config guard (end)
 
@@ -1047,6 +1058,9 @@ ARGS=(
 [ -n "${MAX_NUM_BATCHED_TOKENS:-}" ] && ARGS+=(--max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}")
 [ -n "${LONG_PREFILL_TOKEN_THRESHOLD:-}" ] && ARGS+=(--long-prefill-token-threshold "${LONG_PREFILL_TOKEN_THRESHOLD}")
 [ -n "${KV_CACHE_DTYPE:-}" ] && ARGS+=(--kv-cache-dtype "${KV_CACHE_DTYPE}")
+if [ -n "${GLM53_DEFAULT_REASONING_EFFORT:-}" ]; then
+    ARGS+=(--default-chat-template-kwargs "{\"reasoning_effort\":\"${GLM53_DEFAULT_REASONING_EFFORT}\"}")
+fi
 if [ "${SPEC_METHOD:-mtp}" = "dflash" ]; then
     ARGS+=(--speculative-config "$(python3 -S -c 'import json,os
 spec={"method":"dflash","model":os.environ["DFLASH_MODEL_DIR"],"num_speculative_tokens":int(os.environ.get("DFLASH_TOKENS","7")),"kv_cache_dtype":"auto","draft_sample_method":"probabilistic","rejection_sample_method":"standard"}
@@ -1152,6 +1166,9 @@ ARGS=(
 [ -n "${MAX_NUM_BATCHED_TOKENS:-}" ] && ARGS+=(--max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}")
 [ -n "${LONG_PREFILL_TOKEN_THRESHOLD:-}" ] && ARGS+=(--long-prefill-token-threshold "${LONG_PREFILL_TOKEN_THRESHOLD}")
 [ -n "${KV_CACHE_DTYPE:-}" ] && ARGS+=(--kv-cache-dtype "${KV_CACHE_DTYPE}")
+if [ -n "${GLM53_DEFAULT_REASONING_EFFORT:-}" ]; then
+    ARGS+=(--default-chat-template-kwargs "{\"reasoning_effort\":\"${GLM53_DEFAULT_REASONING_EFFORT}\"}")
+fi
 if [ "${SPEC_METHOD:-mtp}" = "dflash" ]; then
     ARGS+=(--speculative-config "$(python3 -S -c 'import json,os
 spec={"method":"dflash","model":os.environ["DFLASH_MODEL_DIR"],"num_speculative_tokens":int(os.environ.get("DFLASH_TOKENS","7")),"kv_cache_dtype":"auto","draft_sample_method":"probabilistic","rejection_sample_method":"standard"}
@@ -1281,6 +1298,7 @@ launch_cluster() {
         -e VLLM_CACHE_ROOT=/root/.cache/vllm
         -e "GLM53_SUPPRESS_STOPS_IN_REASONING=$GLM53_SUPPRESS_STOPS_IN_REASONING"
         -e "GLM53_MIXED_PREFILL_CHUNK=$GLM53_MIXED_PREFILL_CHUNK"
+        -e "GLM53_DEFAULT_REASONING_EFFORT=${GLM53_DEFAULT_REASONING_EFFORT-}"
         -e "GLM53_INDEXER_WORKSPACE=$GLM53_INDEXER_WORKSPACE"
         -e "GLM53_SPINWAIT_MS=$GLM53_SPINWAIT_MS"
         -e "TRITON_CACHE_DIR=$TRITON_CACHE_DIR"

--- a/tests/test_default_reasoning_effort.sh
+++ b/tests/test_default_reasoning_effort.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# GLM53_DEFAULT_REASONING_EFFORT: launch-time enum guard + the serve-args flag.
+#
+# Two independent claims are checked against start.sh's own text, not a replica:
+#   1. validate_numeric_config accepts exactly "" | low | high | max and rejects
+#      everything else (notably `medium`, which files/chat_template.jinja does
+#      NOT recognize and would silently render as Max).
+#   2. BOTH inner scripts (head rank 0 and headless worker rank 1) append
+#      --default-chat-template-kwargs exactly once, with space-free JSON, when
+#      the knob is set -- and append nothing at all when it is empty.
+# Values are passed through the environment so adversarial strings are
+# exercised safely rather than interpolated into source.
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+START="$HERE/../start.sh"
+[ -f "$START" ] || { echo "start.sh not found" >&2; exit 1; }
+fail=0
+
+# ---------------------------------------------------------------- guard ----
+guard="$(sed -n '/^# GLM53 numeric config guard (begin)$/,/^# GLM53 numeric config guard (end)$/p' "$START")"
+[ -n "$guard" ] || { echo "numeric config guard block not found" >&2; exit 1; }
+printf '%s\n' "$guard" > "/tmp/_effort_guard.$$"
+
+guard_rc() { # reads the value from the environment; echoes validate_numeric_config's rc
+    GLM53_DEFAULT_REASONING_EFFORT="$1" bash -c '
+        source "/tmp/_effort_guard.'$$'"
+        GPU_MEM_UTIL=0.87 MAX_MODEL_LEN=1000000 MAX_NUM_SEQS=4 MAX_NUM_BATCHED_TOKENS=2048
+        validate_numeric_config' >/dev/null 2>&1
+    echo $?
+}
+
+check_guard() {
+    got="$(guard_rc "$1")"
+    if [ "$got" = "$2" ]; then echo "ok   guard [$1] -> rc $got"
+    else echo "FAIL guard [$1] -> rc $got want $2"; fail=1; fi
+}
+
+check_guard ""       0
+check_guard "low"    0
+check_guard "high"   0
+check_guard "max"    0
+check_guard "medium" 2
+check_guard "High"   2
+check_guard "MAX"    2
+check_guard " high"  2
+check_guard "high "  2
+check_guard "junk"   2
+check_guard "1"      2
+check_guard 'high;id' 2
+
+# an UNSET knob must also pass (the guard reads ${VAR-}, not $VAR under set -u)
+if bash -c 'set -u; source "/tmp/_effort_guard.'$$'"
+    GPU_MEM_UTIL=0.87 MAX_MODEL_LEN=1000000 MAX_NUM_SEQS=4 MAX_NUM_BATCHED_TOKENS=2048
+    validate_numeric_config' >/dev/null 2>&1; then
+    echo "ok   guard [<unset>] -> rc 0"
+else
+    echo "FAIL guard [<unset>] must pass with the var unset"; fail=1
+fi
+
+# the rejection message must name the knob and the four legal values
+msg="$(GLM53_DEFAULT_REASONING_EFFORT=medium bash -c '
+    source "/tmp/_effort_guard.'$$'"
+    GPU_MEM_UTIL=0.87 MAX_MODEL_LEN=1000000 MAX_NUM_SEQS=4 MAX_NUM_BATCHED_TOKENS=2048
+    validate_numeric_config' 2>&1 >/dev/null || true)"
+case "$msg" in
+    *GLM53_DEFAULT_REASONING_EFFORT*low*high*max*) echo "ok   guard error names knob and enum" ;;
+    *) echo "FAIL guard error text: [$msg]"; fail=1 ;;
+esac
+
+# ----------------------------------------------------------- serve args ----
+# Slice each inner script out of its quoted heredoc, then keep only the ARGS
+# construction (ARGS=( ... up to the config.json existence check).
+args_block() { # $1 = HEAD_SCRIPT | WORKER_SCRIPT
+    awk -v var="$1" '
+        index($0, "cat > \"$" var "\" <<") { inblk = 1; next }
+        inblk && $0 == "EOF" { exit }
+        inblk { print }
+    ' "$START" | sed -n '/^ARGS=(/,/^\[ -f "${MODEL_DIR}\/config.json"/p' | sed '$d'
+}
+
+for var in HEAD_SCRIPT WORKER_SCRIPT; do
+    args_block "$var" > "/tmp/_effort_args_${var}.$$"
+    if ! [ -s "/tmp/_effort_args_${var}.$$" ]; then
+        echo "FAIL could not slice ARGS block for $var"; fail=1; continue
+    fi
+    if ! grep -q -- '--default-chat-template-kwargs' "/tmp/_effort_args_${var}.$$"; then
+        echo "FAIL $var ARGS block has no --default-chat-template-kwargs"; fail=1
+    fi
+done
+
+emit() { # $1 = HEAD_SCRIPT|WORKER_SCRIPT, $2 = knob value; prints argv one per line
+    GLM53_DEFAULT_REASONING_EFFORT="$2" bash -c '
+        say() { :; }
+        SERVED_MODEL_NAME=m PORT=8888 TP=2 NNODES=2 HEAD_IP=10.0.0.1 MASTER_PORT=29500
+        ENFORCE_EAGER=0 QUANTIZATION=none MAX_MODEL_LEN=1000000 GPU_MEM_UTIL=0.87
+        MAX_NUM_SEQS=4 MAX_NUM_BATCHED_TOKENS=2048 KV_CACHE_DTYPE=fp8
+        SPEC_METHOD=none MTP_TOKENS=0 CHAT_TEMPLATE= LANGUAGE_MODEL_ONLY=0
+        LIMIT_MM= SKIP_MM_PROFILING=0 EXTRA_ARGS=
+        source "/tmp/_effort_args_'"$1"'.'$$'"
+        printf "%s\n" "${ARGS[@]}"' 2>/dev/null
+}
+
+check_emit() { # $1 rank var, $2 value, $3 expected JSON ("" = flag must be absent)
+    local out n json
+    out="$(emit "$1" "$2")"
+    n="$(printf '%s\n' "$out" | grep -c -- '^--default-chat-template-kwargs$' || true)"
+    json="$(printf '%s\n' "$out" | grep -A1 -- '^--default-chat-template-kwargs$' | sed -n '2p')"
+    if [ -z "$3" ]; then
+        if [ "$n" = "0" ]; then echo "ok   $1 [$2] -> no flag"
+        else echo "FAIL $1 [$2] -> emitted $n flag(s): [$json]"; fail=1; fi
+        return
+    fi
+    if [ "$n" != "1" ]; then
+        echo "FAIL $1 [$2] -> flag emitted $n times (want exactly 1)"; fail=1; return
+    fi
+    if [ "$json" != "$3" ]; then
+        echo "FAIL $1 [$2] -> JSON [$json] want [$3]"; fail=1; return
+    fi
+    case "$json" in
+        *" "*) echo "FAIL $1 [$2] -> JSON contains a space: [$json]"; fail=1; return ;;
+    esac
+    echo "ok   $1 [$2] -> $json"
+}
+
+for var in HEAD_SCRIPT WORKER_SCRIPT; do
+    check_emit "$var" ""     ""
+    check_emit "$var" "low"  '{"reasoning_effort":"low"}'
+    check_emit "$var" "high" '{"reasoning_effort":"high"}'
+    check_emit "$var" "max"  '{"reasoning_effort":"max"}'
+done
+
+# the two ranks must build the same flag from the same knob
+h="$(emit HEAD_SCRIPT high | grep -A1 -- '^--default-chat-template-kwargs$' | sed -n '2p')"
+w="$(emit WORKER_SCRIPT high | grep -A1 -- '^--default-chat-template-kwargs$' | sed -n '2p')"
+if [ "$h" = "$w" ] && [ -n "$h" ]; then echo "ok   both ranks build the identical flag"
+else echo "FAIL rank flags differ: head [$h] worker [$w]"; fail=1; fi
+
+# ------------------------------------------------------------- wiring ------
+launcher="$(cat "$START")"
+case "$launcher" in
+    *'_cli_default_effort_set="${GLM53_DEFAULT_REASONING_EFFORT+1}"'*)
+        echo "ok   caller capture is setness-aware" ;;
+    *) echo "FAIL caller capture is not setness-aware"; fail=1 ;;
+esac
+case "$launcher" in
+    *'[ -n "${_cli_default_effort_set}" ] && GLM53_DEFAULT_REASONING_EFFORT="$_cli_default_effort"'*)
+        echo "ok   caller value wins over .env" ;;
+    *) echo "FAIL caller override line missing"; fail=1 ;;
+esac
+case "$launcher" in
+    *'-e "GLM53_DEFAULT_REASONING_EFFORT=${GLM53_DEFAULT_REASONING_EFFORT-}"'*)
+        echo "ok   knob reaches both containers via nccl_common" ;;
+    *) echo "FAIL knob is not exported into the containers"; fail=1 ;;
+esac
+# default must stay empty: this PR changes no behaviour until an operator opts in
+case "$launcher" in
+    *'GLM53_DEFAULT_REASONING_EFFORT="${GLM53_DEFAULT_REASONING_EFFORT-}"'*)
+        echo "ok   launcher default is empty (unchanged behaviour)" ;;
+    *) echo "FAIL launcher default is not empty"; fail=1 ;;
+esac
+
+rm -f "/tmp/_effort_guard.$$" "/tmp/_effort_args_HEAD_SCRIPT.$$" "/tmp/_effort_args_WORKER_SCRIPT.$$"
+[ "$fail" = 0 ] && echo "default reasoning effort tests: PASS"
+exit $fail

--- a/tests/test_start_overrides.py
+++ b/tests/test_start_overrides.py
@@ -42,6 +42,7 @@ def test_max_num_seqs_inline_override_wins() -> None:
 
 
 def _run_preamble(env_file: str, caller: dict[str, str], probe: str) -> str:
+    """Run start.sh's pre-configuration preamble with a synthetic .env."""
     source = (ROOT / "start.sh").read_text()
     marker = "# ----------------------------- configuration -------------------------------"
     preamble, separator, _rest = source.partition(marker)
@@ -55,12 +56,37 @@ def _run_preamble(env_file: str, caller: dict[str, str], probe: str) -> str:
         (tmp / ".env").write_text(env_file)
 
         env = {k: v for k, v in os.environ.items()
-               if k not in ("GLM53_INDEXER_WORKSPACE", "GLM53_SPINWAIT_MS")}
+               if k not in ("GLM53_INDEXER_WORKSPACE", "GLM53_SPINWAIT_MS",
+                            "GLM53_DEFAULT_REASONING_EFFORT")}
         env.update(caller)
         result = subprocess.run(
             ["bash", str(script)], check=True, capture_output=True, text=True, env=env
         )
     return result.stdout.strip()
+
+
+def test_default_reasoning_effort_caller_override_is_setness_aware() -> None:
+    """An explicitly EMPTY caller value must beat .env, not be swallowed by it.
+
+    The knob's own default is empty, so ``[ -n "$_cli_x" ]`` cannot tell
+    ``GLM53_DEFAULT_REASONING_EFFORT= ./start.sh`` (deliberately back to the
+    template default) apart from an unset var. Only ``${VAR+1}`` can.
+    """
+    probe = '\nprintf "EFFORT=[%s]\\n" "${GLM53_DEFAULT_REASONING_EFFORT-unset}"\n'
+    env_file = "GLM53_DEFAULT_REASONING_EFFORT=high\n"
+
+    # caller unset -> .env wins
+    assert _run_preamble(env_file, {}, probe) == "EFFORT=[high]"
+
+    # caller sets a value -> caller wins
+    assert _run_preamble(
+        env_file, {"GLM53_DEFAULT_REASONING_EFFORT": "low"}, probe
+    ) == "EFFORT=[low]"
+
+    # caller sets it EMPTY -> caller still wins (the setness-aware case)
+    assert _run_preamble(
+        env_file, {"GLM53_DEFAULT_REASONING_EFFORT": ""}, probe
+    ) == "EFFORT=[]"
 
 
 def test_indexer_workspace_caller_capture_is_setness_aware() -> None:
@@ -106,6 +132,7 @@ def test_spinwait_caller_capture_is_setness_aware() -> None:
 
 if __name__ == "__main__":
     test_max_num_seqs_inline_override_wins()
+    test_default_reasoning_effort_caller_override_is_setness_aware()
     test_indexer_workspace_caller_capture_is_setness_aware()
     test_spinwait_caller_capture_is_setness_aware()
     print("start.sh caller override regression OK")


### PR DESCRIPTION
## What and why

Reworks #87 as an opt-in `GLM53_DEFAULT_REASONING_EFFORT` launcher setting. Empty remains the default and sends no flag. `low`, `high`, and `max` are accepted; `medium` is rejected because the existing template maps it to Max rather than a distinct effort level.

Both ranks receive `--default-chat-template-kwargs` with a single JSON argument. Caller exports, including an explicit empty value, take precedence over `.env`. Per-request `chat_template_kwargs.reasoning_effort` remains the override mechanism. The template itself is unchanged: omitted effort maps to Max.

Removed repeated explanatory prose, pasted receipt documentation, and the blanket recommendation from the original PR. There is no new launcher helper or wrapper. The existing PR tests are retained rather than weakened to accommodate the rebase.

## Verification

The original shell regression passed: enum rejection, both-rank exact-once argv, and empty/no-flag behavior. Scoped Python tests: `16 passed`. An offline render smoke confirmed omitted/low/high/max/medium map to Max/Low/High/Max/Max. Full `tests/`: `65 passed`, with the pre-existing upstream `test_indexer_workspace.py:788` assertion failing because it expects the old stock default. Shell syntax checks passed. No upstream test or default was changed to conceal that failure.

## Limits

No image build, serving request, or restart was performed for this rework. Owner GO requires the orchestrator's `PR-87-live-ab.json`, using the frozen `PR-87-prompts.json` set, to distinguish effort-omitted requests from the explicit-max control and document tokens, wall time, correctness, and render receipts. Host checks do not establish a performance or quality improvement, or prove the deployed vLLM request-override merge order.
