### PR TITLE
fix(launcher): validate the RoCE GID on every listed CX7 HCA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,15 +19,17 @@ WORKER_IP=10.0.0.2
 # NCCL_SOCKET_IFNAME / NCCL_IB_HCA does NOT override them.
 HEAD_CX7_IF=enp1s0f1np1
 WORKER_CX7_IF=enp1s0f0np0
+# Literal IB device names, or comma-separated names for dual rail (no spaces).
 HEAD_CX7_IB=rocep1s0f1
 WORKER_CX7_IB=rocep1s0f0
 # The RoCEv2 GID index is per-NIC: each node needs the index carrying its OWN
 # ::ffff:<ip> entry. An all-zero entry kills that rank ~60 s in (ibv_modify_qp
-# errno 61); preflight verifies each rank against its own device. Inspect:
+# errno 61); preflight checks every listed device on each node. Inspect:
 #   cat /sys/class/infiniband/<dev>/ports/1/gids/{0..7}
 # If one index works on both nodes, set NCCL_IB_GID_INDEX. If the nodes need
-# different indices (e.g. head 4 / worker 3), set them per rank instead —
-# both default to NCCL_IB_GID_INDEX when unset.
+# different indices (e.g. head 4 / worker 3), set them per rank instead.
+# Each rank's index must be populated on all of its listed devices; both
+# ranks default to NCCL_IB_GID_INDEX when unset.
 # NCCL_IB_GID_INDEX=2
 # HEAD_GID=4
 # WORKER_GID=3

--- a/.github/ISSUE_TEMPLATE/1_bug.md
+++ b/.github/ISSUE_TEMPLATE/1_bug.md
@@ -85,7 +85,7 @@ curl -s http://localhost:8888/v1/chat/completions \
         * Lower context than 1M -> do not reduce MAX_MODEL_LEN; pool size depends on
           MNBT and graph reservations (README "Context").
         * Vision requests rejected -> LANGUAGE_MODEL_ONLY=1 disables image/video;
-          check --limit-mm-per-prompt shape {image:4,video:1}.
+          check --limit-mm-per-prompt shape {image:100,video:1}.
 -->
 
 ```

--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ python3 tests/bench_decode.py --phase structured --structured --runs 5 --max-tok
 python3 tests/bench_decode.py --phase prose --runs 5 --max-tokens 400 --skip-coherence --out /tmp/glm53-prose.json
 ```
 
+For keyed servers, export `VLLM_API_KEY` before running the decode benchmark.
+It sends Bearer auth on completion requests; a non-empty `API_KEY` takes
+precedence over `VLLM_API_KEY`. Unset or empty values fall through, and no
+header is sent when both are unset or empty. `/health` and `/metrics` stay keyless.
+
 ## E2 fat-expert prefill — [PR77](https://github.com/MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks/pull/77) (2026-09-01)
 
 PR77 adds purpose-built direct/scatter CUDA kernels for the routed “fat”

