### PR TITLE
test(perf): add agent-session, Responses-replay and logprob probes + 2026-09-11 findings

### DIFF
--- a/docs/headroom-2026-09-11.md
+++ b/docs/headroom-2026-09-11.md
@@ -1,0 +1,401 @@
+# Headroom investigation — 2026-09-11 (2× DGX Spark, GLM-5.3-Flash-EXL3)
+
+Live, on-kit investigation of remaining speed/efficiency levers. Every number
+below was measured on this kit during the session; raw artifacts are under
+`logs/headroom-20260911/`. The prior live serve was shut down before the
+session; the agent sandboxes that shared the head's UMA were also stopped.
+
+## TL;DR
+
+| # | Lever | Status | Measured effect |
+|---|---|---|---|
+| 1 | Adaptive verification length (`GLM53_ADAPTIVE_K=ema`) | **keep ON** | prose **+10.3 %** (A/B/A medians 29.36 vs 26.63 tok/s); structured neutral (65.9 vs 65.9) |
+| 2 | `GLM53_SPINWAIT_MS=16` | **keep ON** | 30.44 tok/s prose on B1 vs 29.36 B0 A-arm (directional, not isolated); repo sweep +0.95 % decode / −85 % EngineCore CPU |
+| 3 | Long-prefill boot warmup rung | **fixed** | the only mid-serve JIT in the prior 5 h serve was `BuildPrefillChunkMetadataKernel`; rungs added, ARG_MAX staging fixed |
+| 4 | Prefix-cache collapse under ≥3 long sessions | **diagnosed, unfixed** | reproducible hard cliff: 1–2 sessions hit ~96–100 %, 3+ sessions hit 0 %; independent of the 918 k-token pool and of `VLLM_PREFIX_CACHE_RETENTION_INTERVAL` |
+| 5 | Dual-rail CX7 NCCL | **verified** | single HCA 12.84 GB/s vs dual 20.94 GB/s peak busbw; `NCCL_CROSS_NIC` / `MERGE_NICS` no further gain |
+| 6 | Host DRAM headroom | **at ceiling** | 2 GiB MemAvailable under concurrent 40 k prefills even with sandboxes stopped — do **not** raise `GPU_MEM_UTIL` |
+| 7 | Dense FP8 (`GLM53_DENSE_FP8=dense,kda`) | **measured, provisional** | structured **75.0** tok/s (+13.7 %), prose **34.4** (+29 % vs B0 stock, +13 % vs B1 spinwait-only); KLD 0.002–0.016 nats, argmax 97.0–99.7 % |
+
+## 1. Method
+
+- Boots are `./start.sh restart` with caller env overrides (caller wins over
+  `.env`; `tests/test_start_overrides.py`).
+- B0: stock capture list, adaptive-k **on** (needed to capture the `{3,5,8}`
+  graphs) and A/B'd live through the override JSON; `GLM53_SPINWAIT_MS=2`.
+- B1: same + `GLM53_SPINWAIT_MS=16` + `VLLM_PREFIX_CACHE_RETENTION_INTERVAL=3584`.
+- B2: B1 with `GLM53_DENSE_FP8=dense,kda`.
+- Decode: `tests/bench_decode.py` (structured count-1→200 and hash-map prose,
+  400 tokens, thinking off, temp 0). Adaptive-k mode switched live via
+  `~/.cache/vllm-glm53-flash/glm53_adaptive_k.json` (`{"mode":"off"}`).
+- Prefix-cache probes: `tests/replay_responses_traj.py` (replays the real
+  deep-swe mini-swe-agent trajectory payloads), `tests/bench_agent_sessions.py`
+  (N concurrent growing sessions), and the N-repeat probe in section 4.
+- Quality: `tests/bench_logprobs.py` (prompt logprobs top-20, KLD proxy), plus
+  the coherence probes in `tests/bench_decode.py`.
+
+Boot timing on this kit: container start → `/health` ≈ 9–10 min; the new
+boot-shape warmup ≈ 40–140 s after ready.
+
+## 2. Adaptive verification length — validated
+
+B0 (union capture list `1 2 3 4 5 6 8 9 10 12 15 16 20 24 32`, spinwait 2):
+
+| Arm | prose tok/s (median of 5) | accept/step |
+|---|---:|---:|
+| ema | 28.81 | 2.01 |
+| off (stock k=7) | **26.63** | 2.31 |
+| ema (A/B/A re-run) | 29.91 | 2.09 |
+
+Structured (count 1→200): ema **65.95** vs off **65.91** tok/s, accept/step
+6.57 vs 6.71 — neutral, as designed (the high-accept regime saturates the
+verifier at k=7). The gain is concentrated in the low-accept prose regime,
+which is what the agent workload mixes.
+
+B1 (spinwait 16, same captures) prose ema **30.44** tok/s.
+
+## 3. Spinwait 16
+
+The repo's frozen MNBT=2048 sweep selected 16 ms (+0.95 % decode, −85 %
+EngineCore CPU, `overlay/patch_spinwait.py`). B1 used 16 ms; prose was 30.44
+vs the B0 A-arm median 29.36 (+3.7 %, not an isolated A/B and within the ±5 %
+run spread, but not a regression). No downside observed in prefill, TTFT, or
+coherence. Recommended on.
+
+## 4. Prefix caching: the production 5–9 % hit rate is structural
+
+### 4.1 What the workload did
+
+The four deep-swe mini-swe-agent trajectories that drove the live serve
+(`/home/mmizutani/dev/deep-swe/runs/glm53-exl3/20260911T043449Z-high-full-rerun`)
+show 20.2 M cumulative input tokens with only 1.11 M cached (5.5 %). All four
+sessions lost the cache permanently between 05:08 and 05:10 UTC:
+
+```
+task               calls   in_tok   cached  ratio  last-hit  first-miss
+dateutil…            89   6,564,488  308,224  4.7 %  05:08:19  05:10:16
+eicrud…              90   3,469,184  211,456  6.1 %  05:08:28  05:10:29
+gql…                 91   4,935,557  254,464  5.2 %  05:08:29  05:10:46
+ofetch…              88   5,233,468  333,312  6.4 %  04:58:13  05:08:55
+```
+
+### 4.2 The prompts are not the problem
+
+`tests/replay_responses_traj.py` replayed the exact harness payload for
+dateutil calls 16–22 against an idle server (`logprobs`/Responses conversion
+mirrored from
+`minisweagent/models/litellm_response_model.py`):
+
+| call | input tok | live cached | replay cached |
+|---:|---:|---:|---:|
+| 17 | 34,688 | 32,256 | 28,672 |
+| 18 | 35,528 | 32,256 | 32,256 |
+| 19 | 36,492 | 32,256 | 32,256 |
+| 20 | 52,280 | **0** | **32,256** |
+| 21 | 54,229 | **0** | **50,176** |
+| 22 | 54,470 | **0** | **50,176** |
+
+The client is append-only and cacheable; the live misses are server-side.
+
+### 4.3 Reproducible cliff: ≥3 long sessions lose everything
+
+Sequential N-repeat probe (fill N private 30 k-token prefixes, then repeat them
+after a 5 s gap), B0 and B1 identical:
+
+| N | size | repeat wall (s) | prefix hits |
+|---:|---:|---|---|
+| 1 | 30 k | 1.1–1.2 | yes (global 0.955) |
+| 2 | 30 k | 1.1–1.2 | yes (global 0.955) |
+| 3 | 30 k | 17.1–17.4 each | **none (global 0.000)** |
+| 4 | 30 k | 17.1–17.3 each | **none (global 0.000)** |
+| 2 | 60 k | 34–35 each | **none** |
+| 3 | 10 k | 2.0 each | yes (global 0.715) |
+| 4 | 3584 | 0.4 each | yes (global 0.992) |
+
+Order test after three 30 k fills: repeat A2 → 1.2 s (hit), A1 → 1.2 s (hit),
+**A0 → 17.2 s (evicted)**. So the effective retention is roughly the two most
+recent session prefixes ≈ **60–70 k tokens**, never the 918 k-token KV pool.
+
+### 4.4 What was ruled out
+
+- Not capacity of the flat KV pool: `GPU KV cache size: 918,703 tokens`,
+  usage peaked at 0.0 % during the probe (blocks are freed to the cache).
+- Not `VLLM_PREFIX_CACHE_RETENTION_INTERVAL`: B1 booted with `3584`; the cliff
+  is identical to B0 (dense). (The plumb-through was kept in `start.sh`; it is
+  opt-in and documented.)
+- Not adaptive-k: reproduced with `{"mode":"off"}`.
+- Not mixed-prefill scheduling: the cliff is sequential.
+- Not the drafter SWA min: the overlay patch already excludes it.
+
+The shape points at the hybrid state retention (Mamba `align` snapshots /
+sparse-indexer tail), which is a separate, much smaller budget than the
+attention-token pool. **Update 2026-09-11 (later): root-caused, fixed by
+adopting upstream/repo PRs, and re-measured live — see §12.** Boot B3 (per-group
+retention + fine-grained 64-token hits + DFlash block-drop fix) turns the cliff
+into near-full reuse: N=3/4 repeats at 30 k tokens hit **100 %** (0.4 s vs 17 s),
+2×60 k hits 99.9 %, and the 4-agent session bench that scored 0.000 global hits
+from turn 1 now scores **0.916–0.928** with per-turn wall time 150–196 s → **18 s**.
+
+**Operational mitigations that follow from the data:**
+1. Keep the number of *simultaneously cached long sessions* ≤ 2 per engine
+   where possible (e.g., 2 agents on this server, 2 on a second one), or accept
+   re-prefill.
+2. Do not expect a bigger `GPU_MEM_UTIL`/KV pool to fix it (section 6).
+3. Re-check `vllm:prompt_tokens_by_source_total{source="local_compute"}` after
+   any scheduler/mamba change.
+
+## 5. Boot warmup: the remaining mid-serve JIT
+
+The prior 5 h serve compiled exactly one kernel during live traffic:
+`BuildPrefillChunkMetadataKernel.kernel` at 06:17 UTC (hours after boot). The
+other seven JIT warnings happen during the post-ready warmup itself and are
+harmless. `scripts/boot-shape-warmup.sh` now pre-warms prefill metadata with
+`PREFILL_S=(3584 7168 14336 65536)` (64 k covers agent-sized contexts) and
+stages large payloads through a file — the first 64 k rung hit
+`curl: Argument list too long`, now fixed. B2 verifies coverage.
+
+## 6. Host DRAM is the hard boundary
+
+With **all four agent sandboxes stopped** (the ones that previously drove the
+head to 8 GiB swap):
+
+```
+under 4 concurrent ~40 k-token prefills:  MemAvailable ≈ 2 GiB, swap 4 GiB used
+idle, util 0.85, union captures:          used 119 GiB / 121 GiB
+```
+
+The sandboxes were not optional overhead on this UMA — they are what made the
+prior boot swap. But even without them the model + KV + CUDA graphs fill the
+node, so:
+
+- **Do not raise `GPU_MEM_UTIL`** above 0.85 (the union capture list already
+  costs ~0.9 GiB of KV: 984 k tokens with stock captures → 933 k with the
+  adaptive-k union).
+- The union capture list is required for adaptive-k; its ~5 % KV cost is
+  included in the numbers above.
+- Keep the sandboxes off the head (or hard-cap them) as the README already
+  recommends.
+
+## 7. Dense FP8 — measured, provisional numerics
+
+B2 boot: `GLM53_DENSE_FP8=dense,kda`, adaptive ema, spinwait 16, util 0.85,
+union captures. The patch applied (`dense fp8 groups: dense,kda`) and the
+smaller dense weights also leave **1,019,360 KV tokens** — +100 k (+11 %) vs
+B1's 918,703.
+
+**Decode (median of 5, 400 tokens, temp 0, thinking off):**
+
+| Arm | structured | prose |
+|---|---:|---:|
+| B0 BF16 dense, stock k=7 | 65.91 | 26.63 |
+| B0 BF16 dense, adaptive ema | 65.95 | 28.81 / 29.91 (A/B/A) |
+| B2 dense FP8, stock k=7 | — | 32.98 |
+| B2 dense FP8, adaptive ema | **75.01** | **34.43** |
+
+Stacked vs the B0 stock baseline: structured **+13.8 %**, prose **+29.3 %**
+(B2 ema 34.43 vs 26.63); B2 alone adds **+13.7 %** structured and **+17.3 %**
+prose over the B0 adaptive arm (A/B/A median 29.36; +19.5 % vs the first A run;
++13.1 % vs B1 spinwait-only 30.44). Coherence probes pass (`coherent: true`,
+no NaN).
+
+**Quality (prompt-logprob KLD vs B1 BF16 dense, top-20 support):**
+
+| text | positions | mean KL (nats) | argmax agree |
+|---|---:|---:|---:|
+| prose_mla | 460 | 0.0163 | 97.0 % |
+| log_rows | 2292 | 0.0024 | 99.7 % |
+| code | 308 | 0.0043 | 98.4 % |
+| mixed | 381 | 0.0058 | 98.2 % |
+
+The repo's provisional bar is 0.002–0.013 nats with 94–100 % argmax; three of
+four texts are inside it, the repetitive prose text is slightly above
+(0.0163). Treat as an accepted-risk toggle, not a lossless one: it is the
+single biggest measured decode gain here, and the only one that changes target
+numerics.
+
+## 8. Dual-rail NCCL — verified, no further config gain
+
+Standalone torch/NCCL all_reduce (1 GPU/rank, 2×GB10, `NCCL_IB_GID_INDEX=3`,
+`NCCL_CROSS_NIC=0`, `NCCL_IB_MERGE_NICS=0`):
+
+| HCA selection | peak busbw | 16 MiB latency |
+|---|---:|---:|
+| `rocep1s0f0` | 12.84 GB/s | 1.306 ms |
+| `rocep1s0f0,roceP2p1s0f0` | **20.94 GB/s** | 0.801 ms |
+| dual + `NCCL_CROSS_NIC=1` | 20.42 GB/s | 0.878 ms |
+| dual + `NCCL_IB_MERGE_NICS=1` | 20.51 GB/s | 0.857 ms |
+
+Both rails carry traffic and dual gives +63 % peak bandwidth. The production
+settings are already the best of the three. Small-message latencies (4 KiB:
+0.022–0.026 ms) are identical across variants, so no decode-side change is
+left here.
+
+## 9. Recommended configuration (no kernel work required)
+
+```bash
+# .env / caller
+GLM53_ADAPTIVE_K=ema
+GLM53_ADAPTIVE_K_SET=2,4,7
+GLM53_SPINWAIT_MS=16
+EXTRA_ARGS="--cudagraph-capture-sizes 1 2 3 4 5 6 8 9 10 12 15 16 20 24 32"
+# leave GPU_MEM_UTIL=0.85, MAX_NUM_SEQS=4, MNBT=7168, dense KV fp8
+# GLM53_DENSE_FP8=dense,kda  -> accepted-risk; section 7 KLD gate
+# VLLM_PREFIX_CACHE_RETENTION_INTERVAL -> leave unset (no measured gain)
+```
+
+The live server was left running this B2 configuration (booted 12:16 UTC,
+warmup re-run manually after a launcher timeout).
+
+## 10. Artifacts
+
+- `logs/headroom-20260911/B0-*.json` — decode A/B/A, cold prefill
+- `logs/headroom-20260911/B1-*.json`, `B1-logprobs.json` — spinwait 16, quality
+- `logs/headroom-20260911/B2-*.json`, `B2-logprobs.json` — dense FP8 decode + KLD
+- `logs/headroom-20260911/B0-agents2.json`, `off-*.json` — cache probes
+- `logs/headroom-20260911/B0-boot.log`, `B1-boot.log`, `B2-boot.log`
+- `/tmp/opencode/nccl-{dual,single,dualcross1,dualmerge1}/` — NCCL A/B raw logs
+
+## 11. Changes made in this repository
+
+- `scripts/boot-shape-warmup.sh` — long-prefill rungs
+  `PREFILL_S=(3584 7168 14336 65536)` for `BuildPrefillChunkMetadataKernel`,
+  payload staging through a file (long prompts exceeded ARG_MAX), and the
+  outcome tally now ignores the staged `.json` payload files.
+- `start.sh` — adaptive-k auto-selects the union capture list; forwards
+  `VLLM_PREFIX_CACHE_RETENTION_INTERVAL` and `GLM53_FINEGRAINED_APC`; validates
+  `GLM53_APC_RETENTION_INTERVAL_SWA` and `GLM53_FINEGRAINED_APC`; fail-closed
+  `validate_overlay_artifacts` gate; `GLM53_OVERLAY_ORDER` +
+  `emit_overlay_block` for identical rank scripts; mounts/scps the three new
+  overlays.
+- `.env` / `.env.example` — adaptive-k `ema`, spinwait 16, dense FP8 (this kit),
+  `GLM53_APC_RETENTION_INTERVAL_SWA=` (auto), `GLM53_FINEGRAINED_APC=1`, and the
+  retention knob documentation.
+- `README.md`, `CHANGELOG.md` — new defaults, measurements, and the fixed
+  prefix-cache section.
+- Adopted prefix-cache fixes: `overlay/patch_apc_per_group_retention.py` (PR #83
+  + `docs/DESIGN-apc-per-group-retention.md` + test),
+  `overlay/patch_apc_fine_grained_hits.py` (PR #84 + design doc + test),
+  `overlay/patch_dflash_block_drop.py` (vLLM #54163 cherry-pick + test),
+  `tests/test_launcher_rank_parity.py`.
+- Probes added earlier in the session: `tests/bench_agent_sessions.py`,
+  `tests/replay_responses_traj.py`, `tests/bench_logprobs.py`.
+- `docs/headroom-2026-09-11.md` — this document.
+
+`.env` carries the full recommended configuration; boot B3 validated it live.
+
+## 12. Upstream and project-tracker clues (searched 2026-09-11)
+
+The image's vLLM wheel is `0.1.dev20051+g487ecf187`, base commit `487ecf187`
+(2026-08-25). The prefix-cache cliff is a **known, actively-fixed bug family**
+around `mamba_cache_mode=align` + speculative decoding, with several reports
+specific to **GLM-5.3-Flash + DFlash2**:
+
+**vLLM upstream (`vllm-project/vllm`)**
+
+| # | state | relevance |
+|---|---|---|
+| #45238 | open issue | canonical: align-mode Mamba checkpoint lands in request-unique tokens → hybrid min drops **all** reuse to 0 %, no warning |
+| #54094 | open | DFlash2 identical 1.04 M prompt: full-attn hits 1.038 M, **Mamba hit_out=0**, reconciled hit 0; diagnostics in #54381 |
+| #54163 | open PR (fixes #53477) | `SpeculativeConfig.use_eagle()` returns True for `dflash`/`dspark`, so `_mamba_block_aligned_split` backs off a mamba block that DFlash never polluted → final block-aligned chunk skipped, state never materialized, **every reply recomputes the context**. Our image has exactly the pre-fix code (`scheduler.py:409 if self.use_eagle:`). |
+| #54076 | open PR | `_mamba_block_aligned_split` uses `cache_config.block_size` (min over groups) instead of `MambaSpec.block_size`; on heterogeneous layouts chunks never end on the state grid (#55601: GLM-5.3 mamba block **7168**, drafter 64/1024, so our split grid is 64). |
+| #53479 | open draft | "align states are sparse … speculative one-block back-off forfeits a full mamba block"; cites GB10 measurements (~9× warm prefill). Superseded branch, rewrite pending #54076/#54713. |
+| #50551 | open PR | pin the finalized Mamba decode checkpoint and publish it for conversation-history reuse (`VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS=1`, retention 0) — the exact agent next-turn shape. |
+| #55601 | open PR | GLM-5.3-Flash: state-index seeded in `cache_config.block_size` units (64) instead of `mamba_block_size` (7168) → OOB/`cudaErrorIllegalAddress` for hits ≥ 8 mamba blocks, **silently wrong recurrent state** for shorter hits. |
+| #53945 / #54713 | **merged 2026-09-08 / 09-10** | EAGLE-resume Mamba state on the block grid; retain both replay boundaries for exact-block-aligned prompts. **Postdate our image**, so absent. |
+
+**This project (`MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks`)**
+
+| # | state | relevance |
+|---|---|---|
+| #106 | open issue | production symptom identical to this investigation: `prefix_cache_hits_total` freezes after ~1 h of concurrent agentic load, only a restart fixes it; `num_preemptions_total=0`; a comment documents a no-freeze run at `GPU_MEM_UTIL=0.78`, MNBT 2048, `CG_ESTIMATE=0`. |
+| #83 | open PR (P1, changes requested) | **top candidate fix**: cached 3584-token segments cost 38 global block ids (1 MLA + 4 mamba + **33 DFlash2 drafter** SWA); drafter blocks are hashed and freed mid-prefill to the LRU tail ahead of the hit-carrying blocks — a priority inversion. Knee ≈ 14.9 segments/conversation; measured 14 OK / 17 fail. Fix = per-group retention (`VLLM_PREFIX_CACHE_RETENTION_INTERVAL_SWA=0` for the drafter, dense MLA/mamba). Receipts: two 120 K conversations **98.5 %** hits and 2.7 s re-turns; diverging subagent 67.6 %. This explains why our single global `3584` interval did not help. |
+| #125 / #84 | open PRs (P1, changes requested) | KpoolTail veto forces every hybrid hit to the 3584-token page; excluding non-participating groups restores 64-token lookup. Measured 73.7 % → **99.5 %** hit ratio, TTFT −91 %; #124/#84 add the enable knob. |
+| #37 | open | expose `/reset_prefix_cache` (useful for clean A/B probes). |
+
+**Actionable fix path (executed 2026-09-11)**
+
+1. **Short term (config only):** keep the launcher defaults applied in this
+   session; for agent fleets reduce concurrent long sessions and/or split them
+   across engines, and `./start.sh restart` when `prefix_cache_hits_total`
+   freezes (the issue #106 symptom).
+2. **Best local step (overlay):** adopt PR #83 (per-group retention) first — it
+   targets the measured priority inversion and needs no vLLM rebase — then
+   #125/#84 (fine-grained 64-token hits). Both compose with the existing
+   `patch_hybrid_prefix_hit.py`.
+3. **Engine step:** rebase the image's vLLM past `#53945`/`#54713` (merged) and
+   cherry-pick `#54163` + `#54076` once merged; `#55601` is also worth taking
+   for correctness (state seeding units) on this exact model.
+
+The upstream fixes corroborate the live measurements: the cliff is
+length/chunk-grid- and drafter-block-budget-driven, not a client issue, not
+`sessions > 2`, and not solvable by growing the attention-token pool.
+
+### 12.1 What was adopted
+
+- **PR #83** (`overlay/patch_apc_per_group_retention.py`, knob
+  `GLM53_APC_RETENTION_INTERVAL_SWA`, default auto): per-group retention; the
+  EAGLE-exempt DFlash2 drafter keeps only reachable-boundary snapshots while
+  MLA/mamba stay dense. Live receipt:
+  `[glm53-apc-per-group] retention_by_group=[None,None,None,None,None,None,0]`.
+- **PR #84** (`overlay/patch_apc_fine_grained_hits.py`, `GLM53_FINEGRAINED_APC=1`,
+  default): excludes the KpoolTail scratch from the fine-grained veto, restoring
+  64-token hit alignment. Live receipt: `[glm53-apc-finegrained] Fine-grained
+  prefix-cache hits ENABLED … effective alignment=64 tokens`.
+- **vLLM #54163 cherry-pick** (`overlay/patch_dflash_block_drop.py`): DFlash/DSpark
+  no longer take the EAGLE trailing-block back-off. Live receipt: container log
+  `patched speculative.py (use_eagle_block_drop: dflash/dspark exempt)`.
+- Launcher hardening from #83/#84: `validate_overlay_artifacts` fail-closed gate,
+  `GLM53_OVERLAY_ORDER` emitted identically to both ranks, `GLM53_FINEGRAINED_APC`
+  0/1 validation, `GLM53_APC_RETENTION_INTERVAL_SWA` grid validation.
+
+Host tests (all pass): `test_launcher_rank_parity.py`,
+`test_apc_per_group_retention.py`, `test_apc_fine_grained_hits.py`,
+`test_dflash_block_drop_patch.py`, `test_hybrid_prefix_hit.py`,
+`test_spinwait_patch.py`, `test_indexer_workspace.py`,
+`test_kpool_tail_slotmap.py`, `test_xgrammar_termination.py`,
+`test_start_overrides.py`.
+
+### 12.2 Live A/B (same probes before/after)
+
+| Probe | B0/B1 (before) | B3 (after) |
+|---|---|---|
+| N=3 × 30 k repeat | 17.2 s each, 0.000 hits | **0.4 s each, 1.000 hits** |
+| N=4 × 30 k repeat | 17.2 s each, 0.000 | **0.4 s each, 1.000** |
+| 2 × 60 k repeat | 34–35 s each, 0.000 | **0.4 s each, 0.999** |
+| 3 × 5 k repeat | 3.4 s each, 0.000 | 0.4 s each, 0.992 |
+| 4-agent × 60 k, turns 1–3 | 0.000, wall 150–196 s | **0.916–0.928, wall 17.7–18.9 s** |
+| hash-map prose (3 × 400) | 34.43 (B2) | 34.50 (no regression) |
+| coherence probe | pass | pass |
+
+Boot B3 ran `.env` as now shipped: adaptive-k `ema`, spinwait 16, dense FP8,
+`GLM53_APC_RETENTION_INTERVAL_SWA=` (auto), `GLM53_FINEGRAINED_APC=1`, warmup
+24/24. Remaining upstream item: **#54076** (mamba block-grid in the split) is
+still open and would make the final partial-chunk state materialize at exactly
+the mamba grid; #55601 (state-seed units) is a correctness follow-up.
+
+### 12.3 Merge reconciliation A/B (origin PR #130 vs this branch)
+
+`origin/main` advanced to `9348755` (PR #130, a rework of #83's per-group
+retention plus a versioned DFlash SWA replay clamp). The merge surfaced a
+functional conflict, so it was resolved by measurement, not by text. Four
+consecutive boots on this kit, same five probes:
+
+| Boot | Stack | 1×30k | 3×30k | 4×30k | 2×60k | 3×5k |
+|---|---|---|---|---|---|---|
+| B3 | #83 per-group + pre-#130 hybrid + fine-grained + block-drop | 1.000 | **1.000** | **1.000** | **0.999** | **0.992** |
+| B4 | #130 unset/unset + fine-grained + block-drop | 0.716 | 0.000 | 0.000 | 0.000 | 0.000 |
+| B5 | #130 explicit 0/0 + fine-grained + block-drop | 0.000 | 0.000 | 0.000 | 0.955 | 0.000 |
+| B6 | #130 explicit 0/0 + fine-grained, block-drop removed | 0.000 | 0.000 | 0.000 | 0.955 | 0.000 |
+
+B6 isolates the cause: it is not our DFlash block-drop cherry-pick, it is the
+reworked retention/replay overlays themselves. (Upstream's qualification doc
+explicitly frames #130 as "a draft contribution for maintainer discussion, not
+a recommendation", and its measured cases are 128k append/edit/branch, not
+identical-repeat growth.) **Resolution:** this branch ships the #83 overlay
+implementations (live-validated above) and adopts PR #130's launcher machinery,
+artifact gate, overlay order, tests and docs; the two overlay files and their
+host tests are the only functional divergence, recorded here and in
+`.env.example`. Boot **B7** then re-validated the restored stack on the merged
+launcher: 1×/3×/4× 30 k repeats **1.000** at 0.3–0.4 s, 2×60 k **0.999**,
+3×5 k **0.992**, and the 4-agent × 60 k bench turns 1–3 at **0.886–0.928**
+(wall 17.7–23.6 s), matching B3.

--- a/tests/bench_agent_sessions.py
+++ b/tests/bench_agent_sessions.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Non-streaming N-agent multi-turn prefix-cache stress.
+
+Each agent has a private growing prefix (agent salt at position 0, then common
+filler). Per turn every agent appends a unique chunk and all agents fire one
+request concurrently. Records prompt_tokens / cached_tokens per request,
+prefix-cache counter deltas and wall time.
+"""
+import argparse
+import concurrent.futures as cf
+import json
+import math
+import re
+import secrets
+import time
+import urllib.request
+
+BASE = "http://127.0.0.1:8888"
+MODEL = "GLM-5.3-Flash-EXL3"
+HITS_RE = re.compile(r"^vllm:prefix_cache_hits_total(?:\{[^}]*\})?\s+(\S+)", re.M)
+QRY_RE = re.compile(r"^vllm:prefix_cache_queries_total(?:\{[^}]*\})?\s+(\S+)", re.M)
+SALT = secrets.token_hex(8)
+
+
+def metrics() -> dict:
+    raw = urllib.request.urlopen(BASE + "/metrics", timeout=10).read().decode()
+    return {
+        "hits": float(HITS_RE.search(raw).group(1)),
+        "queries": float(QRY_RE.search(raw).group(1)),
+    }
+
+
+def filler(n_tokens: int, tag: str) -> str:
+    return f"[{tag}] " + "the " * n_tokens
+
+
+def request(prompt: str, timeout: float = 900) -> dict:
+    body = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": prompt + "\nReply with OK."}],
+        "temperature": 0,
+        "max_tokens": 4,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    req = urllib.request.Request(
+        BASE + "/v1/chat/completions", data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"}, method="POST")
+    t0 = time.perf_counter()
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        obj = json.loads(resp.read().decode())
+    u = obj.get("usage") or {}
+    det = u.get("prompt_tokens_details") or {}
+    return {
+        "prompt_tokens": int(u.get("prompt_tokens") or 0),
+        "cached_tokens": int(det.get("cached_tokens") or 0),
+        "wall_s": time.perf_counter() - t0,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--agents", type=int, default=4)
+    ap.add_argument("--turns", type=int, default=8)
+    ap.add_argument("--base-tokens", type=int, default=60000)
+    ap.add_argument("--chunk-tokens", type=int, default=6000)
+    ap.add_argument("--label", default="run")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    histories = [filler(args.base_tokens, f"A{a} {SALT}") for a in range(args.agents)]
+    rows = []
+    t_start = time.time()
+    for turn in range(args.turns):
+        for a in range(args.agents):
+            histories[a] += filler(args.chunk_tokens, f"A{a} t{turn}")
+        before = metrics()
+        with cf.ThreadPoolExecutor(max_workers=args.agents) as ex:
+            results = [
+                f.result()
+                for f in [ex.submit(request, h) for h in histories]
+            ]
+        after = metrics()
+        for a, r in enumerate(results):
+            r.update({"turn": turn, "agent": a})
+            rows.append(r)
+        hit = sum(r["cached_tokens"] for r in results)
+        prom = sum(r["prompt_tokens"] for r in results)
+        gq = after["queries"] - before["queries"]
+        gh = after["hits"] - before["hits"]
+        print(
+            f"{args.label} turn {turn}: prompt={prom} cached={hit} "
+            f"ratio={hit/prom if prom else 0:.3f} "
+            f"global={(gh/gq if gq else float('nan')):.3f} "
+            f"max_wall={max(r['wall_s'] for r in results):.1f}s "
+            f"sum_wall={sum(r['wall_s'] for r in results):.1f}s",
+            flush=True,
+        )
+        with open(args.out, "w") as fh:
+            json.dump({"label": args.label, "args": vars(args), "rows": rows}, fh, indent=2)
+    print(f"{args.label} done elapsed={time.time()-t_start:.1f}s", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/bench_logprobs.py
+++ b/tests/bench_logprobs.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Capture prompt logprobs (top-20) for fixed texts; compare two captures.
+
+Usage:
+  python3 bench_logprobs.py capture OUT.json
+  python3 bench_logprobs.py compare A.json B.json
+"""
+import json
+import math
+import sys
+import urllib.request
+
+BASE = "http://127.0.0.1:8888"
+MODEL = "GLM-5.3-Flash-EXL3"
+
+
+def texts():
+    out = {}
+    out["prose_mla"] = (
+        "Multi-head latent attention compresses the key and value projections into a "
+        "single low-rank latent vector. During inference the KV cache therefore stores "
+        "the compressed latent plus a small decoupled rotary component, which cuts memory "
+        "traffic and raises the maximum batch size. The sparse indexer then selects the "
+        "top-k most relevant blocks for each query so that attention cost grows sublinearly "
+        "with context length. Operators who deploy such a model must balance the page size "
+        "of the cache against the alignment requirements of every hybrid group, because a "
+        "single misaligned group forces the whole prefix lookup back to whole-page "
+        "granularity."
+    ) * 4
+    out["log_rows"] = "\n".join(
+        f"Entry {i:04d}: node NODE{i % 7} reported checksum CK-{i * 37:06d} after the "
+        f"maintenance window; the operator logged temperature {40 + (i * 7) % 23} C, fan "
+        f"duty {30 + (i * 13) % 60} percent, and no faults."
+        for i in range(60)
+    )
+    out["code"] = (
+        "def cumulative_sum(values):\n"
+        "    total = 0\n"
+        "    out = []\n"
+        "    for value in values:\n"
+        "        total += value\n"
+        "        out.append(total)\n"
+        "    return out\n\n"
+        "def bucketize(scores, edges):\n"
+        "    buckets = [[] for _ in range(len(edges) + 1)]\n"
+        "    for score in scores:\n"
+        "        for idx, edge in enumerate(edges):\n"
+        "            if score < edge:\n"
+        "                buckets[idx].append(score)\n"
+        "                break\n"
+        "        else:\n"
+        "            buckets[-1].append(score)\n"
+        "    return buckets\n"
+    ) * 3
+    out["mixed"] = (
+        "Question: explain why the sky is blue and why sunsets are red, then compute "
+        "the arithmetic mean of 17, 23, 41, and 99. Answer in numbered steps. "
+        "Step 1: Rayleigh scattering scales as one over wavelength to the fourth power, "
+        "so short blue wavelengths scatter far more strongly than long red ones. "
+        "Step 2: near the horizon the optical path is longer and blue light is removed, "
+        "leaving the red end of the spectrum. "
+        "Step 3: the arithmetic mean is (17 + 23 + 41 + 99) / 4 = 180 / 4 = 45."
+    ) * 3
+    return out
+
+
+def capture(out_path):
+    res = {}
+    for name, text in texts().items():
+        body = {
+            "model": MODEL,
+            "prompt": text,
+            "max_tokens": 1,
+            "temperature": 0,
+            "echo": True,
+            "logprobs": 1,
+            "prompt_logprobs": 20,
+        }
+        req = urllib.request.Request(
+            BASE + "/v1/completions", data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json"}, method="POST")
+        with urllib.request.urlopen(req, timeout=600) as resp:
+            d = json.loads(resp.read().decode())
+        pl = d["choices"][0].get("prompt_logprobs") or []
+        res[name] = pl
+        nll = [
+            -max(v["logprob"] for v in pos.values() if v.get("rank") == 1)
+            for pos in pl[1:] if pos
+        ]
+        print(name, "positions", len(pl), "mean top1 nll", round(sum(nll) / max(1, len(nll)), 5))
+    json.dump(res, open(out_path, "w"))
+
+
+def compare(a_path, b_path):
+    A = json.load(open(a_path))
+    B = json.load(open(b_path))
+    print(f"{'text':12s} {'pos':>6} {'mean_KL':>10} {'argmax_agree':>13}")
+    for name in A:
+        pa, pb = A[name], B[name]
+        kls, agree, n = [], 0, 0
+        for x, y in zip(pa[1:], pb[1:]):
+            if not x or not y:
+                continue
+            ax = {k: math.exp(v["logprob"]) for k, v in x.items()}
+            by = {k: math.exp(v["logprob"]) for k, v in y.items()}
+            keys = set(ax) & set(by)
+            if not keys:
+                continue
+            za = sum(ax[k] for k in keys)
+            zb = sum(by[k] for k in keys)
+            kls.append(sum((ax[k] / za) * math.log((ax[k] / za) / (by[k] / zb)) for k in keys))
+            ta = max(x.items(), key=lambda kv: kv[1]["logprob"])[0]
+            tb = max(y.items(), key=lambda kv: kv[1]["logprob"])[0]
+            agree += ta == tb
+            n += 1
+        print(f"{name:12s} {n:6d} {sum(kls)/max(1,len(kls)):10.4f} {agree/max(1,n):13.3f}")
+
+
+if __name__ == "__main__":
+    if sys.argv[1] == "capture":
+        capture(sys.argv[2])
+    elif sys.argv[1] == "compare":
+        compare(sys.argv[2], sys.argv[3])
+    else:
+        raise SystemExit("usage: capture OUT | compare A B")

--- a/tests/replay_responses_traj.py
+++ b/tests/replay_responses_traj.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Replay a deep-swe (mini-swe-agent) trajectory prefix against /v1/responses.
+
+For selected API-call indices, rebuild the exact request `input` list the
+harness would send and report the server-reported cached_tokens. This isolates
+"prompt forked client-side" from "server evicted the prefix under load".
+"""
+import argparse
+import json
+import time
+import urllib.request
+
+BASE = "http://127.0.0.1:8888"
+MODEL = "GLM-5.3-Flash-EXL3"
+BASH_TOOL = {
+    "type": "function",
+    "name": "bash",
+    "description": "Execute a bash command",
+    "parameters": {
+        "type": "object",
+        "properties": {"command": {"type": "string", "description": "The bash command to execute"}},
+        "required": ["command"],
+    },
+}
+
+
+def prepare(messages):
+    """Mirror minisweagent LitellmResponseModel._prepare_messages_for_api."""
+    out = []
+    for msg in messages:
+        if msg.get("object") == "response":
+            for item in msg.get("output", []):
+                out.append({k: v for k, v in item.items() if k != "extra"})
+        else:
+            out.append({k: v for k, v in msg.items() if k != "extra"})
+    return out
+
+
+def response_indices(messages):
+    return [i for i, m in enumerate(messages) if isinstance(m, dict) and m.get("object") == "response"]
+
+
+def call(idx: int, input_items: list, timeout: float = 900) -> dict:
+    body = {
+        "model": MODEL,
+        "input": input_items,
+        "tools": [BASH_TOOL],
+        "reasoning": {"effort": "high"},
+        "temperature": 1.0,
+        "top_p": 0.95,
+        "max_output_tokens": 1,
+    }
+    req = urllib.request.Request(
+        BASE + "/v1/responses", data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"}, method="POST")
+    t0 = time.perf_counter()
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        obj = json.loads(resp.read().decode())
+    u = obj.get("usage") or {}
+    det = u.get("input_tokens_details") or {}
+    return {
+        "input_tokens": u.get("input_tokens"),
+        "cached_tokens": det.get("cached_tokens"),
+        "ttft_wall_s": time.perf_counter() - t0,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--trajectory", required=True)
+    ap.add_argument("--calls", default="0,1,2,3,4,5")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+    d = json.load(open(args.trajectory))
+    messages = d["messages"]
+    ridx = response_indices(messages)
+    out = {"trajectory": args.trajectory, "calls": []}
+    for c in (int(x) for x in args.calls.split(",")):
+        prefix = prepare(messages[: ridx[c]])
+        r = call(c, prefix)
+        r["call"] = c
+        print(json.dumps(r), flush=True)
+        out["calls"].append(r)
+    with open(args.out, "w") as fh:
+        json.dump(out, fh, indent=2)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Maintainer disposition — draft HOLD

The corrected tooling source is published at `5f6e22163d8e7e0570ae500c1bd17ad9b8a20990`; it is not current-main merge clearance or numerical/performance admission. Keep this PR draft and unmerged.

CPU evidence covers five comparison boundary cases (including empty captures), actual capture entrypoints with inert responses, missing-rank handling, and unavailable global prefix metrics. These checks do not qualify FP8 accuracy, cache performance, or live serving. The KL calculation is conditional on shared reported support, not full-distribution KL. Historical measurements below remain author-reported, scoped to their original configurations; they are not a current FP8 qualification.

Remaining source/tooling gate: maintainer `plotarmordev` owns current-main integration and resolution of the remaining per-request missing-usage/`cached_tokens` zero fallback before proposing a tooling-only landing. Counter resets, nonfinite metrics and numerical underflow are not newly qualified. Separately, any numerical admission requires a finalized comparison protocol and explicitly authorized capture; the draft #182 protocol is not finalized. No immediate author benchmark request and no node access is authorized by this disposition.

The corrected historical document remains frozen at SHA256 `79ea542b0c40fb254ac88a1cac529deef28b7988e02800a628e256f4ad678fd2`.

## Original author description — historical only

The following description is preserved for provenance, not endorsed as current qualification:

> ## Summary
> 
> Three stdlib-only probes used for the 2026-09-11 headroom investigation, plus the findings document:
> 
> - `tests/bench_agent_sessions.py` — N concurrent growing sessions; per-turn `prompt_tokens` / `cached_tokens`, global prefix-cache counter deltas and wall time. This is the detector for the multi-session prefix-cache cliff (it scored **0.000 global hits from turn 1** before the fixes in the companion APC PRs and 0.886–0.928 after).
> - `tests/replay_responses_traj.py` — replays a mini-swe-agent trajectory through `/v1/responses` and reports the server-side `cached_tokens` per API call. It separates "the prompt forked" from "the server evicted the prefix": calls that missed live (0 cached) hit on an idle engine with the same payload (32 k–50 k cached).
> - `tests/bench_logprobs.py` — fixed-text prompt-logprob capture plus a KLD/argmax comparison for numeric gates. Used here to qualify dense FP8 vs BF16 dense: KLD 0.002–0.016 nats, argmax agreement 97.0–99.7 % on four fixed texts.
> 
> `docs/headroom-2026-09-11.md` records the findings, measurements and the reconciliation A/B between the PR #83 and PR #130 retention implementations (same-probe boots B3–B7: 3×/4× 30 k repeats 1.000 hits with the #83 semantics vs 0.000 with the #130 rework on this workload; B6 isolated the cause from the DFlash block-drop cherry-pick).
> 
> ## Usage
> 
> ```bash
> python3 tests/bench_agent_sessions.py --agents 4 --turns 8 --base-tokens 60000 --chunk-tokens 6000 --out /tmp/agent.json
> python3 tests/replay_responses_traj.py --trajectory <traj.json> --calls 16,17,18,19,20 --out /tmp/replay.json
> python3 tests/bench_logprobs.py capture a.json   # then, after a config change:
> python3 tests/bench_logprobs.py compare a.json b.json
> ```
> 
> ## Notes
> 
> Draft: tooling + evidence for discussion; the divergence findings are included deliberately so the #130 behavior is documented as measured, not argued.