### PR TITLE
test: update stale indexer-workspace default assertion to rightsize

### DIFF
--- a/tests/test_indexer_workspace.py
+++ b/tests/test_indexer_workspace.py
@@ -143,7 +143,7 @@ def _set_mode(value):
 def test_mode_enum() -> None:
     """Literal match, exactly like start.sh's ``_glm53_validate_enum``.
 
-    The launcher expands ``${GLM53_INDEXER_WORKSPACE-stock}`` -- default on
+    The launcher expands ``${GLM53_INDEXER_WORKSPACE-rightsize}`` -- default on
     UNSET only -- and then compares the value as-is against ``stock rightsize``.
     The python side must agree character for character, or a value the launcher
     rejects (or accepts) changes meaning across the container boundary.
@@ -194,7 +194,7 @@ def test_mode_enum_matches_launcher_enum() -> None:
     script = (
         guard
         + '\n_glm53_validate_enum GLM53_INDEXER_WORKSPACE '
-        + '"${GLM53_INDEXER_WORKSPACE-stock}" stock rightsize\n'
+        + '"${GLM53_INDEXER_WORKSPACE-rightsize}" stock rightsize\n'
     )
     saved = os.environ.get(ENV_NAME)
     try:
@@ -785,7 +785,7 @@ def test_recipe_wiring_if_present() -> None:
         return
     launcher = start.read_text()
     image = dockerfile.read_text()
-    assert 'GLM53_INDEXER_WORKSPACE="${GLM53_INDEXER_WORKSPACE-stock}"' in launcher
+    assert 'GLM53_INDEXER_WORKSPACE="${GLM53_INDEXER_WORKSPACE-rightsize}"' in launcher
     assert '_cli_indexer_workspace="${GLM53_INDEXER_WORKSPACE-}"' in launcher
     # Setness-aware capture: an explicitly empty caller value must survive the
     # .env source and reach the enum guard, not be swallowed by a .env value.


### PR DESCRIPTION
tests/test_indexer_workspace.py still asserted the launcher default `GLM53_INDEXER_WORKSPACE="${GLM53_INDEXER_WORKSPACE-stock}"`, but start.sh has defaulted to `rightsize` since 2026-09-07 (README "Cold prefill (E3)"), so the test fails on pristine main. This updates the wiring assertion, the enum invocation string, and the docstring to the current default; the Python-side `stock` fallback used when the launcher is absent is unchanged. Verified: `GLM53_INDEXER_LIVE_SSH=0 python3 tests/test_indexer_workspace.py` fails before, prints `indexer workspace right-sizing OK (21 tests)` after; `bash -n start.sh` clean. Test-only change under tests/, so the recipe stamp moves.