--- a/start.sh
+++ b/start.sh
@@ -605,31 +605,26 @@ preflight() {
     worker_ssh "nvidia-smi -L 2>/dev/null | grep -q GB10" \
         || warn "no GB10 GPU visible on worker"
 
-    # Each rank's GID index must name a populated entry on ITS OWN CX7 device.
-    # An empty (all-zero) entry passes every earlier check and then kills that
-    # rank ~60 s in with ibv_modify_qp errno 61 "No data available". The index is
-    # per-NIC, so validate head and worker separately: some pairs share one good
-    # index, others need different ones (HEAD_GID / WORKER_GID).
-    local gid_head gid_worker gid_path
-    gid_path="/sys/class/infiniband/${HEAD_CX7_IB}/ports/1/gids/${HEAD_GID}"
-    gid_head=$(cat "$gid_path" 2>/dev/null | tr -d ':0' || true)
-    gid_path="/sys/class/infiniband/${WORKER_CX7_IB}/ports/1/gids/${WORKER_GID}"
-    gid_worker=$(worker_ssh "cat '$gid_path' 2>/dev/null" | tr -d ':0' || true)
+    # Each rank's GID index must be populated on EVERY selected CX7 device.
+    # Comma-separated device names are passed unchanged to NCCL below.
+    local gid_head=ok gid_worker=ok gid_path hca
+    for hca in ${HEAD_CX7_IB//,/ }; do
+        gid_path="/sys/class/infiniband/${hca}/ports/1/gids/${HEAD_GID}"
+        if [ -z "$(cat "$gid_path" 2>/dev/null | tr -d ':0' || true)" ]; then
+            gid_head=""
+            warn "head GID index ${HEAD_GID} is EMPTY on ${hca}"
+        fi
+    done
+    for hca in ${WORKER_CX7_IB//,/ }; do
+        gid_path="/sys/class/infiniband/${hca}/ports/1/gids/${WORKER_GID}"
+        if [ -z "$(worker_ssh "cat '$gid_path' 2>/dev/null" | tr -d ':0' || true)" ]; then
+            gid_worker=""
+            warn "worker GID index ${WORKER_GID} is EMPTY on ${hca}"
+        fi
+    done
     if [ -z "$gid_head" ] || [ -z "$gid_worker" ]; then
-        if [ -z "$gid_head" ]; then
-            warn "head GID index ${HEAD_GID} is EMPTY on ${HEAD_CX7_IB}"
-        fi
-        if [ -z "$gid_worker" ]; then
-            warn "worker GID index ${WORKER_GID} is EMPTY on ${WORKER_CX7_IB}"
-        fi
-        warn "GID tables — pick each node's ::ffff:<ip> entry whose type is RoCE v2;"
-        warn "the two indices need not match, and a v1 entry at the same index will not work:"
-        for i in 0 1 2 3 4 5 6 7; do
-            printf '    head   gid%s: %-40s %s\n' "$i" \
-                "$(cat "/sys/class/infiniband/${HEAD_CX7_IB}/ports/1/gids/$i" 2>/dev/null)" \
-                "$(cat "/sys/class/infiniband/${HEAD_CX7_IB}/ports/1/gid_attrs/types/$i" 2>/dev/null)" >&2
-        done
-        worker_ssh "for i in 0 1 2 3 4 5 6 7; do printf '    worker gid%s: %-40s %s\n' \"\$i\" \"\$(cat /sys/class/infiniband/${WORKER_CX7_IB}/ports/1/gids/\$i 2>/dev/null)\" \"\$(cat /sys/class/infiniband/${WORKER_CX7_IB}/ports/1/gid_attrs/types/\$i 2>/dev/null)\"; done" >&2 || true
+        warn "Inspect each listed device's /sys/class/infiniband/<device>/ports/1/gids"
+        warn "and gid_attrs/types; select populated RoCE v2 entries on both nodes."
         die "set NCCL_IB_GID_INDEX (same index both ranks) or HEAD_GID/WORKER_GID (per rank) in .env to populated indices"
     fi
 

--- a/start.sh
+++ b/start.sh
@@ -606,16 +606,20 @@ preflight() {
         || warn "no GB10 GPU visible on worker"
 
     # Each rank's GID index must be populated on EVERY selected CX7 device.
-    # Comma-separated device names are passed unchanged to NCCL below.
-    local gid_head=ok gid_worker=ok gid_path hca
-    for hca in ${HEAD_CX7_IB//,/ }; do
+    # HEAD_CX7_IB / WORKER_CX7_IB are literal names or comma-separated lists;
+    # pass the original values unchanged to NCCL below.
+    local gid_head=ok gid_worker=ok gid_path hca i
+    local -a head_hcas worker_hcas
+    IFS=, read -r -a head_hcas <<< "$HEAD_CX7_IB"
+    IFS=, read -r -a worker_hcas <<< "$WORKER_CX7_IB"
+    for hca in "${head_hcas[@]}"; do
         gid_path="/sys/class/infiniband/${hca}/ports/1/gids/${HEAD_GID}"
         if [ -z "$(cat "$gid_path" 2>/dev/null | tr -d ':0' || true)" ]; then
             gid_head=""
             warn "head GID index ${HEAD_GID} is EMPTY on ${hca}"
         fi
     done
-    for hca in ${WORKER_CX7_IB//,/ }; do
+    for hca in "${worker_hcas[@]}"; do
         gid_path="/sys/class/infiniband/${hca}/ports/1/gids/${WORKER_GID}"
         if [ -z "$(worker_ssh "cat '$gid_path' 2>/dev/null" | tr -d ':0' || true)" ]; then
             gid_worker=""
@@ -623,8 +627,18 @@ preflight() {
         fi
     done
     if [ -z "$gid_head" ] || [ -z "$gid_worker" ]; then
-        warn "Inspect each listed device's /sys/class/infiniband/<device>/ports/1/gids"
-        warn "and gid_attrs/types; select populated RoCE v2 entries on both nodes."
+        warn "GID tables — pick each node's ::ffff:<ip> entry whose type is RoCE v2;"
+        warn "the two indices need not match, and a v1 entry at the same index will not work:"
+        for hca in "${head_hcas[@]}"; do
+            for i in 0 1 2 3 4 5 6 7; do
+                printf '    head   %s gid%s: %-40s %s\n' "$hca" "$i" \
+                    "$(cat "/sys/class/infiniband/${hca}/ports/1/gids/$i" 2>/dev/null)" \
+                    "$(cat "/sys/class/infiniband/${hca}/ports/1/gid_attrs/types/$i" 2>/dev/null)" >&2
+            done
+        done
+        for hca in "${worker_hcas[@]}"; do
+            worker_ssh "for i in 0 1 2 3 4 5 6 7; do printf '    worker %s gid%s: %-40s %s\n' '${hca}' \"\$i\" \"\$(cat /sys/class/infiniband/${hca}/ports/1/gids/\$i 2>/dev/null)\" \"\$(cat /sys/class/infiniband/${hca}/ports/1/gid_attrs/types/\$i 2>/dev/null)\"; done" >&2 || true
+        done
         die "set NCCL_IB_GID_INDEX (same index both ranks) or HEAD_GID/WORKER_GID (per rank) in .env to populated indices"
     fi
 

--- a/tests/bench_decode.py
+++ b/tests/bench_decode.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import os
 import re
 import sys
 import time
@@ -32,12 +33,18 @@ SPEC_RE = re.compile(
 )
 
 
+def _auth_headers() -> dict[str, str]:
+    """Return the bearer header for keyed vLLM serves, if configured."""
+    key = os.environ.get("API_KEY") or os.environ.get("VLLM_API_KEY")
+    return {"Authorization": f"Bearer {key}"} if key else {}
+
+
 def _post(path: str, body: dict, timeout: float = 600.0, stream: bool = False):
     data = json.dumps(body).encode()
     req = urllib.request.Request(
         BASE + path,
         data=data,
-        headers={"Content-Type": "application/json"},
+        headers={"Content-Type": "application/json", **_auth_headers()},
         method="POST",
     )
     return urllib.request.urlopen(req, timeout=timeout)

--- a/tests/test_bench_decode_auth.py
+++ b/tests/test_bench_decode_auth.py
@@ -1,11 +1,21 @@
 #!/usr/bin/env python3
-"""Regression tests for bearer auth in the streaming decode benchmark."""
+"""CPU-only bearer-auth regression coverage using an ephemeral localhost API."""
 
 from __future__ import annotations
 
 import importlib.util
+import io
+import json
 import os
+import tempfile
+import threading
+import traceback
+import unittest
+import urllib.error
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from unittest.mock import patch
 
 
 MODULE_PATH = Path(__file__).with_name("bench_decode.py")
@@ -14,67 +24,153 @@ assert SPEC and SPEC.loader
 bench_decode = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(bench_decode)
 
+# Synthetic credentials only; the fixture never reads the caller's credentials.
+API_KEY = "fixture-api-key"
+VLLM_KEY = "fixture-vllm-key"
 
-def _headers(**env: str) -> dict[str, str]:
-    original = {name: os.environ.get(name) for name in ("API_KEY", "VLLM_API_KEY")}
-    try:
-        for name in original:
-            os.environ.pop(name, None)
-        os.environ.update(env)
-        return bench_decode._auth_headers()
-    finally:
-        for name, value in original.items():
-            if value is None:
-                os.environ.pop(name, None)
+
+@contextmanager
+def local_api(env: dict[str, str], key: str | None, status: int = 200):
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format, *args):
+            pass  # Never log request headers or credentials.
+
+        def reply(self, code, body, content_type="application/json"):
+            self.send_response(code)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            # These endpoints must stay keyless, even for an authenticated run.
+            if self.headers.get("Authorization") is not None:
+                self.reply(400, b'{"error":"unexpected authorization"}')
+            elif self.path == "/health":
+                self.reply(200, b"ok", "text/plain")
+            elif self.path == "/metrics":
+                self.reply(200, b'vllm:spec_decode_num_drafts_total{model="fixture"} 4\n', "text/plain")
             else:
-                os.environ[name] = value
+                self.reply(404, b'{"error":"not found"}')
+
+        def do_POST(self):
+            body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            if self.path != "/v1/chat/completions":
+                self.reply(404, b'{"error":"not found"}')
+                return
+            expected = f"Bearer {key}" if key else None
+            if self.headers.get_all("Authorization", []) != ([] if expected is None else [expected]):
+                self.reply(401, b'{"error":"unauthorized"}')
+                return
+            if status != 200:
+                self.reply(status, b'{"error":"request rejected"}')
+                return
+            usage = {"prompt_tokens": 3, "completion_tokens": 2}
+            if body.get("stream"):
+                chunks = [
+                    {"choices": [{"delta": {"content": "fixture completion"}, "finish_reason": "stop"}]},
+                    {"choices": [], "usage": usage},
+                ]
+                payload = "".join(f"data: {json.dumps(chunk)}\n\n" for chunk in chunks)
+                self.reply(200, (payload + "data: [DONE]\n\n").encode(), "text/event-stream")
+            else:
+                payload = {"choices": [{"message": {"content": "fixture completion"}}], "usage": usage}
+                self.reply(200, json.dumps(payload).encode())
+
+    with HTTPServer(("127.0.0.1", 0), Handler) as server:
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            # Clear inherited credentials and proxies; all traffic stays on localhost.
+            with patch.dict(os.environ, {"NO_PROXY": "127.0.0.1", **env}, clear=True), patch.object(
+                bench_decode, "BASE", f"http://127.0.0.1:{server.server_port}"
+            ):
+                yield
+        finally:
+            server.shutdown()
+            thread.join()
 
 
-def test_keyless_serve_has_no_auth_header() -> None:
-    assert _headers() == {}
+class DecodeAuthTests(unittest.TestCase):
+    def test_key_precedence_and_empty_values_over_http(self):
+        cases = [
+            ("unset", {}, None),
+            ("api-empty", {"API_KEY": ""}, None),
+            ("vllm-empty", {"VLLM_API_KEY": ""}, None),
+            ("both-empty", {"API_KEY": "", "VLLM_API_KEY": ""}, None),
+            ("api-only", {"API_KEY": API_KEY}, API_KEY),
+            ("vllm-only", {"VLLM_API_KEY": VLLM_KEY}, VLLM_KEY),
+            ("api-wins", {"API_KEY": API_KEY, "VLLM_API_KEY": VLLM_KEY}, API_KEY),
+            ("empty-api-falls-back", {"API_KEY": "", "VLLM_API_KEY": VLLM_KEY}, VLLM_KEY),
+            ("empty-vllm-keeps-api", {"API_KEY": API_KEY, "VLLM_API_KEY": ""}, API_KEY),
+        ]
+        for name, env, key in cases:
+            with self.subTest(case=name), local_api(env, key):
+                response = bench_decode.chat_nonstream("fixture prompt")
+                self.assertEqual(response["choices"][0]["message"]["content"], "fixture completion")
+                stream = bench_decode.stream_bench(2)
+                self.assertEqual(stream["text"], "fixture completion")
+                self.assertEqual(stream["completion_tokens"], 2)
+                self.assertEqual(stream["finish_reason"], "stop")
 
+    def test_health_and_metrics_remain_keyless(self):
+        with local_api({"API_KEY": API_KEY, "VLLM_API_KEY": VLLM_KEY}, API_KEY):
+            self.assertEqual(bench_decode.health(), (200, "ok"))
+            self.assertEqual(bench_decode.spec_snapshot(), {"vllm:spec_decode_num_drafts_total": 4.0})
 
-def test_vllm_api_key_is_sent_as_bearer_token() -> None:
-    assert _headers(VLLM_API_KEY="secret") == {"Authorization": "Bearer secret"}
+    def test_http_errors_propagate_without_credentials(self):
+        cases = [
+            ("missing", {}, 200, 401),
+            ("wrong-key", {"API_KEY": API_KEY}, 200, 401),
+            ("forbidden", {"VLLM_API_KEY": VLLM_KEY}, 403, 403),
+            ("unavailable", {"VLLM_API_KEY": VLLM_KEY}, 503, 503),
+        ]
+        for name, env, status, expected in cases:
+            with self.subTest(case=name), local_api(env, VLLM_KEY, status):
+                for call in (lambda: bench_decode.chat_nonstream("fixture prompt"), bench_decode.stream_bench):
+                    with self.assertRaises(urllib.error.HTTPError) as caught:
+                        call()
+                    with caught.exception as error:
+                        self.assertEqual(error.code, expected)
+                        self.assertNotIn(API_KEY, str(error))
+                        self.assertNotIn(VLLM_KEY, str(error))
 
+    def test_cli_output_and_report_do_not_disclose_credentials(self):
+        with tempfile.TemporaryDirectory() as tmp, local_api(
+            {"API_KEY": API_KEY, "VLLM_API_KEY": VLLM_KEY}, API_KEY
+        ):
+            report = Path(tmp) / "result.json"
+            output = io.StringIO()
+            argv = ["bench_decode.py", "--phase", "fixture", "--out", str(report),
+                    "--runs", "1", "--max-tokens", "2", "--skip-coherence"]
+            with patch.object(bench_decode.sys, "argv", argv), redirect_stdout(output), redirect_stderr(output):
+                self.assertEqual(bench_decode.main(), 0)
+            recorded = report.read_text()
+            self.assertEqual(json.loads(recorded)["runs"][0]["text"], "fixture completion")
+            for key in (API_KEY, VLLM_KEY):
+                self.assertNotIn(key, output.getvalue() + recorded)
 
-def test_post_applies_bearer_header() -> None:
-    captured = []
-    original_urlopen = bench_decode.urllib.request.urlopen
-    original_api_key = os.environ.get("API_KEY")
-    original_vllm_api_key = os.environ.get("VLLM_API_KEY")
-
-    def fake_urlopen(request, timeout):
-        captured.append(request)
-        return object()
-
-    try:
-        os.environ.pop("API_KEY", None)
-        os.environ["VLLM_API_KEY"] = "secret"
-        bench_decode.urllib.request.urlopen = fake_urlopen
-        bench_decode._post("/v1/chat/completions", {})
-    finally:
-        bench_decode.urllib.request.urlopen = original_urlopen
-        if original_api_key is None:
-            os.environ.pop("API_KEY", None)
-        else:
-            os.environ["API_KEY"] = original_api_key
-        if original_vllm_api_key is None:
-            os.environ.pop("VLLM_API_KEY", None)
-        else:
-            os.environ["VLLM_API_KEY"] = original_vllm_api_key
-
-    assert len(captured) == 1
-    assert captured[0].get_header("Authorization") == "Bearer secret"
-
-
-def test_api_key_compatibility_alias_is_supported() -> None:
-    assert _headers(API_KEY="secret") == {"Authorization": "Bearer secret"}
+    def test_cli_auth_failure_does_not_disclose_credentials(self):
+        with tempfile.TemporaryDirectory() as tmp, local_api(
+            {"API_KEY": API_KEY, "VLLM_API_KEY": VLLM_KEY}, VLLM_KEY
+        ):
+            report = Path(tmp) / "result.json"
+            output = io.StringIO()
+            argv = ["bench_decode.py", "--phase", "fixture", "--out", str(report),
+                    "--runs", "1", "--skip-coherence"]
+            with patch.object(bench_decode.sys, "argv", argv), redirect_stdout(output), redirect_stderr(output):
+                try:
+                    bench_decode.main()
+                except urllib.error.HTTPError as error:
+                    with error:
+                        self.assertEqual(error.code, 401)
+                        traceback.print_exc()
+                else:
+                    self.fail("unauthorized benchmark succeeded")
+            self.assertFalse(report.exists())
+            for key in (API_KEY, VLLM_KEY):
+                self.assertNotIn(key, output.getvalue())
 
 
 if __name__ == "__main__":
-    test_keyless_serve_has_no_auth_header()
-    test_vllm_api_key_is_sent_as_bearer_token()
-    test_post_applies_bearer_header()
-    test_api_key_compatibility_alias_is_supported()
-    print("bench_decode bearer auth regression OK")
+    unittest.main()

--- a/tests/test_bench_decode_auth.py
+++ b/tests/test_bench_decode_auth.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Regression tests for bearer auth in the streaming decode benchmark."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("bench_decode.py")
+SPEC = importlib.util.spec_from_file_location("bench_decode", MODULE_PATH)
+assert SPEC and SPEC.loader
+bench_decode = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(bench_decode)
+
+
+def _headers(**env: str) -> dict[str, str]:
+    original = {name: os.environ.get(name) for name in ("API_KEY", "VLLM_API_KEY")}
+    try:
+        for name in original:
+            os.environ.pop(name, None)
+        os.environ.update(env)
+        return bench_decode._auth_headers()
+    finally:
+        for name, value in original.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+def test_keyless_serve_has_no_auth_header() -> None:
+    assert _headers() == {}
+
+
+def test_vllm_api_key_is_sent_as_bearer_token() -> None:
+    assert _headers(VLLM_API_KEY="secret") == {"Authorization": "Bearer secret"}
+
+
+def test_post_applies_bearer_header() -> None:
+    captured = []
+    original_urlopen = bench_decode.urllib.request.urlopen
+    original_api_key = os.environ.get("API_KEY")
+    original_vllm_api_key = os.environ.get("VLLM_API_KEY")
+
+    def fake_urlopen(request, timeout):
+        captured.append(request)
+        return object()
+
+    try:
+        os.environ.pop("API_KEY", None)
+        os.environ["VLLM_API_KEY"] = "secret"
+        bench_decode.urllib.request.urlopen = fake_urlopen
+        bench_decode._post("/v1/chat/completions", {})
+    finally:
+        bench_decode.urllib.request.urlopen = original_urlopen
+        if original_api_key is None:
+            os.environ.pop("API_KEY", None)
+        else:
+            os.environ["API_KEY"] = original_api_key
+        if original_vllm_api_key is None:
+            os.environ.pop("VLLM_API_KEY", None)
+        else:
+            os.environ["VLLM_API_KEY"] = original_vllm_api_key
+
+    assert len(captured) == 1
+    assert captured[0].get_header("Authorization") == "Bearer secret"
+
+
+def test_api_key_compatibility_alias_is_supported() -> None:
+    assert _headers(API_KEY="secret") == {"Authorization": "Bearer secret"}
+
+
+if __name__ == "__main__":
+    test_keyless_serve_has_no_auth_header()
+    test_vllm_api_key_is_sent_as_bearer_token()
+    test_post_applies_bearer_header()
+    test_api_key_compatibility_alias_is_supported()
+    print("bench_decode bearer auth regression OK")

--- a/tests/test_nccl_multi_hca.py
+++ b/tests/test_nccl_multi_hca.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Exercise the launcher's GID preflight without Docker, SSH, or real sysfs."""
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+SOURCE = (Path(__file__).resolve().parents[1] / "start.sh").read_text()
+BLOCK = SOURCE[SOURCE.index("    # Each rank's GID"):SOURCE.index('    [ "$TP" = "2" ]')]
+
+def check(selector, broken=None):
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        for node in ("head", "worker"):
+            for hca in ("rocep1s0f0", "roceP2p1s0f0"):
+                path = root / node / hca / "ports/1/gids/3"
+                path.parent.mkdir(parents=True)
+                path.write_text("0000:0000:0000:0000:0000:ffff:0a64:5001\n")
+        if broken:
+            node, hca, kind = broken
+            path = root / node / hca / "ports/1/gids/3"
+            if kind == "missing":
+                path.unlink()
+            else:
+                path.write_text("0000:0000:0000:0000:0000:0000:0000:0000\n")
+        block = BLOCK.replace("/sys/class/infiniband", str(root / "head"))
+        script = """
+set -euo pipefail
+warn() { echo "$*" >&2; }
+die() { echo "$*" >&2; exit 1; }
+worker_ssh() {
+    local cmd="$1"
+    bash -c "${cmd//"HEADROOT"/"WORKERROOT"}"
+}
+preflight_gids() {
+BLOCK
+}
+preflight_gids
+""".replace("HEADROOT", str(root / "head")).replace("WORKERROOT", str(root / "worker")).replace("BLOCK", block)
+        env = dict(os.environ, HEAD_CX7_IB=selector, WORKER_CX7_IB=selector,
+                   HEAD_GID="3", WORKER_GID="3")
+        return subprocess.run(["bash", "-c", script], env=env, capture_output=True, text=True)
+
+def test_gid_preflight():
+    dual = "rocep1s0f0,roceP2p1s0f0"
+    for selector in ("rocep1s0f0", dual):
+        result = check(selector)
+        assert result.returncode == 0, result.stderr
+    for node, kind in (("head", "missing"), ("worker", "zero")):
+        result = check(dual, (node, "roceP2p1s0f0", kind))
+        assert result.returncode != 0, "bad second HCA passed preflight"
+        assert node in result.stderr and "roceP2p1s0f0" in result.stderr, result.stderr
+
+if __name__ == "__main__":
+    test_gid_preflight()
+    print("single/dual HCA preflight and missing/zero secondary GID checks passed")

--- a/tests/test_nccl_multi_hca.py
+++ b/tests/test_nccl_multi_hca.py
@@ -1,56 +1,130 @@
 #!/usr/bin/env python3
-"""Exercise the launcher's GID preflight without Docker, SSH, or real sysfs."""
-import os
+"""Run the real preflight with fake sysfs and local-only worker commands."""
+
 from pathlib import Path
 import subprocess
-import tempfile
 
-SOURCE = (Path(__file__).resolve().parents[1] / "start.sh").read_text()
-BLOCK = SOURCE[SOURCE.index("    # Each rank's GID"):SOURCE.index('    [ "$TP" = "2" ]')]
+import pytest
 
-def check(selector, broken=None):
-    with tempfile.TemporaryDirectory() as tmp:
-        root = Path(tmp)
-        for node in ("head", "worker"):
-            for hca in ("rocep1s0f0", "roceP2p1s0f0"):
-                path = root / node / hca / "ports/1/gids/3"
-                path.parent.mkdir(parents=True)
-                path.write_text("0000:0000:0000:0000:0000:ffff:0a64:5001\n")
-        if broken:
-            node, hca, kind = broken
-            path = root / node / hca / "ports/1/gids/3"
-            if kind == "missing":
-                path.unlink()
-            else:
-                path.write_text("0000:0000:0000:0000:0000:0000:0000:0000\n")
-        block = BLOCK.replace("/sys/class/infiniband", str(root / "head"))
-        script = """
+ROOT = Path(__file__).resolve().parents[1]
+HCAS = {
+    "head": ("rocep1s0f1", "roceP2p1s0f1"),
+    "worker": ("rocep1s0f0", "roceP2p1s0f0"),
+}
+GIDS = {"head": "4", "worker": "3"}
+POPULATED = "0000:0000:0000:0000:0000:ffff:c000:0201"
+ZERO = "0000:0000:0000:0000:0000:0000:0000:0000"
+
+# Only preflight is loaded: no .env, entrypoint, model, or deployment access.
+# Its body is executed unchanged, following the function-extraction pattern in
+# test_long_prefill_threshold.py. All host-facing dependencies are replaced.
+STUBS = r"""
 set -euo pipefail
-warn() { echo "$*" >&2; }
-die() { echo "$*" >&2; exit 1; }
+warn() { printf '%s\n' "$*" >&2; }
+die() { warn "$*"; exit 1; }
+log() { printf '%s\n' "$*"; }
+docker() { return 0; }
+curl() { return 0; }
+rsync() { return 0; }
+ip() { printf 'inet %s/24\n' "$HEAD_IP"; }
+nvidia-smi() { printf 'GPU 0: GB10\n'; }
+hostname() { printf 'fake-head\n'; }
+check_port_free() { return 0; }
+df() { printf 'Filesystem 1024-blocks Used Available Capacity Mounted\nfake 999999999 0 999999999 0%% /\n'; }
+cat() {
+    # Never fall through to real sysfs (or any other host file).
+    case "$1" in
+        /sys/class/infiniband/*)
+            command cat "$FAKE_SYSFS/$FAKE_NODE/${1#/sys/class/infiniband/}" ;;
+        *) printf 'unexpected cat: %s\n' "$*" >&2; return 1 ;;
+    esac
+}
 worker_ssh() {
-    local cmd="$1"
-    bash -c "${cmd//"HEADROOT"/"WORKERROOT"}"
+    # A fresh local shell gives the worker its own fake sysfs tree. The real
+    # ssh executable is never invoked, even for the initial connectivity check.
+    FAKE_NODE=worker bash -c "$1"
 }
-preflight_gids() {
-BLOCK
-}
-preflight_gids
-""".replace("HEADROOT", str(root / "head")).replace("WORKERROOT", str(root / "worker")).replace("BLOCK", block)
-        env = dict(os.environ, HEAD_CX7_IB=selector, WORKER_CX7_IB=selector,
-                   HEAD_GID="3", WORKER_GID="3")
-        return subprocess.run(["bash", "-c", script], env=env, capture_output=True, text=True)
+export -f cat docker nvidia-smi df
+"""
 
-def test_gid_preflight():
-    dual = "rocep1s0f0,roceP2p1s0f0"
-    for selector in ("rocep1s0f0", dual):
-        result = check(selector)
-        assert result.returncode == 0, result.stderr
-    for node, kind in (("head", "missing"), ("worker", "zero")):
-        result = check(dual, (node, "roceP2p1s0f0", kind))
-        assert result.returncode != 0, "bad second HCA passed preflight"
-        assert node in result.stderr and "roceP2p1s0f0" in result.stderr, result.stderr
 
-if __name__ == "__main__":
-    test_gid_preflight()
-    print("single/dual HCA preflight and missing/zero secondary GID checks passed")
+def run_preflight(tmp_path, head_count=2, worker_count=2, broken=None):
+    source = (ROOT / "start.sh").read_text()
+    begin = source.index("preflight() {")
+    end = source.index("\n}\n", begin) + 3
+    for node in HCAS:
+        for hca in HCAS[node]:
+            port = tmp_path / "sysfs" / node / hca / "ports/1"
+            (port / "gids").mkdir(parents=True)
+            (port / "gid_attrs/types").mkdir(parents=True)
+            for index in range(8):
+                # Only this rank's index and an alternative RoCEv2 index are
+                # usable. Using the other rank's configured index must fail.
+                value = POPULATED if str(index) in (GIDS[node], "1") else ZERO
+                (port / "gids" / str(index)).write_text(value + "\n")
+                (port / "gid_attrs/types" / str(index)).write_text("RoCE v2\n")
+    if broken:
+        node, hca_index, kind = broken
+        entry = (tmp_path / "sysfs" / node / HCAS[node][hca_index]
+                 / "ports/1/gids" / GIDS[node])
+        if kind == "missing":
+            entry.unlink()
+        else:
+            entry.write_text(ZERO + "\n")
+
+    # The unrelated overlay existence and cache writability checks stay inside
+    # the exercised function; their inputs are temporary files, never checkout
+    # or deployment artifacts.
+    for name in ("overlay/patch_ablit.py", "overlay/ablit_runtime.py", "ablit/LAYER_MAP.json"):
+        path = tmp_path / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+    placeholder = tmp_path / "overlay-placeholder"
+    placeholder.touch()
+    env = {
+        "PATH": "/usr/bin:/bin", "LC_ALL": "C", "HOME": str(tmp_path),
+        "USER": "fake-user", "FAKE_SYSFS": str(tmp_path / "sysfs"),
+        "FAKE_NODE": "head", "HEAD_IP": "192.0.2.1", "WORKER_SSH": "fake-worker",
+        "HEAD_CX7_IB": ",".join(HCAS["head"][:head_count]),
+        "WORKER_CX7_IB": ",".join(HCAS["worker"][:worker_count]),
+        "HEAD_GID": GIDS["head"], "WORKER_GID": GIDS["worker"],
+        "TP": "2", "NNODES": "2", "CONTAINER_WORKER": "fake-worker",
+        "PORT": "8888", "MASTER_PORT": "29521", "SCRIPT_DIR": str(tmp_path),
+        "ABLIT": "0", "HF_CACHE_DIR": str(tmp_path / "head-cache"),
+        "WORKER_HOME": str(tmp_path), "WORKER_CACHE_DIR": str(tmp_path / "worker-cache"),
+    }
+    for key in ("STOP_PATCH_HOST", "SCHED_PATCH_HOST", "DRAFTER_PATCH_HOST",
+                "APC_PATCH_HOST", "PERGROUP_PATCH_HOST", "XGRAMMAR_PATCH_HOST",
+                "KPOOL_TAIL_PATCH_HOST", "SPINWAIT_PATCH_HOST", "ADAPTIVE_K_PATCH_HOST",
+                "DENSE_FP8_PATCH_HOST", "EXL3_OVERLAY_HOST"):
+        env[key] = str(placeholder)
+    return subprocess.run(
+        ["bash", "-c", STUBS + source[begin:end] + "\npreflight\n"],
+        env=env, cwd=tmp_path, capture_output=True, text=True, timeout=15,
+    )
+
+
+@pytest.mark.parametrize("head_count,worker_count", [(1, 1), (1, 2), (2, 1), (2, 2)])
+def test_literal_nic_lists_on_both_nodes(tmp_path, head_count, worker_count):
+    result = run_preflight(tmp_path, head_count, worker_count)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("node", ["head", "worker"])
+@pytest.mark.parametrize("hca_index", [0, 1], ids=["primary", "secondary"])
+@pytest.mark.parametrize("kind", ["missing", "zero"])
+def test_every_selected_nic_must_have_a_gid(tmp_path, node, hca_index, kind):
+    result = run_preflight(tmp_path, broken=(node, hca_index, kind))
+    assert result.returncode != 0, "preflight accepted an unusable selected NIC"
+    # Operators must be able to identify the failing node, device, and index.
+    assert any(node in line and HCAS[node][hca_index] in line and GIDS[node] in line
+               for line in result.stderr.splitlines()), result.stderr
+
+
+def test_failure_displays_alternative_gids_and_types_for_every_device(tmp_path):
+    result = run_preflight(tmp_path, broken=("worker", 1, "zero"))
+    assert result.returncode != 0
+    rows = [line.split() for line in result.stderr.splitlines()]
+    for node, devices in HCAS.items():
+        for device in devices:
+            assert [node, device, "gid1:", POPULATED, "RoCE", "v2"] in rows, result.stderr


### PR DESCRIPTION
## Summary

`preflight()` probed the RoCE GID with the raw comma-separated `NCCL_IB_HCA` value:

```sh
gid_path="/sys/class/infiniband/${HEAD_CX7_IB}/ports/1/gids/${HEAD_GID}"
```

On a dual-rail kit (`HEAD_CX7_IB=rocep1s0f0,roceP2p1s0f0`) that path never exists, so the guard either warned wrongly or skipped GID validation; an all-zero GID then kills that rank ~60 s into the run (`ibv_modify_qp` errno 61 "No data available"), because the index is per-NIC.

This iterates the comma-separated device list on both nodes and requires a populated entry on **every** selected device. Device names are still passed unchanged to NCCL; the diagnostic now points at each device's `gids/` and `gid_attrs/types`.

## Verification

- `tests/test_nccl_multi_hca.py` (new): single- and dual-HCA selectors pass; a missing or all-zero secondary GID on either node fails closed with the device named. No Docker/SSH/sysfs needed.
- On this 2× GB10 kit both rails are wired and active (`rocep1s0f0` + `roceP2p1s0f0`, GID 3, RoCE v2): dual-rail NCCL all-reduce measured **20.9 GB/s** peak busbw vs **12.8 GB/s** with one HCA. `MERGE_NICS`/`CROSS_NIC` variants gave no further gain.

## Notes

Draft. Same GID index is also validated in `.env.example`; `HEAD_GID`/`WORKER_GID` per-rank overrides are unchanged by this PR.
