### PR TITLE
template: add opt-in before-last-user Reasoning Effort placement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,9 @@ MTP_TOKENS=2
 # lower at 850k: the boot refuses a pool that cannot hold one max-length request (13 GiB = ~820k).
 # Stock launcher capture-size default is "1 2 4 8 16 24 32".
 # EXTRA_ARGS="--cudagraph-capture-sizes 1 2 3 4 5 6 8 9 10 12 15 16 20 24 32 --kv-cache-memory-bytes 15032385536"
+# Add --enable-prompt-tokens-details to report usage.prompt_tokens_details.cached_tokens per request
+# (prefix-cache hits; tests/bench_effort_placement.py reads it). Off by default in vLLM; combine with any of the above.
+# EXTRA_ARGS="--enable-prompt-tokens-details"
 # Tuning (defaults shown): GLM53_ADAPTIVE_K_ALPHA=0.25 GLM53_ADAPTIVE_K_MARGIN=1.0
 # GLM53_ADAPTIVE_K_MIN_STEPS=4 GLM53_ADAPTIVE_K_SATURATE=max GLM53_ADAPTIVE_K_HIST=200
 # Runtime override without a reboot: <CACHE_ROOT>/glm53_adaptive_k.json ({"mode","set","margin",...}).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 2026-09-11 — `Reasoning Effort:` directive moved before the last user message (cache-safe effort changes)
+
+`files/chat_template.jinja` now emits `<|system|>Reasoning Effort: <Low|High|Max>` once, immediately before the
+**last** `<|user|>` turn, only when thinking is on and a generation prompt is requested (a conversation with no
+user message falls back to the tail). Everything before that point is byte-identical across thinking off / low /
+high / max, so a per-request `reasoning_effort` change or a thinking toggle re-prefills only the final user turn.
+Before, the directive sat at char ~39 and every change was a full prefix-cache miss (#63 kept it unconditional
+for that reason; a5cc004 re-gated it on thinking for output quality, at the cost of the cache).
+
+- Cache proof (~16.5k-token prompt, 3584-token pages): low → high → low keeps **14,336 / 16,579** cached tokens on
+  every call, TTFT ~2.5 s; head placement: **0** cached on each change, TTFT ~15 s. At ~47k / ~152k tokens an
+  effort change costs **0.9 s / 2.1 s** (46,592 / 150,528 cached) against **28.8 s / 92 s** at the head.
+- Tool-call conversations (tool block + prior call + result + follow-up user): 12/12 correct calls at low/high/max
+  at either position; streaming `reasoning` deltas still arrive before `content`, nothing leaks into `content`.
+- Tail placement (after the last user turn, just before `<|assistant|>`) also keeps the cache but was **rejected**:
+  at `high` on a one-shot code fixture the model emitted a second `</think>` and a duplicated code block 10/22
+  times. Before-last-user matched head 14/14 there and on the JSON and math fixtures.
+- Caveat: at `max` on that code fixture before-last-user reasons ~6× longer than head (1,196 vs 192 tokens; every
+  answer correct). `high` and `low` reasoning lengths are unchanged.
+- Thinking-off output is byte-identical to the previous template. History renders (`add_generation_prompt=false`)
+  carry no directive.
+- `tests/test_chat_template.py` pins the new shape (10 tests; 5 fail on the old template).
+  `tests/bench_effort_placement.py` is the live A/B used for the numbers above.
+
 ## 2026-09-07 — E3 grouped fat-expert MoE prefill (`EXL3_FAT_GROUPED`, now the default)
 
 Cold prefill **+37–45%** on this 2× GB10 kit (16k: 1,155 → 1,578 tok/s; 128k: ~1,150 → 1,629; 256k: 1,087 → 1,576),

--- a/README.md
+++ b/README.md
@@ -539,8 +539,10 @@ curl -s http://127.0.0.1:8888/v1/chat/completions \
 
 Thinking defaults on. Disable it with the **top-level** JSON field
 `"chat_template_kwargs": {"enable_thinking": false}`. This closes the empty
-thinking block in the generation prompt. The `Reasoning Effort:` line itself
-renders unconditionally since #63 (prefix-cache stability), thinking on or off.
+thinking block in the generation prompt and drops the `Reasoning Effort:` line.
+That line is emitted once, **immediately before the last user message** (not at
+the prompt head as before), so toggling thinking or changing the effort only
+re-prefills the final user turn — see *Client request defaults* below.
 
 Do not send a literal nested `extra_body` object over raw HTTP; `extra_body` is
 an OpenAI Python SDK option that merges its contents into the top-level request.
@@ -556,7 +558,7 @@ template reads. None of them need a restart, and none are enforced by
 
 | Field | Send | Why |
 |---|---|---|
-| `reasoning_effort` | `high` for reasoning work | Unset = **Max** (`files/chat_template.jinja:7`); `low` is the model card's lightest simple-Q&A mode. Keep it constant per route — see below |
+| `reasoning_effort` | `high` for reasoning work | Unset = **Max** (`files/chat_template.jinja:7`, or `GLM53_DEFAULT_REASONING_EFFORT`); `low` is the model card's lightest simple-Q&A mode. Safe to change per request since the directive moved before the last user message — see below |
 | `max_tokens` | ≥ `32768` with thinking on | Max-effort reasoning runs well past 8k output tokens. Too small a cap truncates mid-thought and the reply comes back with empty `content` |
 | `chat_template_kwargs.clear_thinking` | `true` for multi-turn agents | Replaces earlier turns' reasoning with `<think></think>` (`chat_template.jinja:154`), keeping the current tool-call chain. Cuts context, not answer quality |
 | `top_p` / `temperature` | leave unset | `generation_config.json` already supplies `0.95` / `1.0`; the boot log prints the override line. Sending `top_p=1.0` explicitly overrides that and is worse |
