### PR TITLE
docs(triage): fix stale per-prompt image cap hint in the bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug.md
+++ b/.github/ISSUE_TEMPLATE/1_bug.md
@@ -85,7 +85,7 @@ curl -s http://localhost:8888/v1/chat/completions \
         * Lower context than 1M -> do not reduce MAX_MODEL_LEN; pool size depends on
           MNBT and graph reservations (README "Context").
         * Vision requests rejected -> LANGUAGE_MODEL_ONLY=1 disables image/video;
-          check --limit-mm-per-prompt shape {image:4,video:1}.
+          check --limit-mm-per-prompt shape {image:100,video:1}.
 -->
 
 ```


### PR DESCRIPTION
## Description and Motivation

`d7dd7de` ("fix(vision): raise the default per-prompt image cap from 4 to 100") updated `start.sh`, `start-tp4.sh`, `.env.example` and three `README.md` references, but the filer-facing hint block in `.github/ISSUE_TEMPLATE/1_bug.md` was missed. It still tells reporters to check `--limit-mm-per-prompt shape {image:4,video:1}`.

* **What changes:** one line of hint text, `{image:4,video:1}` → `{image:100,video:1}`, matching the shipped default.
* **Why it matters:** it is the only tracked site left saying 4 (`git grep -n 'image:4' -- .` returns this line and nothing else), and it contradicts `README.md:198`, `README.md:380`, `README.md:692`, `.env.example:162`, `start.sh:180` and `start-tp4.sh:230`. Because it is the text a reporter reads while deciding what to check, it re-seeds the confusion the raised default was meant to remove: `LIMIT_MM` lives in a copy-once `.env` (`start.sh:52`), so an operator whose file still pins 4 is told here that 4 is the current default, and the mismatch reads as a server fault rather than a local config value. The boot log already prints the effective value (`start.sh:1184`), which is the real source of truth.
* **Measured numbers:** none. This is comment-only; no knob, script behaviour, default or measured number changes. Nothing affects KV pool, TTFT, cold prefill, decode throughput, draft acceptance or concurrency, and nothing runs on either node.
* **Two-node safety:** not applicable — the file is GitHub issue-template front matter and is never executed.

Noticed in the same hint block and deliberately left alone to keep the diff minimal: "Lower context than 1M" (line 86) sits next to the shipped `MAX_MODEL_LEN=850000` (`.env.example:137`). 1M is still a supported opt-in with `EXL3_FAT_GROUPED=0`, so that phrasing may well be intentional.

## Related Issues

Related to #146 (the cap raise that missed this file) and #129 (the docs issue for the same 4-image failure mode). Neither is closed by this change; it only removes the stale number from the triage hints.

---

## Testing

Comment-only change, so no boot was run. Verified on a checkout at `main` (`9348755`):

* `git grep -n 'image:4' -- .` → this line before the change, empty after; `image:100` present at all seven sites after (`start.sh:180`, `start-tp4.sh:230`, `.env.example:162`, `README.md:198/380/692`, template).
* `tests/test_image_recipe.py` and `tests/test_start_overrides.py` — **9 tests pass**. These two modules were executed by importing each file and calling its `test_*` functions directly, because `pytest` is not installed on the reporting host; the files' own assertions are unchanged and unmodified, so a normal `pytest` run should reproduce it. Other modules in `tests/` were not run.
* `bash -n start.sh stop.sh` — clean. No script is touched; run as a sanity check only.
* `git diff` is exactly one line, and the change stays inside the `<!-- ... -->` block of the issue-form front matter.

---

## Checklist:

- [x] I have read the README and kept my changes consistent with it.
- [x] My pull request has a sound title and description (not something vague like `Update README.md`).
- [x] My change is reproducible and verified (a boot and, for behavior changes, measurements). — no boot was run: this is text inside an HTML comment that no script reads, so there is no behaviour to measure. The verification is the grep diff and the two test modules above; happy to attach a boot log if you would rather see one.
- [x] Defaults still work out of the box; a new knob has a sane fallback consistent with the existing ones. — no knob or default touched; the launcher fallbacks at `start.sh:180` and `start-tp4.sh:230` are unchanged (`{"image":100,"video":1}`), confirmed by reading them.
- [x] I updated the README (and docs/ where relevant) for any knob, default, or measured number I changed. — N/A: I changed no knob, default or measured number, so there is nothing to document. This PR only aligns the template with what the README and `.env.example` already say.

---

Optional follow-up, not in this PR: `tests/test_image_recipe.py::test_documented_defaults` pins `start.sh` ↔ `.env.example` parity for `MAX_NUM_BATCHED_TOKENS` and `EXL3_FAT_KERNEL` but not `LIMIT_MM` — the one documented default that just changed value repo-wide. Adding those two literals would catch this class of drift. It would not have caught a stale local `.env`, which is a separate problem (copy-once at `start.sh:52`, with no note that a raised `.env.example` default never reaches an existing install).