@@ -572,10 +574,33 @@ $ curl -s $BASE/v1/chat/completions -d '{...,"reasoning_effort":"low"}' | jq '.c
 ["annotations","audio","content","function_call","reasoning","refusal","role"]
 ```
 
-**Do not vary `reasoning_effort` per request within a conversation.** The effort
-word lands at char 39 of the prompt, so changing it is a full prefix-cache miss
-on an otherwise-warm conversation, not a partial one.
+**Changing `reasoning_effort` (or toggling thinking) per request is cache-safe.**
+The `<|system|>Reasoning Effort: <Low|High|Max>` directive is emitted once,
+immediately before the **last** user message, and only when thinking is on.
+Everything before that point renders byte-identically across off / low / high /
+max, so a change costs one re-prefill of the final user turn, not the whole
+conversation. Measured on this kit (~16.5k-token prompt, 3584-token pages,
+`--enable-prompt-tokens-details` on): low → high → low kept **14,336** cached
+tokens on every call (TTFT ~2.5 s); the old head placement dropped to **0** on
+each change (TTFT ~15 s). At ~47k and ~152k tokens the same effort change cost
+**0.9 s / 2.1 s** before-last-user against **28.8 s / 92 s** at the head.
 `tests/test_chat_template.py` pins that shape.
+
+Why before the last user message and not after it (just before `<|assistant|>`)?
+Both keep the cache, but tail placement was measured and **rejected**: at
+`high` on a one-shot code fixture the model emitted a second `</think>` and a
+duplicated code block 10/22 times (temperature 0, seeded reps); before-last-user
+matched the old head placement 14/14. Thinking off is unaffected either way.
+Caveat: at `max` on the same code fixture before-last-user thinks about 6× longer
+than head did (1,196 vs 192 reasoning tokens, all answers correct); `high` is
+unchanged. Re-measure with `tests/bench_effort_placement.py` (to read
+`usage.prompt_tokens_details.cached_tokens` set `EXTRA_ARGS="--enable-prompt-tokens-details"`;
+the launcher does not add that flag).
+
+Effort words the template does not know (`medium`, `minimal`, `xhigh`) render
+**Max** (`chat_template.jinja:7`), so an OpenAI-style client that sends
+`reasoning_effort: "medium"` gets the longest tier. Send `low` / `high` / `max`,
+or `none` to turn thinking off for that request.
 
 Needs: Docker (no sudo) on both nodes, passwordless SSH head → worker,
 `hf` / `huggingface-cli` + `curl` + `rsync` on the head, ~180 GiB free per
@@ -714,6 +739,7 @@ After CUDA compile, Python overlay edits (`overlay/exl3.py`, tests) are a cheap 
 | `overlay/patch_ablit.py` | install the load_weights hook; bind-mounted and run on both ranks |
 | `ablit/` | direction vectors + `LAYER_MAP.json` from drowzeys' published recipe; `fetch_transplant.py` + `transplant/` for the donor o_proj byte-copy |
 | `tests/test_ablit.py` | recipe integrity, orthogonalization math, TP-shard equivalence, transplant byte-copy + TP slice, hook gating |
+| `tests/bench_effort_placement.py` | live A/B of the `Reasoning Effort:` directive position (head / before-last-user / tail / none): phase 0 cache retention across effort changes on ~16.5k / 42k / 128k prompts (`--phase0-tokens`), phase 1 obedience + answer checks (exec / JSON / exact value / tool call) per fixture × tier × arm, malformed-answer detection |
 | `tests/test_default_reasoning_effort.sh` | `GLM53_DEFAULT_REASONING_EFFORT` enum guard (`""`/`low`/`high`/`max`; `medium` rejected) and the `--default-chat-template-kwargs` flag at both rank sites, sliced out of `start.sh` and evaluated |
 | `scripts/boot-shape-warmup.sh` | post-`/health` DFlash2 k=7 BLOCK ladder + sampler/kpool arms |
 

--- a/files/chat_template.jinja
+++ b/files/chat_template.jinja
@@ -5,7 +5,12 @@
 {%- set thinking_enabled = true -%}
 {%- endif -%}
 {%- set effective_reasoning_effort = reasoning_effort if reasoning_effort is defined and reasoning_effort in ['low', 'high'] else 'max' -%}
-{%- if thinking_enabled and effective_reasoning_effort is not none -%}<|system|>Reasoning Effort: {{ effective_reasoning_effort | capitalize }}{%- endif -%}
+{#- The Reasoning Effort directive is no longer emitted here. It is emitted once, immediately
+    before the LAST user message (see the message loop), so a thinking on/off or effort change
+    never touches the prompt head: vLLM chains prefix-cache block hashes from token 0, and a
+    change at char ~39 re-prefilled the whole conversation. Placing it after the last user
+    message (just before <|assistant|>) was measured and rejected: at High it produced a
+    malformed double-</think> answer 10/22 times. Before-last-user matched head 14/14. -#}
 {%- set clear_thinking = clear_thinking if clear_thinking is defined else false -%}
 {%- if tools -%}
 {%- macro tool_to_json(tool) -%}
@@ -141,7 +146,9 @@ For each function call, output the function name and arguments within the follow
     {%- endif %}
 {%- endfor %}
 {%- for m in messages -%}
-{%- if m.role == 'user' -%}<|user|>{{ visible_text(m.content) }}
+{%- if m.role == 'user' -%}
+{%- if add_generation_prompt and thinking_enabled and effective_reasoning_effort is not none and loop.index0 == ns.last_user_index -%}<|system|>Reasoning Effort: {{ effective_reasoning_effort | capitalize }}{%- endif -%}
+<|user|>{{ visible_text(m.content) }}
 {%- elif m.role == 'assistant' -%}
 <|assistant|>
 {%- set content = visible_text(m.content) %}
@@ -262,5 +269,7 @@ For each function call, output the function name and arguments within the follow
 {%- endif -%}
 {%- endfor -%}
 {%- if add_generation_prompt -%}
+    {#- fallback for a conversation with no user message at all: emit the directive at the tail -#}
+    {%- if thinking_enabled and effective_reasoning_effort is not none and ns.last_user_index == -1 -%}<|system|>Reasoning Effort: {{ effective_reasoning_effort | capitalize }}{%- endif -%}
     <|assistant|>{{- '<think>' if thinking_enabled else '<think></think>' -}}
 {%- endif -%}

--- a/tests/bench_effort_placement.py
+++ b/tests/bench_effort_placement.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Where should the `Reasoning Effort:` directive live? HEAD vs TAIL vs PRE vs NONE.
+
+Runs against a live server. Nothing is persisted server-side and no template
+is changed: the server renders the prompt once (via /tokenize + /detokenize),
+the directive is moved by string surgery, each arm is re-tokenized and sent as
+token ids through /v1/completions at temperature 0, so every byte of every arm
+is controlled and the arms share one code path.
+
+  head  directive at char ~39, right after [gMASK]<sop>   (template before this change)
+  pre   directive immediately before the LAST <|user|>    (template after this change)
+  tail  directive after the last user turn, just before <|assistant|>  (rejected)
+  none  no directive at all (thinking on, effort unspecified)
+
+Phase 0  cache proof: effort low -> high -> low on a long prompt (~16.5k tokens by
+         default; --phase0-tokens 16500,42000,128000 for more). `head` drops
+         cached_tokens to 0 on every change; `pre`/`tail` keep the pages.
+         Needs --enable-prompt-tokens-details on the server for usage.cached_tokens
+         (EXTRA_ARGS="--enable-prompt-tokens-details" in .env; the launcher does not add it).
+Phase 1  obedience + quality: fixtures x tiers x arms x reps, thinking ON.
+         Reasoning tokens are counted from the <think> block; answers are checked
+         by execution (code), parsing (json) or exact value (math), never by
+         token count alone. A `</think>` inside the answer channel is the
+         malformed-output signature that sank tail placement.
+
+  python3 tests/bench_effort_placement.py --reps 4
+  python3 tests/bench_effort_placement.py --phase0-tokens 16500,42000,128000 --arms head,pre --fixtures tool
+  python3 tests/bench_effort_placement.py --fixtures code --arms head,pre --tiers high --reps 10 --skip-phase0
+  python3 tests/bench_effort_placement.py --summary-only --out results/<file>.json
+"""
+from __future__ import annotations
+
+import argparse
+import concurrent.futures as cf
+import json
+import os
+import re
+import sys
+import time
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+BASE = "http://127.0.0.1:8888"
+MODEL = "GLM-5.3-Flash-EXL3"
+API_KEY_ENV = "API_KEY"
+RESULTS_DIR = Path(__file__).resolve().parents[1] / "results"
+
+EFFORT_RE = re.compile(r"<\|system\|>Reasoning Effort: (Low|High|Max)")
+GEN_TAIL = "<|assistant|><think>"
+
+_cfg = {"base": BASE, "model": MODEL, "api_key": ""}
+
+
+def post(path, body, timeout=900):
+    req = urllib.request.Request(_cfg["base"] + path, data=json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    if _cfg["api_key"]:
+        req.add_header("Authorization", f"Bearer {_cfg['api_key']}")
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return json.loads(r.read())
+
+
+def tokenize_text(text):
+    return post("/tokenize", {"model": _cfg["model"], "prompt": text, "add_special_tokens": False})["tokens"]
+
+
+def server_tokens(messages, tier, tools=None):
+    body = {"model": _cfg["model"], "messages": messages, "add_generation_prompt": True,
+            "chat_template_kwargs": {"enable_thinking": True, "reasoning_effort": tier}}
+    if tools:
+        body["tools"] = tools
+    return post("/tokenize", body)["tokens"]
+
+
+def render_server(messages, tier, tools=None):
+    """The server's own rendering as text, whatever placement its template uses."""
+    text = post("/detokenize", {"model": _cfg["model"], "tokens": server_tokens(messages, tier, tools)})["prompt"]
+    assert len(EFFORT_RE.findall(text)) == 1, "expected exactly one effort directive: " + text[:120]
+    assert text.endswith(GEN_TAIL), "unexpected tail: " + text[-40:]
+    return text
+
+
+def make_variants(server_text):
+    """Return {arm: text} for head / tail / pre / none, all from one rendering."""
+    m = EFFORT_RE.search(server_text)
+    line = m.group(0)
+    stripped = server_text.replace(line, "", 1)
+    assert not EFFORT_RE.search(stripped)
+    assert stripped.startswith("[gMASK]<sop>")
+    head = "[gMASK]<sop>" + line + stripped[len("[gMASK]<sop>"):]
+    tail = stripped[: -len(GEN_TAIL)] + line + GEN_TAIL
+    k = stripped.rfind("<|user|>")
+    pre = stripped[:k] + line + stripped[k:]
+    variants = {"head": head, "tail": tail, "none": stripped, "pre": pre}
+    # which arm is the server's own placement? (round-trip guard uses it)
+    server_arm = next(a for a, t in variants.items() if t == server_text)
+    return variants, server_arm
+
+
+def complete(ids, max_tokens, seed=0):
+    t0 = time.time()
+    r = post("/v1/completions", {"model": _cfg["model"], "prompt": ids, "max_tokens": max_tokens,
+                                 "temperature": 0, "seed": seed, "stream": False})
+    dt = time.time() - t0
+    ch = r["choices"][0]
+    return ch["text"], ch.get("finish_reason"), r.get("usage", {}), dt
+
+
+def split_think(text):
+    # the prompt already ends in <think>, so generation begins inside the block
+    if "</think>" in text:
+        think, ans = text.split("</think>", 1)
+        return think, ans, True
+    return text, "", False
+
+
+# ---------------- fixtures (synthetic, checkable) ----------------
+SYS = "You are a precise assistant. Follow the output format exactly."
+
+
+def check_code(ans):
+    fences = re.findall(r"```(?:python)?\n(.*?)```", ans, re.S)
+    if len(fences) != 1:
+        return False, f"fences={len(fences)}"
+    ns = {}
+    try:
+        exec(fences[0], ns)  # synthetic fixture, model-written function under test
+        f = ns["is_balanced"]
+        ok = (f("([]{})") is True and f("([)]") is False and f("") is True
+              and f("((") is False and f("{[()()]}") is True and f("]") is False)
+        return ok, "asserts" if ok else "wrong output"
+    except Exception as e:  # noqa: BLE001 - any failure is a failed fixture
+        return False, type(e).__name__
+
+
+def check_json(ans):
+    s = ans.strip()
+    if s.startswith("```"):
+        return False, "fenced"
+    try:
+        d = json.loads(s)
+    except Exception:  # noqa: BLE001
+        return False, "not raw json"
+    ok = (set(d) == {"city", "population_millions", "founded_year", "is_capital"}
+          and d.get("is_capital") is True and d.get("city") == "Tokyo")
+    return ok, "keys/values" if ok else f"bad content {list(d)[:6]}"
+
+
+def check_math(ans):
+    m = re.findall(r"ANSWER:\s*([0-9,]+)", ans)
+    if not m:
+        return False, "no ANSWER line"
+    return m[-1].replace(",", "") == "201003", m[-1]
+
+
+def check_tool(ans):
+    calls = re.findall(r"<tool_call>(\w+)(.*?)</tool_call>", ans, re.S)
+    if len(calls) != 1:
+        return False, f"tool_calls={len(calls)}"
+    name, args = calls[0]
+    if name != "multiply":
+        return False, f"wrong tool {name}"
+    vals = dict(re.findall(r"<arg_key>(\w+)</arg_key><arg_value>([^<]*)</arg_value>", args))
+    ok = vals.get("a", "").strip() == "8" and vals.get("b", "").strip() == "9"
+    return ok, "args a=8 b=9" if ok else f"bad args {vals}"
+
+
+TOOLS = [{"type": "function", "function": {"name": "multiply", "description": "Multiply two integers.",
+          "parameters": {"type": "object", "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
+                         "required": ["a", "b"]}}}]
+
+# fixture = (messages, checker[, tools]); the tool fixture renders through the same template path
+# with a tool block, one prior tool call + result, and a follow-up user turn.
+FIXTURES = {
+    "code": (
+        [{"role": "system", "content": SYS},
+         {"role": "user", "content": "Write a Python function is_balanced(s) that returns True if the brackets ()[]{} in s are balanced and properly nested, else False. Respond with exactly one fenced python code block and nothing else."}],
+        check_code),
+    "json": (
+        [{"role": "system", "content": SYS},
+         {"role": "user", "content": "Return ONLY a raw JSON object, no code fence, no prose, with keys city, population_millions, founded_year, is_capital, describing Tokyo, Japan."}],
+        check_json),
+    "math": (
+        [{"role": "system", "content": SYS},
+         {"role": "user", "content": "What is the sum of all integers from 1 to 1000 inclusive that are divisible by 3 or by 5 but not by 15? Finish with a line of the form ANSWER: <integer>."}],
+        check_math),
+    "tool": (
+        [{"role": "system", "content": SYS + " Always use the multiply tool for arithmetic."},
+         {"role": "user", "content": "Use the multiply tool to compute 6 times 7."},
+         {"role": "assistant", "content": "", "tool_calls": [{"id": "call_1", "type": "function",
+             "function": {"name": "multiply", "arguments": "{\"a\": 6, \"b\": 7}"}}]},
+         {"role": "tool", "tool_call_id": "call_1", "content": "42"},
+         {"role": "user", "content": "Thanks. Now use the multiply tool for 8 times 9."}],
+        check_tool, TOOLS),
+}
+TIERS = ["low", "high", "max"]
+ARMS = ["head", "tail", "none", "pre"]
+
+
+def _record(i):
+    return f"Record {i}: the quick brown fox jumps over the lazy dog number {i}."
+
+
+def phase0(out, sizes):
+    """Cache proof with a long shared prefix (> 2 x 3584-token page alignment), one pass per prompt size."""
+    per_record = len(tokenize_text(" ".join(_record(i) for i in range(1, 101)))) / 100
+    res = {}
+    for target in sizes:
+        n = max(2, int(target / per_record))
+        filler = " ".join(_record(i) for i in range(1, n))
+        msgs = [{"role": "system", "content": SYS + "\n\n" + filler},
+                {"role": "user", "content": "Reply with the single word OK."}]
+        v_low, _ = make_variants(render_server(msgs, "low"))
+        v_high, _ = make_variants(render_server(msgs, "high"))
+        for arm in [a for a in ARMS if a != "none"]:
+            seq = []
+            for tier, v in (("low", v_low), ("high", v_high), ("low", v_low)):
+                ids = tokenize_text(v[arm])
+                _, _, usage, dt = complete(ids, 4)
+                cached = (usage.get("prompt_tokens_details") or {}).get("cached_tokens")
+                seq.append({"tier": tier, "prompt_tokens": usage.get("prompt_tokens"), "cached_tokens": cached, "ttft_s": round(dt, 2)})
+                print(f"phase0 ~{target} {arm:4s} {tier:4s} prompt={usage.get('prompt_tokens')} cached={cached} t={dt:.2f}s", flush=True)
+            res[f"{target}/{arm}"] = seq
+        Path(out["_path"]).write_text(json.dumps({**out, "phase0": res}, indent=1))
+    out["phase0"] = res
+    if all(s["cached_tokens"] is None for seq in res.values() for s in seq):
+        print("phase0: usage.prompt_tokens_details is absent; the server is not started with "
+              "--enable-prompt-tokens-details (EXTRA_ARGS=\"--enable-prompt-tokens-details\" in .env). "
+              "TTFT still tells the story; cached_tokens will read null.", flush=True)
+
+
+def run_one(name, tier, arm, rep, ids, checker, max_tokens):
+    text, fin, usage, dt = complete(ids, max_tokens, seed=rep)
+    think, ans, closed = split_think(text)
+    think_toks = len(tokenize_text(think)) if think else 0
+    ans_toks = len(tokenize_text(ans)) if ans else 0
+    ok, why = checker(ans) if closed else (False, "think never closed")
+    malformed = closed and "</think>" in ans
+    rec = {"fixture": name, "tier": tier, "arm": arm, "rep": rep, "think_tokens": think_toks,
+           "answer_tokens": ans_toks, "completion_tokens": usage.get("completion_tokens"),
+           "finish": fin, "closed": closed, "correct": ok, "malformed": malformed, "why": why,
+           "secs": round(dt, 1), "answer_head": ans.strip()[:160], "answer_full": ans, "think_full": think}
+    print(f"{name:4s} {tier:4s} {arm:4s} r{rep} think={think_toks:5d} ans={ans_toks:4d} ok={ok!s:5s} "
+          f"{'MALFORMED ' if malformed else ''}{why:14s} {dt:6.1f}s fin={fin}", flush=True)
+    return rec
+
+
+def phase1(out, reps, max_tokens, conc):
+    jobs = []
+    for name, fx in FIXTURES.items():
+        msgs, checker, tools = (fx + (None,))[:3]
+        for tier in TIERS:
+            variants, server_arm = make_variants(render_server(msgs, tier, tools))
+            for arm in ARMS:
+                ids = tokenize_text(variants[arm])
+                if arm == server_arm:
+                    # round-trip guard: our re-tokenized text must equal the server's own tokens
+                    assert ids == server_tokens(msgs, tier, tools), f"round-trip mismatch {name}/{tier}"
+                for rep in range(reps):
+                    jobs.append((name, tier, arm, rep, ids, checker))
+    out["runs"] = []
+    with cf.ThreadPoolExecutor(max_workers=conc) as ex:
+        futs = [ex.submit(run_one, *j, max_tokens) for j in jobs]
+        for f in cf.as_completed(futs):
+            out["runs"].append(f.result())
+            Path(out["_path"]).write_text(json.dumps(out, indent=1))
+
+
+def summarize(out):
+    runs = out.get("runs", [])
+    print("\n=== reasoning tokens (mean), correctness, malformed answers, by fixture x arm x tier ===")
+    for name in FIXTURES:
+        for arm in ARMS:
+            row = []
+            for tier in TIERS:
+                rs = [r for r in runs if r["fixture"] == name and r["arm"] == arm and r["tier"] == tier]
+                if not rs:
+                    row.append(f"{tier}: -")
+                    continue
+                mean = sum(r["think_tokens"] for r in rs) / len(rs)
+                okc = sum(1 for r in rs if r["correct"])
+                bad = sum(1 for r in rs if r.get("malformed") or "</think>" in r.get("answer_full", ""))
+                secs = sum(r["secs"] for r in rs) / len(rs)
+                row.append(f"{tier}: {mean:6.0f} tok {okc}/{len(rs)} ok {secs:5.1f}s" + (f" {bad} malformed" if bad else ""))
+            print(f"{name:4s} {arm:4s} | " + " | ".join(row))
+
+
+def main() -> int:
+    global FIXTURES, ARMS, TIERS
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--base-url", default=BASE)
+    ap.add_argument("--model", default=MODEL)
+    ap.add_argument("--api-key-env", default=API_KEY_ENV)
+    ap.add_argument("--reps", type=int, default=2)
+    ap.add_argument("--max-tokens", type=int, default=6000)
+    ap.add_argument("--conc", type=int, default=2, help="in-flight completions (batched decode)")
+    ap.add_argument("--out", help="results json (default results/glm53-exl3-effort-placement-<utc>.json)")
+    ap.add_argument("--skip-phase0", action="store_true")
+    ap.add_argument("--phase0-tokens", default="16500",
+                    help="comma list of approximate prompt sizes for the cache proof (e.g. 16500,42000,128000)")
+    ap.add_argument("--summary-only", action="store_true", help="re-print the table from --out")
+    ap.add_argument("--fixtures", default=",".join(FIXTURES), help="comma list subset")
+    ap.add_argument("--arms", default=",".join(ARMS))
+    ap.add_argument("--tiers", default=",".join(TIERS))
+    a = ap.parse_args()
+    _cfg.update(base=a.base_url.rstrip("/").removesuffix("/v1"), model=a.model,
+                api_key=os.environ.get(a.api_key_env, ""))
+    FIXTURES = {k: v for k, v in FIXTURES.items() if k in a.fixtures.split(",")}
+    ARMS = [x for x in ARMS if x in a.arms.split(",")]
+    TIERS = [x for x in TIERS if x in a.tiers.split(",")]
+    if a.summary_only:
+        summarize(json.loads(Path(a.out).read_text()))
+        return 0
+    out_path = Path(a.out) if a.out else RESULTS_DIR / \
+        f"glm53-exl3-effort-placement-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out = {"_path": str(out_path), "started": datetime.now(timezone.utc).isoformat(), "model": a.model,
+           "base_url": a.base_url, "reps": a.reps, "max_tokens": a.max_tokens, "conc": a.conc}
+    if not a.skip_phase0:
+        phase0(out, [int(x) for x in a.phase0_tokens.split(",") if x])
+    phase1(out, a.reps, a.max_tokens, a.conc)
+    out["finished"] = datetime.now(timezone.utc).isoformat()
+    out_path.write_text(json.dumps(out, indent=1))
+    summarize(out)
+    print(f"wrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_chat_template.py
+++ b/tests/test_chat_template.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-"""Regression checks for GLM-5.3 chat-template reasoning controls."""
+"""Regression checks for GLM-5.3 chat-template reasoning controls.
+
+Contract: the `<|system|>Reasoning Effort: <Low|High|Max>` directive is emitted
+exactly once, immediately before the LAST user message, and only when thinking
+is on and a generation prompt is requested. Everything before that point is
+byte-identical across thinking off / low / high / max, so toggling thinking or
+changing the effort per request keeps the vLLM prefix cache (block hashes are
+chained from token 0; the old head placement at char ~39 re-prefilled the
+whole conversation on every change).
+"""
 
 import json
 import unittest
@@ -21,6 +30,7 @@ def _environment() -> Environment:
 
 
 TEMPLATE = Path(__file__).parents[1] / "files" / "chat_template.jinja"
+DIRECTIVE = "<|system|>Reasoning Effort: "
 
 TOOLS = [
     {
@@ -44,6 +54,25 @@ CONVERSATION = [
     {"role": "user", "content": "and 3+3?"},
 ]
 
+TOOL_CONVERSATION = [
+    {"role": "user", "content": "multiply 6 by 7"},
+    {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "c1",
+                "type": "function",
+                "function": {"name": "multiply", "arguments": {"a": 6, "b": 7}},
+            }
+        ],
+    },
+    {"role": "tool", "tool_call_id": "c1", "content": "42"},
+    {"role": "user", "content": "thanks, and 8 by 9?"},
+]
+
+SHAPES = ((CONVERSATION, None), (CONVERSATION, TOOLS), (TOOL_CONVERSATION, TOOLS))
+
 
 def render_generation_prompt(**kwargs: object) -> str:
     template = _environment().from_string(TEMPLATE.read_text())
@@ -60,10 +89,20 @@ def render_conversation(**kwargs: object) -> str:
     return template.render(add_generation_prompt=True, **kwargs)
 
 
+def _assert_directive_before_last_user(test, rendered: str, word: str) -> None:
+    """Exactly one directive, and it sits immediately before the final <|user|>."""
+    test.assertEqual(rendered.count(DIRECTIVE), 1, rendered)
+    last_user = rendered.rfind("<|user|>")
+    test.assertTrue(
+        rendered[:last_user].endswith(f"{DIRECTIVE}{word}"),
+        repr(rendered[max(0, last_user - 60):last_user + 20]),
+    )
+
+
 class ChatTemplateTests(unittest.TestCase):
     def test_thinking_defaults_on(self) -> None:
         rendered = render_generation_prompt()
-        self.assertIn("<|system|>Reasoning Effort: Max", rendered)
+        _assert_directive_before_last_user(self, rendered, "Max")
         self.assertTrue(rendered.endswith("<|assistant|><think>"), rendered)
 
     def test_thinking_can_be_disabled(self) -> None:
@@ -86,36 +125,74 @@ class ChatTemplateTests(unittest.TestCase):
             enable_thinking=True,
             reasoning_effort="low",
         )
-        self.assertIn("<|system|>Reasoning Effort: Low", rendered)
+        _assert_directive_before_last_user(self, rendered, "Low")
         self.assertTrue(rendered.endswith("<|assistant|><think>"), rendered)
+
+    def test_directive_sits_before_last_user_in_every_shape(self) -> None:
+        for messages, tools in SHAPES:
+            for effort, word in (("low", "Low"), ("high", "High"), ("max", "Max")):
+                rendered = render_conversation(
+                    messages=messages, tools=tools, enable_thinking=True,
+                    reasoning_effort=effort,
+                )
+                _assert_directive_before_last_user(self, rendered, word)
+                self.assertTrue(rendered.endswith("<|assistant|><think>"), rendered)
+
+    def test_history_render_carries_no_directive(self) -> None:
+        # add_generation_prompt=False is how a history is re-rendered (e.g. by a
+        # training/eval pipeline); the directive is a generation-time control.
+        template = _environment().from_string(TEMPLATE.read_text())
+        rendered = template.render(
+            messages=CONVERSATION, tools=None, add_generation_prompt=False,
+            enable_thinking=True, reasoning_effort="high",
+        )
+        self.assertNotIn("Reasoning Effort", rendered)
+
+    def test_no_user_message_falls_back_to_tail(self) -> None:
+        rendered = render_conversation(
+            messages=[{"role": "system", "content": "Say hi."}], tools=None,
+            enable_thinking=True, reasoning_effort="high",
+        )
+        self.assertTrue(rendered.endswith(f"{DIRECTIVE}High<|assistant|><think>"), rendered)
 
 
 class PrefixStabilityTests(unittest.TestCase):
-    """What a thinking toggle costs in prefix cache, and what it must not cost.
+    """What a thinking toggle or an effort change costs in prefix cache: only
+    the last user turn.
 
-    The Reasoning Effort head line is gated on thinking, so toggling thinking
-    changes token ~2 and re-prefills the prompt (accepted: quality first —
-    agent traffic does not toggle mid-conversation). Everything after the head
-    line must still be byte-identical between the two shapes.
+    vLLM chains prefix-cache block hashes forward from token 0, so any
+    divergence near the head invalidates the whole prompt. Every mode must
+    therefore share the prompt byte-for-byte up to the last user message.
     """
 
-    def _assert_same_after_head(self, tools) -> None:
-        on = render_conversation(
-            messages=CONVERSATION, tools=tools, enable_thinking=True
-        )
-        off = render_conversation(
-            messages=CONVERSATION, tools=tools, enable_thinking=False
-        )
-        head = "<|system|>Reasoning Effort: Max"
-        self.assertIn(head, on)
-        self.assertNotIn("Reasoning Effort", off)
-        self.assertEqual(off, on.replace(head, "", 1) + "</think>")
+    def _modes(self, messages, tools) -> dict[str, str]:
+        return {
+            "off": render_conversation(messages=messages, tools=tools, enable_thinking=False),
+            "low": render_conversation(messages=messages, tools=tools, enable_thinking=True, reasoning_effort="low"),
+            "high": render_conversation(messages=messages, tools=tools, enable_thinking=True, reasoning_effort="high"),
+            "max": render_conversation(messages=messages, tools=tools, enable_thinking=True, reasoning_effort="max"),
+            "default": render_conversation(messages=messages, tools=tools),
+        }
 
-    def test_toggle_only_differs_by_head_line_without_tools(self) -> None:
-        self._assert_same_after_head(None)
+    def test_all_modes_share_the_prompt_up_to_the_last_user_message(self) -> None:
+        for messages, tools in SHAPES:
+            modes = self._modes(messages, tools)
+            off = modes["off"]
+            cut = off.rfind("<|user|>")
+            self.assertGreater(cut, 0)
+            for name, rendered in modes.items():
+                self.assertTrue(
+                    rendered.startswith(off[:cut]),
+                    f"{name} diverges from off at char {len(_common_prefix(off, rendered))} of {cut}",
+                )
 
-    def test_toggle_only_differs_by_head_line_with_tools(self) -> None:
-        self._assert_same_after_head(TOOLS)
+    def test_off_is_on_with_the_directive_removed(self) -> None:
+        for messages, tools in SHAPES:
+            modes = self._modes(messages, tools)
+            for name in ("low", "high", "max"):
+                on = modes[name]
+                stripped = on.replace(f"{DIRECTIVE}{name.capitalize()}", "", 1)
+                self.assertEqual(modes["off"], stripped + "</think>", name)
 
     def test_effort_levels_share_the_prompt_up_to_the_effort_word(self) -> None:
         low = render_conversation(
@@ -126,7 +203,10 @@ class PrefixStabilityTests(unittest.TestCase):
             messages=CONVERSATION, tools=TOOLS, enable_thinking=True,
             reasoning_effort="high",
         )
-        self.assertEqual(len(_common_prefix(low, high)), len("[gMASK]<sop><|system|>Reasoning Effort: "))
+        shared = len(_common_prefix(low, high))
+        self.assertEqual(shared, low.index(DIRECTIVE) + len(DIRECTIVE))
+        # ... and that point is after the whole history, just before the last user turn
+        self.assertGreater(shared, low.index("Hi. How can I help?"))
 
 
 def _common_prefix(a: str, b: str) -> str:


### PR DESCRIPTION
## Current maintainer scope — opt-in, still draft

Current head: [`7f6bb1eaa14989c442bc18703a4996e492ba42fc`](https://github.com/MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks/commit/7f6bb1eaa14989c442bc18703a4996e492ba42fc). The maintainer introduced the opt-in revision; this metadata correction is maintainer-owned and preserves the original author's proposal and measurements below.

- **HEAD remains the default.** Opt in with `chat_template_kwargs.reasoning_effort_placement="before_last_user"`; the other accepted value is `"head"`.
- PRE relocation occurs only with thinking enabled, a generation prompt requested, and a structured user turn present. History/no-user renders retain HEAD behavior; thinking-off renders omit the directive. Invalid placement values are rejected. Literal role-marker text is not used to identify user turns.
- Current-main integration, structured-role handling, rendering boundaries and default-equivalence corrections are already addressed. They are not new source-fix requests.
- CPU placement/equivalence checks do not establish answer quality, reasoning cost, cache benefit or performance qualification of this head. Earlier author tables below concern the earlier candidate, not a default-change approval.

### Evidence hold and next owner

The [maintainer bounded panel](https://github.com/MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks/pull/167#issuecomment-5658992044) retained **34/36 passing checks and two distinct failures**: low-effort HEAD arithmetic exhausted its 512-token allowance without an answer; low-effort PRE arithmetic returned **167,838 rather than 201,003**. Neither failure may be erased by raising the old cap or retrying to pass, and these results do not establish that PRE caused both. The previously reported Max reasoning-cost caveat remains material.

Keep **draft, merge hold and the exact-head changes-requested review**. The existing correctness/reasoning-cost and predeclared HEAD/PRE quality/cache gates remain: separate failure accounting, completed-request cache counters, reasoning/output usage, latency and unchanged controls, with the pinned TheGrill v0.2.0 published checksums/receipts supplementing—not replacing—answer/tool checks. No present gate is declared passed.

**Next-action owner: maintainer (plotarmordev)** to schedule and pin a supported prospective study and available validation resources; the author retains ownership of their evidence contribution once that work is commissioned, and the maintainer owns final exact-head re-review. No immediate live run or repeat source-fix work is requested. Unblock only after the stated quality/cost/cache gates and separate correctness checks are satisfied on the final pinned candidate, then exact-head re-review approves readiness.

## Original author proposal and historical receipts

The following text is retained verbatim for attribution and measurement history. Its default-PRE, no-user-tail, history-render and unconditional cache-safety statements describe the superseded proposal, **not the current contract above**; its related-PR status and test claims are historical.

<details>
<summary>Original author description (superseded implementation framing; retained evidence)</summary>

## Description and Motivation

**Knob/path:** `files/chat_template.jinja` — where the `<|system|>Reasoning Effort: <Low|High|Max>` directive renders.

**Before:** the directive sat at char ~39, right after `[gMASK]<sop>`. #63 made it unconditional so a thinking toggle kept the prefix cache; a5cc004 (#150) re-gated it on thinking for output quality, at the cost of the cache. Either way, changing `reasoning_effort` between turns re-prefilled the whole conversation, because vLLM chains prefix-cache block hashes from token 0 (#111: 54.5 s vs 5.4 s at 42k; ~10 min at 500k).

**After:** the directive is emitted once, **immediately before the last `<|user|>` turn**, only when thinking is on and a generation prompt is requested (a conversation with no user message falls back to the tail). Everything before that point renders byte-identically across thinking off / low / high / max, so an effort change or a thinking toggle re-prefills only the final user turn.

**Expected direction of measured numbers:** TTFT on an effort change goes from a full cold prefill to a warm follow-up; decode, acceptance and KV pool are untouched (the template renders the same token count, one directive, one position). Thinking-off output is byte-identical to the current template.

**Why before the last user message and not after it (#111 option 1, "next to the `<think>` open")?** I measured both. Both keep the cache. Tail placement was **rejected** on output quality: at `high` on a one-shot code fixture the model emitted a second `</think>` and a duplicated code block **10/22** times (temperature 0, seeded reps). Before-last-user matched the old head placement 14/14 on the same fixture. My read: the model was tuned on `<|system|>…` → `<|user|>` → `<|assistant|>` order; a system line landing directly before `<|assistant|>` is out of distribution, a system line before a user turn is not.

**Safe on both nodes:** template-only; the launcher mounts the same file on both ranks and the worker never renders prompts. No knob, default or overlay changes (the only non-template edit is one commented `EXTRA_ARGS="--enable-prompt-tokens-details"` example in `.env.example`, for reading `cached_tokens`). `GLM53_DEFAULT_REASONING_EFFORT` (#158) keeps working: the default kwargs reach the same `effective_reasoning_effort` variable, and a no-effort request still renders Max when the knob is empty.

### Measurements

2× DGX Spark (GB10), TP=2, this kit's recipe: `Mia-AiLab/GLM-5.3-Flash-EXL3-TR3-4bpw` @ `25a44fdb`, DFlash2 k=7 with the adaptive-k patch, dense FP8, `ABLIT=1`, 900k context, 3584-token hybrid pages, prefix caching on, `EXTRA_ARGS="--enable-prompt-tokens-details"` (the launcher does not add that flag; it is only needed to read `usage.prompt_tokens_details.cached_tokens`, TTFT tells the same story without it). All arms rendered by the server's own template via `/tokenize` + `/detokenize`, directive moved by string surgery, re-tokenized, sent as token ids through `/v1/completions` at temperature 0, seed = rep, 2 in flight. Harness: `tests/bench_effort_placement.py` (this PR).

**Cache proof** — 16,579-token prompt, effort low → high → low, `cached_tokens` / TTFT:

| placement | low (cold) | high | low |
|---|---:|---:|---:|
| head (current) | 0 / 14.9 s | **0 / 15.0 s** | 14,336 / 2.6 s |
| before last user (this PR) | 14,336 / 2.4 s* | **14,336 / 2.5 s** | 14,336 / 2.5 s |
| tail | 0 / 14.7 s | 14,336 / 2.5 s | 14,336 / 2.5 s |

\* warm from the preceding arm — same prefix, which is the point.

**Cache proof at scale** — same sequence, the low → high step only (the one that used to be a full miss), then the warm repeat. Head's residual hits at 47k/152k are the pages it shares with the smaller prompt from the previous pass; everything after them was re-prefilled:

| prompt tokens | head: low → high | before last user: low → high | warm repeat (either) |
|---:|---:|---:|---:|
| 17,907 | 0 cached, **16.1 s** | 14,336 cached, **3.5 s** | 14,336, 3.5 s |
| 46,861 | 14,336*, **28.8 s** | 46,592 cached, **0.9 s** | 46,592, 0.9 s |
| 152,280 | 46,592*, **92.3 s** | 150,528 cached, **2.1 s** | 150,528, 2.1 s |

\* shared with the previous, smaller prompt; not an effort-change hit. The 47k row is #111's scenario (54.5 s vs 5.4 s there); the warm cost is the partial last page plus the final user turn, which is why 47k is faster than 18k (269 vs 3,571 uncached tokens).

Through an OpenAI-style client (top-level `reasoning_effort`, 16,573-token prompt): low → high → none → max → low kept 14,336 cached on every call after the first; a two-turn conversation kept 14,336 at turn 2 and a tier switch at turn 2 cost nothing extra.

**Obedience + quality** — mean reasoning tokens in `<think>`, correct answers / n (exec for code, parse for JSON, exact value for math), mean wall time:

| fixture | placement | low | high | max |
|---|---|---|---|---|
| code | head | 0 tok, 2/2 | 4 tok, **12/12**, 2.1 s | 192 tok, 12/12, 11.5 s |
| code | **before last user** | 0 tok, 4/4 | 4 tok, **14/14**, 3.2 s | **1,196 tok**, 4/4, 44.5 s |
| code | tail | 0 tok, 2/2 | 31 tok, **12/22** (10 malformed), 7.5 s | 230 tok, 12/12, 13.7 s |
| code | none | 214 tok, 2/2 | 206 tok, 2/2 | 212 tok, 2/2 |
| json | head | 0 tok, 2/2 | 5 tok, 2/2 | 196 tok, 2/2 |
| json | **before last user** | 9 tok, 4/4 | 4 tok, 4/4 | 282 tok, 4/4 |
| json | tail | 4 tok, 2/2 | 7 tok, 2/2 | 214 tok, 2/2 |
| math | head | 112 tok, 1/2 | 138 tok, 2/2 | 403 tok, 2/2 |
| math | **before last user** | 105 tok, 2/4 | 138 tok, 4/4 | 322 tok, 4/4 |
| math | tail | 109 tok, 1/2 | 164 tok, 2/2 | 340 tok, 2/2 |
| math | none | 448 tok, 2/2 | 356 tok, 2/2 | 389 tok, 2/2 |
| tool† | head | 0 tok, 2/2 | 0 tok, 2/2 | 18 tok, 2/2 |
| tool† | **before last user** | 0 tok, 2/2 | 0 tok, 2/2 | 24 tok, 2/2 |

† tool-call conversation: system + tool block, user → assistant `<tool_call>` → tool result → follow-up user; the check is exactly one `<tool_call>multiply` with `a=8`, `b=9` and no `</think>` in the answer. 12/12, no malformed output at either position.

Reading: the tiers are obeyed at the new position exactly as at the head (low ≈ 0, high ≈ 4, max ≈ hundreds on code/json). `none` (no directive) is not "max", it is its own ~200-token mode, which is why the directive has to exist somewhere. Math at `low` is weak at every placement, including head; that is a tier property, not a placement effect.

**Caveat, stated plainly:** at `max` on the code fixture the new position reasons ~6× longer than head did (1,196 vs 192 tokens, 44 s vs 12 s; every answer correct). JSON `max` is +44%, math `max` is −20%. `high` is unchanged everywhere. If `max` latency on code matters to you more than cache-safe effort changes, that is the trade.

### What this means for clients (no proxy needed)

- **Top-level `reasoning_effort` already reaches the template.** vLLM's chat endpoint passes it into the template kwargs (`build_chat_params` in `chat_completion/protocol.py`) and sets `enable_thinking = effort != "none"` when the client did not set it. Measured on the native port, one-shot code fixture, temperature 0: `low` → 0 reasoning tokens (1.6 s), `high` → 4 (1.8 s), `max` → 1,277 (30 s), `none` → thinking off (1.8 s). `chat_template_kwargs.reasoning_effort` behaves the same (`max` → 924, `low` → 0). Nothing between the client and vLLM is required for cache-safe tier changes.
- **Gotcha, pre-existing and unchanged here:** the template only knows `low` / `high`; anything else (`medium`, `minimal`, `xhigh`) renders **Max** (`chat_template.jinja:7`). Measured: `medium` → 937 reasoning tokens, 25 s, i.e. the longest tier. An OpenAI-style client that defaults to `medium` gets Max without knowing. Now documented in the README. Mapping `medium → high`, `minimal → low`, `xhigh → max` is a one-line template change; I kept it out of this PR so the diff stays about placement, happy to open it separately.
- **`none` is not Max.** With thinking on and no directive at all the model settles into its own ~200-token mode on every fixture (table above). The directive has to exist somewhere; this PR only moves it.
- **`GLM53_DEFAULT_REASONING_EFFORT` (#158) composes.** The default kwargs land in the same `effective_reasoning_effort` variable. Verified with the knob set to `high`: a request with no effort field rendered `High` before the last user turn and reasoned 4 tokens; with the knob empty it renders Max as before.
- **Multi-turn:** only the final user turn is re-prefilled on a change. History renders (`add_generation_prompt=false`) carry no directive, so a client that renders history itself never sees a stray system line.
- **Streaming is unchanged.** `stream: true` on the native port at `high` (math fixture): first `reasoning` delta at 0.43 s, first `content` delta at 3.4 s, `reasoning` strictly before `content`, no `</think>` in the content stream. `max` on the code fixture: 0.41 s → 32.9 s, same shape. At `low`/`high` on the one-shot code fixture the model answers with no reasoning delta at all (42 tokens, 0.44 s TTFT), which matches the ~0–4 reasoning tokens in the table.
- **Malformed-output signature:** a `</think>` inside `content` (or a second fenced block where one was asked for) is the tail-placement failure mode. `tests/bench_effort_placement.py` checks for it; useful to keep around when anyone next touches the template.

### What I did not test
- Contexts beyond ~152k for the cache proof (#111's 500k case). The block-hash argument is length-independent and the 18k → 47k → 152k rows scale as expected, so I stopped there.
- Concurrency above 2 in flight, other quants or kits, and `max` reasoning length on long prompts (phase 0 generates 4 tokens by design).
- Tool calls with thinking on at `max` on anything harder than the two-step arithmetic fixture (12/12 there).

## Related Issues

**Resolves #111** (effort changes invalidate the prefix cache; proposes tail placement, this PR measures why before-last-user is the right spot).

History of this line: #63 (merged, emit unconditionally), #150 / a5cc004 (merged, re-gate on thinking), #158 (merged, `GLM53_DEFAULT_REASONING_EFFORT`), #87 (closed, superseded by #158), #127 (closed).

Open work this touches or complements:

- #125, #84, #83, #130 (fine-grained APC hits, per-group retention, DFlash replay): complementary, no overlap. They make more of a prefix hit; this PR stops the prefix from being invalidated in the first place. With head placement a tier change was a full miss regardless of hit granularity, so their numbers should only improve on top of this. Different code paths (template vs. engine overlay).
- #51 (`DEFAULT_MAX_NEW_TOKENS`): the only other open PR that edits `files/chat_template.jinja` (assistant/tool hunks). `git merge-tree` of #51 against this branch merges cleanly, no conflict markers.
- #95 (`GLM53_APC_NO_STORE`, per-request skip of prefix-cache writes): orthogonal. It lets a request opt out of caching; this PR makes the cached prefix survive an effort change. Nothing shared.
- #37 (`/reset_prefix_cache` overlay): handy for re-running the cache proof from cold; the harness does not need it (it uses distinct arms).
- #162 (`max` burns the whole output budget): not fixed here, and worth reading next to the caveat above. At `max` on the code fixture the new position thinks longer than head did, so the case for a thinking budget gets stronger, not weaker. `high` is unaffected.
- #120, #106, #166 (cache miss / TTFT reports): an effort or thinking change was one guaranteed full-prefix miss per request; this removes that cause. It does not claim to explain the rest of those reports.
- #135 (OpenClaw, thinking-on default): unchanged. This PR does not touch the thinking default or the parser.
- #147 (open-PR triage): template-only, no launcher knob, no new env.

---

## Testing

- `python3 tests/test_chat_template.py` — 10 tests pass on the new template; 5 of them fail on the current one (the shape is pinned).
- 20 equivalence checks (not committed): for one-shot, multi-turn, multi-turn + tools and tool-call + tool-result conversations, thinking-off renders byte-identical to the current template, and thinking-on renders exactly "current template with the directive moved before the last `<|user|>`".
- `bash tests/test_default_reasoning_effort.sh` — passes (launcher untouched).
- Live: engine restarted with the new template on the 2-node deployment, `/health` 200; 32-check live verification through vLLM and an OpenAI-style proxy: render shape per mode with and without tools, thinking-off JSON, thinking-on at low/high/max, tool call + tool continuation (off and high), a five-image request, the cache sequence above, and the two-turn re-prefill bound. 31/32 on the first pass; the miss was one arithmetic slip on the math fixture at `high`, rerun 6/6 at `high` and 6/6 at `max`.
- `python3 tests/bench_effort_placement.py` — the numbers above: four runs totalling 118 phase-1 completions on code/json/math, plus one run with `--phase0-tokens 16500,42000,128000 --arms head,pre --fixtures tool` for the scale table and the tool row (12 completions).
- Streaming: five `stream: true` requests on the native port (`high`/`low`/`max` code, `high`/`low` math) with `stream_options.include_usage`; delta order and content cleanliness as stated in *What this means for clients*.
- Native port, no proxy: eight one-shot code requests through `/v1/chat/completions` with top-level `reasoning_effort` `low` / `medium` / `high` / `max` / `none`, no effort field, and `chat_template_kwargs` `max` / `low` — the reasoning-token counts in *What this means for clients*.

---

## Checklist:

- [x] I have read the README and kept my changes consistent with it.
- [x] My pull request has a sound title and description (not something vague like `Update README.md`).
- [x] My change is reproducible and verified (a boot and, for behavior changes, measurements).
- [x] Defaults still work out of the box; a new knob has a sane fallback consistent with the existing ones.
- [x] I updated the README (and docs/ where relevant) for any knob, default, or measured number I changed.


</details>
